### PR TITLE
feat: add write hooks sdk support and live tests through phase 4

### DIFF
--- a/.changeset/write-hooks-phase2.md
+++ b/.changeset/write-hooks-phase2.md
@@ -1,0 +1,8 @@
+---
+"@tinycloud/sdk-services": minor
+"@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+---
+
+Add write-hooks support across the JS SDK surface for SDK services, core, Node, and web packages.

--- a/bun.lock
+++ b/bun.lock
@@ -248,6 +248,7 @@
         "zod": "^3.23.0",
       },
       "devDependencies": {
+        "@tinycloud/node-sdk-wasm": "workspace:*",
         "@types/node": "^20",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",

--- a/packages/node-sdk/src/DelegatedAccess.ts
+++ b/packages/node-sdk/src/DelegatedAccess.ts
@@ -2,6 +2,8 @@ import {
   TinyCloudSession,
   KVService,
   IKVService,
+  HooksService,
+  IHooksService,
   SQLService,
   ISQLService,
   DuckDbService,
@@ -26,6 +28,7 @@ export class DelegatedAccess {
   private _kv: KVService;
   private _sql: SQLService;
   private _duckdb: DuckDbService;
+  private _hooks: HooksService;
 
   constructor(
     session: TinyCloudSession,
@@ -60,6 +63,11 @@ export class DelegatedAccess {
     this._duckdb = new DuckDbService({});
     this._duckdb.initialize(this._serviceContext);
     this._serviceContext.registerService('duckdb', this._duckdb);
+
+    // Create and initialize Hooks service with same delegation context
+    this._hooks = new HooksService({});
+    this._hooks.initialize(this._serviceContext);
+    this._serviceContext.registerService('hooks', this._hooks);
 
     // Set session on context
     const serviceSession: ServiceSession = {
@@ -112,5 +120,12 @@ export class DelegatedAccess {
    */
   get duckdb(): IDuckDbService {
     return this._duckdb;
+  }
+
+  /**
+   * Hooks write-stream subscriptions on the delegated space.
+   */
+  get hooks(): IHooksService {
+    return this._hooks;
   }
 }

--- a/packages/node-sdk/src/NodeWasmBindings.ts
+++ b/packages/node-sdk/src/NodeWasmBindings.ts
@@ -9,6 +9,7 @@
 
 import {
   invoke,
+  invokeAny,
   prepareSession,
   completeSessionSetup,
   ensureEip55,
@@ -47,6 +48,7 @@ export class NodeWasmBindings implements IWasmBindings {
   }
 
   invoke = invoke;
+  invokeAny = invokeAny;
   prepareSession = prepareSession;
   completeSessionSetup = completeSessionSetup;
   ensureEip55 = ensureEip55;

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -41,8 +41,10 @@ import {
   ISQLService,
   DuckDbService,
   IDuckDbService,
+  HooksService,
   DataVaultService,
   IDataVaultService,
+  IHooksService,
   createVaultCrypto,
   ServiceSession,
   ServiceContext,
@@ -159,6 +161,7 @@ export class TinyCloudNode {
   private _kv?: KVService;
   private _sql?: SQLService;
   private _duckdb?: DuckDbService;
+  private _hooks?: HooksService;
   private _vault?: DataVaultService;
   /** Cached public KV with proper delegation (set by ensurePublicSpace) */
   private _publicKV?: KVService;
@@ -328,7 +331,9 @@ export class TinyCloudNode {
       siweConfig: config.siweConfig,
     });
 
-    this.tc = new TinyCloud(this.auth);
+    this.tc = new TinyCloud(this.auth, {
+      invokeAny: this.wasmBindings.invokeAny,
+    });
   }
 
   /**
@@ -411,6 +416,7 @@ export class TinyCloudNode {
     this._kv = undefined;
     this._sql = undefined;
     this._duckdb = undefined;
+    this._hooks = undefined;
     this._serviceContext = undefined;
 
     await this.tc.signIn();
@@ -446,6 +452,7 @@ export class TinyCloudNode {
     this._kv = undefined;
     this._sql = undefined;
     this._duckdb = undefined;
+    this._hooks = undefined;
     this._serviceContext = undefined;
 
     if (sessionData.address) {
@@ -458,6 +465,7 @@ export class TinyCloudNode {
     // Create service context
     this._serviceContext = new ServiceContext({
       invoke: this.wasmBindings.invoke,
+      invokeAny: this.wasmBindings.invokeAny,
       fetch: globalThis.fetch.bind(globalThis),
       hosts: [this.config.host!],
     });
@@ -476,6 +484,10 @@ export class TinyCloudNode {
     this._duckdb = new DuckDbService({});
     this._duckdb.initialize(this._serviceContext);
     this._serviceContext.registerService('duckdb', this._duckdb);
+
+    this._hooks = new HooksService({});
+    this._hooks.initialize(this._serviceContext);
+    this._serviceContext.registerService('hooks', this._hooks);
 
     // Set session on context
     const serviceSession: ServiceSession = {
@@ -585,7 +597,9 @@ export class TinyCloudNode {
     });
 
     // Create TinyCloud instance
-    this.tc = new TinyCloud(this.auth);
+    this.tc = new TinyCloud(this.auth, {
+      invokeAny: this.wasmBindings.invokeAny,
+    });
 
     // Update config with prefix
     this.config.prefix = prefix;
@@ -630,7 +644,9 @@ export class TinyCloudNode {
       siweConfig: this.config.siweConfig,
     });
 
-    this.tc = new TinyCloud(this.auth);
+    this.tc = new TinyCloud(this.auth, {
+      invokeAny: this.wasmBindings.invokeAny,
+    });
     this.config.prefix = prefix;
   }
 
@@ -650,6 +666,7 @@ export class TinyCloudNode {
     // Create service context
     this._serviceContext = new ServiceContext({
       invoke: this.wasmBindings.invoke,
+      invokeAny: this.wasmBindings.invokeAny,
       fetch: globalThis.fetch.bind(globalThis),
       hosts: [this.config.host!],
     });
@@ -673,6 +690,10 @@ export class TinyCloudNode {
       this._duckdb.initialize(this._serviceContext);
       this._serviceContext.registerService('duckdb', this._duckdb);
     }
+
+    this._hooks = new HooksService({});
+    this._hooks.initialize(this._serviceContext);
+    this._serviceContext.registerService('hooks', this._hooks);
 
     // Set session on context
     const serviceSession: ServiceSession = {
@@ -1113,6 +1134,16 @@ export class TinyCloudNode {
       throw new Error("Not signed in. Call signIn() first.");
     }
     return this._vault;
+  }
+
+  /**
+   * Hooks write stream subscription API.
+   */
+  get hooks(): IHooksService {
+    if (!this._hooks) {
+      throw new Error("Not signed in. Call signIn() first.");
+    }
+    return this._hooks;
   }
 
   // ===========================================================================

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -166,6 +166,9 @@ export class NodeUserAuthorization implements IUserAuthorization {
       capabilities: {
         "": ["tinycloud.capabilities/read"],
       },
+      hooks: {
+        "": ["tinycloud.hooks/subscribe"],
+      },
     };
     this.sessionExpirationMs = config.sessionExpirationMs ?? 60 * 60 * 1000;
     this.autoCreateSpace = config.autoCreateSpace ?? false;

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -167,13 +167,20 @@ export class NodeUserAuthorization implements IUserAuthorization {
         "": ["tinycloud.capabilities/read"],
       },
       hooks: {
-        "": ["tinycloud.hooks/subscribe"],
+        "": [
+          "tinycloud.hooks/subscribe",
+          "tinycloud.hooks/register",
+          "tinycloud.hooks/list",
+          "tinycloud.hooks/unregister",
+        ],
       },
     };
     this.sessionExpirationMs = config.sessionExpirationMs ?? 60 * 60 * 1000;
     this.autoCreateSpace = config.autoCreateSpace ?? false;
     this.spaceCreationHandler = config.spaceCreationHandler;
-    this.tinycloudHosts = config.tinycloudHosts ?? ["https://node.tinycloud.xyz"];
+    this.tinycloudHosts = config.tinycloudHosts ?? [
+      "https://node.tinycloud.xyz",
+    ];
     this.enablePublicSpace = config.enablePublicSpace ?? true;
     this.nonce = config.nonce;
     this.siweConfig = config.siweConfig;
@@ -234,7 +241,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
     if (uri) {
       console.warn(
         "[tinycloud] siweConfig.uri is overwriting the delegation target URI. " +
-        "This may break delegation chain validation if the URI does not match the session key DID.",
+          "This may break delegation chain validation if the URI does not match the session key DID.",
       );
       overrides.uri = uri;
     }
@@ -318,15 +325,18 @@ export class NodeUserAuthorization implements IUserAuthorization {
     // Try to activate the session
     const result = await activateSessionWithHost(
       host,
-      this._tinyCloudSession.delegationHeader
+      this._tinyCloudSession.delegationHeader,
     );
 
     // Determine the effective space creation handler:
     // 1. Explicit spaceCreationHandler takes precedence
     // 2. autoCreateSpace: true uses AutoApproveSpaceCreationHandler
     // 3. Otherwise, no handler (space creation skipped silently)
-    const handler: ISpaceCreationHandler | undefined = this.spaceCreationHandler
-      ?? (this.autoCreateSpace ? new AutoApproveSpaceCreationHandler() : undefined);
+    const handler: ISpaceCreationHandler | undefined =
+      this.spaceCreationHandler ??
+      (this.autoCreateSpace
+        ? new AutoApproveSpaceCreationHandler()
+        : undefined);
 
     const creationContext = {
       spaceId: primarySpaceId,
@@ -363,7 +373,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
           throw err;
         }
       } catch (error) {
-        handler.onSpaceCreationFailed?.(creationContext, error instanceof Error ? error : new Error(String(error)));
+        handler.onSpaceCreationFailed?.(
+          creationContext,
+          error instanceof Error ? error : new Error(String(error)),
+        );
         throw error;
       }
 
@@ -373,12 +386,12 @@ export class NodeUserAuthorization implements IUserAuthorization {
       // Retry activation
       const retryResult = await activateSessionWithHost(
         host,
-        this._tinyCloudSession.delegationHeader
+        this._tinyCloudSession.delegationHeader,
       );
 
       if (!retryResult.success) {
         const err = new Error(
-          `Failed to activate session after creating space: ${retryResult.error}`
+          `Failed to activate session after creating space: ${retryResult.error}`,
         );
         handler.onSpaceCreationFailed?.(creationContext, err);
         throw err;
@@ -407,7 +420,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
           throw err;
         }
       } catch (error) {
-        handler.onSpaceCreationFailed?.(creationContext, error instanceof Error ? error : new Error(String(error)));
+        handler.onSpaceCreationFailed?.(
+          creationContext,
+          error instanceof Error ? error : new Error(String(error)),
+        );
         throw error;
       }
 
@@ -415,12 +431,12 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
       const retryResult = await activateSessionWithHost(
         host,
-        this._tinyCloudSession.delegationHeader
+        this._tinyCloudSession.delegationHeader,
       );
 
       if (!retryResult.success) {
         const err = new Error(
-          `Failed to activate session after creating space: ${retryResult.error}`
+          `Failed to activate session after creating space: ${retryResult.error}`,
         );
         handler.onSpaceCreationFailed?.(creationContext, err);
         throw err;
@@ -507,10 +523,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
     // Compute additional spaces as metadata (not in the delegation itself).
     // The public space delegation is created lazily via ensurePublicSpace(),
     // not at signIn time, to avoid creating spaces the user may never use.
-    const spacesMetadata: Record<string, string> | undefined =
-        this.enablePublicSpace
-            ? { public: this.wasm.makeSpaceId(address, chainId, "public") }
-            : undefined;
+    const spacesMetadata: Record<string, string> | undefined = this
+      .enablePublicSpace
+      ? { public: this.wasm.makeSpaceId(address, chainId, "public") }
+      : undefined;
 
     // Create TinyCloud session with full delegation data
     // Use sessionManager.getDID(keyId) for verificationMethod to get properly formatted DID URL
@@ -556,7 +572,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this._chainId = chainId;
 
     // Verify SDK-node protocol compatibility and discover supported features
-    const nodeInfo = await checkNodeInfo(this.tinycloudHosts[0], this.wasm.protocolVersion());
+    const nodeInfo = await checkNodeInfo(
+      this.tinycloudHosts[0],
+      this.wasm.protocolVersion(),
+    );
     this._nodeFeatures = nodeInfo.features;
 
     // Call extension hooks
@@ -614,7 +633,6 @@ export class NodeUserAuthorization implements IUserAuthorization {
       type: "message",
     });
   }
-
 
   /**
    * Prepare a session for external signing.
@@ -729,10 +747,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
     };
 
     // Compute additional spaces as metadata (not in the delegation itself).
-    const spacesMetadata: Record<string, string> | undefined =
-        this.enablePublicSpace
-            ? { public: this.wasm.makeSpaceId(address, chainId, "public") }
-            : undefined;
+    const spacesMetadata: Record<string, string> | undefined = this
+      .enablePublicSpace
+      ? { public: this.wasm.makeSpaceId(address, chainId, "public") }
+      : undefined;
 
     // Create TinyCloud session with full delegation data
     // Use sessionManager.getDID(keyId) for properly formatted DID URL
@@ -785,7 +803,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this._chainId = chainId;
 
     // Verify SDK-node protocol compatibility and discover supported features
-    const nodeInfo = await checkNodeInfo(this.tinycloudHosts[0], this.wasm.protocolVersion());
+    const nodeInfo = await checkNodeInfo(
+      this.tinycloudHosts[0],
+      this.wasm.protocolVersion(),
+    );
     this._nodeFeatures = nodeInfo.features;
 
     // Call extension hooks
@@ -833,7 +854,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
         const response = await this.signStrategy.handler(request);
         if (!response.approved) {
           throw new Error(
-            response.reason ?? "Sign request rejected by callback"
+            response.reason ?? "Sign request rejected by callback",
           );
         }
         // If callback provides signature, use it; otherwise sign with signer
@@ -846,12 +867,14 @@ export class NodeUserAuthorization implements IUserAuthorization {
         return this.requestSignatureViaEmitter(
           request,
           this.signStrategy.emitter,
-          this.signStrategy.timeout ?? 60000
+          this.signStrategy.timeout ?? 60000,
         );
       }
 
       default:
-        throw new Error(`Unknown sign strategy: ${(this.signStrategy as any).type}`);
+        throw new Error(
+          `Unknown sign strategy: ${(this.signStrategy as any).type}`,
+        );
     }
   }
 
@@ -861,7 +884,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
   private requestSignatureViaEmitter(
     request: SignRequest,
     emitter: EventEmitter,
-    timeout: number
+    timeout: number,
   ): Promise<string> {
     return new Promise((resolve, reject) => {
       const timeoutId = setTimeout(() => {
@@ -872,7 +895,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
         clearTimeout(timeoutId);
         if (!response.approved) {
           reject(
-            new Error(response.reason ?? "Sign request rejected via emitter")
+            new Error(response.reason ?? "Sign request rejected via emitter"),
           );
         } else {
           // If response provides signature, use it; otherwise sign with signer

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -138,7 +138,11 @@ export type {
 } from "@tinycloud/sdk-core";
 
 // Re-export DuckDB service values
-export { DuckDbService, DuckDbDatabaseHandle, DuckDbAction } from "@tinycloud/sdk-core";
+export {
+  DuckDbService,
+  DuckDbDatabaseHandle,
+  DuckDbAction,
+} from "@tinycloud/sdk-core";
 
 // Re-export DuckDB service types
 export type {
@@ -162,7 +166,12 @@ export type {
 } from "@tinycloud/sdk-core";
 
 // Re-export Vault service values
-export { DataVaultService, VaultHeaders, VaultPublicSpaceKVActions, createVaultCrypto } from "@tinycloud/sdk-core";
+export {
+  DataVaultService,
+  VaultHeaders,
+  VaultPublicSpaceKVActions,
+  createVaultCrypto,
+} from "@tinycloud/sdk-core";
 
 // Re-export Vault service types
 export type {
@@ -184,9 +193,15 @@ export { HooksService } from "@tinycloud/sdk-core";
 // Re-export Hooks service types
 export type {
   IHooksService,
+  HookServiceName,
   HookSubscription,
   HookEvent,
   HookStreamEvent,
+  HookWebhookScope,
+  HookWebhookRegistration,
+  HookWebhookRecord,
+  HookWebhookListOptions,
+  HookWebhookUnregisterOptions,
   SubscribeOptions,
   HooksServiceConfig,
 } from "@tinycloud/sdk-core";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -178,6 +178,19 @@ export type {
   VaultError,
 } from "@tinycloud/sdk-core";
 
+// Re-export Hooks service values
+export { HooksService } from "@tinycloud/sdk-core";
+
+// Re-export Hooks service types
+export type {
+  IHooksService,
+  HookSubscription,
+  HookEvent,
+  HookStreamEvent,
+  SubscribeOptions,
+  HooksServiceConfig,
+} from "@tinycloud/sdk-core";
+
 // Re-export v2 Delegation service values
 export {
   DelegationManager,

--- a/packages/sdk-core/src/TinyCloud.ts
+++ b/packages/sdk-core/src/TinyCloud.ts
@@ -14,8 +14,11 @@ import {
   IDuckDbService,
   DuckDbService,
   IDataVaultService,
+  IHooksService,
+  HooksService,
   ServiceSession,
   InvokeFunction,
+  InvokeAnyFunction,
   FetchFunction,
   RetryPolicy,
   defaultRetryPolicy,
@@ -49,6 +52,11 @@ export interface TinyCloudConfig {
    * Required when using services.
    */
   invoke?: InvokeFunction;
+
+  /**
+   * Optional multi-resource invoke function for aggregated capability requests.
+   */
+  invokeAny?: InvokeAnyFunction;
 
   /**
    * Custom fetch implementation.
@@ -202,6 +210,7 @@ export class TinyCloud {
     // Create service context
     this._serviceContext = new ServiceContext({
       invoke: effectiveInvoke,
+      invokeAny: this.config.invokeAny,
       fetch: fetchFn ?? this.config.fetch ?? globalThis.fetch.bind(globalThis),
       hosts: effectiveHosts,
       retryPolicy: this.config.retryPolicy,
@@ -212,6 +221,7 @@ export class TinyCloud {
       kv: KVService,
       sql: SQLService,
       duckdb: DuckDbService,
+      hooks: HooksService,
       ...this.config.services,
     };
 
@@ -300,6 +310,24 @@ export class TinyCloud {
     const service = this._services.get("duckdb") as IDuckDbService | undefined;
     if (!service) {
       throw new Error("DuckDB service is not registered.");
+    }
+    return service;
+  }
+
+  /**
+   * Get the Hooks service.
+   * @throws Error if services are not initialized
+   */
+  public get hooks(): IHooksService {
+    if (!this._servicesInitialized) {
+      throw new Error(
+        "Services not initialized. Call initializeServices() first, " +
+          "or use TinyCloudWeb/TinyCloudNode which handles this automatically."
+      );
+    }
+    const service = this._services.get("hooks") as IHooksService | undefined;
+    if (!service) {
+      throw new Error("Hooks service is not registered.");
     }
     return service;
   }

--- a/packages/sdk-core/src/TinyCloud.ts
+++ b/packages/sdk-core/src/TinyCloud.ts
@@ -188,7 +188,7 @@ export class TinyCloud {
   public initializeServices(
     invoke?: InvokeFunction,
     hosts?: string[],
-    fetchFn?: FetchFunction
+    fetchFn?: FetchFunction,
   ): void {
     const effectiveInvoke = invoke ?? this.config.invoke;
     const effectiveHosts = hosts ?? this.config.hosts;
@@ -196,14 +196,14 @@ export class TinyCloud {
     if (!effectiveInvoke) {
       throw new Error(
         "invoke function is required to initialize services. " +
-          "Provide it via config.invoke or initializeServices()."
+          "Provide it via config.invoke or initializeServices().",
       );
     }
 
     if (!effectiveHosts || effectiveHosts.length === 0) {
       throw new Error(
         "hosts are required to initialize services. " +
-          "Provide them via config.hosts or initializeServices()."
+          "Provide them via config.hosts or initializeServices().",
       );
     }
 
@@ -244,7 +244,7 @@ export class TinyCloud {
   public get serviceContext(): IServiceContext {
     if (!this._serviceContext) {
       throw new Error(
-        "Services not initialized. Call initializeServices() first."
+        "Services not initialized. Call initializeServices() first.",
       );
     }
     return this._serviceContext;
@@ -268,7 +268,7 @@ export class TinyCloud {
     if (!this._servicesInitialized) {
       throw new Error(
         "Services not initialized. Call initializeServices() first, " +
-          "or use TinyCloudWeb/TinyCloudNode which handles this automatically."
+          "or use TinyCloudWeb/TinyCloudNode which handles this automatically.",
       );
     }
     const service = this._services.get("kv") as IKVService | undefined;
@@ -286,7 +286,7 @@ export class TinyCloud {
     if (!this._servicesInitialized) {
       throw new Error(
         "Services not initialized. Call initializeServices() first, " +
-          "or use TinyCloudWeb/TinyCloudNode which handles this automatically."
+          "or use TinyCloudWeb/TinyCloudNode which handles this automatically.",
       );
     }
     const service = this._services.get("sql") as ISQLService | undefined;
@@ -304,7 +304,7 @@ export class TinyCloud {
     if (!this._servicesInitialized) {
       throw new Error(
         "Services not initialized. Call initializeServices() first, " +
-          "or use TinyCloudWeb/TinyCloudNode which handles this automatically."
+          "or use TinyCloudWeb/TinyCloudNode which handles this automatically.",
       );
     }
     const service = this._services.get("duckdb") as IDuckDbService | undefined;
@@ -322,7 +322,7 @@ export class TinyCloud {
     if (!this._servicesInitialized) {
       throw new Error(
         "Services not initialized. Call initializeServices() first, " +
-          "or use TinyCloudWeb/TinyCloudNode which handles this automatically."
+          "or use TinyCloudWeb/TinyCloudNode which handles this automatically.",
       );
     }
     const service = this._services.get("hooks") as IHooksService | undefined;
@@ -340,10 +340,12 @@ export class TinyCloud {
     if (!this._servicesInitialized) {
       throw new Error(
         "Services not initialized. Call initializeServices() first, " +
-          "or use TinyCloudWeb/TinyCloudNode which handles this automatically."
+          "or use TinyCloudWeb/TinyCloudNode which handles this automatically.",
       );
     }
-    const service = this._services.get("vault") as IDataVaultService | undefined;
+    const service = this._services.get("vault") as
+      | IDataVaultService
+      | undefined;
     if (!service) {
       throw new Error("Vault service is not registered.");
     }
@@ -377,7 +379,7 @@ export class TinyCloud {
    * Returns null if session lacks required fields.
    */
   private toServiceSession(
-    clientSession: ClientSession | undefined
+    clientSession: ClientSession | undefined,
   ): ServiceSession | null {
     if (!clientSession) return null;
 
@@ -514,8 +516,8 @@ export class TinyCloud {
         serviceError(
           ErrorCodes.AUTH_REQUIRED,
           "Must be signed in to ensure public space",
-          "public-space"
-        )
+          "public-space",
+        ),
       );
     }
 
@@ -524,8 +526,8 @@ export class TinyCloud {
         serviceError(
           ErrorCodes.AUTH_REQUIRED,
           "Services not initialized. Call initializeServices() or signIn() first.",
-          "public-space"
-        )
+          "public-space",
+        ),
       );
     }
 
@@ -539,8 +541,8 @@ export class TinyCloud {
           serviceError(
             ErrorCodes.AUTH_REQUIRED,
             "No active session",
-            "public-space"
-          )
+            "public-space",
+          ),
         );
       }
 
@@ -548,12 +550,12 @@ export class TinyCloud {
         session,
         "space",
         spaceId,
-        "tinycloud.space/info"
+        "tinycloud.space/info",
       );
 
       const response = await this._serviceContext.fetch(
         `${this._serviceContext.hosts[0]}/invoke`,
-        { method: "POST", headers, body: JSON.stringify({ spaceId }) }
+        { method: "POST", headers, body: JSON.stringify({ spaceId }) },
       );
 
       if (response.ok) {
@@ -566,7 +568,7 @@ export class TinyCloud {
           session,
           "space",
           "public",
-          "tinycloud.space/create"
+          "tinycloud.space/create",
         );
 
         const createResponse = await this._serviceContext.fetch(
@@ -575,7 +577,7 @@ export class TinyCloud {
             method: "POST",
             headers: createHeaders,
             body: JSON.stringify({ name: "public" }),
-          }
+          },
         );
 
         if (!createResponse.ok) {
@@ -588,8 +590,8 @@ export class TinyCloud {
             serviceError(
               ErrorCodes.NETWORK_ERROR,
               `Failed to create public space: ${createResponse.status} - ${errorText}`,
-              "public-space"
-            )
+              "public-space",
+            ),
           );
         }
 
@@ -602,8 +604,8 @@ export class TinyCloud {
         serviceError(
           ErrorCodes.NETWORK_ERROR,
           `Failed to check public space: ${response.status} - ${errorText}`,
-          "public-space"
-        )
+          "public-space",
+        ),
       );
     } catch (error) {
       return err(
@@ -611,8 +613,8 @@ export class TinyCloud {
           ErrorCodes.NETWORK_ERROR,
           `Network error ensuring public space: ${String(error)}`,
           "public-space",
-          { cause: error instanceof Error ? error : undefined }
-        )
+          { cause: error instanceof Error ? error : undefined },
+        ),
       );
     }
   }
@@ -627,7 +629,7 @@ export class TinyCloud {
     if (!this._servicesInitialized || !this._serviceContext) {
       throw new Error(
         "Services not initialized. Call initializeServices() first, " +
-          "or use TinyCloudWeb/TinyCloudNode which handles this automatically."
+          "or use TinyCloudWeb/TinyCloudNode which handles this automatically.",
       );
     }
 
@@ -680,10 +682,10 @@ export class TinyCloud {
     host: string,
     spaceId: string,
     key: string,
-    fetchFn?: FetchFunction
+    fetchFn?: FetchFunction,
   ): Promise<Result<T, ServiceError>> {
     const doFetch = fetchFn ?? globalThis.fetch.bind(globalThis);
-    const encodedKey = key.split('/').map(encodeURIComponent).join('/');
+    const encodedKey = key.split("/").map(encodeURIComponent).join("/");
     const url = `${host}/public/${encodeURIComponent(spaceId)}/kv/${encodedKey}`;
 
     try {
@@ -695,8 +697,8 @@ export class TinyCloud {
             serviceError(
               ErrorCodes.NOT_FOUND,
               `Key not found: ${key} in space ${spaceId}`,
-              "public-space"
-            )
+              "public-space",
+            ),
           );
         }
         const errorText = await response.text();
@@ -705,8 +707,8 @@ export class TinyCloud {
             ErrorCodes.NETWORK_ERROR,
             `Failed to read public space: ${response.status} - ${errorText}`,
             "public-space",
-            { meta: { status: response.status } }
-          )
+            { meta: { status: response.status } },
+          ),
         );
       }
 
@@ -731,8 +733,8 @@ export class TinyCloud {
           ErrorCodes.NETWORK_ERROR,
           `Network error reading public space: ${String(error)}`,
           "public-space",
-          { cause: error instanceof Error ? error : undefined }
-        )
+          { cause: error instanceof Error ? error : undefined },
+        ),
       );
     }
   }
@@ -753,10 +755,9 @@ export class TinyCloud {
     address: string,
     chainId: number,
     key: string,
-    fetchFn?: FetchFunction
+    fetchFn?: FetchFunction,
   ): Promise<Result<T, ServiceError>> {
     const spaceId = makePublicSpaceId(address, chainId);
     return TinyCloud.readPublicSpace<T>(host, spaceId, key, fetchFn);
   }
-
 }

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -60,10 +60,7 @@ export {
 } from "./userAuthorization";
 
 // Main TinyCloud class
-export {
-  TinyCloud,
-  TinyCloudConfig,
-} from "./TinyCloud";
+export { TinyCloud, TinyCloudConfig } from "./TinyCloud";
 
 // Re-export service types from sdk-services for convenience
 export {
@@ -145,9 +142,15 @@ export {
   // Hooks Service
   HooksService,
   type IHooksService,
+  type HookServiceName,
   type HookSubscription,
   type HookEvent,
   type HookStreamEvent,
+  type HookWebhookScope,
+  type HookWebhookRegistration,
+  type HookWebhookRecord,
+  type HookWebhookListOptions,
+  type HookWebhookUnregisterOptions,
   type SubscribeOptions,
   type HooksServiceConfig,
   // Vault Service

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -99,6 +99,8 @@ export {
   type ServiceSession,
   // Platform dependencies
   type InvokeFunction,
+  type InvokeAnyFunction,
+  type InvokeAnyEntry,
   type FetchFunction,
   // Retry
   type RetryPolicy,
@@ -140,6 +142,14 @@ export {
   type TableInfo,
   type ColumnInfo,
   type ViewInfo,
+  // Hooks Service
+  HooksService,
+  type IHooksService,
+  type HookSubscription,
+  type HookEvent,
+  type HookStreamEvent,
+  type SubscribeOptions,
+  type HooksServiceConfig,
   // Vault Service
   DataVaultService,
   VaultHeaders,
@@ -273,4 +283,3 @@ export {
   checkNodeInfo,
 } from "./version";
 export type { NodeInfo } from "./version";
-

--- a/packages/sdk-core/src/wasm.ts
+++ b/packages/sdk-core/src/wasm.ts
@@ -7,7 +7,7 @@
  * @packageDocumentation
  */
 
-import type { InvokeFunction } from "@tinycloud/sdk-services";
+import type { InvokeAnyFunction, InvokeFunction } from "@tinycloud/sdk-services";
 
 /**
  * Platform-agnostic WASM bindings interface.
@@ -19,6 +19,8 @@ import type { InvokeFunction } from "@tinycloud/sdk-services";
 export interface IWasmBindings {
   /** Invoke a TinyCloud action */
   invoke: InvokeFunction;
+  /** Invoke multiple TinyCloud capabilities in one authorization header */
+  invokeAny?: InvokeAnyFunction;
   /** Prepare a session (generate session key, build SIWE message) */
   prepareSession: (params: any) => any;
   /** Complete session setup (create delegation) */

--- a/packages/sdk-rs/packages/node/src/index.ts
+++ b/packages/sdk-rs/packages/node/src/index.ts
@@ -16,6 +16,7 @@ export {
   prepareSession,
   completeSessionSetup,
   invoke,
+  invokeAny,
   makeSpaceId,
   ensureEip55,
   signEthereumMessage,

--- a/packages/sdk-rs/packages/web/src/index.ts
+++ b/packages/sdk-rs/packages/web/src/index.ts
@@ -19,6 +19,7 @@ export namespace tinycloud {
   export import generateHostSIWEMessage = lib.generateHostSIWEMessage;
   export import siweToDelegationHeaders = lib.siweToDelegationHeaders;
   export import invoke = lib.invoke;
+  export import invokeAny = lib.invokeAny;
   export import makeSpaceId = lib.makeSpaceId;
   export import prepareSession = lib.prepareSession;
   export import Session = lib.Session;

--- a/packages/sdk-rs/src/lib.rs
+++ b/packages/sdk-rs/src/lib.rs
@@ -5,7 +5,26 @@ pub mod session;
 #[cfg(feature = "nodejs")]
 pub mod keys;
 
+use serde::Deserialize;
+use tinycloud_sdk_rs::authorization::InvocationHeaders;
+use tinycloud_sdk_rs::tinycloud_auth::{
+    resource::{Path, Service, SpaceId},
+    siwe_recap::Ability,
+};
 use wasm_bindgen::prelude::*;
+
+fn map_jserr<E: std::error::Error>(e: E) -> JsValue {
+    e.to_string().into()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InvokeAnyEntry {
+    space_id: String,
+    service: String,
+    path: String,
+    action: String,
+}
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
@@ -14,4 +33,35 @@ use wasm_bindgen::prelude::*;
 /// Run once on initialisation.
 pub fn initPanicHook() {
     console_error_panic_hook::set_once();
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn invokeAny(
+    session: JsValue,
+    entries: JsValue,
+    facts: JsValue,
+) -> Result<JsValue, JsValue> {
+    let session: tinycloud_sdk_wasm::session::Session = serde_wasm_bindgen::from_value(session)?;
+    let entries: Vec<InvokeAnyEntry> = serde_wasm_bindgen::from_value(entries)?;
+    let facts_opt: Option<Vec<serde_json::Value>> = if facts.is_undefined() || facts.is_null() {
+        None
+    } else {
+        Some(serde_wasm_bindgen::from_value(facts)?)
+    };
+
+    let actions = entries
+        .into_iter()
+        .map(|entry| {
+            let space_id: SpaceId = entry.space_id.parse().map_err(map_jserr)?;
+            let service: Service = entry.service.parse().map_err(map_jserr)?;
+            let action: Ability = entry.action.parse().map_err(map_jserr)?;
+            let path: Path = entry.path.parse().map_err(map_jserr)?;
+            let resource = space_id.to_resource(service, Some(path), None, None);
+            Ok::<_, JsValue>((resource, std::iter::once(action)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let authz = session.invoke_any(actions, facts_opt).map_err(map_jserr)?;
+    Ok(serde_wasm_bindgen::to_value(&InvocationHeaders::new(authz))?)
 }

--- a/packages/sdk-services/package.json
+++ b/packages/sdk-services/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@tinycloud/node-sdk-wasm": "workspace:*",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0"
   },

--- a/packages/sdk-services/src/context.ts
+++ b/packages/sdk-services/src/context.ts
@@ -9,6 +9,7 @@ import {
   ServiceSession,
   RetryPolicy,
   InvokeFunction,
+  InvokeAnyFunction,
   FetchFunction,
   defaultRetryPolicy,
 } from "./types";
@@ -24,6 +25,8 @@ type EventHandler = (data: unknown) => void;
 export interface ServiceContextConfig {
   /** Function to invoke WASM operations */
   invoke: InvokeFunction;
+  /** Optional function to mint a single authorization header for multiple capabilities */
+  invokeAny?: InvokeAnyFunction;
   /** Function to make HTTP requests (defaults to globalThis.fetch) */
   fetch?: FetchFunction;
   /** List of TinyCloud host URLs */
@@ -61,12 +64,14 @@ export class ServiceContext implements IServiceContext {
   private _eventHandlers: Map<string, Set<EventHandler>> = new Map();
   private _abortController: AbortController = new AbortController();
   private readonly _invoke: InvokeFunction;
+  private readonly _invokeAny?: InvokeAnyFunction;
   private readonly _fetch: FetchFunction;
   private readonly _hosts: string[];
   private readonly _retryPolicy: RetryPolicy;
 
   constructor(config: ServiceContextConfig) {
     this._invoke = config.invoke;
+    this._invokeAny = config.invokeAny;
     this._fetch = config.fetch ?? globalThis.fetch.bind(globalThis);
     this._hosts = config.hosts;
     this._session = config.session ?? null;
@@ -118,6 +123,13 @@ export class ServiceContext implements IServiceContext {
    */
   get invoke(): InvokeFunction {
     return this._invoke;
+  }
+
+  /**
+   * Get the multi-resource invoke function when available.
+   */
+  get invokeAny(): InvokeAnyFunction | undefined {
+    return this._invokeAny;
   }
 
   /**

--- a/packages/sdk-services/src/hooks/HooksService.test.ts
+++ b/packages/sdk-services/src/hooks/HooksService.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { HooksService } from "./HooksService";
+import { ErrorCodes, type IServiceContext } from "../types";
+import type { HookWebhookRegistration } from "./types";
+
+function createContext(fetchImpl: IServiceContext["fetch"]): IServiceContext {
+  return {
+    session: {
+      delegationHeader: { Authorization: "Bearer test" },
+      delegationCid: "bafybeitest",
+      spaceId: "space-123",
+      verificationMethod: "did:key:test",
+      jwk: {},
+    },
+    isAuthenticated: true,
+    invoke: () => ({}) as never,
+    invokeAny: undefined,
+    fetch: fetchImpl,
+    hosts: ["https://node.tinycloud.xyz"],
+    getService: () => undefined,
+    emit: () => undefined,
+    on: () => () => undefined,
+    abortSignal: new AbortController().signal,
+    retryPolicy: {
+      maxAttempts: 3,
+      backoff: "exponential",
+      baseDelayMs: 1000,
+      maxDelayMs: 10000,
+      retryableErrors: [],
+    },
+  };
+}
+
+describe("HooksService.register", () => {
+  test("rejects missing or empty secrets before issuing a request", async () => {
+    let fetchCalls = 0;
+    const service = new HooksService({ host: "https://node.tinycloud.xyz" });
+    service.initialize(
+      createContext(async () => {
+        fetchCalls += 1;
+        throw new Error("unexpected fetch");
+      }),
+    );
+
+    const webhook = {
+      space: "space-123",
+      service: "kv",
+      pathPrefix: "hooks",
+      abilities: ["tinycloud.kv/put"],
+      callbackUrl: "https://example.com/hooks",
+    } as Omit<HookWebhookRegistration, "secret">;
+
+    const invalidSecrets = [undefined, "", "   "];
+    for (const secret of invalidSecrets) {
+      const result = await service.register({
+        ...webhook,
+        secret: secret as unknown as string,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe(ErrorCodes.INVALID_INPUT);
+        expect(result.error.message).toContain("Webhook secret is required");
+      }
+    }
+
+    expect(fetchCalls).toBe(0);
+  });
+});

--- a/packages/sdk-services/src/hooks/HooksService.ts
+++ b/packages/sdk-services/src/hooks/HooksService.ts
@@ -5,7 +5,7 @@ import type {
   ServiceHeaders,
   Result,
 } from "../types";
-import { err, ok } from "../types";
+import { ErrorCodes, err, ok, serviceError } from "../types";
 import { authRequiredError, wrapError } from "../errors";
 import type { IHooksService } from "./IHooksService";
 import type {
@@ -157,6 +157,17 @@ export class HooksService extends BaseService implements IHooksService {
   ): Promise<Result<HookWebhookRecord>> {
     if (!this.requireAuth()) {
       return err(authRequiredError("hooks"));
+    }
+
+    if (typeof webhook.secret !== "string" || webhook.secret.trim().length === 0) {
+      return err(
+        serviceError(
+          ErrorCodes.INVALID_INPUT,
+          "Webhook secret is required",
+          "hooks",
+          { meta: { field: "secret" } },
+        ),
+      );
     }
 
     try {

--- a/packages/sdk-services/src/hooks/HooksService.ts
+++ b/packages/sdk-services/src/hooks/HooksService.ts
@@ -1,0 +1,571 @@
+import { BaseService } from "../base/BaseService";
+import type { FetchResponse, InvokeAnyEntry, ServiceHeaders } from "../types";
+import type { IHooksService } from "./IHooksService";
+import type {
+  HookEvent,
+  HookStreamEvent,
+  HookSubscription,
+  HooksServiceConfig,
+  SubscribeOptions,
+} from "./types";
+
+interface HookTicketResponse {
+  ticket: string;
+  expiresAt: string;
+}
+
+interface HookSubscriber {
+  requested: HookSubscription[];
+  ttlSeconds?: number;
+  queue: AsyncQueue<HookEvent>;
+}
+
+class AsyncQueue<T> implements AsyncIterable<T>, AsyncIterator<T> {
+  private readonly values: T[] = [];
+  private readonly waiters: Array<(result: IteratorResult<T>) => void> = [];
+  private closed = false;
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return this;
+  }
+
+  push(value: T): void {
+    if (this.closed) {
+      return;
+    }
+
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ value, done: false });
+      return;
+    }
+
+    this.values.push(value);
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift();
+      waiter?.({ value: undefined as never, done: true });
+    }
+  }
+
+  next(): Promise<IteratorResult<T>> {
+    if (this.values.length > 0) {
+      const value = this.values.shift()!;
+      return Promise.resolve({ value, done: false });
+    }
+
+    if (this.closed) {
+      return Promise.resolve({ value: undefined as never, done: true });
+    }
+
+    return new Promise<IteratorResult<T>>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+}
+
+export class HooksService extends BaseService implements IHooksService {
+  static readonly serviceName = "hooks";
+
+  declare protected _config: HooksServiceConfig;
+  private readonly _subscribers: Set<HookSubscriber> = new Set();
+  private _sharedStreamTask?: Promise<void>;
+  private _sharedStreamAbort?: AbortController;
+  private _refreshChain: Promise<void> = Promise.resolve();
+  private _activeSignature = "";
+
+  constructor(config: HooksServiceConfig = {}) {
+    super();
+    this._config = config;
+  }
+
+  get config(): HooksServiceConfig {
+    return this._config;
+  }
+
+  async *subscribe(
+    subscriptions: HookSubscription[],
+    options: SubscribeOptions = {}
+  ): AsyncIterable<HookEvent> {
+    if (!this.requireAuth()) {
+      throw new Error("Authentication required for hooks subscription");
+    }
+    if (subscriptions.length === 0) {
+      throw new Error("At least one hook subscription is required");
+    }
+
+    const normalized = subscriptions.map(normalizeSubscription);
+    const subscriber: HookSubscriber = {
+      requested: normalized,
+      ttlSeconds: options.ttlSeconds,
+      queue: new AsyncQueue<HookEvent>(),
+    };
+
+    this._subscribers.add(subscriber);
+    const abortHandler = () => {
+      this._subscribers.delete(subscriber);
+      subscriber.queue.close();
+      void this.scheduleSharedStreamRefresh();
+    };
+
+    if (options.signal) {
+      if (options.signal.aborted) {
+        abortHandler();
+      } else {
+        options.signal.addEventListener("abort", abortHandler, { once: true });
+      }
+    }
+
+    void this.scheduleSharedStreamRefresh();
+
+    try {
+      for await (const event of subscriber.queue) {
+        yield event;
+      }
+    } finally {
+      if (options.signal) {
+        options.signal.removeEventListener("abort", abortHandler);
+      }
+      abortHandler();
+    }
+  }
+
+  private async scheduleSharedStreamRefresh(): Promise<void> {
+    this._refreshChain = this._refreshChain
+      .then(() => this.refreshSharedStream())
+      .catch(() => undefined);
+    await this._refreshChain;
+  }
+
+  private async refreshSharedStream(): Promise<void> {
+    if (!this.requireAuth() || this._subscribers.size === 0) {
+      this.abortSharedStream();
+      this._activeSignature = "";
+      return;
+    }
+
+    const state = this.collectSharedStreamState();
+    if (state.signature !== this._activeSignature) {
+      this._activeSignature = state.signature;
+      this.abortSharedStream();
+    }
+
+    if (!this._sharedStreamTask) {
+      this._sharedStreamTask = this.runSharedStream(state)
+        .catch((error: unknown) => {
+          if (!isAbortError(error)) {
+            throw error;
+          }
+        })
+        .finally(() => {
+          this._sharedStreamTask = undefined;
+          this._sharedStreamAbort = undefined;
+          if (this._subscribers.size > 0) {
+            void this.scheduleSharedStreamRefresh();
+          }
+        });
+    }
+  }
+
+  private collectSharedStreamState(): {
+    subscriptions: HookSubscription[];
+    ttlSeconds?: number;
+    signature: string;
+  } {
+    const merged = new Map<string, HookSubscription>();
+    const ttlCandidates: number[] = [];
+
+    for (const subscriber of this._subscribers) {
+      if (typeof subscriber.ttlSeconds === "number") {
+        ttlCandidates.push(subscriber.ttlSeconds);
+      }
+      for (const subscription of subscriber.requested) {
+        merged.set(subscriptionSignature(subscription), subscription);
+      }
+    }
+
+    const subscriptions = [...merged.values()].sort((left, right) =>
+      subscriptionSignature(left).localeCompare(subscriptionSignature(right))
+    );
+    const ttlSeconds =
+      ttlCandidates.length > 0 ? Math.min(...ttlCandidates) : undefined;
+    const signature = JSON.stringify({
+      subscriptions: subscriptions.map(subscriptionSignature),
+      ttlSeconds,
+    });
+
+    return {
+      subscriptions,
+      ttlSeconds,
+      signature,
+    };
+  }
+
+  private async runSharedStream(state: {
+    subscriptions: HookSubscription[];
+    ttlSeconds?: number;
+  }): Promise<void> {
+    const abortController = new AbortController();
+    this._sharedStreamAbort = abortController;
+
+    try {
+      const host = this._config.host ?? this.context.hosts[0];
+      const ticketResponse = await this.mintHookTicket(
+        state.subscriptions,
+        state.ttlSeconds,
+        abortController.signal
+      );
+      const streamResponse = await this.openHookStream(
+        host,
+        ticketResponse.ticket,
+        abortController.signal
+      );
+
+      for await (const message of parseSseStream(
+        streamResponse.body,
+        abortController.signal
+      )) {
+        if (!message.data) {
+          continue;
+        }
+        const event = parseHookEvent(message);
+        for (const subscriber of this._subscribers) {
+          if (matchesAnySubscription(event, subscriber.requested)) {
+            subscriber.queue.push(event);
+          }
+        }
+      }
+    } finally {
+      if (this._sharedStreamAbort === abortController) {
+        this._sharedStreamAbort = undefined;
+      }
+    }
+  }
+
+  private abortSharedStream(): void {
+    this._sharedStreamAbort?.abort();
+  }
+
+  private async mintHookTicket(
+    subscriptions: HookSubscription[],
+    ttlSeconds: number | undefined,
+    signal?: AbortSignal
+  ): Promise<HookTicketResponse> {
+    const host = this._config.host ?? this.context.hosts[0];
+    const headers = this.createInvokeHeaders(subscriptions);
+    const ticketResponse = await this.context.fetch(`${host}/hooks/tickets`, {
+      method: "POST",
+      headers: {
+        ...serviceHeadersToRecord(headers),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        subscriptions,
+        ttlSeconds,
+      }),
+      signal,
+    });
+
+    if (!ticketResponse.ok) {
+      throw await responseError(
+        "hooks",
+        "failed to mint hook ticket",
+        ticketResponse
+      );
+    }
+
+    const ticketJson = (await ticketResponse.json()) as HookTicketResponse;
+    if (!ticketJson?.ticket) {
+      throw new Error("Hook ticket response did not include a ticket");
+    }
+
+    return ticketJson;
+  }
+
+  private async openHookStream(
+    host: string,
+    ticket: string,
+    signal?: AbortSignal
+  ): Promise<FetchResponse> {
+    const streamResponse = await this.context.fetch(
+      `${host}/hooks/events?ticket=${encodeURIComponent(ticket)}`,
+      {
+        method: "GET",
+        headers: { accept: "text/event-stream" },
+        signal,
+      }
+    );
+
+    if (!streamResponse.ok) {
+      throw await responseError(
+        "hooks",
+        "failed to open hook stream",
+        streamResponse
+      );
+    }
+
+    return streamResponse;
+  }
+
+  private createInvokeHeaders(subscriptions: HookSubscription[]): ServiceHeaders {
+    const entries: InvokeAnyEntry[] = subscriptions.map((subscription) => ({
+      spaceId: subscription.space,
+      service: "hooks",
+      path: subscription.pathPrefix
+        ? `${subscription.service}/${subscription.pathPrefix}`
+        : subscription.service,
+      action: "tinycloud.hooks/subscribe",
+    }));
+
+    if (this.context.invokeAny) {
+      return this.context.invokeAny(this.session, entries);
+    }
+
+    if (entries.length === 1) {
+      const entry = entries[0];
+      return this.context.invoke(
+        this.session,
+        entry.service,
+        entry.path,
+        entry.action
+      );
+    }
+
+    throw new Error(
+      "This SDK runtime does not support multi-scope hook invocations"
+    );
+  }
+}
+
+function normalizeSubscription(subscription: HookSubscription): HookSubscription {
+  return {
+    ...subscription,
+    pathPrefix: normalizePathPrefix(subscription.pathPrefix),
+    abilities: subscription.abilities ?? [],
+  };
+}
+
+function subscriptionSignature(subscription: HookSubscription): string {
+  return JSON.stringify({
+    space: subscription.space,
+    service: subscription.service,
+    pathPrefix: subscription.pathPrefix ?? "",
+    abilities: [...(subscription.abilities ?? [])].sort(),
+  });
+}
+
+function matchesAnySubscription(
+  event: HookEvent,
+  subscriptions: HookSubscription[]
+): boolean {
+  return subscriptions.some((subscription) => matchesSubscription(event, subscription));
+}
+
+function matchesSubscription(
+  event: HookEvent,
+  subscription: HookSubscription
+): boolean {
+  if (event.space !== subscription.space) {
+    return false;
+  }
+  if (event.service !== subscription.service) {
+    return false;
+  }
+  if (subscription.pathPrefix) {
+    const prefix = subscription.pathPrefix.endsWith("/")
+      ? subscription.pathPrefix
+      : `${subscription.pathPrefix}/`;
+    if (event.path && event.path !== subscription.pathPrefix && !event.path.startsWith(prefix)) {
+      return false;
+    }
+  }
+  const abilities = subscription.abilities ?? [];
+  if (abilities.length > 0 && !abilities.includes(event.ability)) {
+    return false;
+  }
+  return true;
+}
+
+function normalizePathPrefix(pathPrefix?: string): string | undefined {
+  if (!pathPrefix) {
+    return undefined;
+  }
+  const trimmed = pathPrefix.replace(/^\/+|\/+$/g, "");
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function serviceHeadersToRecord(headers: ServiceHeaders): Record<string, string> {
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return { ...headers };
+}
+
+async function responseError(
+  service: string,
+  message: string,
+  response: FetchResponse
+): Promise<Error> {
+  let detail = response.statusText;
+  try {
+    const text = await response.text();
+    if (text) {
+      detail = text;
+    }
+  } catch {
+    // Ignore secondary body read failure.
+  }
+  return new Error(`${service}: ${message}: ${response.status} ${detail}`);
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    error.name === "AbortError"
+  );
+}
+
+async function* parseSseStream(
+  body: unknown,
+  signal?: AbortSignal
+): AsyncIterable<HookStreamEvent> {
+  if (!body) {
+    throw new Error("Hook stream response does not expose a readable body");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of readBodyChunks(body, signal)) {
+    buffer += decoder.decode(chunk, { stream: true }).replace(/\r\n/g, "\n");
+
+    let separatorIndex = buffer.indexOf("\n\n");
+    while (separatorIndex >= 0) {
+      const rawEvent = buffer.slice(0, separatorIndex);
+      buffer = buffer.slice(separatorIndex + 2);
+      const parsed = parseSseEvent(rawEvent);
+      if (parsed) {
+        yield parsed;
+      }
+      separatorIndex = buffer.indexOf("\n\n");
+    }
+  }
+
+  buffer += decoder.decode();
+  const trailing = parseSseEvent(buffer.trim());
+  if (trailing) {
+    yield trailing;
+  }
+}
+
+async function* readBodyChunks(
+  body: unknown,
+  signal?: AbortSignal
+): AsyncIterable<Uint8Array> {
+  const asyncIterable = body as AsyncIterable<Uint8Array>;
+  if (typeof asyncIterable?.[Symbol.asyncIterator] === "function") {
+    for await (const chunk of asyncIterable) {
+      if (signal?.aborted) {
+        break;
+      }
+      yield chunk;
+    }
+    return;
+  }
+
+  const stream = body as {
+    getReader?: () => {
+      read: () => Promise<{ done: boolean; value?: Uint8Array }>;
+      releaseLock?: () => void;
+      cancel?: () => Promise<void>;
+    };
+  };
+
+  if (typeof stream.getReader !== "function") {
+    throw new Error("Unsupported hook stream body type");
+  }
+
+  const reader = stream.getReader();
+  try {
+    while (!signal?.aborted) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        yield value;
+      }
+    }
+  } finally {
+    try {
+      await reader.cancel?.();
+    } catch {
+      // Ignore cancellation failures.
+    }
+    reader.releaseLock?.();
+  }
+}
+
+function parseSseEvent(rawEvent: string): HookStreamEvent | null {
+  if (!rawEvent) {
+    return null;
+  }
+
+  let event = "message";
+  let id: string | undefined;
+  const dataLines: string[] = [];
+
+  for (const line of rawEvent.split("\n")) {
+    if (!line || line.startsWith(":")) {
+      continue;
+    }
+    const [field, ...rest] = line.split(":");
+    const value = rest.join(":").replace(/^ /, "");
+    switch (field) {
+      case "event":
+        event = value;
+        break;
+      case "id":
+        id = value;
+        break;
+      case "data":
+        dataLines.push(value);
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (dataLines.length === 0) {
+    return null;
+  }
+
+  return {
+    event,
+    id,
+    data: dataLines.join("\n"),
+  };
+}
+
+function parseHookEvent(message: HookStreamEvent): HookEvent {
+  const parsed = JSON.parse(message.data) as Partial<HookEvent>;
+  return {
+    type: "write",
+    id: parsed.id ?? message.id ?? "",
+    space: parsed.space ?? "",
+    service: parsed.service ?? "",
+    ability: parsed.ability ?? "",
+    path: parsed.path,
+    actor: parsed.actor ?? "",
+    epoch: parsed.epoch ?? "",
+    eventIndex: parsed.eventIndex ?? 0,
+    timestamp: parsed.timestamp ?? "",
+  };
+}

--- a/packages/sdk-services/src/hooks/HooksService.ts
+++ b/packages/sdk-services/src/hooks/HooksService.ts
@@ -1,5 +1,12 @@
 import { BaseService } from "../base/BaseService";
-import type { FetchResponse, InvokeAnyEntry, ServiceHeaders } from "../types";
+import type {
+  FetchResponse,
+  InvokeAnyEntry,
+  ServiceHeaders,
+  Result,
+} from "../types";
+import { err, ok } from "../types";
+import { authRequiredError, wrapError } from "../errors";
 import type { IHooksService } from "./IHooksService";
 import type {
   HookEvent,
@@ -7,6 +14,10 @@ import type {
   HookSubscription,
   HooksServiceConfig,
   SubscribeOptions,
+  HookWebhookListOptions,
+  HookWebhookRecord,
+  HookWebhookRegistration,
+  HookWebhookUnregisterOptions,
 } from "./types";
 
 interface HookTicketResponse {
@@ -90,9 +101,13 @@ export class HooksService extends BaseService implements IHooksService {
     return this._config;
   }
 
+  private get host(): string {
+    return this._config.host ?? this.context.hosts[0];
+  }
+
   async *subscribe(
     subscriptions: HookSubscription[],
-    options: SubscribeOptions = {}
+    options: SubscribeOptions = {},
   ): AsyncIterable<HookEvent> {
     if (!this.requireAuth()) {
       throw new Error("Authentication required for hooks subscription");
@@ -134,6 +149,160 @@ export class HooksService extends BaseService implements IHooksService {
         options.signal.removeEventListener("abort", abortHandler);
       }
       abortHandler();
+    }
+  }
+
+  async register(
+    webhook: HookWebhookRegistration,
+  ): Promise<Result<HookWebhookRecord>> {
+    if (!this.requireAuth()) {
+      return err(authRequiredError("hooks"));
+    }
+
+    try {
+      const response = await this.context.fetch(`${this.host}/hooks/webhooks`, {
+        method: "POST",
+        headers: {
+          ...serviceHeadersToRecord(
+            this.createHookHeaders(
+              "tinycloud.hooks/register",
+              buildScopePath(webhook.service, webhook.pathPrefix),
+            ),
+          ),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          space: webhook.space,
+          service: webhook.service,
+          pathPrefix: normalizePathPrefix(webhook.pathPrefix),
+          abilities: webhook.abilities ?? [],
+          callbackUrl: webhook.callbackUrl,
+          secret: webhook.secret,
+        }),
+      });
+
+      if (!response.ok) {
+        return err(
+          await responseError("hooks", "failed to register webhook", response),
+        );
+      }
+
+      const data = normalizeWebhookRecord(await response.json());
+      if (!data) {
+        return err(
+          wrapError(
+            "hooks",
+            new Error("Webhook registration response did not include a record"),
+          ),
+        );
+      }
+
+      return ok(data);
+    } catch (error) {
+      return err(wrapError("hooks", error));
+    }
+  }
+
+  async list(
+    options: HookWebhookListOptions = {},
+  ): Promise<Result<HookWebhookRecord[]>> {
+    if (!this.requireAuth()) {
+      return err(authRequiredError("hooks"));
+    }
+
+    try {
+      const query = new URLSearchParams();
+      if (options.space) {
+        query.set("space", options.space);
+      }
+      if (options.service) {
+        query.set("service", options.service);
+      }
+      if (options.pathPrefix) {
+        const normalizedPrefix = normalizePathPrefix(options.pathPrefix);
+        if (normalizedPrefix) {
+          query.set("prefix", normalizedPrefix);
+        }
+      }
+
+      const response = await this.context.fetch(
+        `${this.host}/hooks/webhooks${query.size > 0 ? `?${query.toString()}` : ""}`,
+        {
+          method: "GET",
+          headers: serviceHeadersToRecord(
+            this.createHookHeaders(
+              "tinycloud.hooks/list",
+              options.service
+                ? buildScopePath(options.service, options.pathPrefix)
+                : "webhooks",
+            ),
+          ),
+        },
+      );
+
+      if (!response.ok) {
+        return err(
+          await responseError("hooks", "failed to list webhooks", response),
+        );
+      }
+
+      const payload = await response.json();
+      const records = normalizeWebhookRecordList(payload);
+      if (!records) {
+        return err(
+          wrapError(
+            "hooks",
+            new Error("Webhook list response did not include records"),
+          ),
+        );
+      }
+
+      return ok(records);
+    } catch (error) {
+      return err(wrapError("hooks", error));
+    }
+  }
+
+  async unregister(
+    id: string,
+    options: HookWebhookUnregisterOptions = {},
+  ): Promise<Result<void>> {
+    if (!this.requireAuth()) {
+      return err(authRequiredError("hooks"));
+    }
+
+    try {
+      const response = await this.context.fetch(
+        `${this.host}/hooks/webhooks/${encodeURIComponent(id)}`,
+        {
+          method: "DELETE",
+          headers: serviceHeadersToRecord(
+            this.createHookHeaders(
+              "tinycloud.hooks/unregister",
+              options.target
+                ? buildScopePath(
+                    options.target.service,
+                    options.target.pathPrefix,
+                  )
+                : `webhooks/${id}`,
+            ),
+          ),
+        },
+      );
+
+      if (!response.ok) {
+        return err(
+          await responseError(
+            "hooks",
+            "failed to unregister webhook",
+            response,
+          ),
+        );
+      }
+
+      return ok(undefined);
+    } catch (error) {
+      return err(wrapError("hooks", error));
     }
   }
 
@@ -192,7 +361,7 @@ export class HooksService extends BaseService implements IHooksService {
     }
 
     const subscriptions = [...merged.values()].sort((left, right) =>
-      subscriptionSignature(left).localeCompare(subscriptionSignature(right))
+      subscriptionSignature(left).localeCompare(subscriptionSignature(right)),
     );
     const ttlSeconds =
       ttlCandidates.length > 0 ? Math.min(...ttlCandidates) : undefined;
@@ -220,17 +389,17 @@ export class HooksService extends BaseService implements IHooksService {
       const ticketResponse = await this.mintHookTicket(
         state.subscriptions,
         state.ttlSeconds,
-        abortController.signal
+        abortController.signal,
       );
       const streamResponse = await this.openHookStream(
         host,
         ticketResponse.ticket,
-        abortController.signal
+        abortController.signal,
       );
 
       for await (const message of parseSseStream(
         streamResponse.body,
-        abortController.signal
+        abortController.signal,
       )) {
         if (!message.data) {
           continue;
@@ -253,10 +422,14 @@ export class HooksService extends BaseService implements IHooksService {
     this._sharedStreamAbort?.abort();
   }
 
+  private createHookHeaders(action: string, path: string): ServiceHeaders {
+    return this.context.invoke(this.session, "hooks", path, action);
+  }
+
   private async mintHookTicket(
     subscriptions: HookSubscription[],
     ttlSeconds: number | undefined,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<HookTicketResponse> {
     const host = this._config.host ?? this.context.hosts[0];
     const headers = this.createInvokeHeaders(subscriptions);
@@ -277,7 +450,7 @@ export class HooksService extends BaseService implements IHooksService {
       throw await responseError(
         "hooks",
         "failed to mint hook ticket",
-        ticketResponse
+        ticketResponse,
       );
     }
 
@@ -292,7 +465,7 @@ export class HooksService extends BaseService implements IHooksService {
   private async openHookStream(
     host: string,
     ticket: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<FetchResponse> {
     const streamResponse = await this.context.fetch(
       `${host}/hooks/events?ticket=${encodeURIComponent(ticket)}`,
@@ -300,21 +473,23 @@ export class HooksService extends BaseService implements IHooksService {
         method: "GET",
         headers: { accept: "text/event-stream" },
         signal,
-      }
+      },
     );
 
     if (!streamResponse.ok) {
       throw await responseError(
         "hooks",
         "failed to open hook stream",
-        streamResponse
+        streamResponse,
       );
     }
 
     return streamResponse;
   }
 
-  private createInvokeHeaders(subscriptions: HookSubscription[]): ServiceHeaders {
+  private createInvokeHeaders(
+    subscriptions: HookSubscription[],
+  ): ServiceHeaders {
     const entries: InvokeAnyEntry[] = subscriptions.map((subscription) => ({
       spaceId: subscription.space,
       service: "hooks",
@@ -334,17 +509,27 @@ export class HooksService extends BaseService implements IHooksService {
         this.session,
         entry.service,
         entry.path,
-        entry.action
+        entry.action,
       );
     }
 
     throw new Error(
-      "This SDK runtime does not support multi-scope hook invocations"
+      "This SDK runtime does not support multi-scope hook invocations",
     );
   }
 }
 
-function normalizeSubscription(subscription: HookSubscription): HookSubscription {
+function buildScopePath(
+  service: HookSubscription["service"],
+  pathPrefix?: string,
+): string {
+  const normalized = normalizePathPrefix(pathPrefix);
+  return normalized ? `${service}/${normalized}` : service;
+}
+
+function normalizeSubscription(
+  subscription: HookSubscription,
+): HookSubscription {
   return {
     ...subscription,
     pathPrefix: normalizePathPrefix(subscription.pathPrefix),
@@ -363,14 +548,16 @@ function subscriptionSignature(subscription: HookSubscription): string {
 
 function matchesAnySubscription(
   event: HookEvent,
-  subscriptions: HookSubscription[]
+  subscriptions: HookSubscription[],
 ): boolean {
-  return subscriptions.some((subscription) => matchesSubscription(event, subscription));
+  return subscriptions.some((subscription) =>
+    matchesSubscription(event, subscription),
+  );
 }
 
 function matchesSubscription(
   event: HookEvent,
-  subscription: HookSubscription
+  subscription: HookSubscription,
 ): boolean {
   if (event.space !== subscription.space) {
     return false;
@@ -382,7 +569,11 @@ function matchesSubscription(
     const prefix = subscription.pathPrefix.endsWith("/")
       ? subscription.pathPrefix
       : `${subscription.pathPrefix}/`;
-    if (event.path && event.path !== subscription.pathPrefix && !event.path.startsWith(prefix)) {
+    if (
+      event.path &&
+      event.path !== subscription.pathPrefix &&
+      !event.path.startsWith(prefix)
+    ) {
       return false;
     }
   }
@@ -401,7 +592,9 @@ function normalizePathPrefix(pathPrefix?: string): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function serviceHeadersToRecord(headers: ServiceHeaders): Record<string, string> {
+function serviceHeadersToRecord(
+  headers: ServiceHeaders,
+): Record<string, string> {
   if (Array.isArray(headers)) {
     return Object.fromEntries(headers);
   }
@@ -411,8 +604,8 @@ function serviceHeadersToRecord(headers: ServiceHeaders): Record<string, string>
 async function responseError(
   service: string,
   message: string,
-  response: FetchResponse
-): Promise<Error> {
+  response: FetchResponse,
+): Promise<ReturnType<typeof wrapError>> {
   let detail = response.statusText;
   try {
     const text = await response.text();
@@ -422,19 +615,19 @@ async function responseError(
   } catch {
     // Ignore secondary body read failure.
   }
-  return new Error(`${service}: ${message}: ${response.status} ${detail}`);
+  return wrapError(
+    service,
+    new Error(`${message}: ${response.status} ${detail}`),
+  );
 }
 
 function isAbortError(error: unknown): boolean {
-  return (
-    error instanceof DOMException &&
-    error.name === "AbortError"
-  );
+  return error instanceof DOMException && error.name === "AbortError";
 }
 
 async function* parseSseStream(
   body: unknown,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ): AsyncIterable<HookStreamEvent> {
   if (!body) {
     throw new Error("Hook stream response does not expose a readable body");
@@ -467,7 +660,7 @@ async function* parseSseStream(
 
 async function* readBodyChunks(
   body: unknown,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ): AsyncIterable<Uint8Array> {
   const asyncIterable = body as AsyncIterable<Uint8Array>;
   if (typeof asyncIterable?.[Symbol.asyncIterator] === "function") {
@@ -568,4 +761,155 @@ function parseHookEvent(message: HookStreamEvent): HookEvent {
     eventIndex: parsed.eventIndex ?? 0,
     timestamp: parsed.timestamp ?? "",
   };
+}
+
+function normalizeWebhookRecord(data: unknown): HookWebhookRecord | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const record = isRecordContainer(data);
+  const candidate =
+    pickWebhookRecord(record) ??
+    normalizeWebhookRecord(record.webhook) ??
+    normalizeWebhookRecord(record.hook) ??
+    normalizeWebhookRecord(record.subscription) ??
+    normalizeWebhookRecord(record.data);
+  return candidate ?? null;
+}
+
+function normalizeWebhookRecordList(data: unknown): HookWebhookRecord[] | null {
+  if (Array.isArray(data)) {
+    const records = data
+      .map((entry) => normalizeWebhookRecord(entry))
+      .filter((entry): entry is HookWebhookRecord => entry !== null);
+    return records;
+  }
+
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const record = isRecordContainer(data);
+  const nested =
+    maybeRecordArray(record.webhooks) ??
+    maybeRecordArray(record.subscriptions) ??
+    maybeRecordArray(record.hooks) ??
+    maybeRecordArray(record.data);
+  if (nested) {
+    return nested;
+  }
+
+  const single = pickWebhookRecord(record);
+  return single ? [single] : null;
+}
+
+function maybeRecordArray(value: unknown): HookWebhookRecord[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const records = value
+    .map((entry) => normalizeWebhookRecord(entry))
+    .filter((entry): entry is HookWebhookRecord => entry !== null);
+  return records;
+}
+
+function pickWebhookRecord(
+  value: Record<string, unknown>,
+): HookWebhookRecord | null {
+  const id = stringField(value, "id");
+  const space = stringField(value, "space") ?? stringField(value, "spaceId");
+  const service = stringField(value, "service");
+  const callbackUrl =
+    stringField(value, "callbackUrl") ?? stringField(value, "callback_url");
+  if (!id || !space || !service || !callbackUrl) {
+    return null;
+  }
+
+  return {
+    id,
+    space,
+    service: service as HookWebhookRecord["service"],
+    pathPrefix:
+      optionalStringField(value, "pathPrefix") ??
+      optionalStringField(value, "path_prefix"),
+    abilities:
+      stringArrayField(value, "abilities") ??
+      parsedStringArrayField(value, "abilitiesJson") ??
+      parsedStringArrayField(value, "abilities_json"),
+    callbackUrl,
+    active: booleanField(value, "active") ?? true,
+    createdAt:
+      stringField(value, "createdAt") ??
+      stringField(value, "created_at") ??
+      new Date().toISOString(),
+    subscriberDid:
+      optionalStringField(value, "subscriberDid") ??
+      optionalStringField(value, "subscriber_did"),
+  };
+}
+
+function isRecordContainer(value: object): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const field = value[key];
+  return typeof field === "string" ? field : undefined;
+}
+
+function optionalStringField(
+  value: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  return stringField(value, key);
+}
+
+function booleanField(
+  value: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const field = value[key];
+  return typeof field === "boolean" ? field : undefined;
+}
+
+function stringArrayField(
+  value: Record<string, unknown>,
+  key: string,
+): string[] | undefined {
+  const field = value[key];
+  if (!Array.isArray(field)) {
+    return undefined;
+  }
+  const strings = field.filter(
+    (item): item is string => typeof item === "string",
+  );
+  return strings.length === field.length ? strings : undefined;
+}
+
+function parsedStringArrayField(
+  value: Record<string, unknown>,
+  key: string,
+): string[] | undefined {
+  const field = value[key];
+  if (typeof field !== "string") {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(field) as unknown;
+    if (!Array.isArray(parsed)) {
+      return undefined;
+    }
+    const strings = parsed.filter(
+      (item): item is string => typeof item === "string",
+    );
+    return strings.length === parsed.length ? strings : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/sdk-services/src/hooks/IHooksService.ts
+++ b/packages/sdk-services/src/hooks/IHooksService.ts
@@ -1,8 +1,25 @@
-import type { HookEvent, HookSubscription, SubscribeOptions } from "./types";
+import type {
+  HookEvent,
+  HookSubscription,
+  SubscribeOptions,
+  HookWebhookListOptions,
+  HookWebhookRecord,
+  HookWebhookRegistration,
+  HookWebhookUnregisterOptions,
+} from "./types";
+import type { Result } from "../types";
 
 export interface IHooksService {
   subscribe(
     subscriptions: HookSubscription[],
-    options?: SubscribeOptions
+    options?: SubscribeOptions,
   ): AsyncIterable<HookEvent>;
+  register(
+    webhook: HookWebhookRegistration,
+  ): Promise<Result<HookWebhookRecord>>;
+  list(options?: HookWebhookListOptions): Promise<Result<HookWebhookRecord[]>>;
+  unregister(
+    id: string,
+    options?: HookWebhookUnregisterOptions,
+  ): Promise<Result<void>>;
 }

--- a/packages/sdk-services/src/hooks/IHooksService.ts
+++ b/packages/sdk-services/src/hooks/IHooksService.ts
@@ -1,0 +1,8 @@
+import type { HookEvent, HookSubscription, SubscribeOptions } from "./types";
+
+export interface IHooksService {
+  subscribe(
+    subscriptions: HookSubscription[],
+    options?: SubscribeOptions
+  ): AsyncIterable<HookEvent>;
+}

--- a/packages/sdk-services/src/hooks/index.ts
+++ b/packages/sdk-services/src/hooks/index.ts
@@ -1,0 +1,9 @@
+export { HooksService } from "./HooksService";
+export type { IHooksService } from "./IHooksService";
+export type {
+  HookSubscription,
+  HookEvent,
+  HookStreamEvent,
+  SubscribeOptions,
+  HooksServiceConfig,
+} from "./types";

--- a/packages/sdk-services/src/hooks/index.ts
+++ b/packages/sdk-services/src/hooks/index.ts
@@ -1,9 +1,15 @@
 export { HooksService } from "./HooksService";
 export type { IHooksService } from "./IHooksService";
 export type {
+  HookServiceName,
   HookSubscription,
   HookEvent,
   HookStreamEvent,
+  HookWebhookScope,
+  HookWebhookRegistration,
+  HookWebhookRecord,
+  HookWebhookListOptions,
+  HookWebhookUnregisterOptions,
   SubscribeOptions,
   HooksServiceConfig,
 } from "./types";

--- a/packages/sdk-services/src/hooks/types.ts
+++ b/packages/sdk-services/src/hooks/types.ts
@@ -1,0 +1,34 @@
+export interface HookSubscription {
+  space: string;
+  service: "kv" | "sql" | "duckdb";
+  pathPrefix?: string;
+  abilities?: string[];
+}
+
+export interface HookEvent {
+  type: "write";
+  id: string;
+  space: string;
+  service: string;
+  ability: string;
+  path?: string;
+  actor: string;
+  epoch: string;
+  eventIndex: number;
+  timestamp: string;
+}
+
+export interface HookStreamEvent {
+  event: string;
+  data: string;
+  id?: string;
+}
+
+export interface SubscribeOptions {
+  ttlSeconds?: number;
+  signal?: AbortSignal;
+}
+
+export interface HooksServiceConfig extends Record<string, unknown> {
+  host?: string;
+}

--- a/packages/sdk-services/src/hooks/types.ts
+++ b/packages/sdk-services/src/hooks/types.ts
@@ -1,8 +1,40 @@
+export type HookServiceName = "kv" | "sql" | "duckdb";
+
 export interface HookSubscription {
   space: string;
-  service: "kv" | "sql" | "duckdb";
+  service: HookServiceName;
   pathPrefix?: string;
   abilities?: string[];
+}
+
+export interface HookWebhookScope {
+  space: string;
+  service: HookServiceName;
+  pathPrefix?: string;
+  abilities?: string[];
+}
+
+export interface HookWebhookRegistration extends HookWebhookScope {
+  callbackUrl: string;
+  secret?: string;
+}
+
+export interface HookWebhookRecord extends HookWebhookScope {
+  id: string;
+  subscriberDid?: string;
+  callbackUrl: string;
+  active: boolean;
+  createdAt: string;
+}
+
+export interface HookWebhookListOptions {
+  space?: string;
+  service?: HookServiceName;
+  pathPrefix?: string;
+}
+
+export interface HookWebhookUnregisterOptions {
+  target?: HookWebhookScope;
 }
 
 export interface HookEvent {

--- a/packages/sdk-services/src/hooks/types.ts
+++ b/packages/sdk-services/src/hooks/types.ts
@@ -16,7 +16,7 @@ export interface HookWebhookScope {
 
 export interface HookWebhookRegistration extends HookWebhookScope {
   callbackUrl: string;
-  secret?: string;
+  secret: string;
 }
 
 export interface HookWebhookRecord extends HookWebhookScope {

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -199,9 +199,15 @@ export type {
 export { HooksService } from "./hooks";
 export type {
   IHooksService,
+  HookServiceName,
   HookSubscription,
   HookEvent,
   HookStreamEvent,
+  HookWebhookScope,
+  HookWebhookRegistration,
+  HookWebhookRecord,
+  HookWebhookListOptions,
+  HookWebhookUnregisterOptions,
   SubscribeOptions,
   HooksServiceConfig,
 } from "./hooks";
@@ -211,8 +217,17 @@ export { TinyCloudQuota } from "./quota";
 export type { QuotaConfig, QuotaStatus } from "./quota";
 
 // Vault service
-export { DataVaultService, VaultHeaders, VaultPublicSpaceKVActions, createVaultCrypto } from "./vault";
-export type { IDataVaultService, VaultCrypto, WasmVaultFunctions } from "./vault";
+export {
+  DataVaultService,
+  VaultHeaders,
+  VaultPublicSpaceKVActions,
+  createVaultCrypto,
+} from "./vault";
+export type {
+  IDataVaultService,
+  VaultCrypto,
+  WasmVaultFunctions,
+} from "./vault";
 export type {
   DataVaultConfig,
   VaultPutOptions,

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -45,6 +45,8 @@ export type {
   ServiceSession,
   RetryPolicy,
   InvokeFunction,
+  InvokeAnyFunction,
+  InvokeAnyEntry,
   InvocationFact,
   InvocationFacts,
   FetchFunction,
@@ -192,6 +194,17 @@ export type {
   ColumnInfo,
   ViewInfo,
 } from "./duckdb";
+
+// Hooks service
+export { HooksService } from "./hooks";
+export type {
+  IHooksService,
+  HookSubscription,
+  HookEvent,
+  HookStreamEvent,
+  SubscribeOptions,
+  HooksServiceConfig,
+} from "./hooks";
 
 // Quota
 export { TinyCloudQuota } from "./quota";

--- a/packages/sdk-services/src/types.ts
+++ b/packages/sdk-services/src/types.ts
@@ -166,6 +166,26 @@ export type InvokeFunction = (
 ) => ServiceHeaders;
 
 /**
+ * Multi-resource invocation entry.
+ */
+export interface InvokeAnyEntry {
+  spaceId: string;
+  service: string;
+  path: string;
+  action: string;
+}
+
+/**
+ * Invoke function for minting a single authorization header that covers
+ * multiple capabilities across one effective invoker.
+ */
+export type InvokeAnyFunction = (
+  session: ServiceSession,
+  entries: InvokeAnyEntry[],
+  facts?: InvocationFacts
+) => ServiceHeaders;
+
+/**
  * Fetch request options - compatible with standard fetch API.
  */
 export interface FetchRequestInit {
@@ -182,6 +202,7 @@ export interface FetchResponse {
   ok: boolean;
   status: number;
   statusText: string;
+  body?: unknown;
   headers: {
     get(name: string): string | null;
   };
@@ -271,6 +292,8 @@ export interface IServiceContext {
   // Platform dependencies (injected by SDK)
   /** Platform-specific invoke function from WASM binding */
   readonly invoke: InvokeFunction;
+  /** Optional multi-resource invoke function */
+  readonly invokeAny?: InvokeAnyFunction;
   /** Fetch function (defaults to globalThis.fetch) */
   readonly fetch: FetchFunction;
   /** Available TinyCloud host URLs */

--- a/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
+++ b/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
@@ -1,6 +1,6 @@
 import { IWasmBindings, ISessionManager } from "@tinycloud/sdk-core";
 import { tinycloud, tcwSession, initialized } from "@tinycloud/web-sdk-wasm";
-import { invoke, prepareSession, completeSessionSetup } from "../modules/Storage/tinycloud/module";
+import { invoke, invokeAny, prepareSession, completeSessionSetup } from "../modules/Storage/tinycloud/module";
 
 let wasmReady = false;
 
@@ -15,6 +15,7 @@ export class BrowserWasmBindings implements IWasmBindings {
   }
 
   get invoke() { return invoke; }
+  get invokeAny() { return invokeAny; }
   get prepareSession() { return prepareSession; }
   get completeSessionSetup() { return completeSessionSetup; }
 

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -68,6 +68,19 @@ export {
   IPrefixedKVService,
 } from '@tinycloud/sdk-core';
 
+// Hooks service
+export {
+  HooksService,
+} from '@tinycloud/sdk-core';
+export type {
+  IHooksService,
+  HookSubscription,
+  HookEvent,
+  HookStreamEvent,
+  SubscribeOptions,
+  HooksServiceConfig,
+} from '@tinycloud/sdk-core';
+
 // Re-export delegation types and services from sdk-core
 export {
   // DelegationManager

--- a/packages/web-sdk/src/modules/Storage/tinycloud/module.ts
+++ b/packages/web-sdk/src/modules/Storage/tinycloud/module.ts
@@ -15,7 +15,7 @@ function getModule(): TinyCloudModule {
 
 export const makeSpaceId: TinyCloudModule['makeSpaceId'] = (...args) => {
   try {
-    return getModule().makeSpaceId(...args);
+    return Reflect.apply(getModule().makeSpaceId, getModule(), args);
   } catch (e) {
     throw `${msg}: ${e}`;
   }
@@ -23,7 +23,7 @@ export const makeSpaceId: TinyCloudModule['makeSpaceId'] = (...args) => {
 
 export const prepareSession: TinyCloudModule['prepareSession'] = (...args) => {
   try {
-    return getModule().prepareSession(...args);
+    return Reflect.apply(getModule().prepareSession, getModule(), args);
   } catch (e) {
     throw `${msg}: ${e}`;
   }
@@ -33,7 +33,7 @@ export const completeSessionSetup: TinyCloudModule['completeSessionSetup'] = (
   ...args
 ) => {
   try {
-    return getModule().completeSessionSetup(...args);
+    return Reflect.apply(getModule().completeSessionSetup, getModule(), args);
   } catch (e) {
     throw `${msg}: ${e}`;
   }
@@ -41,7 +41,15 @@ export const completeSessionSetup: TinyCloudModule['completeSessionSetup'] = (
 
 export const invoke: InvokeFunction = (...args) => {
   try {
-    return getModule().invoke(...args) as any;
+    return Reflect.apply(getModule().invoke, getModule(), args) as any;
+  } catch (e) {
+    throw `${msg}: ${e}`;
+  }
+};
+
+export const invokeAny: TinyCloudModule['invokeAny'] = (...args) => {
+  try {
+    return Reflect.apply(getModule().invokeAny, getModule(), args) as any;
   } catch (e) {
     throw `${msg}: ${e}`;
   }
@@ -50,7 +58,11 @@ export const invoke: InvokeFunction = (...args) => {
 export const generateHostSIWEMessage: TinyCloudModule['generateHostSIWEMessage'] =
   (...args) => {
     try {
-      return getModule().generateHostSIWEMessage(...args);
+      return Reflect.apply(
+        getModule().generateHostSIWEMessage,
+        getModule(),
+        args
+      );
     } catch (e) {
       throw `${msg}: ${e}`;
     }
@@ -59,7 +71,11 @@ export const generateHostSIWEMessage: TinyCloudModule['generateHostSIWEMessage']
 export const siweToDelegationHeaders: TinyCloudModule['siweToDelegationHeaders'] =
   (...args) => {
     try {
-      return getModule().siweToDelegationHeaders(...args);
+      return Reflect.apply(
+        getModule().siweToDelegationHeaders,
+        getModule(),
+        args
+      );
     } catch (e) {
       throw `${msg}: ${e}`;
     }

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -270,6 +270,7 @@ export class TinyCloudWeb {
   get sharing(): ISharingService { return this.node.sharing; }
   get delegations(): DelegationManager { return this.node.delegationManager; }
   get capabilityRegistry(): ICapabilityKeyRegistry { return this.node.capabilityRegistry; }
+  get spaceId(): string | undefined { return this._node?.spaceId; }
 
   space(nameOrUri: string): ISpace { return this.spaces.get(nameOrUri); }
   get kvPrefix(): string { return this.config.kvPrefix || ""; }

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -20,6 +20,7 @@ import {
   ISpace,
   ISharingService,
   ICapabilityKeyRegistry,
+  IHooksService,
   DelegationManager,
   Delegation,
   CreateDelegationParams,
@@ -263,6 +264,7 @@ export class TinyCloudWeb {
   get kv(): IKVService { return this.node.kv; }
   get sql(): ISQLService { return this.node.sql; }
   get duckdb(): IDuckDbService { return this.node.duckdb; }
+  get hooks(): IHooksService { return this.node.hooks; }
   get vault(): IDataVaultService { return this.node.vault; }
   get spaces(): ISpaceService { return this.node.spaces; }
   get sharing(): ISharingService { return this.node.sharing; }

--- a/packages/web-sdk/tests/tcw-spaceId.test.js
+++ b/packages/web-sdk/tests/tcw-spaceId.test.js
@@ -1,0 +1,16 @@
+global.HTMLElement = class {};
+global.customElements = {
+  define() {},
+  get() {
+    return undefined;
+  },
+};
+
+const { TinyCloudWeb } = require("../dist/index.cjs");
+
+test("TinyCloudWeb exposes spaceId from the underlying node wrapper", () => {
+  const tcw = Object.create(TinyCloudWeb.prototype);
+  tcw._node = { spaceId: "space-123" };
+
+  expect(tcw.spaceId).toBe("space-123");
+});

--- a/tests/node-sdk/hooks/hooks-coalescing.test.ts
+++ b/tests/node-sdk/hooks/hooks-coalescing.test.ts
@@ -1,0 +1,197 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { TinyCloudNode } from "@tinycloud/node-sdk";
+import { checkServerHealth, createClient, TEST_KEY } from "../setup";
+
+type HookMetrics = {
+  ticketRequests: number;
+  streamRequests: number;
+  activeStreams: number;
+  maxActiveStreams: number;
+};
+
+describe("Hooks integration", () => {
+  let alice: TinyCloudNode;
+  let restoreFetch: (() => void) | undefined;
+  let metrics: HookMetrics;
+
+  beforeAll(async () => {
+    await checkServerHealth();
+    ({ restoreFetch, metrics } = installFetchMetrics());
+    alice = createClient("alice-hooks", TEST_KEY);
+    await alice.signIn();
+  });
+
+  afterAll(() => {
+    restoreFetch?.();
+  });
+
+  test(
+    "coalesces subscriptions into one physical stream per host and invoker",
+    async () => {
+      const firstAbort = new AbortController();
+      const secondAbort = new AbortController();
+
+      const firstSubscription = alice.hooks.subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "kv",
+            pathPrefix: "hooks-a/",
+            abilities: ["tinycloud.kv/put"],
+          },
+        ],
+        { signal: firstAbort.signal }
+      )[Symbol.asyncIterator]();
+
+      const firstNext = firstSubscription.next();
+      await waitFor(() => metrics.activeStreams === 1);
+
+      const secondSubscription = alice.hooks.subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "kv",
+            pathPrefix: "hooks-b/",
+            abilities: ["tinycloud.kv/put"],
+          },
+        ],
+        { signal: secondAbort.signal }
+      )[Symbol.asyncIterator]();
+
+      const secondNext = secondSubscription.next();
+      await waitFor(() => metrics.streamRequests >= 2);
+      await waitFor(() => metrics.maxActiveStreams === 1);
+
+      firstAbort.abort();
+      secondAbort.abort();
+
+      await Promise.allSettled([firstNext, secondNext]);
+
+      expect(metrics.maxActiveStreams).toBe(1);
+      expect(metrics.streamRequests).toBe(2);
+      expect(metrics.ticketRequests).toBe(2);
+    },
+    30000
+  );
+});
+
+function installFetchMetrics(): { metrics: HookMetrics; restoreFetch: () => void } {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  const metrics: HookMetrics = {
+    ticketRequests: 0,
+    streamRequests: 0,
+    activeStreams: 0,
+    maxActiveStreams: 0,
+  };
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = toUrl(input);
+    const response = await realFetch(input, init);
+
+    if (url.pathname === "/hooks/tickets") {
+      metrics.ticketRequests += 1;
+      return response;
+    }
+
+    if (url.pathname === "/hooks/events") {
+      metrics.streamRequests += 1;
+      return wrapStreamResponse(response, metrics);
+    }
+
+    return response;
+  }) as typeof globalThis.fetch;
+
+  return {
+    metrics,
+    restoreFetch: () => {
+      globalThis.fetch = realFetch as typeof globalThis.fetch;
+    },
+  };
+}
+
+function wrapStreamResponse(response: Response, metrics: HookMetrics): Response {
+  if (!response.body) {
+    return response;
+  }
+
+  let accounted = false;
+  const release = () => {
+    if (!accounted) {
+      accounted = true;
+      metrics.activeStreams = Math.max(0, metrics.activeStreams - 1);
+    }
+  };
+
+  const body = {
+    getReader(): ReadableStreamDefaultReader<Uint8Array> {
+      const reader = response.body!.getReader();
+      metrics.activeStreams += 1;
+      metrics.maxActiveStreams = Math.max(
+        metrics.maxActiveStreams,
+        metrics.activeStreams
+      );
+
+      return {
+        read: async () => {
+          const result = await reader.read();
+          if (result.done) {
+            release();
+          }
+          return result;
+        },
+        cancel: async () => {
+          release();
+          return reader.cancel();
+        },
+        releaseLock: () => {
+          reader.releaseLock();
+        },
+      };
+    },
+  };
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+    json: () => response.json(),
+    text: () => response.text(),
+    arrayBuffer: () => response.arrayBuffer(),
+    blob: () => response.blob(),
+    body,
+  } as Response;
+}
+
+function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error("Timed out waiting for hooks condition"));
+        return;
+      }
+      setTimeout(tick, 25);
+    };
+
+    tick();
+  });
+}
+
+function toUrl(input: RequestInfo | URL): URL {
+  if (input instanceof URL) {
+    return input;
+  }
+  if (typeof input === "string") {
+    return new URL(input);
+  }
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+  return new URL(input.url);
+}

--- a/tests/node-sdk/hooks/hooks-duckdb-sse.test.ts
+++ b/tests/node-sdk/hooks/hooks-duckdb-sse.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { TinyCloudNode } from "@tinycloud/node-sdk";
+import { checkServerHealth, createClient, TEST_KEY } from "../setup";
+import { installFetchMetrics, sleep, waitFor } from "./hooks-test-utils";
+
+const STAMP = Date.now();
+const DB_NAME = `phase2_duck_${STAMP}`;
+const TABLE_NAME = `phase2_duck_items_${STAMP}`;
+
+describe("DuckDB hooks SSE", () => {
+  let alice: TinyCloudNode;
+  let restoreFetch: (() => void) | undefined;
+  let metrics: ReturnType<typeof installFetchMetrics>["metrics"];
+
+  beforeAll(async () => {
+    await checkServerHealth();
+    ({ restoreFetch, metrics } = installFetchMetrics());
+    alice = createClient("alice-hooks-duckdb", TEST_KEY);
+    await alice.signIn();
+    await alice.duckdb
+      .db(DB_NAME)
+      .execute(`DROP TABLE IF EXISTS ${TABLE_NAME}`);
+  });
+
+  afterAll(async () => {
+    restoreFetch?.();
+    await alice.duckdb
+      .db(DB_NAME)
+      .execute(`DROP TABLE IF EXISTS ${TABLE_NAME}`);
+  });
+
+  test("delivers named DuckDB database writes on the hooks stream", async () => {
+    const abort = new AbortController();
+    const stream = alice.hooks
+      .subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "duckdb",
+            pathPrefix: DB_NAME,
+            abilities: ["tinycloud.duckdb/write"],
+          },
+        ],
+        { signal: abort.signal },
+      )
+      [Symbol.asyncIterator]();
+
+    const nextEvent = stream.next();
+    await waitFor(() => metrics.activeStreams === 1);
+
+    const createResult = await alice.duckdb
+      .db(DB_NAME)
+      .execute(
+        `CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (id INTEGER PRIMARY KEY, label VARCHAR)`,
+      );
+    expect(createResult.ok).toBe(true);
+
+    const event = await nextEvent;
+    abort.abort();
+    await waitFor(() => metrics.activeStreams === 0);
+
+    expect(event.done).toBe(false);
+    if (!event.done) {
+      expect(event.value.type).toBe("write");
+      expect(event.value.service).toBe("duckdb");
+      expect(event.value.ability).toBe("tinycloud.duckdb/write");
+      expect(event.value.space).toBe(alice.spaceId);
+      expect(event.value.path).toBe(`${DB_NAME}/${TABLE_NAME}`);
+    }
+  }, 30000);
+
+  test("filters DuckDB hook delivery by path", async () => {
+    const seedResult = await alice.duckdb
+      .db(DB_NAME)
+      .execute(
+        `CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (id INTEGER PRIMARY KEY, label VARCHAR)`,
+      );
+    expect(seedResult.ok).toBe(true);
+
+    const pathAbort = new AbortController();
+    const pathStream = alice.hooks
+      .subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "duckdb",
+            pathPrefix: `${DB_NAME}/missing`,
+            abilities: ["tinycloud.duckdb/write"],
+          },
+        ],
+        { signal: pathAbort.signal },
+      )
+      [Symbol.asyncIterator]();
+    const pathNext = pathStream.next();
+    await waitFor(() => metrics.activeStreams === 1);
+
+    const updateResult = await alice.duckdb
+      .db(DB_NAME)
+      .execute(
+        `INSERT INTO ${TABLE_NAME} (id, label) VALUES (1, 'duck-write')`,
+      );
+    expect(updateResult.ok).toBe(true);
+
+    await sleep(250);
+    pathAbort.abort();
+    const pathResult = await pathNext;
+    expect(pathResult.done).toBe(true);
+    await waitFor(() => metrics.activeStreams === 0);
+
+    const secondPathAbort = new AbortController();
+    const secondPathStream = alice.hooks
+      .subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "duckdb",
+            pathPrefix: `${DB_NAME}/other`,
+            abilities: ["tinycloud.duckdb/write"],
+          },
+        ],
+        { signal: secondPathAbort.signal },
+      )
+      [Symbol.asyncIterator]();
+    const secondPathNext = secondPathStream.next();
+
+    const secondWriteResult = await alice.duckdb
+      .db(DB_NAME)
+      .execute(
+        `INSERT INTO ${TABLE_NAME} (id, label) VALUES (2, 'duck-path-filter')`,
+      );
+    expect(secondWriteResult.ok).toBe(true);
+
+    await sleep(250);
+    secondPathAbort.abort();
+    const secondPathResult = await secondPathNext;
+    expect(secondPathResult.done).toBe(true);
+    await waitFor(() => metrics.activeStreams === 0);
+  }, 30000);
+});

--- a/tests/node-sdk/hooks/hooks-sql-sse.test.ts
+++ b/tests/node-sdk/hooks/hooks-sql-sse.test.ts
@@ -1,0 +1,189 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { TinyCloudNode } from "@tinycloud/node-sdk";
+import { checkServerHealth, createClient, TEST_KEY } from "../setup";
+import { installFetchMetrics, sleep, waitFor } from "./hooks-test-utils";
+
+const STAMP = Date.now();
+const DB_NAME = `phase2_sql_${STAMP}`;
+const TABLE_NAME = `phase2_items_${STAMP}`;
+
+describe("SQL hooks SSE", () => {
+  let alice: TinyCloudNode;
+  let bob: TinyCloudNode;
+  let restoreFetch: (() => void) | undefined;
+  let metrics: ReturnType<typeof installFetchMetrics>["metrics"];
+
+  beforeAll(async () => {
+    await checkServerHealth();
+    ({ restoreFetch, metrics } = installFetchMetrics());
+    alice = createClient("alice-hooks-sql", TEST_KEY);
+    bob = createClient("bob-hooks-sql");
+    await alice.signIn();
+    await bob.signIn();
+    await alice.sql.db(DB_NAME).execute(`DROP TABLE IF EXISTS ${TABLE_NAME}`);
+  });
+
+  afterAll(async () => {
+    restoreFetch?.();
+    await alice.sql.db(DB_NAME).execute(`DROP TABLE IF EXISTS ${TABLE_NAME}`);
+  });
+
+  test("delivers named SQL database writes on the hooks stream", async () => {
+    const abort = new AbortController();
+    const stream = alice.hooks
+      .subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "sql",
+            pathPrefix: DB_NAME,
+            abilities: ["tinycloud.sql/write"],
+          },
+        ],
+        { signal: abort.signal },
+      )
+      [Symbol.asyncIterator]();
+
+    const nextEvent = stream.next();
+    await waitFor(() => metrics.activeStreams === 1);
+
+    const createResult = await alice.sql
+      .db(DB_NAME)
+      .execute(
+        `CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (id INTEGER PRIMARY KEY, label TEXT)`,
+      );
+    expect(createResult.ok).toBe(true);
+
+    const event = await nextEvent;
+    abort.abort();
+    await waitFor(() => metrics.activeStreams === 0);
+
+    expect(event.done).toBe(false);
+    if (!event.done) {
+      expect(event.value.type).toBe("write");
+      expect(event.value.service).toBe("sql");
+      expect(event.value.ability).toBe("tinycloud.sql/write");
+      expect(event.value.space).toBe(alice.spaceId);
+      expect(event.value.path).toBe(`${DB_NAME}/${TABLE_NAME}`);
+    }
+  }, 30000);
+
+  test("filters SQL hook delivery by path", async () => {
+    const seedResult = await alice.sql
+      .db(DB_NAME)
+      .execute(
+        `CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (id INTEGER PRIMARY KEY, label TEXT)`,
+      );
+    expect(seedResult.ok).toBe(true);
+
+    const pathAbort = new AbortController();
+    const pathStream = alice.hooks
+      .subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "sql",
+            pathPrefix: `${DB_NAME}/missing`,
+            abilities: ["tinycloud.sql/write"],
+          },
+        ],
+        { signal: pathAbort.signal },
+      )
+      [Symbol.asyncIterator]();
+    const pathNext = pathStream.next();
+    await waitFor(() => metrics.activeStreams === 1);
+
+    const updateResult = await alice.sql
+      .db(DB_NAME)
+      .execute(
+        `INSERT OR REPLACE INTO ${TABLE_NAME} (id, label) VALUES (1, 'sql-write')`,
+      );
+    expect(updateResult.ok).toBe(true);
+
+    await sleep(250);
+    pathAbort.abort();
+    const pathResult = await pathNext;
+    expect(pathResult.done).toBe(true);
+    await waitFor(() => metrics.activeStreams === 0);
+
+    const secondPathAbort = new AbortController();
+    const secondPathStream = alice.hooks
+      .subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "sql",
+            pathPrefix: `${DB_NAME}/other`,
+            abilities: ["tinycloud.sql/write"],
+          },
+        ],
+        { signal: secondPathAbort.signal },
+      )
+      [Symbol.asyncIterator]();
+    const secondPathNext = secondPathStream.next();
+
+    const secondWriteResult = await alice.sql
+      .db(DB_NAME)
+      .execute(
+        `INSERT OR REPLACE INTO ${TABLE_NAME} (id, label) VALUES (2, 'sql-path-filter')`,
+      );
+    expect(secondWriteResult.ok).toBe(true);
+
+    await sleep(250);
+    secondPathAbort.abort();
+    const secondPathResult = await secondPathNext;
+    expect(secondPathResult.done).toBe(true);
+    await waitFor(() => metrics.activeStreams === 0);
+  }, 30000);
+
+  test("allows a delegated writer to trigger SQL hook events", async () => {
+    const seedResult = await alice.sql
+      .db(DB_NAME)
+      .execute(
+        `CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (id INTEGER PRIMARY KEY, label TEXT)`,
+      );
+    expect(seedResult.ok).toBe(true);
+
+    const delegation = await alice.createDelegation({
+      path: "",
+      actions: ["tinycloud.sql/write"],
+      delegateDID: bob.did,
+    });
+    const access = await bob.useDelegation(delegation);
+
+    const abort = new AbortController();
+    const stream = alice.hooks
+      .subscribe(
+        [
+          {
+            space: alice.spaceId!,
+            service: "sql",
+            pathPrefix: DB_NAME,
+            abilities: ["tinycloud.sql/write"],
+          },
+        ],
+        { signal: abort.signal },
+      )
+      [Symbol.asyncIterator]();
+
+    const nextEvent = stream.next();
+    await waitFor(() => metrics.activeStreams === 1);
+
+    const writeResult = await access.sql
+      .db(DB_NAME)
+      .execute(
+        `INSERT INTO ${TABLE_NAME} (id, label) VALUES (3, 'delegated-sql')`,
+      );
+    expect(writeResult.ok).toBe(true);
+
+    const event = await nextEvent;
+    abort.abort();
+    await waitFor(() => metrics.activeStreams === 0);
+
+    expect(event.done).toBe(false);
+    if (!event.done) {
+      expect(event.value.actor).not.toBe(alice.did);
+      expect(event.value.path).toBe(`${DB_NAME}/${TABLE_NAME}`);
+    }
+  }, 30000);
+});

--- a/tests/node-sdk/hooks/hooks-test-utils.ts
+++ b/tests/node-sdk/hooks/hooks-test-utils.ts
@@ -1,0 +1,140 @@
+type HookMetrics = {
+  ticketRequests: number;
+  streamRequests: number;
+  activeStreams: number;
+  maxActiveStreams: number;
+};
+
+export function installFetchMetrics(): {
+  metrics: HookMetrics;
+  restoreFetch: () => void;
+} {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  const metrics: HookMetrics = {
+    ticketRequests: 0,
+    streamRequests: 0,
+    activeStreams: 0,
+    maxActiveStreams: 0,
+  };
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = toUrl(input);
+    const response = await realFetch(input, init);
+
+    if (url.pathname === "/hooks/tickets") {
+      metrics.ticketRequests += 1;
+      return response;
+    }
+
+    if (url.pathname === "/hooks/events") {
+      metrics.streamRequests += 1;
+      return wrapStreamResponse(response, metrics);
+    }
+
+    return response;
+  }) as typeof globalThis.fetch;
+
+  return {
+    metrics,
+    restoreFetch: () => {
+      globalThis.fetch = realFetch as typeof globalThis.fetch;
+    },
+  };
+}
+
+export function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error("Timed out waiting for hooks condition"));
+        return;
+      }
+      setTimeout(tick, 25);
+    };
+
+    tick();
+  });
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function wrapStreamResponse(
+  response: Response,
+  metrics: HookMetrics,
+): Response {
+  if (!response.body) {
+    return response;
+  }
+
+  let accounted = false;
+  const release = () => {
+    if (!accounted) {
+      accounted = true;
+      metrics.activeStreams = Math.max(0, metrics.activeStreams - 1);
+    }
+  };
+
+  const body = {
+    getReader(): ReadableStreamDefaultReader<Uint8Array> {
+      const reader = response.body!.getReader();
+      metrics.activeStreams += 1;
+      metrics.maxActiveStreams = Math.max(
+        metrics.maxActiveStreams,
+        metrics.activeStreams,
+      );
+
+      return {
+        read: async () => {
+          const result = await reader.read();
+          if (result.done) {
+            release();
+          }
+          return result;
+        },
+        cancel: async () => {
+          release();
+          return reader.cancel();
+        },
+        releaseLock: () => {
+          reader.releaseLock();
+        },
+      };
+    },
+  };
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+    json: () => response.json(),
+    text: () => response.text(),
+    arrayBuffer: () => response.arrayBuffer(),
+    blob: () => response.blob(),
+    body,
+  } as Response;
+}
+
+function toUrl(input: RequestInfo | URL): URL {
+  if (input instanceof URL) {
+    return input;
+  }
+  if (typeof input === "string") {
+    return new URL(input);
+  }
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+  return new URL(input.url);
+}

--- a/tests/node-sdk/hooks/hooks-webhooks.test.ts
+++ b/tests/node-sdk/hooks/hooks-webhooks.test.ts
@@ -22,6 +22,7 @@ const SQL_DB_NAME = `phase4_sql_${PHASE4_STAMP}`;
 const SQL_TABLE_NAME = `phase4_sql_items_${PHASE4_STAMP}`;
 const DUCKDB_DB_NAME = `phase4_duckdb_${PHASE4_STAMP}`;
 const DUCKDB_TABLE_NAME = `phase4_duckdb_items_${PHASE4_STAMP}`;
+let duckDbRowId = 1;
 
 describe("Hooks webhooks integration", () => {
   let alice: TinyCloudNode;
@@ -434,10 +435,11 @@ async function putDuckDbValue(
   node: TinyCloudNode,
   label: string,
 ): Promise<void> {
+  const id = duckDbRowId++;
   const result = await node.duckdb
     .db(DUCKDB_DB_NAME)
     .execute(
-      `INSERT INTO ${DUCKDB_TABLE_NAME} (id, label) VALUES (${Date.now()}, '${label}')`,
+      `INSERT INTO ${DUCKDB_TABLE_NAME} (id, label) VALUES (${id}, '${label}')`,
     );
   expect(result.ok).toBe(true);
   if (!result.ok) {

--- a/tests/node-sdk/hooks/hooks-webhooks.test.ts
+++ b/tests/node-sdk/hooks/hooks-webhooks.test.ts
@@ -15,7 +15,13 @@ import {
   findWebhookEvent,
   verifyWebhookSignature,
 } from "./webhook-test-utils";
-import { waitFor } from "./hooks-test-utils";
+import { sleep, waitFor } from "./hooks-test-utils";
+
+const PHASE4_STAMP = Date.now();
+const SQL_DB_NAME = `phase4_sql_${PHASE4_STAMP}`;
+const SQL_TABLE_NAME = `phase4_sql_items_${PHASE4_STAMP}`;
+const DUCKDB_DB_NAME = `phase4_duckdb_${PHASE4_STAMP}`;
+const DUCKDB_TABLE_NAME = `phase4_duckdb_items_${PHASE4_STAMP}`;
 
 describe("Hooks webhooks integration", () => {
   let alice: TinyCloudNode;
@@ -24,14 +30,22 @@ describe("Hooks webhooks integration", () => {
     await checkServerHealth();
     alice = createClient("hooks-webhooks", TEST_KEY);
     await alice.signIn();
-    await cleanupPhase3Hooks(alice);
+    await cleanupHooksByPrefix(alice, "phase3", ["kv"]);
+    await cleanupHooksByPrefix(alice, "phase4", ["kv", "sql", "duckdb"]);
+    await ensureSqlTable(alice);
+    await ensureDuckDbTable(alice);
   });
 
   beforeEach(async () => {
-    await cleanupPhase3Hooks(alice);
+    await cleanupHooksByPrefix(alice, "phase3", ["kv"]);
+    await cleanupHooksByPrefix(alice, "phase4", ["kv", "sql", "duckdb"]);
   });
 
   afterAll(async () => {
+    await cleanupHooksByPrefix(alice, "phase3", ["kv"]);
+    await cleanupHooksByPrefix(alice, "phase4", ["kv", "sql", "duckdb"]);
+    await dropSqlTable(alice);
+    await dropDuckDbTable(alice);
     await alice?.signOut?.();
   });
 
@@ -252,10 +266,179 @@ describe("Hooks webhooks integration", () => {
       await server.close();
     }
   }, 240000);
+
+  test("delivers live SQL webhook POSTs with generic envelope fields", async () => {
+    const server = await WebhookCallbackServer.start();
+    const callbackPath = `/hooks/sql-delivery-${cryptoRandomSuffix()}`;
+    const secret = randomBytes(32).toString("hex");
+    const scope = {
+      space: alice.spaceId!,
+      service: "sql" as const,
+      pathPrefix: `${SQL_DB_NAME}/${SQL_TABLE_NAME}`,
+      abilities: ["tinycloud.sql/write"],
+    };
+
+    try {
+      const createdResult = await alice.hooks.register({
+        ...scope,
+        callbackUrl: `${server.url}${callbackPath}`,
+        secret,
+      });
+      expect(createdResult.ok).toBe(true);
+      if (!createdResult.ok) {
+        throw createdResult.error;
+      }
+
+      try {
+        await putSqlValue(alice, `sql-${cryptoRandomSuffix()}`);
+
+        const requests = await waitForWebhookRequestsForPath(
+          server,
+          callbackPath,
+          1,
+          90000,
+        );
+        const request = requests[0];
+        const event = findWebhookEvent(request.jsonBody);
+        expect(event).not.toBeNull();
+        if (!event) {
+          throw new Error("Webhook delivery did not include an event payload");
+        }
+
+        expect(event.space).toBe(scope.space);
+        expect(event.service).toBe(scope.service);
+        expect(event.ability).toBe("tinycloud.sql/write");
+        expect(event.path).toBe(`${SQL_DB_NAME}/${SQL_TABLE_NAME}`);
+        expect(typeof event.actor).toBe("string");
+        expect(verifyWebhookSignature(request, secret)).toBe(true);
+      } finally {
+        await unregisterWebhook(alice, createdResult.data.id, scope);
+      }
+    } finally {
+      await server.close();
+    }
+  }, 90000);
+
+  test("delivers live DuckDB webhook POSTs with generic envelope fields", async () => {
+    const server = await WebhookCallbackServer.start();
+    const callbackPath = `/hooks/duckdb-delivery-${cryptoRandomSuffix()}`;
+    const secret = randomBytes(32).toString("hex");
+    const scope = {
+      space: alice.spaceId!,
+      service: "duckdb" as const,
+      pathPrefix: `${DUCKDB_DB_NAME}/${DUCKDB_TABLE_NAME}`,
+      abilities: ["tinycloud.duckdb/write"],
+    };
+
+    try {
+      const createdResult = await alice.hooks.register({
+        ...scope,
+        callbackUrl: `${server.url}${callbackPath}`,
+        secret,
+      });
+      expect(createdResult.ok).toBe(true);
+      if (!createdResult.ok) {
+        throw createdResult.error;
+      }
+
+      try {
+        await putDuckDbValue(alice, `duckdb-${cryptoRandomSuffix()}`);
+
+        const requests = await waitForWebhookRequestsForPath(
+          server,
+          callbackPath,
+          1,
+          90000,
+        );
+        const request = requests[0];
+        const event = findWebhookEvent(request.jsonBody);
+        expect(event).not.toBeNull();
+        if (!event) {
+          throw new Error("Webhook delivery did not include an event payload");
+        }
+
+        expect(event.space).toBe(scope.space);
+        expect(event.service).toBe(scope.service);
+        expect(event.ability).toBe("tinycloud.duckdb/write");
+        expect(event.path).toBe(`${DUCKDB_DB_NAME}/${DUCKDB_TABLE_NAME}`);
+        expect(typeof event.actor).toBe("string");
+        expect(verifyWebhookSignature(request, secret)).toBe(true);
+      } finally {
+        await unregisterWebhook(alice, createdResult.data.id, scope);
+      }
+    } finally {
+      await server.close();
+    }
+  }, 90000);
+
+  test("does not deliver SQL webhooks when path prefix does not match", async () => {
+    const server = await WebhookCallbackServer.start();
+    const callbackPath = `/hooks/sql-filter-${cryptoRandomSuffix()}`;
+    const secret = randomBytes(32).toString("hex");
+    const scope = {
+      space: alice.spaceId!,
+      service: "sql" as const,
+      pathPrefix: `${SQL_DB_NAME}/missing`,
+      abilities: ["tinycloud.sql/write"],
+    };
+
+    try {
+      const createdResult = await alice.hooks.register({
+        ...scope,
+        callbackUrl: `${server.url}${callbackPath}`,
+        secret,
+      });
+      expect(createdResult.ok).toBe(true);
+      if (!createdResult.ok) {
+        throw createdResult.error;
+      }
+
+      try {
+        await putSqlValue(alice, `sql-filter-${cryptoRandomSuffix()}`);
+        await sleep(3000);
+
+        const requests = server.requests.filter(
+          (request) => request.path === callbackPath,
+        );
+        expect(requests.length).toBe(0);
+      } finally {
+        await unregisterWebhook(alice, createdResult.data.id, scope);
+      }
+    } finally {
+      await server.close();
+    }
+  }, 45000);
 });
 
 async function putKvValue(node: TinyCloudNode, key: string, value: string) {
   const result = await node.kv.put(key, value);
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+async function putSqlValue(node: TinyCloudNode, label: string): Promise<void> {
+  const result = await node.sql
+    .db(SQL_DB_NAME)
+    .execute(
+      `INSERT OR REPLACE INTO ${SQL_TABLE_NAME} (id, label) VALUES (${Date.now()}, '${label}')`,
+    );
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+async function putDuckDbValue(
+  node: TinyCloudNode,
+  label: string,
+): Promise<void> {
+  const result = await node.duckdb
+    .db(DUCKDB_DB_NAME)
+    .execute(
+      `INSERT INTO ${DUCKDB_TABLE_NAME} (id, label) VALUES (${Date.now()}, '${label}')`,
+    );
   expect(result.ok).toBe(true);
   if (!result.ok) {
     throw result.error;
@@ -292,31 +475,81 @@ async function waitForWebhookRequestsForPath(
   return server.requests.filter((request) => request.path === path);
 }
 
-async function cleanupPhase3Hooks(node: TinyCloudNode): Promise<void> {
+async function ensureSqlTable(node: TinyCloudNode): Promise<void> {
+  const result = await node.sql
+    .db(SQL_DB_NAME)
+    .execute(
+      `CREATE TABLE IF NOT EXISTS ${SQL_TABLE_NAME} (id INTEGER PRIMARY KEY, label TEXT)`,
+    );
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+async function ensureDuckDbTable(node: TinyCloudNode): Promise<void> {
+  const result = await node.duckdb
+    .db(DUCKDB_DB_NAME)
+    .execute(
+      `CREATE TABLE IF NOT EXISTS ${DUCKDB_TABLE_NAME} (id INTEGER PRIMARY KEY, label VARCHAR)`,
+    );
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+async function dropSqlTable(node: TinyCloudNode): Promise<void> {
+  const result = await node.sql
+    .db(SQL_DB_NAME)
+    .execute(`DROP TABLE IF EXISTS ${SQL_TABLE_NAME}`);
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+async function dropDuckDbTable(node: TinyCloudNode): Promise<void> {
+  const result = await node.duckdb
+    .db(DUCKDB_DB_NAME)
+    .execute(`DROP TABLE IF EXISTS ${DUCKDB_TABLE_NAME}`);
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+async function cleanupHooksByPrefix(
+  node: TinyCloudNode,
+  prefix: string,
+  services: HookWebhookScope["service"][],
+): Promise<void> {
   if (!node.spaceId) {
     return;
   }
 
-  const listed = await node.hooks.list({
-    space: node.spaceId,
-    service: "kv",
-    pathPrefix: "phase3",
-  });
-  if (!listed.ok) {
-    throw listed.error;
-  }
-
-  for (const hook of listed.data) {
-    const deleted = await node.hooks.unregister(hook.id, {
-      target: {
-        space: hook.space,
-        service: hook.service,
-        pathPrefix: hook.pathPrefix,
-        abilities: hook.abilities,
-      },
+  for (const service of services) {
+    const listed = await node.hooks.list({
+      space: node.spaceId,
+      service,
+      pathPrefix: prefix,
     });
-    if (!deleted.ok) {
-      throw deleted.error;
+    if (!listed.ok) {
+      throw listed.error;
+    }
+
+    for (const hook of listed.data) {
+      const deleted = await node.hooks.unregister(hook.id, {
+        target: {
+          space: hook.space,
+          service: hook.service,
+          pathPrefix: hook.pathPrefix,
+          abilities: hook.abilities,
+        },
+      });
+      if (!deleted.ok) {
+        throw deleted.error;
+      }
     }
   }
 }

--- a/tests/node-sdk/hooks/hooks-webhooks.test.ts
+++ b/tests/node-sdk/hooks/hooks-webhooks.test.ts
@@ -1,0 +1,322 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { randomBytes } from "node:crypto";
+import { TinyCloudNode, type HookWebhookScope } from "@tinycloud/node-sdk";
+import { checkServerHealth, createClient, TEST_KEY } from "../setup";
+import {
+  type CapturedWebhookRequest,
+  WebhookCallbackServer,
+  findWebhookEvent,
+  verifyWebhookSignature,
+} from "./webhook-test-utils";
+import { waitFor } from "./hooks-test-utils";
+
+describe("Hooks webhooks integration", () => {
+  let alice: TinyCloudNode;
+
+  beforeAll(async () => {
+    await checkServerHealth();
+    alice = createClient("hooks-webhooks", TEST_KEY);
+    await alice.signIn();
+    await cleanupPhase3Hooks(alice);
+  });
+
+  beforeEach(async () => {
+    await cleanupPhase3Hooks(alice);
+  });
+
+  afterAll(async () => {
+    await alice?.signOut?.();
+  });
+
+  test("registers, lists, and unregisters KV webhooks over the live server", async () => {
+    const server = await WebhookCallbackServer.start();
+    const callbackPath = `/hooks/crud-${cryptoRandomSuffix()}`;
+    const scope = {
+      space: alice.spaceId!,
+      service: "kv" as const,
+      pathPrefix: "phase3/crud/",
+      abilities: ["tinycloud.kv/put"],
+    };
+    const secret = randomBytes(32).toString("hex");
+
+    try {
+      const createdResult = await alice.hooks.register({
+        ...scope,
+        callbackUrl: `${server.url}${callbackPath}`,
+        secret,
+      });
+      expect(createdResult.ok).toBe(true);
+      if (!createdResult.ok) {
+        throw createdResult.error;
+      }
+
+      try {
+        expect(createdResult.data.id).toBeTruthy();
+        expect(createdResult.data.callbackUrl).toBe(
+          `${server.url}${callbackPath}`,
+        );
+        expect(createdResult.data.space).toBe(scope.space);
+        expect(createdResult.data.service).toBe(scope.service);
+
+        const listResult = await alice.hooks.list(scope);
+        expect(listResult.ok).toBe(true);
+        if (!listResult.ok) {
+          throw listResult.error;
+        }
+
+        expect(
+          listResult.data.some((hook) => hook.id === createdResult.data.id),
+        ).toBe(true);
+      } finally {
+        await unregisterWebhook(alice, createdResult.data.id, scope);
+      }
+
+      const listAfterDelete = await alice.hooks.list(scope);
+      expect(listAfterDelete.ok).toBe(true);
+      if (!listAfterDelete.ok) {
+        throw listAfterDelete.error;
+      }
+
+      expect(
+        listAfterDelete.data.some((hook) => hook.id === createdResult.data.id),
+      ).toBe(false);
+    } finally {
+      await server.close();
+    }
+  }, 30000);
+
+  test("delivers live KV webhook POSTs with a verifiable HMAC signature", async () => {
+    const server = await WebhookCallbackServer.start();
+    const callbackPath = `/hooks/delivery-${cryptoRandomSuffix()}`;
+    const secret = randomBytes(32).toString("hex");
+    const scope = {
+      space: alice.spaceId!,
+      service: "kv" as const,
+      pathPrefix: "phase3/delivery/",
+      abilities: ["tinycloud.kv/put"],
+    };
+
+    try {
+      const createdResult = await alice.hooks.register({
+        ...scope,
+        callbackUrl: `${server.url}${callbackPath}`,
+        secret,
+      });
+      expect(createdResult.ok).toBe(true);
+      if (!createdResult.ok) {
+        throw createdResult.error;
+      }
+
+      try {
+        const key = `phase3/delivery/${cryptoRandomSuffix()}`;
+        const value = `value-${cryptoRandomSuffix()}`;
+        await putKvValue(alice, key, value);
+
+        const requests = await waitForWebhookRequestsForPath(
+          server,
+          callbackPath,
+          1,
+          60000,
+        );
+        const request = requests[0];
+        expect(request.method).toBe("POST");
+        expect(request.path).toBe(callbackPath);
+
+        const event = findWebhookEvent(request.jsonBody);
+        expect(event).not.toBeNull();
+        if (!event) {
+          throw new Error("Webhook delivery did not include an event payload");
+        }
+
+        expect(event.space).toBe(scope.space);
+        expect(event.service).toBe(scope.service);
+        expect(event.ability).toBe("tinycloud.kv/put");
+        expect(event.path).toBe(key);
+        expect(typeof event.actor).toBe("string");
+        expect(verifyWebhookSignature(request, secret)).toBe(true);
+      } finally {
+        await unregisterWebhook(alice, createdResult.data.id, scope);
+      }
+    } finally {
+      await server.close();
+    }
+  }, 90000);
+
+  test("retries a failed webhook delivery before succeeding", async () => {
+    let requestCount = 0;
+    const callbackPath = `/hooks/retry-${cryptoRandomSuffix()}`;
+    const server = await WebhookCallbackServer.start(() => {
+      requestCount += 1;
+      return {
+        status: requestCount === 1 ? 500 : 200,
+        body: requestCount === 1 ? { error: "transient" } : { ok: true },
+      };
+    });
+    const secret = randomBytes(32).toString("hex");
+    const scope = {
+      space: alice.spaceId!,
+      service: "kv" as const,
+      pathPrefix: "phase3/retry/",
+      abilities: ["tinycloud.kv/put"],
+    };
+
+    try {
+      const createdResult = await alice.hooks.register({
+        ...scope,
+        callbackUrl: `${server.url}${callbackPath}`,
+        secret,
+      });
+      expect(createdResult.ok).toBe(true);
+      if (!createdResult.ok) {
+        throw createdResult.error;
+      }
+
+      try {
+        const key = `phase3/retry/${cryptoRandomSuffix()}`;
+        await putKvValue(alice, key, `retry-${cryptoRandomSuffix()}`);
+
+        const requests = await waitForWebhookRequestsForPath(
+          server,
+          callbackPath,
+          2,
+          120000,
+        );
+        const matching = requests.filter((request) => {
+          const event = findWebhookEvent(request.jsonBody);
+          return event?.path === key;
+        });
+
+        expect(matching.length).toBeGreaterThanOrEqual(2);
+        expect(matching[0].rawBody).toBe(matching[1].rawBody);
+        expect(verifyWebhookSignature(matching[0], secret)).toBe(true);
+        expect(verifyWebhookSignature(matching[1], secret)).toBe(true);
+      } finally {
+        await unregisterWebhook(alice, createdResult.data.id, scope);
+      }
+    } finally {
+      await server.close();
+    }
+  }, 150000);
+
+  test("stops retrying after repeated webhook failures", async () => {
+    const callbackPath = `/hooks/dead-letter-${cryptoRandomSuffix()}`;
+    const server = await WebhookCallbackServer.start(() => ({
+      status: 500,
+      body: { error: "permanent" },
+    }));
+    const secret = randomBytes(32).toString("hex");
+    const scope = {
+      space: alice.spaceId!,
+      service: "kv" as const,
+      pathPrefix: "phase3/dead-letter/",
+      abilities: ["tinycloud.kv/put"],
+    };
+
+    try {
+      const createdResult = await alice.hooks.register({
+        ...scope,
+        callbackUrl: `${server.url}${callbackPath}`,
+        secret,
+      });
+      expect(createdResult.ok).toBe(true);
+      if (!createdResult.ok) {
+        throw createdResult.error;
+      }
+
+      try {
+        await putKvValue(
+          alice,
+          `phase3/dead-letter/${cryptoRandomSuffix()}`,
+          `dead-${cryptoRandomSuffix()}`,
+        );
+
+        await waitForWebhookRequestsForPath(server, callbackPath, 2, 180000);
+        await server.waitForQuiet(2500, 120000);
+
+        const requests = server.requests.filter(
+          (request) => request.path === callbackPath,
+        );
+        expect(requests.length).toBeGreaterThanOrEqual(2);
+        expect(requests.length).toBeLessThanOrEqual(6);
+      } finally {
+        await unregisterWebhook(alice, createdResult.data.id, scope);
+      }
+    } finally {
+      await server.close();
+    }
+  }, 240000);
+});
+
+async function putKvValue(node: TinyCloudNode, key: string, value: string) {
+  const result = await node.kv.put(key, value);
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+function cryptoRandomSuffix(): string {
+  return randomBytes(6).toString("hex");
+}
+
+async function unregisterWebhook(
+  node: TinyCloudNode,
+  id: string,
+  target: HookWebhookScope,
+): Promise<void> {
+  const result = await node.hooks.unregister(id, { target });
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+async function waitForWebhookRequestsForPath(
+  server: WebhookCallbackServer,
+  path: string,
+  count: number,
+  timeoutMs: number,
+): Promise<CapturedWebhookRequest[]> {
+  await waitFor(
+    () =>
+      server.requests.filter((request) => request.path === path).length >=
+      count,
+    timeoutMs,
+  );
+  return server.requests.filter((request) => request.path === path);
+}
+
+async function cleanupPhase3Hooks(node: TinyCloudNode): Promise<void> {
+  if (!node.spaceId) {
+    return;
+  }
+
+  const listed = await node.hooks.list({
+    space: node.spaceId,
+    service: "kv",
+    pathPrefix: "phase3",
+  });
+  if (!listed.ok) {
+    throw listed.error;
+  }
+
+  for (const hook of listed.data) {
+    const deleted = await node.hooks.unregister(hook.id, {
+      target: {
+        space: hook.space,
+        service: hook.service,
+        pathPrefix: hook.pathPrefix,
+        abilities: hook.abilities,
+      },
+    });
+    if (!deleted.ok) {
+      throw deleted.error;
+    }
+  }
+}

--- a/tests/node-sdk/hooks/webhook-test-utils.ts
+++ b/tests/node-sdk/hooks/webhook-test-utils.ts
@@ -1,0 +1,276 @@
+import { createHmac, randomUUID } from "node:crypto";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface CapturedWebhookRequest {
+  id: string;
+  attempt: number;
+  method: string;
+  url: string;
+  path: string;
+  headers: Record<string, string>;
+  rawBody: string;
+  jsonBody: unknown;
+  receivedAt: number;
+}
+
+export interface WebhookResponse {
+  status: number;
+  headers?: Record<string, string>;
+  body?: unknown;
+  delayMs?: number;
+}
+
+export type WebhookResponsePlan = (
+  request: CapturedWebhookRequest,
+) => WebhookResponse | Promise<WebhookResponse>;
+
+export class WebhookCallbackServer {
+  private readonly requestsLog: CapturedWebhookRequest[] = [];
+  private readonly attemptsByPath = new Map<string, number>();
+  private readonly server = createServer((req, res) => {
+    void this.handleRequest(req, res);
+  });
+  private listeningPort = 0;
+  private lastRequestAt = 0;
+
+  private constructor(private readonly plan: WebhookResponsePlan) {}
+
+  static async start(plan: WebhookResponsePlan = () => ({ status: 200 })) {
+    const server = new WebhookCallbackServer(plan);
+    await server.listen();
+    return server;
+  }
+
+  get url(): string {
+    return `http://127.0.0.1:${this.listeningPort}`;
+  }
+
+  get requests(): CapturedWebhookRequest[] {
+    return [...this.requestsLog];
+  }
+
+  async close(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.server.close(() => resolve());
+    });
+  }
+
+  async waitForRequests(count: number, timeoutMs = 15000): Promise<void> {
+    await waitFor(
+      () => this.requestsLog.length >= count,
+      timeoutMs,
+      () =>
+        `Timed out waiting for ${count} webhook requests; received ${this.requestsLog.length}`,
+    );
+  }
+
+  async waitForQuiet(quiescenceMs: number, timeoutMs = 30000): Promise<void> {
+    await waitFor(
+      () =>
+        this.lastRequestAt !== 0 &&
+        Date.now() - this.lastRequestAt >= quiescenceMs,
+      timeoutMs,
+      () =>
+        `Timed out waiting for webhook quiet period of ${quiescenceMs}ms; received ${this.requestsLog.length} requests`,
+    );
+  }
+
+  private async listen(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.server.once("error", reject);
+      this.server.listen(0, "127.0.0.1", () => {
+        this.server.off("error", reject);
+        const address = this.server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("Webhook server did not expose an address"));
+          return;
+        }
+        this.listeningPort = (address as AddressInfo).port;
+        resolve();
+      });
+    });
+  }
+
+  private async handleRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<void> {
+    const bodyText = await readRequestBody(req);
+    const path = new URL(req.url ?? "/", this.url).pathname;
+    const attempt = (this.attemptsByPath.get(path) ?? 0) + 1;
+    this.attemptsByPath.set(path, attempt);
+
+    const request: CapturedWebhookRequest = {
+      id: randomUUID(),
+      attempt,
+      method: req.method ?? "GET",
+      url: new URL(req.url ?? "/", this.url).toString(),
+      path,
+      headers: normalizeHeaders(req.headers),
+      rawBody: bodyText,
+      jsonBody: parseJson(bodyText),
+      receivedAt: Date.now(),
+    };
+
+    this.requestsLog.push(request);
+    this.lastRequestAt = request.receivedAt;
+
+    const response = await this.plan(request);
+    if (response.delayMs && response.delayMs > 0) {
+      await sleep(response.delayMs);
+    }
+
+    res.statusCode = response.status;
+    for (const [name, value] of Object.entries(response.headers ?? {})) {
+      res.setHeader(name, value);
+    }
+    if (response.body === undefined || response.body === null) {
+      res.end();
+      return;
+    }
+
+    if (typeof response.body === "string") {
+      res.end(response.body);
+      return;
+    }
+
+    if (!res.getHeader("content-type")) {
+      res.setHeader("content-type", "application/json");
+    }
+    res.end(JSON.stringify(response.body));
+  }
+}
+
+export function verifyWebhookSignature(
+  request: CapturedWebhookRequest,
+  secret: string,
+): boolean {
+  const digest = createHmac("sha256", secret).update(request.rawBody).digest();
+  const expectedValues = new Set([
+    digest.toString("hex"),
+    digest.toString("base64"),
+    `sha256=${digest.toString("hex")}`,
+    `sha256=${digest.toString("base64")}`,
+    `v1=${digest.toString("hex")}`,
+    `v1=${digest.toString("base64")}`,
+  ]);
+
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (!/signature|digest/i.test(name)) {
+      continue;
+    }
+
+    const tokens = value
+      .split(/[,\s]/)
+      .map((token) => token.trim())
+      .filter(Boolean);
+    for (const token of tokens) {
+      if (expectedValues.has(token)) {
+        return true;
+      }
+      const [, tokenValue] = token.split("=", 2);
+      if (tokenValue && expectedValues.has(tokenValue)) {
+        return true;
+      }
+    }
+    if (expectedValues.has(value)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function findWebhookEvent(
+  payload: unknown,
+): Record<string, unknown> | null {
+  return searchForEvent(payload, 0);
+}
+
+function searchForEvent(
+  value: unknown,
+  depth: number,
+): Record<string, unknown> | null {
+  if (depth > 5 || !value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.space === "string" &&
+    typeof record.service === "string" &&
+    typeof record.ability === "string"
+  ) {
+    return record;
+  }
+
+  for (const child of Object.values(record)) {
+    const found = searchForEvent(child, depth + 1);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+}
+
+function normalizeHeaders(
+  headers: IncomingMessage["headers"],
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      normalized[name.toLowerCase()] = value;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      normalized[name.toLowerCase()] = value.join(", ");
+    }
+  }
+  return normalized;
+}
+
+function parseJson(bodyText: string): unknown {
+  if (!bodyText) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(bodyText);
+  } catch {
+    return undefined;
+  }
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+  timeoutMessage: () => string,
+): Promise<void> {
+  const started = Date.now();
+  while (true) {
+    if (predicate()) {
+      return;
+    }
+    if (Date.now() - started >= timeoutMs) {
+      throw new Error(timeoutMessage());
+    }
+    await sleep(50);
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/node-sdk/setup.ts
+++ b/tests/node-sdk/setup.ts
@@ -1,10 +1,11 @@
 import { TinyCloudNode } from "@tinycloud/node-sdk";
 import { Wallet } from "ethers";
 
-const SERVER_URL = process.env.TC_TEST_SERVER ?? "http://localhost:8000";
+const SERVER_URL = process.env.TC_TEST_SERVER ?? "http://localhost:9000";
 
 // Hardhat account #0 (well-known test key), env override
-const DEFAULT_KEY = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const DEFAULT_KEY =
+  "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const TEST_KEY = process.env.TC_TEST_PRIVATE_KEY ?? DEFAULT_KEY;
 
 export async function checkServerHealth(): Promise<void> {
@@ -16,9 +17,9 @@ export async function checkServerHealth(): Promise<void> {
   } catch (e) {
     throw new Error(
       `Cannot reach tinycloud-node at ${SERVER_URL}.\n` +
-      `Start the server: cd tinycloud-node && cargo run\n` +
-      `Or set TC_TEST_SERVER=https://node.tinycloud.xyz\n` +
-      `Error: ${e}`
+        `Start the server on port 9000: cd tinycloud-node && ROCKET_PORT=9000 cargo run\n` +
+        `Or set TC_TEST_SERVER=https://node.tinycloud.xyz\n` +
+        `Error: ${e}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add hooks service support for shared SSE subscriptions and webhook management in the SDK surface
- add real node-sdk coverage for phase 2 SQL/DuckDB SSE and phase 3/4 webhook delivery flows
- fix phase 4 DuckDB test ids to stay within DuckDB `INTEGER` range and apply final formatting cleanup

## Verification
- `bun run build` in `packages/node-sdk`
- `bun run build` in `packages/sdk-core`
- `bun run build` in `packages/sdk-services`
- `bunx prettier --check tests/node-sdk/hooks/hooks-webhooks.test.ts tests/node-sdk/hooks/webhook-test-utils.ts tests/node-sdk/hooks/hooks-test-utils.ts tests/node-sdk/setup.ts packages/sdk-core/src/TinyCloud.ts`
- `TC_TEST_SERVER=http://localhost:9000 bun test tests/node-sdk/hooks/hooks-sql-sse.test.ts`
- `TC_TEST_SERVER=http://localhost:9000 bun test tests/node-sdk/hooks/hooks-duckdb-sse.test.ts`
- `TC_TEST_SERVER=http://localhost:9000 bun test tests/node-sdk/hooks/hooks-coalescing.test.ts`
- `TC_TEST_SERVER=http://localhost:9000 bun test tests/node-sdk/hooks/hooks-webhooks.test.ts`

## Notes
- Final live webhook verification passed `7/7` against the real Phase 4 node branch on localhost:9000.