### PR TITLE
fix: update WASM rev for SIWE nonce passthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "cacaos"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b46899d#b46899d332ed4c7255d811ceb57170928c97086b"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
 dependencies = [
  "async-trait",
  "hex",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b46899d#b46899d332ed4c7255d811ceb57170928c97086b"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
 dependencies = [
  "hex",
  "http 1.4.0",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "siwe-recap"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b46899d#b46899d332ed4c7255d811ceb57170928c97086b"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
 dependencies = [
  "base64 0.22.1",
  "ipld-core",
@@ -4955,8 +4955,8 @@ dependencies = [
 
 [[package]]
 name = "tinycloud-auth"
-version = "1.1.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b46899d#b46899d332ed4c7255d811ceb57170928c97086b"
+version = "1.2.1"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4979,8 +4979,8 @@ dependencies = [
 
 [[package]]
 name = "tinycloud-sdk-rs"
-version = "1.1.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b46899d#b46899d332ed4c7255d811ceb57170928c97086b"
+version = "1.2.1"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
 dependencies = [
  "async-trait",
  "hex",
@@ -4997,8 +4997,8 @@ dependencies = [
 
 [[package]]
 name = "tinycloud-sdk-wasm"
-version = "1.1.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b46899d#b46899d332ed4c7255d811ceb57170928c97086b"
+version = "1.2.1"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
 dependencies = [
  "aes-gcm",
  "chrono",

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -26,8 +26,8 @@ js-sys = "0.3.59"
 # tinycloud-sdk-rs = { path = "../../../tinycloud-node/tinycloud-sdk-rs" }
 # tinycloud-sdk-wasm = { path = "../../../tinycloud-node/tinycloud-sdk-wasm" }
 # For release, update rev after pushing tinycloud-node changes:
-tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "b46899d" }
-tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "b46899d" }
+tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "e0449685" }
+tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "e0449685" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.83"
 serde-wasm-bindgen = "0.6.5"


### PR DESCRIPTION
## Summary
- Updates `tinycloud-node` git dependency rev from `b46899d` to `e0449685` in `packages/sdk-rs/Cargo.toml`
- The new rev includes the fix to pass through the SIWE nonce from SDK config instead of always generating a random one (TinyCloudLabs/tinycloud-node#43)
- WASM builds (web + node targets) verified locally — compiles cleanly

## Test plan
- [ ] CI passes WASM build
- [ ] Verify SIWE nonce passthrough works end-to-end with a consuming app that sets `siweConfig.nonce`