### PR TITLE
fix(node-sdk): preserve siweConfig on wallet upgrade

### DIFF
--- a/.changeset/preserve-siwe-upgrade.md
+++ b/.changeset/preserve-siwe-upgrade.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk": patch
+---
+
+Preserve `siweConfig` when upgrading from session-only mode via `connectWallet()` or `connectSigner()`

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -574,6 +574,7 @@ export class TinyCloudNode {
       autoCreateSpace: this.config.autoCreateSpace,
       enablePublicSpace: this.config.enablePublicSpace ?? true,
       spaceCreationHandler: this.config.spaceCreationHandler,
+      siweConfig: this.config.siweConfig,
     });
 
     // Create TinyCloud instance
@@ -618,6 +619,7 @@ export class TinyCloudNode {
       autoCreateSpace: this.config.autoCreateSpace,
       enablePublicSpace: this.config.enablePublicSpace ?? true,
       spaceCreationHandler: this.config.spaceCreationHandler,
+      siweConfig: this.config.siweConfig,
     });
 
     this.tc = new TinyCloud(this.auth);


### PR DESCRIPTION
## Summary
- preserve `siweConfig` when `TinyCloudNode` upgrades from session-only mode via `connectWallet()`
- preserve `siweConfig` when `TinyCloudNode` upgrades from session-only mode via `connectSigner()`
- keep the fix scoped to the current `master` codepath instead of the older sdk-unification branch

## Testing
- patch reviewed against current `origin/master`
- no clean package-local build was available from the detached worktree because workspace dependencies are not installed there