### PR TITLE
fix(web-sdk): restore siwe config overrides

### DIFF
--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -72,8 +72,12 @@ import {
   CreateDelegationWasmResult,
   UnsupportedFeatureError,
   makePublicSpaceId,
+  SiweConfig,
 } from "@tinycloud/sdk-core";
-import { NodeUserAuthorization } from "./authorization/NodeUserAuthorization";
+import {
+  NodeUserAuthorization,
+  NodeUserAuthorizationConfig,
+} from "./authorization/NodeUserAuthorization";
 import { FileSessionStorage } from "./storage/FileSessionStorage";
 import { MemorySessionStorage } from "./storage/MemorySessionStorage";
 import { PortableDelegation } from "./delegation";
@@ -98,6 +102,8 @@ export interface TinyCloudNodeConfig {
   prefix?: string;
   /** Domain for SIWE messages (default: derived from host) */
   domain?: string;
+  /** Optional SIWE overrides for primary auth message preparation. */
+  siweConfig?: Pick<SiweConfig, "domain" | "uri" | "statement" | "nonce">;
   /** Session expiration time in milliseconds (default: 1 hour) */
   sessionExpirationMs?: number;
   /** Whether to automatically create space if it doesn't exist (default: false) */
@@ -297,24 +303,45 @@ export class TinyCloudNode {
    * @internal
    */
   private setupAuth(config: TinyCloudNodeConfig): void {
-    const host = this.config.host!;
-    const domain = config.domain ?? new URL(host).hostname;
+    this.auth = new NodeUserAuthorization(
+      this.createAuthorizationConfig({
+        prefix: config.prefix,
+        sessionStorage: config.sessionStorage,
+      })
+    );
 
-    this.auth = new NodeUserAuthorization({
+    this.tc = new TinyCloud(this.auth);
+  }
+
+  private resolveSiweDomain(): string {
+    return this.config.domain
+      ?? this.config.siweConfig?.domain
+      ?? new URL(this.config.host!).hostname;
+  }
+
+  private createAuthorizationConfig(options: {
+    prefix?: string;
+    sessionStorage?: ISessionStorage;
+  } = {}): NodeUserAuthorizationConfig {
+    return {
       signer: this.signer!,
       signStrategy: { type: "auto-sign" },
       wasmBindings: this.wasmBindings,
-      sessionStorage: config.sessionStorage ?? new MemorySessionStorage(),
-      domain,
-      spacePrefix: config.prefix,
-      sessionExpirationMs: config.sessionExpirationMs ?? 60 * 60 * 1000,
-      tinycloudHosts: [host],
-      autoCreateSpace: config.autoCreateSpace,
-      enablePublicSpace: config.enablePublicSpace ?? true,
-      spaceCreationHandler: config.spaceCreationHandler,
-    });
-
-    this.tc = new TinyCloud(this.auth);
+      sessionStorage:
+        options.sessionStorage
+        ?? this.config.sessionStorage
+        ?? new MemorySessionStorage(),
+      domain: this.resolveSiweDomain(),
+      uri: this.config.siweConfig?.uri,
+      statement: this.config.siweConfig?.statement,
+      nonce: this.config.siweConfig?.nonce,
+      spacePrefix: options.prefix ?? this.config.prefix,
+      sessionExpirationMs: this.config.sessionExpirationMs ?? 60 * 60 * 1000,
+      tinycloudHosts: [this.config.host!],
+      autoCreateSpace: this.config.autoCreateSpace,
+      enablePublicSpace: this.config.enablePublicSpace ?? true,
+      spaceCreationHandler: this.config.spaceCreationHandler,
+    };
   }
 
   /**
@@ -542,8 +569,6 @@ export class TinyCloudNode {
     }
 
     const prefix = options?.prefix ?? "default";
-    const host = this.config.host!;
-    const domain = new URL(host).hostname;
 
     // Create signer from private key
     if (!TinyCloudNode.nodeDefaults) {
@@ -555,19 +580,12 @@ export class TinyCloudNode {
     this.signer = TinyCloudNode.nodeDefaults.createSigner(privateKey);
 
     // Create authorization handler
-    this.auth = new NodeUserAuthorization({
-      signer: this.signer,
-      signStrategy: { type: "auto-sign" },
-      wasmBindings: this.wasmBindings,
-      sessionStorage: options?.sessionStorage ?? this.config.sessionStorage ?? new MemorySessionStorage(),
-      domain,
-      spacePrefix: prefix,
-      sessionExpirationMs: this.config.sessionExpirationMs ?? 60 * 60 * 1000,
-      tinycloudHosts: [host],
-      autoCreateSpace: this.config.autoCreateSpace,
-      enablePublicSpace: this.config.enablePublicSpace ?? true,
-      spaceCreationHandler: this.config.spaceCreationHandler,
-    });
+    this.auth = new NodeUserAuthorization(
+      this.createAuthorizationConfig({
+        prefix,
+        sessionStorage: options?.sessionStorage,
+      })
+    );
 
     // Create TinyCloud instance
     this.tc = new TinyCloud(this.auth);
@@ -595,24 +613,15 @@ export class TinyCloudNode {
     }
 
     const prefix = options?.prefix ?? "default";
-    const host = this.config.host!;
-    const domain = new URL(host).hostname;
 
     this.signer = signer;
 
-    this.auth = new NodeUserAuthorization({
-      signer: this.signer,
-      signStrategy: { type: "auto-sign" },
-      wasmBindings: this.wasmBindings,
-      sessionStorage: options?.sessionStorage ?? this.config.sessionStorage ?? new MemorySessionStorage(),
-      domain,
-      spacePrefix: prefix,
-      sessionExpirationMs: this.config.sessionExpirationMs ?? 60 * 60 * 1000,
-      tinycloudHosts: [host],
-      autoCreateSpace: this.config.autoCreateSpace,
-      enablePublicSpace: this.config.enablePublicSpace ?? true,
-      spaceCreationHandler: this.config.spaceCreationHandler,
-    });
+    this.auth = new NodeUserAuthorization(
+      this.createAuthorizationConfig({
+        prefix,
+        sessionStorage: options?.sessionStorage,
+      })
+    );
 
     this.tc = new TinyCloud(this.auth);
     this.config.prefix = prefix;

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -40,6 +40,8 @@ export interface NodeUserAuthorizationConfig {
   uri?: string;
   /** Statement included in SIWE messages */
   statement?: string;
+  /** Nonce override included in SIWE messages */
+  nonce?: string;
   /** Space prefix for new sessions */
   spacePrefix?: string;
   /** Default actions for sessions */
@@ -97,6 +99,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
   private readonly domain: string;
   private readonly uri: string;
   private readonly statement?: string;
+  private readonly nonce?: string;
   private readonly spacePrefix: string;
   private readonly defaultActions: Record<string, Record<string, string[]>>;
   private readonly sessionExpirationMs: number;
@@ -123,6 +126,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this.domain = config.domain;
     this.uri = config.uri ?? `https://${config.domain}`;
     this.statement = config.statement;
+    this.nonce = config.nonce;
     this.spacePrefix = config.spacePrefix ?? "default";
     this.defaultActions = config.defaultActions ?? {
       kv: {
@@ -184,6 +188,29 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
   get nodeFeatures(): string[] {
     return this._nodeFeatures;
+  }
+
+  private preparePrimarySession(params: {
+    address: string;
+    chainId: number;
+    issuedAt: string;
+    expirationTime: string;
+    spaceId: string;
+    jwk: Record<string, unknown>;
+  }) {
+    return this.wasm.prepareSession({
+      abilities: this.defaultActions,
+      address: params.address,
+      chainId: params.chainId,
+      domain: this.domain,
+      uri: this.uri,
+      issuedAt: params.issuedAt,
+      expirationTime: params.expirationTime,
+      spaceId: params.spaceId,
+      jwk: params.jwk,
+      ...(this.statement ? { statement: this.statement } : {}),
+      ...(this.nonce ? { nonce: this.nonce } : {}),
+    });
   }
 
   /**
@@ -412,11 +439,9 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const expirationTime = new Date(now.getTime() + this.sessionExpirationMs);
 
     // Prepare session - this creates the SIWE message with ReCap capabilities
-    const prepared = this.wasm.prepareSession({
-      abilities: this.defaultActions,
+    const prepared = this.preparePrimarySession({
       address,
       chainId,
-      domain: this.domain,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId,
@@ -606,11 +631,9 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const expirationTime = new Date(now.getTime() + this.sessionExpirationMs);
 
     // Prepare session - this creates the SIWE message with ReCap capabilities
-    const prepared = this.wasm.prepareSession({
-      abilities: this.defaultActions,
+    const prepared = this.preparePrimarySession({
       address,
       chainId,
-      domain: this.domain,
       issuedAt: now.toISOString(),
       expirationTime: expirationTime.toISOString(),
       spaceId,

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -195,6 +195,7 @@ export class TinyCloudWeb {
     const nodeConfig: TinyCloudNodeConfig = {
       host: this.config.tinycloudHosts?.[0] ?? "https://node.tinycloud.xyz",
       prefix: this.config.spacePrefix,
+      siweConfig: this.config.siweConfig,
       autoCreateSpace: this.config.autoCreateSpace ?? true,
       sessionExpirationMs: this.config.sessionExpirationMs,
       notificationHandler: this.notificationHandler,


### PR DESCRIPTION
## Summary
- thread `siweConfig` from `TinyCloudWeb` into `TinyCloudNode`
- centralize SIWE auth config creation in `TinyCloudNode`
- restore `uri`, `statement`, and `nonce` overrides in the unified `NodeUserAuthorization` sign-in paths

## Testing
- bun --cwd packages/node-sdk build
- tsc -p packages/web-sdk/tsconfig.json --noEmit