### PR TITLE
fix: use calling app's hostname as SIWE domain

### DIFF
--- a/.changeset/fix-siwe-domain.md
+++ b/.changeset/fix-siwe-domain.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/web-sdk": patch
+---
+
+Fix SIWE domain to use calling app's hostname instead of TinyCloud node URL

--- a/.changeset/fix-siwe-domain.md
+++ b/.changeset/fix-siwe-domain.md
@@ -1,5 +1,6 @@
 ---
 "@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk": patch
 ---
 
-Fix SIWE domain to use calling app's hostname instead of TinyCloud node URL
+Fix SIWE domain to default to app.tinycloud.xyz instead of TinyCloud node URL

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -178,6 +178,11 @@ export class TinyCloudNode {
     return this.auth?.nodeFeatures ?? [];
   }
 
+  /** SIWE domain — uses config override or defaults to app.tinycloud.xyz */
+  private get siweDomain(): string {
+    return this.config.domain ?? 'app.tinycloud.xyz';
+  }
+
   /**
    * Create a new TinyCloudNode instance.
    *
@@ -301,14 +306,13 @@ export class TinyCloudNode {
    */
   private setupAuth(config: TinyCloudNodeConfig): void {
     const host = this.config.host!;
-    const domain = config.domain ?? new URL(host).hostname;
 
     this.auth = new NodeUserAuthorization({
       signer: this.signer!,
       signStrategy: { type: "auto-sign" },
       wasmBindings: this.wasmBindings,
       sessionStorage: config.sessionStorage ?? new MemorySessionStorage(),
-      domain,
+      domain: this.siweDomain,
       spacePrefix: config.prefix,
       sessionExpirationMs: config.sessionExpirationMs ?? 60 * 60 * 1000,
       tinycloudHosts: [host],
@@ -547,7 +551,6 @@ export class TinyCloudNode {
 
     const prefix = options?.prefix ?? "default";
     const host = this.config.host!;
-    const domain = new URL(host).hostname;
 
     // Create signer from private key
     if (!TinyCloudNode.nodeDefaults) {
@@ -564,7 +567,7 @@ export class TinyCloudNode {
       signStrategy: { type: "auto-sign" },
       wasmBindings: this.wasmBindings,
       sessionStorage: options?.sessionStorage ?? this.config.sessionStorage ?? new MemorySessionStorage(),
-      domain,
+      domain: this.siweDomain,
       spacePrefix: prefix,
       sessionExpirationMs: this.config.sessionExpirationMs ?? 60 * 60 * 1000,
       tinycloudHosts: [host],
@@ -600,7 +603,6 @@ export class TinyCloudNode {
 
     const prefix = options?.prefix ?? "default";
     const host = this.config.host!;
-    const domain = new URL(host).hostname;
 
     this.signer = signer;
 
@@ -609,7 +611,7 @@ export class TinyCloudNode {
       signStrategy: { type: "auto-sign" },
       wasmBindings: this.wasmBindings,
       sessionStorage: options?.sessionStorage ?? this.config.sessionStorage ?? new MemorySessionStorage(),
-      domain,
+      domain: this.siweDomain,
       spacePrefix: prefix,
       sessionExpirationMs: this.config.sessionExpirationMs ?? 60 * 60 * 1000,
       tinycloudHosts: [host],
@@ -979,7 +981,7 @@ export class TinyCloudNode {
         abilities,
         address: this.wasmBindings.ensureEip55(session.address),
         chainId: session.chainId,
-        domain: new URL(host).hostname,
+        domain: this.siweDomain,
         issuedAt: now.toISOString(),
         expirationTime: params.requestedExpiry.toISOString(),
         spaceId: params.spaceId,
@@ -1331,7 +1333,7 @@ export class TinyCloudNode {
       abilities,
       address: this.wasmBindings.ensureEip55(this.session.address),
       chainId: this.session.chainId,
-      domain: new URL(this.config.host!).hostname,
+      domain: this.siweDomain,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId: publicSpaceId,
@@ -1538,7 +1540,7 @@ export class TinyCloudNode {
       abilities,
       address: this.wasmBindings.ensureEip55(session.address),
       chainId: session.chainId,
-      domain: new URL(this.config.host!).hostname,
+      domain: this.siweDomain,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId: params.spaceIdOverride ?? session.spaceId,
@@ -1592,7 +1594,7 @@ export class TinyCloudNode {
         abilities: publicAbilities,
         address: this.wasmBindings.ensureEip55(session.address),
         chainId: session.chainId,
-        domain: new URL(this.config.host!).hostname,
+        domain: this.siweDomain,
         issuedAt: now.toISOString(),
         expirationTime: expirationTime.toISOString(),
         spaceId: publicSpaceId,
@@ -1721,7 +1723,7 @@ export class TinyCloudNode {
       abilities,
       address: this.wasmBindings.ensureEip55(mySession.address),
       chainId: mySession.chainId,
-      domain: new URL(targetHost).hostname,
+      domain: this.siweDomain,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId: delegation.spaceId,
@@ -1856,7 +1858,7 @@ export class TinyCloudNode {
       abilities,
       address: this.wasmBindings.ensureEip55(this._address),
       chainId: this._chainId,
-      domain: new URL(targetHost).hostname,
+      domain: this.siweDomain,
       issuedAt: now.toISOString(),
       expirationTime: actualExpiry.toISOString(),
       spaceId: parentDelegation.spaceId,

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -422,11 +422,12 @@ export class NodeUserAuthorization implements IUserAuthorization {
       address,
       chainId,
       domain: this.domain,
+      uri: this.uri,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId,
       jwk,
-      nonce: this.siweConfig?.nonce,
+      ...this.siweConfig,
     });
 
     // Sign the SIWE message from prepareSession (NOT a separately generated SIWE)
@@ -617,11 +618,12 @@ export class NodeUserAuthorization implements IUserAuthorization {
       address,
       chainId,
       domain: this.domain,
+      uri: this.uri,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId,
       jwk,
-      nonce: this.siweConfig?.nonce,
+      ...this.siweConfig,
     });
 
     return {

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -192,6 +192,40 @@ export class NodeUserAuthorization implements IUserAuthorization {
   }
 
   /**
+   * Build SIWE overrides from siweConfig.
+   * - statement is prepended to the default statement
+   * - resources are appended to the default resources
+   * - uri triggers a warning (overwriting delegation target)
+   * - all other fields override directly
+   */
+  private buildSiweOverrides(): Record<string, unknown> {
+    if (!this.siweConfig) return { uri: this.uri };
+
+    const { statement, resources, uri, ...rest } = this.siweConfig;
+    const overrides: Record<string, unknown> = { uri: this.uri, ...rest };
+
+    if (statement) {
+      overrides.statement = this.statement
+        ? `${statement}\n${this.statement}`
+        : statement;
+    }
+
+    if (resources && resources.length > 0) {
+      overrides.resources = resources;
+    }
+
+    if (uri) {
+      console.warn(
+        "[tinycloud] siweConfig.uri is overwriting the delegation target URI. " +
+        "This may break delegation chain validation if the URI does not match the session key DID.",
+      );
+      overrides.uri = uri;
+    }
+
+    return overrides;
+  }
+
+  /**
    * Add an extension to the authorization flow.
    */
   extend(extension: Extension): void {
@@ -422,12 +456,11 @@ export class NodeUserAuthorization implements IUserAuthorization {
       address,
       chainId,
       domain: this.domain,
-      uri: this.uri,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId,
       jwk,
-      ...this.siweConfig,
+      ...this.buildSiweOverrides(),
     });
 
     // Sign the SIWE message from prepareSession (NOT a separately generated SIWE)
@@ -618,12 +651,11 @@ export class NodeUserAuthorization implements IUserAuthorization {
       address,
       chainId,
       domain: this.domain,
-      uri: this.uri,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId,
       jwk,
-      ...this.siweConfig,
+      ...this.buildSiweOverrides(),
     });
 
     return {

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -206,7 +206,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
     if (statement) {
       overrides.statement = this.statement
-        ? `${statement}\n${this.statement}`
+        ? `${statement} ${this.statement}`
         : statement;
     }
 

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -85,7 +85,7 @@ export interface Config extends ClientConfig {
   /** Session expiration time in milliseconds (default: 1 hour) */
   sessionExpirationMs?: number;
 
-  /** SIWE domain (default: window.location.hostname in browser) */
+  /** SIWE domain (default: window.location.hostname in browser, app.tinycloud.xyz otherwise) */
   domain?: string;
 
   /** Shorthand for passing a Web3 provider */
@@ -197,7 +197,7 @@ export class TinyCloudWeb {
 
     const nodeConfig: TinyCloudNodeConfig = {
       host: this.config.tinycloudHosts?.[0] ?? "https://node.tinycloud.xyz",
-      domain: this.config.domain ?? (typeof window !== 'undefined' ? window.location.hostname : undefined),
+      domain: this.config.domain ?? (typeof window !== 'undefined' ? window.location.hostname : 'app.tinycloud.xyz'),
       prefix: this.config.spacePrefix,
       autoCreateSpace: this.config.autoCreateSpace ?? true,
       sessionExpirationMs: this.config.sessionExpirationMs,

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -85,6 +85,9 @@ export interface Config extends ClientConfig {
   /** Session expiration time in milliseconds (default: 1 hour) */
   sessionExpirationMs?: number;
 
+  /** SIWE domain (default: window.location.hostname in browser) */
+  domain?: string;
+
   /** Shorthand for passing a Web3 provider */
   provider?: any;
 }
@@ -194,6 +197,7 @@ export class TinyCloudWeb {
 
     const nodeConfig: TinyCloudNodeConfig = {
       host: this.config.tinycloudHosts?.[0] ?? "https://node.tinycloud.xyz",
+      domain: this.config.domain ?? (typeof window !== 'undefined' ? window.location.hostname : undefined),
       prefix: this.config.spacePrefix,
       autoCreateSpace: this.config.autoCreateSpace ?? true,
       sessionExpirationMs: this.config.sessionExpirationMs,


### PR DESCRIPTION
## Summary

- Adds `domain` option to `TinyCloudWeb` `Config` interface so apps can explicitly set the SIWE domain
- Defaults to `window.location.hostname` in browser environments instead of the TinyCloud node URL
- Passes `domain` through to `TinyCloudNode` config where it's already supported

## Problem

The SIWE domain was derived from the TinyCloud node hostname (e.g., `node.tinycloud.xyz`) instead of the calling app's domain (e.g., `secrets.tinycloud.xyz`). Per EIP-4361, the domain should match the app's origin.

## Test plan

- [ ] Verify SIWE message domain matches `window.location.hostname` when no explicit domain is provided
- [ ] Verify explicit `domain` config option overrides the default
- [ ] Verify non-browser environments (SSR) gracefully fall back to node URL hostname