### PR TITLE
feat: add live replication sdk and e2e coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "cacaos"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=20d08e8d4affeb55e1654b638925bbf2ed21ab30#20d08e8d4affeb55e1654b638925bbf2ed21ab30"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=75f18680bb4486e29961de747a11b47679192e26#75f18680bb4486e29961de747a11b47679192e26"
 dependencies = [
  "async-trait",
  "hex",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=20d08e8d4affeb55e1654b638925bbf2ed21ab30#20d08e8d4affeb55e1654b638925bbf2ed21ab30"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=75f18680bb4486e29961de747a11b47679192e26#75f18680bb4486e29961de747a11b47679192e26"
 dependencies = [
  "hex",
  "http 1.4.0",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "siwe-recap"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=20d08e8d4affeb55e1654b638925bbf2ed21ab30#20d08e8d4affeb55e1654b638925bbf2ed21ab30"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=75f18680bb4486e29961de747a11b47679192e26#75f18680bb4486e29961de747a11b47679192e26"
 dependencies = [
  "base64 0.22.1",
  "ipld-core",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-auth"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=20d08e8d4affeb55e1654b638925bbf2ed21ab30#20d08e8d4affeb55e1654b638925bbf2ed21ab30"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=75f18680bb4486e29961de747a11b47679192e26#75f18680bb4486e29961de747a11b47679192e26"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4928,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-rs"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=20d08e8d4affeb55e1654b638925bbf2ed21ab30#20d08e8d4affeb55e1654b638925bbf2ed21ab30"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=75f18680bb4486e29961de747a11b47679192e26#75f18680bb4486e29961de747a11b47679192e26"
 dependencies = [
  "async-trait",
  "hex",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-wasm"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=20d08e8d4affeb55e1654b638925bbf2ed21ab30#20d08e8d4affeb55e1654b638925bbf2ed21ab30"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=75f18680bb4486e29961de747a11b47679192e26#75f18680bb4486e29961de747a11b47679192e26"
 dependencies = [
  "aes-gcm",
  "chrono",

--- a/packages/node-sdk/src/DelegatedAccess.ts
+++ b/packages/node-sdk/src/DelegatedAccess.ts
@@ -7,6 +7,7 @@ import {
   type KVServiceConfig,
   SQLService,
   ISQLService,
+  type SQLServiceConfig,
   DuckDbService,
   IDuckDbService,
   ServiceSession,
@@ -59,6 +60,7 @@ export class DelegatedAccess {
     host: string,
     invoke: InvokeFunction,
     kvConfig: KVServiceConfig = {},
+    sqlConfig: SQLServiceConfig = {},
   ) {
     this.session = session;
     this._delegation = delegation;
@@ -82,7 +84,7 @@ export class DelegatedAccess {
     this._serviceContext.registerService('kv', this._kv);
 
     // Create and initialize SQL service with same delegation context
-    this._sql = new SQLService({});
+    this._sql = new SQLService({ ...sqlConfig });
     this._sql.initialize(this._serviceContext);
     this._serviceContext.registerService('sql', this._sql);
 

--- a/packages/node-sdk/src/DelegatedAccess.ts
+++ b/packages/node-sdk/src/DelegatedAccess.ts
@@ -4,6 +4,7 @@ import {
   IKVService,
   HooksService,
   IHooksService,
+  type KVServiceConfig,
   SQLService,
   ISQLService,
   DuckDbService,
@@ -57,6 +58,7 @@ export class DelegatedAccess {
     delegation: PortableDelegation,
     host: string,
     invoke: InvokeFunction,
+    kvConfig: KVServiceConfig = {},
   ) {
     this.session = session;
     this._delegation = delegation;
@@ -72,7 +74,10 @@ export class DelegatedAccess {
     // Create and initialize KV service with path prefix from delegation
     // Strip trailing slash to avoid double-slash in paths
     const prefix = this._delegation.path.replace(/\/$/, '');
-    this._kv = new KVService({ prefix });
+    this._kv = new KVService({
+      ...kvConfig,
+      prefix,
+    });
     this._kv.initialize(this._serviceContext);
     this._serviceContext.registerService('kv', this._kv);
 

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -2234,14 +2234,78 @@ export class TinyCloudNode {
     return this.delegationManager.create(params);
   }
 
-  /**
-   * Revoke a delegation using the v2 DelegationManager.
-   *
-   * @param cid - The CID of the delegation to revoke
-   * @returns Result indicating success or failure
-   */
   async revokeDelegation(cid: string): Promise<DelegationResult<void>> {
-    return this.delegationManager.revoke(cid);
+    if (!this.signer) {
+      return {
+        ok: false,
+        error: {
+          code: "NOT_INITIALIZED",
+          message:
+            "Cannot revokeDelegation() in session-only mode. Requires wallet mode.",
+          service: "delegation",
+        },
+      };
+    }
+
+    const session = this.auth?.tinyCloudSession;
+    if (!session) {
+      return {
+        ok: false,
+        error: {
+          code: "NOT_INITIALIZED",
+          message: "Not signed in. Call signIn() first.",
+          service: "delegation",
+        },
+      };
+    }
+
+    try {
+      const issuedAt = new Date().toISOString();
+      const nonce = crypto.randomUUID().replace(/-/g, "");
+      const siwe = [
+        `${this.siweDomain} wants you to sign in with your Ethereum account:`,
+        this.wasmBindings.ensureEip55(session.address),
+        "",
+        "",
+        `URI: ucan:${cid}`,
+        "Version: 1",
+        `Chain ID: ${session.chainId}`,
+        `Nonce: ${nonce}`,
+        `Issued At: ${issuedAt}`,
+      ].join("\n");
+      const signature = await this.signer.signMessage(siwe);
+
+      const response = await globalThis.fetch(`${this.config.host!}/revoke`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ siwe, signature }),
+      });
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: {
+            code: "NETWORK_ERROR",
+            message: `Failed to revoke delegation: ${response.status} - ${await response.text()}`,
+            service: "delegation",
+          },
+        };
+      }
+
+      this._capabilityRegistry.revokeDelegation(cid);
+      return { ok: true, data: undefined };
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: "NETWORK_ERROR",
+          message: `Network error revoking delegation: ${String(error)}`,
+          service: "delegation",
+        },
+      };
+    }
   }
 
   /**

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -39,6 +39,7 @@ import {
   type KVServiceConfig,
   IKVService,
   SQLService,
+  type SQLServiceConfig,
   ISQLService,
   DuckDbService,
   IDuckDbService,
@@ -211,6 +212,8 @@ export interface TinyCloudNodeConfig {
   defaultActions?: NodeUserAuthorizationConfig["defaultActions"];
   /** Optional KV service config used for all KV services created by this node wrapper. */
   kvConfig?: KVServiceConfig;
+  /** Optional SQL service config used for all SQL services created by this node wrapper. */
+  sqlConfig?: SQLServiceConfig;
 }
 
 export interface TinyCloudKVReplicationScope {
@@ -395,6 +398,17 @@ export class TinyCloudNode {
   private createKVService(config: KVServiceConfig = {}): KVService {
     return new KVService({
       ...this.kvServiceConfig,
+      ...config,
+    });
+  }
+
+  private get sqlServiceConfig(): SQLServiceConfig {
+    return this.config.sqlConfig ?? {};
+  }
+
+  private createSQLService(config: SQLServiceConfig = {}): SQLService {
+    return new SQLService({
+      ...this.sqlServiceConfig,
       ...config,
     });
   }
@@ -588,8 +602,13 @@ export class TinyCloudNode {
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
       serviceConfigs: this.config.kvConfig
-        ? { kv: this.config.kvConfig }
-        : undefined,
+        ? {
+            kv: this.config.kvConfig,
+            ...(this.config.sqlConfig ? { sql: this.config.sqlConfig } : {}),
+          }
+        : this.config.sqlConfig
+          ? { sql: this.config.sqlConfig }
+          : undefined,
     });
   }
 
@@ -988,7 +1007,7 @@ export class TinyCloudNode {
     this._serviceContext.registerService('kv', this._kv);
 
     // Create and register SQL service
-    this._sql = new SQLService({});
+    this._sql = this.createSQLService();
     this._sql.initialize(this._serviceContext);
     this._serviceContext.registerService('sql', this._sql);
 
@@ -1126,8 +1145,13 @@ export class TinyCloudNode {
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
       serviceConfigs: this.config.kvConfig
-        ? { kv: this.config.kvConfig }
-        : undefined,
+        ? {
+            kv: this.config.kvConfig,
+            ...(this.config.sqlConfig ? { sql: this.config.sqlConfig } : {}),
+          }
+        : this.config.sqlConfig
+          ? { sql: this.config.sqlConfig }
+          : undefined,
     });
 
     // Update config with prefix
@@ -1181,8 +1205,13 @@ export class TinyCloudNode {
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
       serviceConfigs: this.config.kvConfig
-        ? { kv: this.config.kvConfig }
-        : undefined,
+        ? {
+            kv: this.config.kvConfig,
+            ...(this.config.sqlConfig ? { sql: this.config.sqlConfig } : {}),
+          }
+        : this.config.sqlConfig
+          ? { sql: this.config.sqlConfig }
+          : undefined,
     });
     this.config.prefix = prefix;
   }
@@ -1216,7 +1245,7 @@ export class TinyCloudNode {
     // Create and register SQL service (if supported)
     const features = this.nodeFeatures;
     if (features.length === 0 || features.includes("sql")) {
-      this._sql = new SQLService({});
+      this._sql = this.createSQLService();
       this._sql.initialize(this._serviceContext);
       this._serviceContext.registerService('sql', this._sql);
     }
@@ -3436,7 +3465,8 @@ export class TinyCloudNode {
         delegation,
         targetHost,
         this.wasmBindings.invoke,
-        this.kvServiceConfig
+        this.kvServiceConfig,
+        this.sqlServiceConfig
       );
     }
 
@@ -3528,7 +3558,8 @@ export class TinyCloudNode {
       delegation,
       targetHost,
       this.wasmBindings.invoke,
-      this.kvServiceConfig
+      this.kvServiceConfig,
+      this.sqlServiceConfig
     );
   }
 

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -201,12 +201,17 @@ export interface TinyCloudKVReplicationScope {
   prefix: string;
 }
 
+export interface TinyCloudAuthReplicationScope {
+  service: "auth";
+}
+
 export interface TinyCloudSqlReplicationScope {
   service: "sql";
   dbName: string;
 }
 
 export type TinyCloudReplicationScope =
+  | TinyCloudAuthReplicationScope
   | TinyCloudKVReplicationScope
   | TinyCloudSqlReplicationScope;
 
@@ -230,6 +235,10 @@ export interface TinyCloudReplicationSession {
 export type OpenReplicationSessionResult = TinyCloudReplicationSession;
 
 function buildReplicationScopeResource(scope: TinyCloudReplicationScope): string {
+  if (scope.service === "auth") {
+    return "auth";
+  }
+
   if (scope.service === "kv") {
     const normalizedPrefix = scope.prefix.replace(/^\/+/, "").replace(/\/+$/, "");
     return normalizedPrefix.length > 0 ? `kv/${normalizedPrefix}` : "kv";

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -107,6 +107,20 @@ import {
 import { FileSessionStorage } from "./storage/FileSessionStorage";
 import { MemorySessionStorage } from "./storage/MemorySessionStorage";
 import { PortableDelegation } from "./delegation";
+import {
+  notifyReplication as notifyReplicationTransport,
+  reconcileKvReplication as reconcileKvReplicationTransport,
+  reconcileSqlReplication as reconcileSqlReplicationTransport,
+} from "./replication";
+import type {
+  ReplicationNotifyRequest,
+  ReplicationNotifyResponse,
+  ReplicationKvReconcileRequest,
+  ReplicationKvReconcileResponse,
+  ReplicationSqlReconcileRequest,
+  ReplicationSqlReconcileResponse,
+  ReplicationPullSessions,
+} from "./replication";
 import { DelegatedAccess } from "./DelegatedAccess";
 import { WasmKeyProvider } from "./keys/WasmKeyProvider";
 import {
@@ -754,6 +768,35 @@ export class TinyCloudNode {
       verificationMethod: session.verificationMethod,
       expiresAt: expirationTime,
     };
+  }
+
+  async notifyReplication(
+    session: TinyCloudReplicationSession,
+    request: ReplicationNotifyRequest
+  ): Promise<ReplicationNotifyResponse> {
+    return notifyReplicationTransport(session, request);
+  }
+
+  async reconcileKvFromPeer(
+    sessions: ReplicationPullSessions,
+    request: ReplicationKvReconcileRequest
+  ): Promise<ReplicationKvReconcileResponse> {
+    return reconcileKvReplicationTransport(
+      sessions.target,
+      sessions.peer,
+      request
+    );
+  }
+
+  async reconcileSqlFromPeer(
+    sessions: ReplicationPullSessions,
+    request: ReplicationSqlReconcileRequest
+  ): Promise<ReplicationSqlReconcileResponse> {
+    return reconcileSqlReplicationTransport(
+      sessions.target,
+      sessions.peer,
+      request
+    );
   }
 
   /**

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -220,6 +220,7 @@ export interface TinyCloudReplicationSession {
   host: string;
   scope: TinyCloudReplicationScope;
   delegationHeader: { Authorization: string };
+  supportingDelegations: string[];
   delegationCid: string;
   spaceId: string;
   verificationMethod: string;
@@ -717,21 +718,11 @@ export class TinyCloudNode {
       signature,
     });
 
-    const activateResult = await activateSessionWithHost(
-      host,
-      scopedSession.delegationHeader
-    );
-
-    if (!activateResult.success) {
-      throw new Error(
-        `Failed to activate replication sync delegation: ${activateResult.error}`
-      );
-    }
-
     return {
       host,
       scope,
       delegationHeader: scopedSession.delegationHeader,
+      supportingDelegations: [session.delegationHeader.Authorization],
       delegationCid: scopedSession.delegationCid,
       spaceId,
       verificationMethod: session.verificationMethod,

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -99,7 +99,10 @@ import {
   SERVICE_LONG_TO_SHORT,
   EXPIRY,
 } from "@tinycloud/sdk-core";
-import { NodeUserAuthorization } from "./authorization/NodeUserAuthorization";
+import {
+  NodeUserAuthorization,
+  type NodeUserAuthorizationConfig,
+} from "./authorization/NodeUserAuthorization";
 import { FileSessionStorage } from "./storage/FileSessionStorage";
 import { MemorySessionStorage } from "./storage/MemorySessionStorage";
 import { PortableDelegation } from "./delegation";
@@ -114,6 +117,8 @@ import { NodeSecretsService } from "./NodeSecretsService";
 
 /** Default TinyCloud host */
 const DEFAULT_HOST = "https://node.tinycloud.xyz";
+
+type AbilityMap = NonNullable<NodeUserAuthorizationConfig["defaultActions"]>;
 
 /**
  * Default lifetime of a SIWE session when {@link TinyCloudNodeConfig.sessionExpirationMs}
@@ -187,6 +192,50 @@ export interface TinyCloudNodeConfig {
   capabilityRequest?: ComposedManifestRequest;
   /** Include implicit account registry permissions when composing `manifest`. Default true. */
   includeAccountRegistryPermissions?: boolean;
+  /** Optional default actions to grant on sign-in sessions. */
+  defaultActions?: NodeUserAuthorizationConfig["defaultActions"];
+}
+
+export interface TinyCloudKVReplicationScope {
+  service: "kv";
+  prefix: string;
+}
+
+export interface TinyCloudSqlReplicationScope {
+  service: "sql";
+  dbName: string;
+}
+
+export type TinyCloudReplicationScope =
+  | TinyCloudKVReplicationScope
+  | TinyCloudSqlReplicationScope;
+
+export interface OpenReplicationSessionParams {
+  host?: string;
+  scope: TinyCloudReplicationScope;
+  spaceIdOverride?: string;
+}
+
+export interface TinyCloudReplicationSession {
+  host: string;
+  scope: TinyCloudReplicationScope;
+  delegationHeader: { Authorization: string };
+  delegationCid: string;
+  spaceId: string;
+  verificationMethod: string;
+  expiresAt: Date;
+}
+
+export type OpenReplicationSessionResult = TinyCloudReplicationSession;
+
+function buildReplicationScopeResource(scope: TinyCloudReplicationScope): string {
+  if (scope.service === "kv") {
+    const normalizedPrefix = scope.prefix.replace(/^\/+/, "").replace(/\/+$/, "");
+    return normalizedPrefix.length > 0 ? `kv/${normalizedPrefix}` : "kv";
+  }
+
+  const normalizedDbName = scope.dbName.replace(/^\/+/, "").replace(/\/+$/, "");
+  return `sql/${normalizedDbName}`;
 }
 
 /**
@@ -487,6 +536,7 @@ export class TinyCloudNode {
       tinycloudHosts: this.explicitHost ? [this.explicitHost] : undefined,
       tinycloudRegistryUrl: config.tinycloudRegistryUrl,
       tinycloudFallbackHosts: config.tinycloudFallbackHosts,
+      defaultActions: config.defaultActions,
       autoCreateSpace: config.autoCreateSpace,
       enablePublicSpace: config.enablePublicSpace ?? true,
       spaceCreationHandler: config.spaceCreationHandler,
@@ -614,6 +664,79 @@ export class TinyCloudNode {
    */
   get session(): TinyCloudSession | undefined {
     return this.auth?.tinyCloudSession;
+  }
+
+  async openReplicationSession(
+    params: OpenReplicationSessionParams
+  ): Promise<TinyCloudReplicationSession> {
+    if (!this.signer) {
+      throw new Error(
+        "Cannot openReplicationSession() in session-only mode. Requires wallet mode."
+      );
+    }
+
+    const session = this.session;
+    if (!session) {
+      throw new Error("Not signed in. Call signIn() first.");
+    }
+
+    const host = (params.host ?? this.config.host)?.replace(/\/$/, "");
+    if (!host) {
+      throw new Error("Replication session host is required.");
+    }
+
+    const scope = params.scope;
+    const spaceId = params.spaceIdOverride ?? session.spaceId;
+    const resource = buildReplicationScopeResource(scope);
+    const abilities: AbilityMap = {
+      space: {
+        [resource]: ["tinycloud.space/sync"],
+      },
+    };
+
+    const now = new Date();
+    const expirationTime = new Date(
+      now.getTime() + (this.config.sessionExpirationMs ?? 60 * 60 * 1000)
+    );
+
+    const prepared = this.wasmBindings.prepareSession({
+      abilities,
+      address: this.wasmBindings.ensureEip55(session.address),
+      chainId: session.chainId,
+      domain: this.siweDomain,
+      issuedAt: now.toISOString(),
+      expirationTime: expirationTime.toISOString(),
+      spaceId,
+      jwk: session.jwk,
+      parents: [session.delegationCid],
+    });
+
+    const signature = await this.signer.signMessage(prepared.siwe);
+    const scopedSession = this.wasmBindings.completeSessionSetup({
+      ...prepared,
+      signature,
+    });
+
+    const activateResult = await activateSessionWithHost(
+      host,
+      scopedSession.delegationHeader
+    );
+
+    if (!activateResult.success) {
+      throw new Error(
+        `Failed to activate replication sync delegation: ${activateResult.error}`
+      );
+    }
+
+    return {
+      host,
+      scope,
+      delegationHeader: scopedSession.delegationHeader,
+      delegationCid: scopedSession.delegationCid,
+      spaceId,
+      verificationMethod: session.verificationMethod,
+      expiresAt: expirationTime,
+    };
   }
 
   /**
@@ -936,6 +1059,7 @@ export class TinyCloudNode {
       manifest: this.config.manifest,
       capabilityRequest: this.config.capabilityRequest,
       includeAccountRegistryPermissions: this.config.includeAccountRegistryPermissions,
+      defaultActions: this.config.defaultActions,
     });
 
     // Create TinyCloud instance
@@ -988,6 +1112,7 @@ export class TinyCloudNode {
       manifest: this.config.manifest,
       capabilityRequest: this.config.capabilityRequest,
       includeAccountRegistryPermissions: this.config.includeAccountRegistryPermissions,
+      defaultActions: this.config.defaultActions,
     });
 
     this.tc = new TinyCloud(this.auth, {

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -36,6 +36,7 @@ import {
   TinyCloudSession,
   activateSessionWithHost,
   KVService,
+  type KVServiceConfig,
   IKVService,
   SQLService,
   ISQLService,
@@ -194,6 +195,8 @@ export interface TinyCloudNodeConfig {
   includeAccountRegistryPermissions?: boolean;
   /** Optional default actions to grant on sign-in sessions. */
   defaultActions?: NodeUserAuthorizationConfig["defaultActions"];
+  /** Optional KV service config used for all KV services created by this node wrapper. */
+  kvConfig?: KVServiceConfig;
 }
 
 export interface TinyCloudKVReplicationScope {
@@ -371,6 +374,17 @@ export class TinyCloudNode {
     return this.auth?.nodeFeatures ?? [];
   }
 
+  private get kvServiceConfig(): KVServiceConfig {
+    return this.config.kvConfig ?? {};
+  }
+
+  private createKVService(config: KVServiceConfig = {}): KVService {
+    return new KVService({
+      ...this.kvServiceConfig,
+      ...config,
+    });
+  }
+
   /** SIWE domain — uses config override or defaults to app.tinycloud.xyz */
   private get siweDomain(): string {
     return this.config.domain ?? 'app.tinycloud.xyz';
@@ -501,7 +515,7 @@ export class TinyCloudNode {
         // Use pathPrefix as the KV service prefix for sharing links
         // Strip trailing slash to match DelegatedAccess behavior
         const prefix = config.pathPrefix?.replace(/\/$/, '');
-        const kvService = new KVService({ prefix });
+        const kvService = this.createKVService({ prefix });
         // Create a new service context for the KV service
         const kvContext = new ServiceContext({
           invoke: config.invoke,
@@ -559,6 +573,9 @@ export class TinyCloudNode {
 
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
+      serviceConfigs: this.config.kvConfig
+        ? { kv: this.config.kvConfig }
+        : undefined,
     });
   }
 
@@ -923,7 +940,7 @@ export class TinyCloudNode {
     });
 
     // Create and register KV service
-    this._kv = new KVService({});
+    this._kv = this.createKVService();
     this._kv.initialize(this._serviceContext);
     this._serviceContext.registerService('kv', this._kv);
 
@@ -1065,6 +1082,9 @@ export class TinyCloudNode {
     // Create TinyCloud instance
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
+      serviceConfigs: this.config.kvConfig
+        ? { kv: this.config.kvConfig }
+        : undefined,
     });
 
     // Update config with prefix
@@ -1117,6 +1137,9 @@ export class TinyCloudNode {
 
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
+      serviceConfigs: this.config.kvConfig
+        ? { kv: this.config.kvConfig }
+        : undefined,
     });
     this.config.prefix = prefix;
   }
@@ -1143,7 +1166,7 @@ export class TinyCloudNode {
     });
 
     // Create and register KV service
-    this._kv = new KVService({});
+    this._kv = this.createKVService();
     this._kv.initialize(this._serviceContext);
     this._serviceContext.registerService('kv', this._kv);
 
@@ -1187,7 +1210,7 @@ export class TinyCloudNode {
   }
 
   private createSpaceScopedKVService(spaceId: string): KVService {
-    const kvService = new KVService({});
+    const kvService = this.createKVService();
     if (this._serviceContext) {
       const spaceScopedContext = new ServiceContext({
         invoke: this._serviceContext.invoke,
@@ -2180,7 +2203,7 @@ export class TinyCloudNode {
 
     // Cache a properly authorized public KV service using the new delegation
     if (this._serviceContext) {
-      const publicKV = new KVService({ prefix: "" });
+      const publicKV = this.createKVService({ prefix: "" });
       const publicContext = new ServiceContext({
         invoke: this.invokeWithRuntimePermissions,
         fetch: this._serviceContext.fetch,
@@ -3365,7 +3388,13 @@ export class TinyCloudNode {
       // Track received delegation in registry
       this.trackReceivedDelegation(delegation, this.sessionKeyJwk as unknown as JWK);
 
-      return new DelegatedAccess(session, delegation, targetHost, this.wasmBindings.invoke);
+      return new DelegatedAccess(
+        session,
+        delegation,
+        targetHost,
+        this.wasmBindings.invoke,
+        this.kvServiceConfig
+      );
     }
 
     // Wallet mode: create a SIWE sub-delegation
@@ -3451,7 +3480,13 @@ export class TinyCloudNode {
     // Track received delegation in registry
     this.trackReceivedDelegation(delegation, jwk as unknown as JWK);
 
-    return new DelegatedAccess(session, delegation, targetHost, this.wasmBindings.invoke);
+    return new DelegatedAccess(
+      session,
+      delegation,
+      targetHost,
+      this.wasmBindings.invoke,
+      this.kvServiceConfig
+    );
   }
 
   /**

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -35,6 +35,74 @@ import {
 } from "./strategies";
 import { MemorySessionStorage } from "../storage/MemorySessionStorage";
 
+type AbilityMap = Record<string, Record<string, string[]>>;
+
+const DEFAULT_SESSION_ACTIONS: AbilityMap = {
+  kv: {
+    "": [
+      "tinycloud.kv/put",
+      "tinycloud.kv/get",
+      "tinycloud.kv/del",
+      "tinycloud.kv/list",
+      "tinycloud.kv/metadata",
+    ],
+  },
+  sql: {
+    "": [
+      "tinycloud.sql/read",
+      "tinycloud.sql/write",
+      "tinycloud.sql/admin",
+      "tinycloud.sql/export",
+    ],
+  },
+  duckdb: {
+    "": [
+      "tinycloud.duckdb/read",
+      "tinycloud.duckdb/write",
+      "tinycloud.duckdb/admin",
+      "tinycloud.duckdb/describe",
+      "tinycloud.duckdb/export",
+      "tinycloud.duckdb/import",
+      "tinycloud.duckdb/execute",
+    ],
+  },
+  capabilities: {
+    "": ["tinycloud.capabilities/read"],
+  },
+  hooks: {
+    "": [
+      "tinycloud.hooks/subscribe",
+      "tinycloud.hooks/register",
+      "tinycloud.hooks/list",
+      "tinycloud.hooks/unregister",
+    ],
+  },
+};
+
+function mergeAbilityMaps(base: AbilityMap, extra?: AbilityMap): AbilityMap {
+  const merged: AbilityMap = {};
+
+  for (const [service, paths] of Object.entries(base)) {
+    merged[service] = Object.fromEntries(
+      Object.entries(paths).map(([path, actions]) => [path, [...actions]])
+    );
+  }
+
+  if (!extra) {
+    return merged;
+  }
+
+  for (const [service, paths] of Object.entries(extra)) {
+    const mergedPaths = (merged[service] ??= {});
+    for (const [path, actions] of Object.entries(paths)) {
+      const existingActions = mergedPaths[path] ?? [];
+      mergedPaths[path] = Array.from(new Set([...existingActions, ...actions]));
+    }
+  }
+
+  return merged;
+}
+
 /**
  * Configuration for NodeUserAuthorization.
  */
@@ -143,7 +211,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
   private readonly uri: string;
   private readonly statement?: string;
   private readonly spacePrefix: string;
-  private readonly defaultActions: Record<string, Record<string, string[]>>;
+  private readonly defaultActions: AbilityMap;
   private readonly sessionExpirationMs: number;
   private readonly autoCreateSpace: boolean;
   private readonly spaceCreationHandler?: ISpaceCreationHandler;
@@ -181,47 +249,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this.uri = config.uri ?? `https://${config.domain}`;
     this.statement = config.statement;
     this.spacePrefix = config.spacePrefix ?? "default";
-    this.defaultActions = config.defaultActions ?? {
-      kv: {
-        "": [
-          "tinycloud.kv/put",
-          "tinycloud.kv/get",
-          "tinycloud.kv/del",
-          "tinycloud.kv/list",
-          "tinycloud.kv/metadata",
-        ],
-      },
-      sql: {
-        "": [
-          "tinycloud.sql/read",
-          "tinycloud.sql/write",
-          "tinycloud.sql/admin",
-          "tinycloud.sql/export",
-        ],
-      },
-      duckdb: {
-        "": [
-          "tinycloud.duckdb/read",
-          "tinycloud.duckdb/write",
-          "tinycloud.duckdb/admin",
-          "tinycloud.duckdb/describe",
-          "tinycloud.duckdb/export",
-          "tinycloud.duckdb/import",
-          "tinycloud.duckdb/execute",
-        ],
-      },
-      capabilities: {
-        "": ["tinycloud.capabilities/read"],
-      },
-      hooks: {
-        "": [
-          "tinycloud.hooks/subscribe",
-          "tinycloud.hooks/register",
-          "tinycloud.hooks/list",
-          "tinycloud.hooks/unregister",
-        ],
-      },
-    };
+    this.defaultActions = mergeAbilityMaps(
+      DEFAULT_SESSION_ACTIONS,
+      config.defaultActions
+    );
     this.sessionExpirationMs = config.sessionExpirationMs ?? EXPIRY.SESSION_MS;
     this.autoCreateSpace = config.autoCreateSpace ?? false;
     this.spaceCreationHandler = config.spaceCreationHandler;

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -76,6 +76,7 @@ export {
   type RuntimePermissionGrantOptions,
 } from "./TinyCloudNode";
 export type {
+  TinyCloudAuthReplicationScope,
   TinyCloudKVReplicationScope,
   TinyCloudSqlReplicationScope,
   TinyCloudReplicationScope,
@@ -83,7 +84,6 @@ export type {
   OpenReplicationSessionParams,
   OpenReplicationSessionResult,
 } from "./TinyCloudNode";
-
 // Capability-chain primitives (spec: .claude/specs/capability-chain.md).
 // Re-exported here so TinyCloudWeb and other consumers can pass
 // `PermissionEntry[]` to `delegateTo` and catch the error classes without
@@ -119,6 +119,26 @@ export {
   parseExpiry,
   resourceCapabilitiesToSpaceAbilitiesMap,
 } from "@tinycloud/sdk-core";
+
+// Replication helpers
+export {
+  openTransportSession,
+  requestTransportSession,
+  notifyReplication,
+  reconcileKvReplication,
+  reconcileSqlReplication,
+} from "./replication";
+export type {
+  RequestTransportSessionOptions,
+  ReplicationNotifyRequest,
+  ReplicationNotifyResponse,
+  ReplicationPullSessions,
+  ReplicationKvReconcileRequest,
+  ReplicationKvReconcileResponse,
+  ReplicationSqlReconcileRequest,
+  ReplicationSqlReconcileResponse,
+  ReplicationSessionOpenResponse,
+} from "./replication";
 
 // Delegation
 export { DelegatedAccess } from "./DelegatedAccess";

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -75,6 +75,14 @@ export {
   type DelegateToResult,
   type RuntimePermissionGrantOptions,
 } from "./TinyCloudNode";
+export type {
+  TinyCloudKVReplicationScope,
+  TinyCloudSqlReplicationScope,
+  TinyCloudReplicationScope,
+  TinyCloudReplicationSession,
+  OpenReplicationSessionParams,
+  OpenReplicationSessionResult,
+} from "./TinyCloudNode";
 
 // Capability-chain primitives (spec: .claude/specs/capability-chain.md).
 // Re-exported here so TinyCloudWeb and other consumers can pass

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -168,6 +168,7 @@ export type {
   ISQLService,
   IDatabaseHandle,
   SQLServiceConfig,
+  SQLReadMode,
   SqlValue,
   SqlStatement,
   QueryOptions,

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -135,6 +135,7 @@ export { KVService, PrefixedKVService } from "@tinycloud/sdk-core";
 export type {
   IKVService,
   KVServiceConfig,
+  KVReadMode,
   KVResponse,
   IPrefixedKVService,
 } from "@tinycloud/sdk-core";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -103,6 +103,7 @@ export {
   type RuntimePermissionGrantOptions,
 } from "./TinyCloudNode";
 export type {
+  TinyCloudAuthReplicationScope,
   TinyCloudKVReplicationScope,
   TinyCloudSqlReplicationScope,
   TinyCloudReplicationScope,
@@ -110,7 +111,6 @@ export type {
   OpenReplicationSessionParams,
   OpenReplicationSessionResult,
 } from "./TinyCloudNode";
-
 // Capability-chain primitives (spec: .claude/specs/capability-chain.md).
 export {
   type PermissionEntry,
@@ -143,6 +143,26 @@ export {
   parseExpiry,
   resourceCapabilitiesToSpaceAbilitiesMap,
 } from "@tinycloud/sdk-core";
+
+// Replication helpers
+export {
+  openTransportSession,
+  requestTransportSession,
+  notifyReplication,
+  reconcileKvReplication,
+  reconcileSqlReplication,
+} from "./replication";
+export type {
+  RequestTransportSessionOptions,
+  ReplicationNotifyRequest,
+  ReplicationNotifyResponse,
+  ReplicationPullSessions,
+  ReplicationKvReconcileRequest,
+  ReplicationKvReconcileResponse,
+  ReplicationSqlReconcileRequest,
+  ReplicationSqlReconcileResponse,
+  ReplicationSessionOpenResponse,
+} from "./replication";
 
 // WASM bindings
 export { NodeWasmBindings } from "./NodeWasmBindings";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -102,6 +102,14 @@ export {
   type DelegateToResult,
   type RuntimePermissionGrantOptions,
 } from "./TinyCloudNode";
+export type {
+  TinyCloudKVReplicationScope,
+  TinyCloudSqlReplicationScope,
+  TinyCloudReplicationScope,
+  TinyCloudReplicationSession,
+  OpenReplicationSessionParams,
+  OpenReplicationSessionResult,
+} from "./TinyCloudNode";
 
 // Capability-chain primitives (spec: .claude/specs/capability-chain.md).
 export {

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -196,6 +196,7 @@ export type {
   ISQLService,
   IDatabaseHandle,
   SQLServiceConfig,
+  SQLReadMode,
   SqlValue,
   SqlStatement,
   QueryOptions,

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -163,6 +163,7 @@ export { KVService, PrefixedKVService } from "@tinycloud/sdk-core";
 export type {
   IKVService,
   KVServiceConfig,
+  KVReadMode,
   KVResponse,
   IPrefixedKVService,
 } from "@tinycloud/sdk-core";

--- a/packages/node-sdk/src/replication.ts
+++ b/packages/node-sdk/src/replication.ts
@@ -1,0 +1,258 @@
+import type { TinyCloudReplicationSession } from "./TinyCloudNode";
+
+export interface ReplicationNotifyRequest {
+  spaceId: string;
+  service: "kv" | "sql";
+  prefix?: string;
+  dbName?: string;
+  lastSeenSeq?: number;
+  timeoutMs?: number;
+}
+
+export interface ReplicationNotifyResponse {
+  spaceId: string;
+  service: "kv" | "sql";
+  prefix?: string;
+  dbName?: string;
+  lastSeenSeq?: number;
+  latestSeq: number;
+  dirty: boolean;
+  timedOut: boolean;
+}
+
+export interface ReplicationPullSessions {
+  target: TinyCloudReplicationSession;
+  peer: TinyCloudReplicationSession;
+}
+
+export interface ReplicationKvReconcileRequest {
+  peerUrl: string;
+  spaceId: string;
+  prefix?: string;
+  sinceSeq?: number;
+  limit?: number;
+}
+
+export interface ReplicationKvReconcileResponse {
+  spaceId: string;
+  requestedSinceSeq?: number;
+  peerUrl?: string;
+  appliedSequences: number;
+  appliedEvents: number;
+  appliedUntilSeq?: number;
+}
+
+export interface ReplicationSqlReconcileRequest {
+  peerUrl: string;
+  spaceId: string;
+  dbName: string;
+  sinceSeq?: number;
+}
+
+export interface ReplicationSqlReconcileResponse {
+  spaceId: string;
+  dbName: string;
+  peerUrl?: string;
+  mode?: "snapshot" | "changeset";
+  snapshotReason?: string | null;
+  changesetBytes?: number;
+  snapshotBytes?: number;
+  appliedUntilSeq?: number;
+}
+
+export interface ReplicationSessionOpenResponse {
+  sessionToken: string;
+  spaceId: string;
+  service: string;
+  serverDid: string;
+  rolesEnabled: string[];
+  peerServing: boolean;
+  canExport: boolean;
+  recon: boolean;
+  authSync: boolean;
+  prefix?: string;
+  dbName?: string;
+  expiresAt: string;
+}
+
+export interface RequestTransportSessionOptions {
+  supportingDelegations?: string[] | null;
+}
+
+function normalizeHeaders(
+  headers: Record<string, string> | [string, string][]
+): Record<string, string> {
+  return Array.isArray(headers) ? Object.fromEntries(headers) : { ...headers };
+}
+
+const transportSessionCache = new WeakMap<
+  TinyCloudReplicationSession,
+  ReplicationSessionOpenResponse
+>();
+
+function transportSessionIsFresh(
+  session: ReplicationSessionOpenResponse | undefined
+): session is ReplicationSessionOpenResponse {
+  if (!session) {
+    return false;
+  }
+
+  return new Date(session.expiresAt).getTime() > Date.now() + 1_000;
+}
+
+export async function requestTransportSession(
+  session: TinyCloudReplicationSession | undefined,
+  options: RequestTransportSessionOptions = {}
+): Promise<Response | undefined> {
+  if (!session) {
+    return undefined;
+  }
+
+  const body =
+    session.scope.service === "auth"
+      ? {
+          spaceId: session.spaceId,
+          service: "auth",
+          prefix: null,
+          dbName: null,
+        }
+      : session.scope.service === "kv"
+        ? {
+            spaceId: session.spaceId,
+            service: "kv",
+            prefix: session.scope.prefix,
+          }
+        : {
+            spaceId: session.spaceId,
+            service: "sql",
+            dbName: session.scope.dbName,
+          };
+
+  const supportingDelegations =
+    options.supportingDelegations === undefined
+      ? session.supportingDelegations
+      : options.supportingDelegations;
+  const requestBody =
+    supportingDelegations === null
+      ? body
+      : {
+          ...body,
+          supportingDelegations,
+        };
+
+  return fetch(`${session.host}/replication/session/open`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...normalizeHeaders(session.delegationHeader),
+    },
+    body: JSON.stringify(requestBody),
+  });
+}
+
+export async function openTransportSession(
+  session: TinyCloudReplicationSession | undefined
+): Promise<ReplicationSessionOpenResponse | undefined> {
+  if (!session) {
+    return undefined;
+  }
+
+  const cached = transportSessionCache.get(session);
+  if (transportSessionIsFresh(cached)) {
+    return cached;
+  }
+
+  const response = await requestTransportSession(session);
+  if (!response?.ok) {
+    throw new Error(
+      `Replication session open failed on ${session.host}: ${response?.status} ${await response?.text()}`
+    );
+  }
+
+  const opened = (await response.json()) as ReplicationSessionOpenResponse;
+  transportSessionCache.set(session, opened);
+  return opened;
+}
+
+async function buildSessionHeaders(
+  headerName: string,
+  session: TinyCloudReplicationSession | undefined
+): Promise<Record<string, string>> {
+  const opened = await openTransportSession(session);
+  return opened ? { [headerName]: opened.sessionToken } : {};
+}
+
+export async function notifyReplication(
+  session: TinyCloudReplicationSession,
+  request: ReplicationNotifyRequest
+): Promise<ReplicationNotifyResponse> {
+  const headers = await buildSessionHeaders("Replication-Session", session);
+  const response = await fetch(`${session.host}/replication/notify/poll`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Replication notify failed on ${session.host}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as ReplicationNotifyResponse;
+}
+
+export async function reconcileKvReplication(
+  target: TinyCloudReplicationSession,
+  peer: TinyCloudReplicationSession,
+  request: ReplicationKvReconcileRequest
+): Promise<ReplicationKvReconcileResponse> {
+  const targetHeaders = await buildSessionHeaders("Replication-Session", target);
+  const peerHeaders = await buildSessionHeaders("Peer-Replication-Session", peer);
+  const response = await fetch(`${target.host}/replication/reconcile`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...targetHeaders,
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `KV replication reconcile failed on ${target.host}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as ReplicationKvReconcileResponse;
+}
+
+export async function reconcileSqlReplication(
+  target: TinyCloudReplicationSession,
+  peer: TinyCloudReplicationSession,
+  request: ReplicationSqlReconcileRequest
+): Promise<ReplicationSqlReconcileResponse> {
+  const targetHeaders = await buildSessionHeaders("Replication-Session", target);
+  const peerHeaders = await buildSessionHeaders("Peer-Replication-Session", peer);
+  const response = await fetch(`${target.host}/replication/sql/reconcile`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...targetHeaders,
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `SQL replication reconcile failed on ${target.host}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as ReplicationSqlReconcileResponse;
+}

--- a/packages/node-sdk/src/signers/PrivateKeySigner.ts
+++ b/packages/node-sdk/src/signers/PrivateKeySigner.ts
@@ -59,18 +59,8 @@ export class PrivateKeySigner implements ISigner {
    */
   private deriveAddress(): string {
     try {
-      // Derive public key from private key using secp256k1
-      const { keccak256 } = require("ethers/lib/utils");
-      const { SigningKey } = require("ethers/lib/utils");
-
-      const signingKey = new SigningKey("0x" + this.privateKeyHex);
-      const publicKey = signingKey.publicKey;
-      // Remove '0x04' prefix (uncompressed point indicator)
-      const pubKeyWithoutPrefix = publicKey.slice(4);
-      const hash = keccak256("0x" + pubKeyWithoutPrefix);
-      // Take last 20 bytes
-      const address = "0x" + hash.slice(-40);
-      return ensureEip55(address);
+      const { Wallet } = require("ethers");
+      return ensureEip55(new Wallet("0x" + this.privateKeyHex).address);
     } catch {
       // Fallback: use dummy address for testing
       return "0x" + this.privateKeyHex.slice(0, 40);
@@ -94,7 +84,7 @@ export class PrivateKeySigner implements ISigner {
     const messageStr =
       typeof message === "string"
         ? message
-        : Buffer.from(message as ArrayLike<number>).toString("utf-8");
+        : Buffer.from(Uint8Array.from(message)).toString("utf-8");
 
     // Use WASM to sign with Ethereum personal_sign format
     // WASM now accepts hex-encoded private key directly

--- a/packages/sdk-core/src/TinyCloud.ts
+++ b/packages/sdk-core/src/TinyCloud.ts
@@ -653,7 +653,10 @@ export class TinyCloud {
     }
 
     // Create a KV service with a context that targets the public space
-    const publicKV = new KVService({ prefix: "" });
+    const publicKV = new KVService({
+      ...(this.config.serviceConfigs?.kv ?? {}),
+      prefix: "",
+    });
     const publicContext = new ServiceContext({
       invoke: this._serviceContext.invoke,
       fetch: this._serviceContext.fetch,

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -111,6 +111,7 @@ export {
   type ISQLService,
   type IDatabaseHandle,
   type SQLServiceConfig,
+  type SQLReadMode,
   type SqlValue,
   type SqlStatement,
   type QueryOptions,

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -77,6 +77,7 @@ export {
   type IKVService,
   type IPrefixedKVService,
   type KVServiceConfig,
+  type KVReadMode,
   type KVGetOptions,
   type KVPutOptions,
   type KVListOptions,

--- a/packages/sdk-core/src/version.ts
+++ b/packages/sdk-core/src/version.ts
@@ -58,6 +58,7 @@ export interface NodeServicesInfo {
 export interface NodeReplicationInfo {
   supported: boolean;
   enabled: boolean;
+  peerServing: boolean;
   recon: boolean;
   authSync: boolean;
   authoredFactExchange: boolean;

--- a/packages/sdk-core/src/version.ts
+++ b/packages/sdk-core/src/version.ts
@@ -47,9 +47,31 @@ export class UnsupportedFeatureError extends Error {
   }
 }
 
+export interface NodeServicesInfo {
+  kv: boolean;
+  delegation: boolean;
+  sharing: boolean;
+  sql: boolean;
+  duckdb: boolean;
+}
+
+export interface NodeReplicationInfo {
+  supported: boolean;
+  enabled: boolean;
+  recon: boolean;
+  authSync: boolean;
+  authoredFactExchange: boolean;
+  notifications: boolean;
+  snapshots: boolean;
+}
+
 export interface NodeInfo {
   features: string[];
   quotaUrl?: string;
+  rolesSupported?: string[];
+  rolesEnabled?: string[];
+  services?: NodeServicesInfo;
+  replication?: NodeReplicationInfo;
 }
 
 export async function checkNodeInfo(
@@ -75,6 +97,10 @@ export async function checkNodeInfo(
     version: string;
     features: string[];
     quota_url?: string;
+    rolesSupported?: string[];
+    rolesEnabled?: string[];
+    services?: NodeServicesInfo;
+    replication?: NodeReplicationInfo;
   };
 
   if (sdkProtocol !== data.protocol) {
@@ -89,5 +115,9 @@ export async function checkNodeInfo(
   return {
     features: data.features ?? [],
     quotaUrl: data.quota_url,
+    rolesSupported: data.rolesSupported ?? [],
+    rolesEnabled: data.rolesEnabled ?? [],
+    services: data.services,
+    replication: data.replication,
   };
 }

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -26,8 +26,8 @@ js-sys = "0.3.59"
 # tinycloud-sdk-rs = { path = "../../../tinycloud-node/tinycloud-sdk-rs" }
 # tinycloud-sdk-wasm = { path = "../../../tinycloud-node/tinycloud-sdk-wasm" }
 # For release, update rev after pushing tinycloud-node changes:
-tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "20d08e8d4affeb55e1654b638925bbf2ed21ab30" }
-tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "20d08e8d4affeb55e1654b638925bbf2ed21ab30" }
+tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "75f18680bb4486e29961de747a11b47679192e26" }
+tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "75f18680bb4486e29961de747a11b47679192e26" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 serde-wasm-bindgen = "0.6.5"

--- a/packages/sdk-rs/src/lib.rs
+++ b/packages/sdk-rs/src/lib.rs
@@ -5,26 +5,7 @@ pub mod session;
 #[cfg(feature = "nodejs")]
 pub mod keys;
 
-use serde::Deserialize;
-use tinycloud_sdk_rs::authorization::InvocationHeaders;
-use tinycloud_sdk_rs::tinycloud_auth::{
-    resource::{Path, Service, SpaceId},
-    siwe_recap::Ability,
-};
 use wasm_bindgen::prelude::*;
-
-fn map_jserr<E: std::error::Error>(e: E) -> JsValue {
-    e.to_string().into()
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct InvokeAnyEntry {
-    space_id: String,
-    service: String,
-    path: String,
-    action: String,
-}
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
@@ -33,35 +14,4 @@ struct InvokeAnyEntry {
 /// Run once on initialisation.
 pub fn initPanicHook() {
     console_error_panic_hook::set_once();
-}
-
-#[wasm_bindgen]
-#[allow(non_snake_case)]
-pub fn invokeAny(
-    session: JsValue,
-    entries: JsValue,
-    facts: JsValue,
-) -> Result<JsValue, JsValue> {
-    let session: tinycloud_sdk_wasm::session::Session = serde_wasm_bindgen::from_value(session)?;
-    let entries: Vec<InvokeAnyEntry> = serde_wasm_bindgen::from_value(entries)?;
-    let facts_opt: Option<Vec<serde_json::Value>> = if facts.is_undefined() || facts.is_null() {
-        None
-    } else {
-        Some(serde_wasm_bindgen::from_value(facts)?)
-    };
-
-    let actions = entries
-        .into_iter()
-        .map(|entry| {
-            let space_id: SpaceId = entry.space_id.parse().map_err(map_jserr)?;
-            let service: Service = entry.service.parse().map_err(map_jserr)?;
-            let action: Ability = entry.action.parse().map_err(map_jserr)?;
-            let path: Path = entry.path.parse().map_err(map_jserr)?;
-            let resource = space_id.to_resource(service, Some(path), None, None);
-            Ok::<_, JsValue>((resource, std::iter::once(action)))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let authz = session.invoke_any(actions, facts_opt).map_err(map_jserr)?;
-    Ok(serde_wasm_bindgen::to_value(&InvocationHeaders::new(authz))?)
 }

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -147,6 +147,7 @@ export { KVService, PrefixedKVService, IKVService, KVAction } from "./kv";
 export type {
   IPrefixedKVService,
   KVServiceConfig,
+  KVReadMode,
   KVGetOptions,
   KVPutOptions,
   KVListOptions,

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -164,6 +164,7 @@ export { SQLService, DatabaseHandle, SQLAction } from "./sql";
 export type { ISQLService, IDatabaseHandle } from "./sql";
 export type {
   SQLServiceConfig,
+  SQLReadMode,
   QueryOptions,
   ExecuteOptions,
   BatchOptions,

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -13,6 +13,7 @@ import {
   ErrorCodes,
   serviceError,
   FetchResponse,
+  type InvocationFacts,
 } from "../types";
 import {
   authRequiredError,
@@ -35,6 +36,7 @@ import {
   KVListResponse,
   KVResponseHeaders,
   KVAction,
+  type KVReadMode,
 } from "./types";
 
 /**
@@ -174,15 +176,11 @@ export class KVService extends BaseService implements IKVService {
     path: string,
     action: string,
     body?: Blob | string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    facts?: InvocationFacts
   ): Promise<FetchResponse> {
     const session = this.context.session!;
-    const headers = this.context.invoke(
-      session,
-      "kv",
-      path,
-      action
-    );
+    const headers = this.context.invoke(session, "kv", path, action, facts);
 
     return this.context.fetch(`${this.host}/invoke`, {
       method: "POST",
@@ -210,6 +208,20 @@ export class KVService extends BaseService implements IKVService {
         : undefined,
       get: (name: string) => headers.get(name),
     };
+  }
+
+  private resolveReadMode(readMode?: KVReadMode): KVReadMode {
+    return readMode ?? this._config.readMode ?? "canonical";
+  }
+
+  private readModeFacts(readMode: KVReadMode): InvocationFacts {
+    return [
+      {
+        kvReadParams: {
+          type: readMode,
+        },
+      },
+    ];
   }
 
   /**
@@ -263,13 +275,15 @@ export class KVService extends BaseService implements IKVService {
       }
 
       const path = this.getFullPath(key, options?.prefix);
+      const readMode = this.resolveReadMode(options?.readMode);
 
       try {
         const response = await this.invokeOperation(
           path,
           KVAction.GET,
           undefined,
-          options?.signal
+          options?.signal,
+          this.readModeFacts(readMode)
         );
 
         if (!response.ok) {
@@ -403,13 +417,15 @@ export class KVService extends BaseService implements IKVService {
       if (options?.path) {
         listPath = listPath ? `${listPath}/${options.path}` : options.path;
       }
+      const readMode = this.resolveReadMode(options?.readMode);
 
       try {
         const response = await this.invokeOperation(
           listPath,
           KVAction.LIST,
           undefined,
-          options?.signal
+          options?.signal,
+          this.readModeFacts(readMode)
         );
 
         if (!response.ok) {
@@ -527,13 +543,15 @@ export class KVService extends BaseService implements IKVService {
       }
 
       const path = this.getFullPath(key, options?.prefix);
+      const readMode = this.resolveReadMode(options?.readMode);
 
       try {
         const response = await this.invokeOperation(
           path,
           KVAction.HEAD,
           undefined,
-          options?.signal
+          options?.signal,
+          this.readModeFacts(readMode)
         );
 
         if (!response.ok) {

--- a/packages/sdk-services/src/kv/index.ts
+++ b/packages/sdk-services/src/kv/index.ts
@@ -14,8 +14,9 @@ export { PrefixedKVService, IPrefixedKVService } from "./PrefixedKVService";
 export { IKVService } from "./IKVService";
 
 // Types
-export {
+export type {
   KVServiceConfig,
+  KVReadMode,
   KVGetOptions,
   KVPutOptions,
   KVListOptions,
@@ -24,6 +25,6 @@ export {
   KVResponse,
   KVListResponse,
   KVResponseHeaders,
-  KVAction,
   KVActionType,
 } from "./types";
+export { KVAction } from "./types";

--- a/packages/sdk-services/src/kv/types.ts
+++ b/packages/sdk-services/src/kv/types.ts
@@ -9,6 +9,12 @@
  */
 export interface KVServiceConfig {
   /**
+   * Default read mode for KV read operations.
+   * Defaults to canonical, which hides quarantined keys from normal reads.
+   */
+  readMode?: KVReadMode;
+
+  /**
    * Default prefix for all keys.
    * Useful for namespacing data within a space.
    *
@@ -31,9 +37,19 @@ export interface KVServiceConfig {
 }
 
 /**
+ * KV read mode.
+ */
+export type KVReadMode = "canonical" | "provisional";
+
+/**
  * Options for KV get operations.
  */
 export interface KVGetOptions {
+  /**
+   * Override the default read mode for this operation.
+   */
+  readMode?: KVReadMode;
+
   /**
    * Override the default prefix for this operation.
    */
@@ -92,6 +108,11 @@ export interface KVPutOptions {
  */
 export interface KVListOptions {
   /**
+   * Override the default read mode for this operation.
+   */
+  readMode?: KVReadMode;
+
+  /**
    * Override the default prefix for this operation.
    */
   prefix?: string;
@@ -147,6 +168,11 @@ export interface KVDeleteOptions {
  * Options for KV head (metadata) operations.
  */
 export interface KVHeadOptions {
+  /**
+   * Override the default read mode for this operation.
+   */
+  readMode?: KVReadMode;
+
   /**
    * Override the default prefix for this operation.
    */

--- a/packages/sdk-services/src/sql/SQLService.ts
+++ b/packages/sdk-services/src/sql/SQLService.ts
@@ -13,6 +13,7 @@ import {
   ErrorCodes,
   serviceError,
   type FetchResponse,
+  type InvocationFacts,
 } from "../types";
 import { authRequiredError, wrapError, parseAuthError } from "../errors";
 import type { ISQLService } from "./ISQLService";
@@ -23,6 +24,7 @@ import {
   type QueryOptions,
   type ExecuteOptions,
   type BatchOptions,
+  type SQLReadMode,
   type SqlValue,
   type SqlStatement,
   type QueryResponse,
@@ -51,6 +53,20 @@ export class SQLService extends BaseService implements ISQLService {
 
   private get host(): string {
     return this.context.hosts[0];
+  }
+
+  private resolveReadMode(readMode?: SQLReadMode): SQLReadMode {
+    return readMode ?? this._config.readMode ?? "canonical";
+  }
+
+  private readModeFacts(readMode: SQLReadMode): InvocationFacts {
+    return [
+      {
+        sqlReadParams: {
+          type: readMode,
+        },
+      },
+    ];
   }
 
   /**
@@ -106,11 +122,13 @@ export class SQLService extends BaseService implements ISQLService {
       }
 
       try {
+        const readMode = this.resolveReadMode(options?.readMode);
         const response = await this.invokeSQL(
           dbName,
           SQLAction.READ,
           { action: "query", sql, params: params ?? [] },
-          options?.signal
+          options?.signal,
+          this.readModeFacts(readMode)
         );
 
         if (!response.ok) {
@@ -207,11 +225,13 @@ export class SQLService extends BaseService implements ISQLService {
       }
 
       try {
+        const readMode = this.resolveReadMode(options?.readMode);
         const response = await this.invokeSQL(
           dbName,
           SQLAction.EXECUTE,
           { action: "execute_statement", name, params: params ?? [] },
-          options?.signal
+          options?.signal,
+          this.readModeFacts(readMode)
         );
 
         if (!response.ok) {
@@ -238,11 +258,13 @@ export class SQLService extends BaseService implements ISQLService {
       }
 
       try {
+        const readMode = this.resolveReadMode(options?.readMode);
         const response = await this.invokeSQL(
           dbName,
           SQLAction.EXPORT,
           { action: "export" },
-          options?.signal
+          options?.signal,
+          this.readModeFacts(readMode)
         );
 
         if (!response.ok) {
@@ -271,10 +293,11 @@ export class SQLService extends BaseService implements ISQLService {
     dbName: string,
     action: string,
     body: Record<string, unknown>,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    facts?: InvocationFacts
   ): Promise<FetchResponse> {
     const session = this.context.session!;
-    const headers = this.context.invoke(session, "sql", dbName, action);
+    const headers = this.context.invoke(session, "sql", dbName, action, facts);
 
     return this.context.fetch(`${this.host}/invoke`, {
       method: "POST",

--- a/packages/sdk-services/src/sql/index.ts
+++ b/packages/sdk-services/src/sql/index.ts
@@ -11,6 +11,7 @@ export {
   SQLAction,
   type SQLActionType,
   type SQLServiceConfig,
+  type SQLReadMode,
   type QueryOptions,
   type ExecuteOptions,
   type BatchOptions,

--- a/packages/sdk-services/src/sql/types.ts
+++ b/packages/sdk-services/src/sql/types.ts
@@ -15,6 +15,12 @@ export interface SQLServiceConfig {
   defaultDatabase?: string;
 
   /**
+   * Default read mode for SQL queries.
+   * Defaults to canonical.
+   */
+  readMode?: SQLReadMode;
+
+  /**
    * Default timeout in milliseconds for SQL operations.
    */
   timeout?: number;
@@ -31,6 +37,12 @@ export interface QueryOptions {
    * Custom abort signal for this operation.
    */
   signal?: AbortSignal;
+
+  /**
+   * Read canonical or provisional SQL state.
+   * Defaults to the service config, then canonical.
+   */
+  readMode?: SQLReadMode;
 }
 
 /**
@@ -58,6 +70,8 @@ export interface BatchOptions {
    */
   signal?: AbortSignal;
 }
+
+export type SQLReadMode = "canonical" | "provisional";
 
 /**
  * A SQL value: null, number, string, or binary data.

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -68,6 +68,7 @@ export {
   PrefixedKVService,
   IPrefixedKVService,
 } from '@tinycloud/sdk-core';
+export type { KVReadMode } from '@tinycloud/sdk-core';
 
 // Hooks service
 export {

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -55,6 +55,7 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 
 - requires a replication session handshake before export begins
 - opens a replication session on a first-contact peer by carrying the supporting delegation chain
+- invalidates a replication transport session after its sync delegation is revoked
 - blocks unauthenticated export and reconcile pull-through
 - preserves local authored facts during authority outage
 - resumes convergence after reconnect
@@ -69,6 +70,7 @@ tests/node-sdk/
 ├── setup.ts
 └── replication/
     ├── cluster.ts
+    ├── auth-revocation.test.ts
     ├── auth-session.test.ts
     ├── auth-first-contact.test.ts
     ├── helpers.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -73,6 +73,7 @@ tests/node-sdk/
     ├── auth-revocation.test.ts
     ├── auth-session.test.ts
     ├── auth-first-contact.test.ts
+    ├── auth-recovery.test.ts
     ├── helpers.ts
     ├── kv-baseline.test.ts
     ├── kv-delete-reconcile.test.ts
@@ -90,7 +91,7 @@ tests/node-sdk/
 
 Later stages should add:
 
-- `auth-recovery.test.ts` for full auth-sync and recovery semantics beyond session gating
+- `auth-recovery-propagation.test.ts` for broader auth-fact replay and recovery semantics beyond session gating
 
 ---
 

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -51,6 +51,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves a partial replay reconcile can make one child prefix match while another remains missing
 - proves the root split summary converges after both child prefixes are replayed
 
+### KV Recon Split Compare
+
+- compares immediate KV child scopes through an authenticated `recon/split/compare` endpoint
+- proves a partial replay reconcile marks one child prefix as `match` while another remains `local-missing`
+- proves the root split comparison converges to all `match` after the remaining child prefix is replayed
+
 ### KV Recon Bounded Windows
 
 - pages scoped KV inventory through authenticated `recon/export` and `recon/compare` with `startAfter` and `limit`
@@ -108,6 +114,7 @@ tests/node-sdk/
     ├── kv-reconcile.test.ts
     ├── kv-restart-catchup.test.ts
     ├── kv-recon-export.test.ts
+    ├── kv-recon-split-compare.test.ts
     ├── kv-recon-split.test.ts
     ├── kv-recon-window.test.ts
     ├── sql-baseline.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -45,6 +45,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves mismatch before replay reconcile and match after reconcile
 - proves sibling prefixes remain isolated when compare is run on a narrower prefix
 
+### KV Recon Bounded Windows
+
+- pages scoped KV inventory through authenticated `recon/export` and `recon/compare` with `startAfter` and `limit`
+- proves a reconciled primary scope can be traversed page by page until the cursor is exhausted
+- proves sibling prefixes remain isolated across page boundaries
+
 ### KV Offline / Provisional
 
 - authors KV state on a disconnected replica
@@ -96,6 +102,7 @@ tests/node-sdk/
     ├── kv-reconcile.test.ts
     ├── kv-restart-catchup.test.ts
     ├── kv-recon-export.test.ts
+    ├── kv-recon-window.test.ts
     ├── sql-baseline.test.ts
     ├── sql-reconcile.test.ts
     ├── sql-schema-drift.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -64,6 +64,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves a broad-scope reconcile skips an already-matched child prefix and repairs only the remaining missing child prefix
 - proves root split comparison converges after the selective replay
 
+### KV Split-Driven Reconcile Pagination
+
+- pages child-level replay on `reconcile/split` with `childStartAfter` and `childLimit`
+- proves a wide root child set can be repaired across multiple paged reconcile calls
+- proves peer-missing child semantics remain unchanged while local-missing children are replayed
+
 ### KV Split-Driven Grandchild Replay
 
 - descends from a broad root scope into a deeper mismatched grandchild prefix under one coarse child via `maxDepth: 2`
@@ -137,6 +143,7 @@ tests/node-sdk/
     ├── kv-recon-split-reconcile.test.ts
     ├── kv-recon-split-grandchild.test.ts
     ├── kv-recon-split-pagination.test.ts
+    ├── kv-recon-split-reconcile-pagination.test.ts
     ├── kv-recon-split.test.ts
     ├── kv-recon-window.test.ts
     ├── sql-baseline.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -30,7 +30,8 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - writes a KV value through `node-a`
 - waits for the value to appear through `node-b`
 - proves catch-up still works after a temporary disconnect and restart
-- proves a peer-serving hop from `node-b` into `node-c`
+- proves a host peer-serving hop from `node-b` into `node-c`
+- proves replica peer-serving is denied by default and only enabled when explicitly opted in
 
 ### KV Offline / Provisional
 
@@ -72,6 +73,7 @@ tests/node-sdk/
     ├── kv-baseline.test.ts
     ├── kv-delete-reconcile.test.ts
     ├── kv-offline-provisional.test.ts
+    ├── kv-peer-serving-enforcement.test.ts
     ├── kv-peer-serving-reconcile.test.ts
     ├── kv-reconcile.test.ts
     ├── kv-restart-catchup.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -1,6 +1,6 @@
 # Replication E2E Test Specification
 
-**Status:** Draft  
+**Status:** Draft
 **Runner:** `bun test`
 
 ---

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -70,6 +70,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - pages grandchild children with `childLimit: 1` so only one nested child is repaired per pass
 - proves the coarse child and root remain mismatched until the remaining grandchild is replayed
 
+### KV Split Child Pagination
+
+- pages wide child lists on `recon/split` and `recon/split/compare` with `childStartAfter` and `childLimit`
+- proves `hasMore` and `nextChildStartAfter` advance deterministically across child-page boundaries
+- proves both split surfaces traverse the same child ordering across repeated requests
+
 ### KV Recon Bounded Windows
 
 - pages scoped KV inventory through authenticated `recon/export` and `recon/compare` with `startAfter` and `limit`
@@ -130,6 +136,7 @@ tests/node-sdk/
     ├── kv-recon-split-compare.test.ts
     ├── kv-recon-split-reconcile.test.ts
     ├── kv-recon-split-grandchild.test.ts
+    ├── kv-recon-split-pagination.test.ts
     ├── kv-recon-split.test.ts
     ├── kv-recon-window.test.ts
     ├── sql-baseline.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -107,6 +107,21 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves a key deleted on the peer but still locally visible reports `peerStatus: deleted`
 - proves a local-only key reports `peerStatus: absent`
 
+### Peer-Missing Planning
+
+- builds an authenticated action plan for `peer-missing` KV divergence
+- rejects authority-mode planning against a peer-serving replica that is not a host
+- classifies peer-visible deletes as `prune-delete`
+- classifies bare peer absence as `quarantine-absent`
+- keeps still-present peer keys as `keep`
+
+### Peer-Missing Apply
+
+- applies only delete-backed `peer-missing` actions from explicit tombstone evidence
+- persists bare peer absence as quarantine records rather than deleting local data
+- proves a second apply reports already-quarantined local-only keys
+- proves local-only data remains visible after apply
+
 ### SQLite Canonical Replication
 
 - creates a replicated table with an explicit primary key
@@ -152,6 +167,8 @@ tests/node-sdk/
     ├── kv-offline-provisional.test.ts
     ├── kv-peer-serving-enforcement.test.ts
     ├── kv-peer-serving-reconcile.test.ts
+    ├── kv-peer-missing-apply.test.ts
+    ├── kv-peer-missing-plan.test.ts
     ├── kv-state.test.ts
     ├── kv-state-compare.test.ts
     ├── kv-recon-compare.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -122,6 +122,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves a second apply reports already-quarantined local-only keys
 - proves local-only data remains visible after apply
 
+### Peer-Missing Quarantine
+
+- lists persisted quarantine records for a scoped prefix through an authenticated local endpoint
+- clears quarantine records when a later peer-missing apply resolves the key as `keep`
+- clears quarantine records when a later peer-missing apply resolves the key as `prune-delete`
+
 ### SQLite Canonical Replication
 
 - creates a replicated table with an explicit primary key
@@ -169,6 +175,7 @@ tests/node-sdk/
     ├── kv-peer-serving-reconcile.test.ts
     ├── kv-peer-missing-apply.test.ts
     ├── kv-peer-missing-plan.test.ts
+    ├── kv-peer-missing-quarantine.test.ts
     ├── kv-state.test.ts
     ├── kv-state-compare.test.ts
     ├── kv-recon-compare.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -33,6 +33,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves a host peer-serving hop from `node-b` into `node-c`
 - proves replica peer-serving is denied by default and only enabled when explicitly opted in
 
+### KV Recon Inventory Export
+
+- exports scoped KV inventory through an authenticated `recon/export` endpoint
+- proves the same scoped inventory matches after replay reconcile on both nodes
+- proves sibling prefixes do not leak into the scoped inventory
+
 ### KV Offline / Provisional
 
 - authors KV state on a disconnected replica
@@ -82,6 +88,7 @@ tests/node-sdk/
     ├── kv-peer-serving-reconcile.test.ts
     ├── kv-reconcile.test.ts
     ├── kv-restart-catchup.test.ts
+    ├── kv-recon-export.test.ts
     ├── sql-baseline.test.ts
     ├── sql-reconcile.test.ts
     ├── sql-schema-drift.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -57,6 +57,13 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves a partial replay reconcile marks one child prefix as `match` while another remains `local-missing`
 - proves the root split comparison converges to all `match` after the remaining child prefix is replayed
 
+### KV Split-Driven Replay
+
+- replays only the missing immediate child scopes through an authenticated `reconcile/split` endpoint
+- manually reconciles one child first, then runs a broad-scope `reconcile/split` and proves only the remaining child needed replay
+- proves a broad-scope reconcile skips an already-matched child prefix and repairs only the remaining missing child prefix
+- proves root split comparison converges after the selective replay
+
 ### KV Recon Bounded Windows
 
 - pages scoped KV inventory through authenticated `recon/export` and `recon/compare` with `startAfter` and `limit`
@@ -115,6 +122,7 @@ tests/node-sdk/
     ├── kv-restart-catchup.test.ts
     ├── kv-recon-export.test.ts
     ├── kv-recon-split-compare.test.ts
+    ├── kv-recon-split-reconcile.test.ts
     ├── kv-recon-split.test.ts
     ├── kv-recon-window.test.ts
     ├── sql-baseline.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -39,6 +39,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves the same scoped inventory matches after replay reconcile on both nodes
 - proves sibling prefixes do not leak into the scoped inventory
 
+### KV Recon Compare
+
+- compares scoped KV state through an authenticated `recon/compare` endpoint
+- proves mismatch before replay reconcile and match after reconcile
+- proves sibling prefixes remain isolated when compare is run on a narrower prefix
+
 ### KV Offline / Provisional
 
 - authors KV state on a disconnected replica
@@ -86,6 +92,7 @@ tests/node-sdk/
     ├── kv-offline-provisional.test.ts
     ├── kv-peer-serving-enforcement.test.ts
     ├── kv-peer-serving-reconcile.test.ts
+    ├── kv-recon-compare.test.ts
     ├── kv-reconcile.test.ts
     ├── kv-restart-catchup.test.ts
     ├── kv-recon-export.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -94,6 +94,19 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - reads provisional local state before canonical commit arrives
 - later observes converged canonical state on all nodes
 
+### KV State Proof
+
+- distinguishes a present KV key from a deleted key and an absent key through an authenticated `kv/state` endpoint
+- proves a peer can ask the authority host for key state after partial reconciliation
+- keeps deleted-key status distinct from never-seen-key status
+
+### KV State Compare
+
+- compares local KV state against a peer through an authenticated `kv/state/compare` endpoint
+- proves a present key reports `peerStatus: present`
+- proves a key deleted on the peer but still locally visible reports `peerStatus: deleted`
+- proves a local-only key reports `peerStatus: absent`
+
 ### SQLite Canonical Replication
 
 - creates a replicated table with an explicit primary key
@@ -139,6 +152,8 @@ tests/node-sdk/
     ├── kv-offline-provisional.test.ts
     ├── kv-peer-serving-enforcement.test.ts
     ├── kv-peer-serving-reconcile.test.ts
+    ├── kv-state.test.ts
+    ├── kv-state-compare.test.ts
     ├── kv-recon-compare.test.ts
     ├── kv-reconcile.test.ts
     ├── kv-restart-catchup.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -109,6 +109,7 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 ### Auth / Recovery
 
 - requires a replication session handshake before export begins
+- surfaces a per-space `serverDid` from `replication/session/open` for session identity checks
 - opens a replication session on a first-contact peer by carrying the supporting delegation chain
 - invalidates a replication transport session after its sync delegation is revoked
 - blocks unauthenticated export and reconcile pull-through
@@ -130,6 +131,7 @@ tests/node-sdk/
     ├── auth-first-contact.test.ts
     ├── auth-recovery.test.ts
     ├── helpers.ts
+    ├── auth-session-serverdid.test.ts
     ├── kv-baseline.test.ts
     ├── kv-delete-reconcile.test.ts
     ├── kv-offline-provisional.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -60,7 +60,7 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 ### KV Split-Driven Replay
 
 - replays only the missing immediate child scopes through an authenticated `reconcile/split` endpoint
-- manually reconciles one child first, then runs a broad-scope `reconcile/split` and proves only the remaining child needed replay
+- pages missing child scopes through `childLimit: 1`, proving one child is repaired per pass and the root only converges after the second pass
 - proves a broad-scope reconcile skips an already-matched child prefix and repairs only the remaining missing child prefix
 - proves root split comparison converges after the selective replay
 

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -110,13 +110,17 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 ### Peer-Missing Planning
 
 - builds an authenticated action plan for `peer-missing` KV divergence
-- rejects authority-mode planning against a peer-serving replica that is not a host
+- syncs auth facts before authority-mode planning so host delegations are locally verifiable
+- binds authority-mode planning to the peer's per-space `serverDid`
+- requires an auth-DAG-backed `tinycloud.space/host` delegation for that peer identity
+- rejects authority-mode planning until those host-delegation facts have been auth-synced locally
 - classifies peer-visible deletes as `prune-delete`
 - classifies bare peer absence as `quarantine-absent`
 - keeps still-present peer keys as `keep`
 
 ### Peer-Missing Apply
 
+- syncs auth facts before authority-mode apply so host delegations are locally verifiable
 - applies only delete-backed `peer-missing` actions from explicit tombstone evidence
 - persists bare peer absence as quarantine records rather than deleting local data
 - proves a second apply reports already-quarantined local-only keys

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -45,6 +45,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves mismatch before replay reconcile and match after reconcile
 - proves sibling prefixes remain isolated when compare is run on a narrower prefix
 
+### KV Recon Split
+
+- summarizes immediate KV child scopes through an authenticated `recon/split` endpoint
+- proves a partial replay reconcile can make one child prefix match while another remains missing
+- proves the root split summary converges after both child prefixes are replayed
+
 ### KV Recon Bounded Windows
 
 - pages scoped KV inventory through authenticated `recon/export` and `recon/compare` with `startAfter` and `limit`
@@ -102,6 +108,7 @@ tests/node-sdk/
     ├── kv-reconcile.test.ts
     ├── kv-restart-catchup.test.ts
     ├── kv-recon-export.test.ts
+    ├── kv-recon-split.test.ts
     ├── kv-recon-window.test.ts
     ├── sql-baseline.test.ts
     ├── sql-reconcile.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -110,6 +110,7 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 
 - requires a replication session handshake before export begins
 - surfaces a per-space `serverDid` from `replication/session/open` for session identity checks
+- surfaces per-space serving assessment fields from `replication/session/open` for `canExport` and role checks
 - opens a replication session on a first-contact peer by carrying the supporting delegation chain
 - invalidates a replication transport session after its sync delegation is revoked
 - blocks unauthenticated export and reconcile pull-through
@@ -132,6 +133,7 @@ tests/node-sdk/
     ├── auth-recovery.test.ts
     ├── helpers.ts
     ├── auth-session-serverdid.test.ts
+    ├── auth-session-serving-assessment.test.ts
     ├── kv-baseline.test.ts
     ├── kv-delete-reconcile.test.ts
     ├── kv-offline-provisional.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -1,0 +1,106 @@
+# Replication E2E Test Specification
+
+**Status:** Draft  
+**Runner:** `bun test`
+
+---
+
+## Goal
+
+Drive replication end-to-end through the real `@tinycloud/node-sdk` client against multiple live `tinycloud-node` processes.
+
+This suite complements the existing single-node SQL and DuckDB tests. It does not replace them.
+
+No replication test in this suite may use mocked transport, mocked node responses, or fake replication state.
+If a scenario cannot be exercised against live nodes yet, it should stay unimplemented or be captured as a blocker rather than replaced with a mock.
+
+---
+
+## Stage 0 Scenarios
+
+### Cluster Smoke
+
+- boots `node-a`, `node-b`, and `node-c`
+- reaches `/info` and `/healthz` on all three nodes
+- signs the same Alice identity into `node-a` and `node-b`
+- observes the same `spaceId` across those hosts for the same key and prefix
+
+### KV Canonical Replication
+
+- writes a KV value through `node-a`
+- waits for the value to appear through `node-b`
+- proves catch-up still works after a temporary disconnect and restart
+- proves a peer-serving hop from `node-b` into `node-c`
+
+### KV Offline / Provisional
+
+- authors KV state on a disconnected replica
+- reads provisional local state before canonical commit arrives
+- later observes converged canonical state on all nodes
+
+### SQLite Canonical Replication
+
+- creates a replicated table with an explicit primary key
+- inserts, updates, and deletes rows through the authority host
+- observes converged query-visible state through another node
+
+### SQLite Schema Drift
+
+- applies divergent local schema/state on one node
+- reconciles from the authority host
+- observes authority snapshot override of the local drift
+
+### Auth / Recovery
+
+- requires a replication session handshake before export begins
+- blocks unauthenticated export and reconcile pull-through
+- preserves local authored facts during authority outage
+- resumes convergence after reconnect
+
+---
+
+## Initial File Layout
+
+```text
+tests/node-sdk/
+├── REPLICATION-E2E-SPEC.md
+├── setup.ts
+└── replication/
+    ├── cluster.ts
+    ├── auth-session.test.ts
+    ├── helpers.ts
+    ├── kv-baseline.test.ts
+    ├── kv-delete-reconcile.test.ts
+    ├── kv-offline-provisional.test.ts
+    ├── kv-peer-serving-reconcile.test.ts
+    ├── kv-reconcile.test.ts
+    ├── kv-restart-catchup.test.ts
+    ├── sql-baseline.test.ts
+    ├── sql-reconcile.test.ts
+    ├── sql-schema-drift.test.ts
+    ├── delegation-baseline.test.ts
+    └── smoke.test.ts
+```
+
+Later stages should add:
+
+- `auth-recovery.test.ts` for full auth-sync and recovery semantics beyond session gating
+
+---
+
+## Test Conventions
+
+- Use one deterministic Alice key across hosts when proving same-space behavior.
+- Use unique prefixes and DB names per test case.
+- Prefer public SDK-visible assertions over internal state inspection.
+- Keep the first suite local and process-based, not Docker-required.
+
+---
+
+## Exit Criteria
+
+The Stage 0 spec is satisfied when:
+
+- the cluster harness exists,
+- the smoke test passes,
+- and later replication tests can reuse the same helpers instead of inventing a second harness.

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -64,6 +64,12 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 - proves a broad-scope reconcile skips an already-matched child prefix and repairs only the remaining missing child prefix
 - proves root split comparison converges after the selective replay
 
+### KV Split-Driven Grandchild Replay
+
+- descends from a broad root scope into a deeper mismatched grandchild prefix under one coarse child via `maxDepth: 2`
+- pages grandchild children with `childLimit: 1` so only one nested child is repaired per pass
+- proves the coarse child and root remain mismatched until the remaining grandchild is replayed
+
 ### KV Recon Bounded Windows
 
 - pages scoped KV inventory through authenticated `recon/export` and `recon/compare` with `startAfter` and `limit`
@@ -123,6 +129,7 @@ tests/node-sdk/
     ├── kv-recon-export.test.ts
     ├── kv-recon-split-compare.test.ts
     ├── kv-recon-split-reconcile.test.ts
+    ├── kv-recon-split-grandchild.test.ts
     ├── kv-recon-split.test.ts
     ├── kv-recon-window.test.ts
     ├── sql-baseline.test.ts

--- a/tests/node-sdk/REPLICATION-E2E-SPEC.md
+++ b/tests/node-sdk/REPLICATION-E2E-SPEC.md
@@ -54,6 +54,7 @@ If a scenario cannot be exercised against live nodes yet, it should stay unimple
 ### Auth / Recovery
 
 - requires a replication session handshake before export begins
+- opens a replication session on a first-contact peer by carrying the supporting delegation chain
 - blocks unauthenticated export and reconcile pull-through
 - preserves local authored facts during authority outage
 - resumes convergence after reconnect
@@ -69,6 +70,7 @@ tests/node-sdk/
 └── replication/
     ├── cluster.ts
     ├── auth-session.test.ts
+    ├── auth-first-contact.test.ts
     ├── helpers.ts
     ├── kv-baseline.test.ts
     ├── kv-delete-reconcile.test.ts

--- a/tests/node-sdk/package.json
+++ b/tests/node-sdk/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "bun test",
+    "test:replication": "bun test replication/",
     "test:sql": "bun test sql/",
     "test:duckdb": "bun test duckdb/"
   },

--- a/tests/node-sdk/replication/auth-first-contact.test.ts
+++ b/tests/node-sdk/replication/auth-first-contact.test.ts
@@ -5,6 +5,7 @@ import {
   getClusterNode,
   openKvReplicationSession,
   openTransportSession,
+  requestTransportSession,
   uniqueReplicationPrefix,
 } from "./helpers";
 
@@ -29,22 +30,10 @@ describe("Replication Auth First Contact", () => {
           scope
         );
 
-        const missingSupportingChain = await fetch(
-          `${hostNode.url}/replication/session/open`,
-          {
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-              ...hostSession.delegationHeader,
-            },
-            body: JSON.stringify({
-              spaceId: authority.spaceId,
-              service: "kv",
-              prefix: scope,
-            }),
-          }
-        );
-        expect(missingSupportingChain.status).toBe(401);
+        const missingSupportingChain = await requestTransportSession(hostSession, {
+          supportingDelegations: null,
+        });
+        expect(missingSupportingChain?.status).toBe(401);
 
         const hostTransport = await openTransportSession(hostSession);
         expect(hostTransport?.service).toBe("kv");

--- a/tests/node-sdk/replication/auth-first-contact.test.ts
+++ b/tests/node-sdk/replication/auth-first-contact.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  openTransportSession,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Auth First Contact", () => {
+  test(
+    "opens a replication session on a peer the user has not signed into yet",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("auth-first-contact");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const hostNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        expect(authority.spaceId).toBeDefined();
+
+        const scope = `replication/auth-first-contact/${Date.now()}`;
+        const hostSession = await openKvReplicationSession(
+          authority,
+          hostNode.url,
+          scope
+        );
+
+        const missingSupportingChain = await fetch(
+          `${hostNode.url}/replication/session/open`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...hostSession.delegationHeader,
+            },
+            body: JSON.stringify({
+              spaceId: authority.spaceId,
+              service: "kv",
+              prefix: scope,
+            }),
+          }
+        );
+        expect(missingSupportingChain.status).toBe(401);
+
+        const hostTransport = await openTransportSession(hostSession);
+        expect(hostTransport?.service).toBe("kv");
+        expect(hostTransport?.prefix).toBe(scope);
+        expect(typeof hostTransport?.sessionToken).toBe("string");
+        expect((hostTransport?.sessionToken.length ?? 0)).toBeGreaterThan(0);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/auth-recovery.test.ts
+++ b/tests/node-sdk/replication/auth-recovery.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication Auth Recovery", () => {
+  test(
+    "preserves a node-c authored KV write during authority outage and converges after reconnect",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster({
+        nodes: [
+          { name: "node-a", role: "authority", port: 8010 },
+          { name: "node-b", role: "host", port: 8011 },
+          {
+            name: "node-c",
+            role: "replica",
+            port: 8012,
+            env: {
+              TINYCLOUD_REPLICATION_PEER_SERVING: "true",
+            },
+          },
+        ],
+      });
+      try {
+        const prefix = uniqueReplicationPrefix("auth-recovery");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const host = createClusterClient(cluster, "node-b", prefix);
+        const replica = createClusterClient(cluster, "node-c", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const hostNode = getClusterNode(cluster, "node-b");
+        const replicaNode = getClusterNode(cluster, "node-c");
+
+        await authority.signIn();
+        await host.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(host.spaceId).toBe(authority.spaceId);
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/auth-recovery/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const initialValue = {
+          owner: "alice",
+          stage: "node-c-offline",
+          createdAt: new Date().toISOString(),
+        };
+
+        await cluster.stopNode("node-a");
+
+        const offlineWrite = await replica.kv.put(key, initialValue);
+        expect(offlineWrite.ok).toBe(true);
+
+        const localReplicaValue = await replica.kv.get<typeof initialValue>(key);
+        expect(localReplicaValue.ok).toBe(true);
+        if (!localReplicaValue.ok) {
+          throw new Error(localReplicaValue.error.message);
+        }
+        expect(localReplicaValue.data.data).toEqual(initialValue);
+
+        const hostBeforeRecovery = await host.kv.get(key);
+        expect(hostBeforeRecovery.ok).toBe(false);
+        if (hostBeforeRecovery.ok) {
+          throw new Error("Expected node-b to miss the offline-authored write before recovery");
+        }
+        expect(hostBeforeRecovery.error.code).toBe("KV_NOT_FOUND");
+
+        const restartedAuthority = await cluster.startNode("node-a");
+        expect(restartedAuthority.name).toBe("node-a");
+
+        const authorityAfterRestart = createClusterClient(cluster, "node-a", prefix);
+        await authorityAfterRestart.signIn();
+        expect(authorityAfterRestart.spaceId).toBe(authority.spaceId);
+
+        const nodeCToAuthority = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scope
+        );
+        const authorityTargetSession = await openKvReplicationSession(
+          authorityAfterRestart,
+          authorityNode.url,
+          scope
+        );
+        const recoverToAuthority = await reconcileFromPeer(
+          cluster,
+          "node-a",
+          {
+            peerUrl: replicaNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          { target: authorityTargetSession, peer: nodeCToAuthority }
+        );
+
+        expect(recoverToAuthority.appliedSequences).toBeGreaterThan(0);
+        expect(recoverToAuthority.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("authority converges on node-c authored KV write", async () => {
+          const result = await authorityAfterRestart.kv.get<typeof initialValue>(key);
+          return result.ok && result.data.data.stage === "node-c-offline";
+        });
+
+        const authorityRecovered = await authorityAfterRestart.kv.get<typeof initialValue>(key);
+        expect(authorityRecovered.ok).toBe(true);
+        if (!authorityRecovered.ok) {
+          throw new Error(authorityRecovered.error.message);
+        }
+        expect(authorityRecovered.data.data).toEqual(initialValue);
+
+        const authorityToHost = await openKvReplicationSession(
+          authorityAfterRestart,
+          authorityNode.url,
+          scope
+        );
+        const hostTargetSession = await openKvReplicationSession(
+          host,
+          hostNode.url,
+          scope
+        );
+        const recoverToHost = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          { target: hostTargetSession, peer: authorityToHost }
+        );
+
+        expect(recoverToHost.appliedSequences).toBeGreaterThan(0);
+        expect(recoverToHost.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("host converges after authority recovery", async () => {
+          const result = await host.kv.get<typeof initialValue>(key);
+          return result.ok && result.data.data.stage === "node-c-offline";
+        });
+
+        const hostRecovered = await host.kv.get<typeof initialValue>(key);
+        expect(hostRecovered.ok).toBe(true);
+        if (!hostRecovered.ok) {
+          throw new Error(hostRecovered.error.message);
+        }
+        expect(hostRecovered.data.data).toEqual(initialValue);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/auth-recovery.test.ts
+++ b/tests/node-sdk/replication/auth-recovery.test.ts
@@ -4,6 +4,7 @@ import {
   createClusterClient,
   getClusterNode,
   openKvReplicationSession,
+  openTransportSession,
   reconcileFromPeer,
   uniqueReplicationPrefix,
   waitForCondition,
@@ -11,7 +12,100 @@ import {
 
 describe("Replication Auth Recovery", () => {
   test(
-    "preserves a node-c authored KV write during authority outage and converges after reconnect",
+    "requires both local and peer replication sessions for reconcile pull-through",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("replication-reconcile-auth");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/auth-recovery/reconcile/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const putResult = await authority.kv.put(key, {
+          createdAt: new Date().toISOString(),
+        });
+        expect(putResult.ok).toBe(true);
+
+        const peerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
+        const targetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scope
+        );
+        const openedPeerSession = await openTransportSession(peerSession);
+        const openedTargetSession = await openTransportSession(targetSession);
+
+        const unauthorized = await fetch(`${replicaNode.url}/replication/reconcile`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId,
+            prefix: scope,
+          }),
+        });
+        expect(unauthorized.status).toBe(401);
+
+        const missingPeerSession = await fetch(
+          `${replicaNode.url}/replication/reconcile`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "Replication-Session": openedTargetSession!.sessionToken,
+            },
+            body: JSON.stringify({
+              peerUrl: authorityNode.url,
+              spaceId: authority.spaceId,
+              prefix: scope,
+            }),
+          }
+        );
+        expect(missingPeerSession.status).toBe(401);
+        expect(await missingPeerSession.text()).toContain(
+          "missing Peer-Replication-Session"
+        );
+
+        const missingTargetSession = await fetch(
+          `${replicaNode.url}/replication/reconcile`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "Peer-Replication-Session": openedPeerSession!.sessionToken,
+            },
+            body: JSON.stringify({
+              peerUrl: authorityNode.url,
+              spaceId: authority.spaceId,
+              prefix: scope,
+            }),
+          }
+        );
+        expect(missingTargetSession.status).toBe(401);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+
+  test(
+    "preserves node-c authored KV facts during authority outage and converges after reconnect",
     { timeout: 600_000 },
     async () => {
       const cluster = await startCluster({
@@ -29,127 +123,131 @@ describe("Replication Auth Recovery", () => {
         ],
       });
       try {
-        const prefix = uniqueReplicationPrefix("auth-recovery");
+        const prefix = uniqueReplicationPrefix("replication-authority-outage");
         const authority = createClusterClient(cluster, "node-a", prefix);
         const host = createClusterClient(cluster, "node-b", prefix);
-        const replica = createClusterClient(cluster, "node-c", prefix);
+        const authoringReplica = createClusterClient(cluster, "node-c", prefix);
         const authorityNode = getClusterNode(cluster, "node-a");
         const hostNode = getClusterNode(cluster, "node-b");
         const replicaNode = getClusterNode(cluster, "node-c");
 
         await authority.signIn();
         await host.signIn();
-        await replica.signIn();
+        await authoringReplica.signIn();
 
         expect(authority.spaceId).toBeDefined();
         expect(host.spaceId).toBe(authority.spaceId);
-        expect(replica.spaceId).toBe(authority.spaceId);
+        expect(authoringReplica.spaceId).toBe(authority.spaceId);
 
-        const scope = `replication/auth-recovery/${Date.now()}`;
+        const scope = `replication/auth-recovery/outage/${Date.now()}`;
         const key = `${scope}/profile.json`;
-        const initialValue = {
+        const value = {
           owner: "alice",
-          stage: "node-c-offline",
+          stage: "authority-outage",
           createdAt: new Date().toISOString(),
         };
 
         await cluster.stopNode("node-a");
 
-        const offlineWrite = await replica.kv.put(key, initialValue);
-        expect(offlineWrite.ok).toBe(true);
+        const writeResult = await authoringReplica.kv.put(key, value);
+        expect(writeResult.ok).toBe(true);
 
-        const localReplicaValue = await replica.kv.get<typeof initialValue>(key);
-        expect(localReplicaValue.ok).toBe(true);
-        if (!localReplicaValue.ok) {
-          throw new Error(localReplicaValue.error.message);
+        const localReplicaGet = await authoringReplica.kv.get<typeof value>(key);
+        expect(localReplicaGet.ok).toBe(true);
+        if (!localReplicaGet.ok) {
+          throw new Error(localReplicaGet.error.message);
         }
-        expect(localReplicaValue.data.data).toEqual(initialValue);
+        expect(localReplicaGet.data.data).toEqual(value);
 
-        const hostBeforeRecovery = await host.kv.get(key);
-        expect(hostBeforeRecovery.ok).toBe(false);
-        if (hostBeforeRecovery.ok) {
-          throw new Error("Expected node-b to miss the offline-authored write before recovery");
+        const hostBefore = await host.kv.get(key);
+        expect(hostBefore.ok).toBe(false);
+        if (hostBefore.ok) {
+          throw new Error(
+            "Expected node-b to miss the node-c-authored write during authority outage"
+          );
         }
-        expect(hostBeforeRecovery.error.code).toBe("KV_NOT_FOUND");
+        expect(hostBefore.error.code).toBe("KV_NOT_FOUND");
 
-        const restartedAuthority = await cluster.startNode("node-a");
-        expect(restartedAuthority.name).toBe("node-a");
+        await cluster.startNode("node-a");
 
-        const authorityAfterRestart = createClusterClient(cluster, "node-a", prefix);
-        await authorityAfterRestart.signIn();
-        expect(authorityAfterRestart.spaceId).toBe(authority.spaceId);
+        const restartedAuthority = createClusterClient(cluster, "node-a", prefix);
+        await restartedAuthority.signIn();
+        expect(restartedAuthority.spaceId).toBe(authoringReplica.spaceId);
 
-        const nodeCToAuthority = await openKvReplicationSession(
-          replica,
-          replicaNode.url,
-          scope
-        );
         const authorityTargetSession = await openKvReplicationSession(
-          authorityAfterRestart,
+          restartedAuthority,
           authorityNode.url,
           scope
         );
-        const recoverToAuthority = await reconcileFromPeer(
+        const replicaPeerSession = await openKvReplicationSession(
+          authoringReplica,
+          replicaNode.url,
+          scope
+        );
+        const authorityCatchup = await reconcileFromPeer(
           cluster,
           "node-a",
           {
             peerUrl: replicaNode.url,
-            spaceId: authority.spaceId!,
+            spaceId: restartedAuthority.spaceId!,
             prefix: scope,
           },
-          { target: authorityTargetSession, peer: nodeCToAuthority }
+          {
+            target: authorityTargetSession,
+            peer: replicaPeerSession,
+          }
+        );
+        expect(authorityCatchup.appliedSequences).toBeGreaterThan(0);
+        expect(authorityCatchup.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition(
+          "authority sees node-c-authored KV after reconnect",
+          async () => {
+            const result = await restartedAuthority.kv.get<typeof value>(key);
+            return result.ok && result.data.data.stage === "authority-outage";
+          }
         );
 
-        expect(recoverToAuthority.appliedSequences).toBeGreaterThan(0);
-        expect(recoverToAuthority.appliedEvents).toBeGreaterThan(0);
-
-        await waitForCondition("authority converges on node-c authored KV write", async () => {
-          const result = await authorityAfterRestart.kv.get<typeof initialValue>(key);
-          return result.ok && result.data.data.stage === "node-c-offline";
-        });
-
-        const authorityRecovered = await authorityAfterRestart.kv.get<typeof initialValue>(key);
-        expect(authorityRecovered.ok).toBe(true);
-        if (!authorityRecovered.ok) {
-          throw new Error(authorityRecovered.error.message);
-        }
-        expect(authorityRecovered.data.data).toEqual(initialValue);
-
-        const authorityToHost = await openKvReplicationSession(
-          authorityAfterRestart,
-          authorityNode.url,
-          scope
-        );
         const hostTargetSession = await openKvReplicationSession(
           host,
           hostNode.url,
           scope
         );
-        const recoverToHost = await reconcileFromPeer(
+        const authorityPeerSession = await openKvReplicationSession(
+          restartedAuthority,
+          authorityNode.url,
+          scope
+        );
+        const hostCatchup = await reconcileFromPeer(
           cluster,
           "node-b",
           {
             peerUrl: authorityNode.url,
-            spaceId: authority.spaceId!,
+            spaceId: restartedAuthority.spaceId!,
             prefix: scope,
           },
-          { target: hostTargetSession, peer: authorityToHost }
+          {
+            target: hostTargetSession,
+            peer: authorityPeerSession,
+          }
+        );
+        expect(hostCatchup.appliedSequences).toBeGreaterThan(0);
+        expect(hostCatchup.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition(
+          "node-b converges after authority reconnect",
+          async () => {
+            const result = await host.kv.get<typeof value>(key);
+            return result.ok && result.data.data.stage === "authority-outage";
+          }
         );
 
-        expect(recoverToHost.appliedSequences).toBeGreaterThan(0);
-        expect(recoverToHost.appliedEvents).toBeGreaterThan(0);
-
-        await waitForCondition("host converges after authority recovery", async () => {
-          const result = await host.kv.get<typeof initialValue>(key);
-          return result.ok && result.data.data.stage === "node-c-offline";
-        });
-
-        const hostRecovered = await host.kv.get<typeof initialValue>(key);
-        expect(hostRecovered.ok).toBe(true);
-        if (!hostRecovered.ok) {
-          throw new Error(hostRecovered.error.message);
+        const convergedHostGet = await host.kv.get<typeof value>(key);
+        expect(convergedHostGet.ok).toBe(true);
+        if (!convergedHostGet.ok) {
+          throw new Error(convergedHostGet.error.message);
         }
-        expect(hostRecovered.data.data).toEqual(initialValue);
+        expect(convergedHostGet.data.data).toEqual(value);
       } finally {
         await cluster.stop();
       }

--- a/tests/node-sdk/replication/auth-recovery.test.ts
+++ b/tests/node-sdk/replication/auth-recovery.test.ts
@@ -152,7 +152,16 @@ describe("Replication Auth Recovery", () => {
         const writeResult = await authoringReplica.kv.put(key, value);
         expect(writeResult.ok).toBe(true);
 
-        const localReplicaGet = await authoringReplica.kv.get<typeof value>(key);
+        const localReplicaCanonical = await authoringReplica.kv.get<typeof value>(key);
+        expect(localReplicaCanonical.ok).toBe(false);
+        if (localReplicaCanonical.ok) {
+          throw new Error("Expected canonical replica read to stay absent during authority outage");
+        }
+        expect(localReplicaCanonical.error.code).toBe("KV_NOT_FOUND");
+
+        const localReplicaGet = await authoringReplica.kv.get<typeof value>(key, {
+          readMode: "provisional",
+        });
         expect(localReplicaGet.ok).toBe(true);
         if (!localReplicaGet.ok) {
           throw new Error(localReplicaGet.error.message);

--- a/tests/node-sdk/replication/auth-revocation-propagation.test.ts
+++ b/tests/node-sdk/replication/auth-revocation-propagation.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  openTransportSession,
+  reconcileAuthFromPeer,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Auth Revocation Propagation", () => {
+  test(
+    "propagates revoked sync delegations across peers through auth sync",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("auth-revocation-propagation");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const hostNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        expect(authority.spaceId).toBeDefined();
+
+        const sharedScope = `replication/auth-revocation-propagation/shared/${Date.now()}`;
+        const sharedSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          sharedScope
+        );
+        await openTransportSession(sharedSession);
+
+        const bootstrapSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          sharedScope
+        );
+        const bootstrapApply = await reconcileAuthFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            service: "kv",
+            prefix: sharedScope,
+          },
+          bootstrapSession
+        );
+
+        expect(bootstrapApply.importedDelegations).toBeGreaterThan(0);
+
+        const preRevocationOpen = await fetch(
+          `${hostNode.url}/replication/session/open`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...sharedSession.delegationHeader,
+            },
+            body: JSON.stringify({
+              spaceId: authority.spaceId,
+              service: "kv",
+              prefix: sharedScope,
+            }),
+          }
+        );
+        expect(preRevocationOpen.status).toBe(200);
+
+        await authority.revokeDelegation(sharedSession.delegationCid);
+
+        const revocationSyncSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          sharedScope
+        );
+        const revocationApply = await reconcileAuthFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            service: "kv",
+            prefix: sharedScope,
+          },
+          revocationSyncSession
+        );
+
+        expect(revocationApply.importedRevocations).toBeGreaterThan(0);
+
+        const postRevocationOpen = await fetch(
+          `${hostNode.url}/replication/session/open`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...sharedSession.delegationHeader,
+            },
+            body: JSON.stringify({
+              spaceId: authority.spaceId,
+              service: "kv",
+              prefix: sharedScope,
+            }),
+          }
+        );
+
+        expect(postRevocationOpen.status).toBe(401);
+        expect(await postRevocationOpen.text()).toContain(
+          "replication delegation is no longer active"
+        );
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/auth-revocation-propagation.test.ts
+++ b/tests/node-sdk/replication/auth-revocation-propagation.test.ts
@@ -3,9 +3,11 @@ import { startCluster } from "./cluster";
 import {
   createClusterClient,
   getClusterNode,
+  openAuthReplicationSession,
   openKvReplicationSession,
   openTransportSession,
   reconcileAuthFromPeer,
+  requestTransportSession,
   uniqueReplicationPrefix,
 } from "./helpers";
 
@@ -32,10 +34,13 @@ describe("Replication Auth Revocation Propagation", () => {
         );
         await openTransportSession(sharedSession);
 
-        const bootstrapSession = await openKvReplicationSession(
+        const bootstrapSession = await openAuthReplicationSession(
           authority,
-          authorityNode.url,
-          sharedScope
+          authorityNode.url
+        );
+        const bootstrapTargetSession = await openAuthReplicationSession(
+          authority,
+          hostNode.url
         );
         const bootstrapApply = await reconcileAuthFromPeer(
           cluster,
@@ -43,37 +48,30 @@ describe("Replication Auth Revocation Propagation", () => {
           {
             peerUrl: authorityNode.url,
             spaceId: authority.spaceId!,
-            service: "kv",
-            prefix: sharedScope,
           },
-          bootstrapSession
+          {
+            target: bootstrapTargetSession,
+            peer: bootstrapSession,
+          }
         );
 
         expect(bootstrapApply.importedDelegations).toBeGreaterThan(0);
 
-        const preRevocationOpen = await fetch(
-          `${hostNode.url}/replication/session/open`,
-          {
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-              ...sharedSession.delegationHeader,
-            },
-            body: JSON.stringify({
-              spaceId: authority.spaceId,
-              service: "kv",
-              prefix: sharedScope,
-            }),
-          }
-        );
-        expect(preRevocationOpen.status).toBe(200);
+        const preRevocationOpen = await requestTransportSession(sharedSession, {
+          supportingDelegations: null,
+        });
+        expect(preRevocationOpen).toBeDefined();
+        expect(preRevocationOpen?.status).toBe(200);
 
         await authority.revokeDelegation(sharedSession.delegationCid);
 
-        const revocationSyncSession = await openKvReplicationSession(
+        const revocationSyncSession = await openAuthReplicationSession(
           authority,
-          authorityNode.url,
-          sharedScope
+          authorityNode.url
+        );
+        const revocationTargetSession = await openAuthReplicationSession(
+          authority,
+          hostNode.url
         );
         const revocationApply = await reconcileAuthFromPeer(
           cluster,
@@ -81,32 +79,22 @@ describe("Replication Auth Revocation Propagation", () => {
           {
             peerUrl: authorityNode.url,
             spaceId: authority.spaceId!,
-            service: "kv",
-            prefix: sharedScope,
           },
-          revocationSyncSession
+          {
+            target: revocationTargetSession,
+            peer: revocationSyncSession,
+          }
         );
 
         expect(revocationApply.importedRevocations).toBeGreaterThan(0);
 
-        const postRevocationOpen = await fetch(
-          `${hostNode.url}/replication/session/open`,
-          {
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-              ...sharedSession.delegationHeader,
-            },
-            body: JSON.stringify({
-              spaceId: authority.spaceId,
-              service: "kv",
-              prefix: sharedScope,
-            }),
-          }
-        );
+        const postRevocationOpen = await requestTransportSession(sharedSession, {
+          supportingDelegations: null,
+        });
 
-        expect(postRevocationOpen.status).toBe(401);
-        expect(await postRevocationOpen.text()).toContain(
+        expect(postRevocationOpen).toBeDefined();
+        expect(postRevocationOpen?.status).toBe(401);
+        expect(await postRevocationOpen!.text()).toContain(
           "replication delegation is no longer active"
         );
       } finally {

--- a/tests/node-sdk/replication/auth-revocation.test.ts
+++ b/tests/node-sdk/replication/auth-revocation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  openTransportSession,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Auth Revocation", () => {
+  test(
+    "rejects an existing replication transport session after its sync delegation is revoked",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("auth-revocation");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const hostAccess = createClusterClient(cluster, "node-b", prefix);
+        const hostNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await hostAccess.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(hostAccess.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/auth-revocation/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const putResult = await authority.kv.put(key, {
+          owner: "alice",
+          source: "node-a",
+          createdAt: new Date().toISOString(),
+        });
+        expect(putResult.ok).toBe(true);
+
+        const hostSession = await openKvReplicationSession(
+          authority,
+          hostNode.url,
+          scope
+        );
+        const hostTransport = await openTransportSession(hostSession);
+        const initialExport = await fetch(`${hostNode.url}/replication/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": hostTransport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: authority.spaceId,
+            prefix: scope,
+          }),
+        });
+        expect(initialExport.status).toBe(200);
+
+        const revokeResult = await hostAccess.revokeDelegation(
+          hostSession.delegationCid
+        );
+        expect(revokeResult.ok).toBe(true);
+
+        const revokedExport = await fetch(`${hostNode.url}/replication/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": hostTransport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: authority.spaceId,
+            prefix: scope,
+          }),
+        });
+        expect(revokedExport.status).toBe(401);
+        expect(await revokedExport.text()).toContain("no longer active");
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/auth-second-contact.test.ts
+++ b/tests/node-sdk/replication/auth-second-contact.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconcileAuthFromPeer,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Auth Second Contact", () => {
+  test(
+    "opens a fresh replication session without supporting delegations after auth sync",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("auth-second-contact");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const hostNode = getClusterNode(cluster, "node-b");
+        const sharedScope = `replication/auth-second-contact/shared/${Date.now()}`;
+
+        await authority.signIn();
+        expect(authority.spaceId).toBeDefined();
+
+        const authSyncSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          sharedScope
+        );
+        const authApply = await reconcileAuthFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            service: "kv",
+            prefix: sharedScope,
+          },
+          authSyncSession
+        );
+
+        expect(authApply.importedDelegations).toBeGreaterThan(0);
+
+        const secondContactScope = `replication/auth-second-contact/fresh/${Date.now()}`;
+        const hostSession = await openKvReplicationSession(
+          authority,
+          hostNode.url,
+          secondContactScope
+        );
+        const secondContactOpen = await fetch(
+          `${hostNode.url}/replication/session/open`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...hostSession.delegationHeader,
+            },
+            body: JSON.stringify({
+              spaceId: authority.spaceId,
+              service: "kv",
+              prefix: secondContactScope,
+            }),
+          }
+        );
+
+        expect(secondContactOpen.status).toBe(200);
+        const secondContactTransport = await secondContactOpen.json();
+        expect(secondContactTransport.service).toBe("kv");
+        expect(secondContactTransport.prefix).toBe(secondContactScope);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/auth-second-contact.test.ts
+++ b/tests/node-sdk/replication/auth-second-contact.test.ts
@@ -3,8 +3,10 @@ import { startCluster } from "./cluster";
 import {
   createClusterClient,
   getClusterNode,
+  openAuthReplicationSession,
   openKvReplicationSession,
   reconcileAuthFromPeer,
+  requestTransportSession,
   uniqueReplicationPrefix,
 } from "./helpers";
 
@@ -19,15 +21,16 @@ describe("Replication Auth Second Contact", () => {
         const authority = createClusterClient(cluster, "node-a", prefix);
         const authorityNode = getClusterNode(cluster, "node-a");
         const hostNode = getClusterNode(cluster, "node-b");
-        const sharedScope = `replication/auth-second-contact/shared/${Date.now()}`;
-
         await authority.signIn();
         expect(authority.spaceId).toBeDefined();
 
-        const authSyncSession = await openKvReplicationSession(
+        const peerAuthSession = await openAuthReplicationSession(
           authority,
-          authorityNode.url,
-          sharedScope
+          authorityNode.url
+        );
+        const targetAuthSession = await openAuthReplicationSession(
+          authority,
+          hostNode.url
         );
         const authApply = await reconcileAuthFromPeer(
           cluster,
@@ -35,10 +38,11 @@ describe("Replication Auth Second Contact", () => {
           {
             peerUrl: authorityNode.url,
             spaceId: authority.spaceId!,
-            service: "kv",
-            prefix: sharedScope,
           },
-          authSyncSession
+          {
+            target: targetAuthSession,
+            peer: peerAuthSession,
+          }
         );
 
         expect(authApply.importedDelegations).toBeGreaterThan(0);
@@ -49,24 +53,13 @@ describe("Replication Auth Second Contact", () => {
           hostNode.url,
           secondContactScope
         );
-        const secondContactOpen = await fetch(
-          `${hostNode.url}/replication/session/open`,
-          {
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-              ...hostSession.delegationHeader,
-            },
-            body: JSON.stringify({
-              spaceId: authority.spaceId,
-              service: "kv",
-              prefix: secondContactScope,
-            }),
-          }
-        );
+        const secondContactOpen = await requestTransportSession(hostSession, {
+          supportingDelegations: null,
+        });
 
-        expect(secondContactOpen.status).toBe(200);
-        const secondContactTransport = await secondContactOpen.json();
+        expect(secondContactOpen).toBeDefined();
+        expect(secondContactOpen?.status).toBe(200);
+        const secondContactTransport = await secondContactOpen!.json();
         expect(secondContactTransport.service).toBe("kv");
         expect(secondContactTransport.prefix).toBe(secondContactScope);
       } finally {

--- a/tests/node-sdk/replication/auth-session-serverdid.test.ts
+++ b/tests/node-sdk/replication/auth-session-serverdid.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openTransportSession,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Session Server Identity", () => {
+  test(
+    "surfaces a per-space serverDid from replication/session/open",
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("replication-session-serverdid");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/session-serverdid/${Date.now()}`;
+
+        const authorityAuthoritySession = await authority.openReplicationSession({
+          host: authorityNode.url,
+          scope: {
+            service: "kv",
+            prefix: scope,
+          },
+        });
+        const replicaAuthoritySession = await replica.openReplicationSession({
+          host: authorityNode.url,
+          scope: {
+            service: "kv",
+            prefix: scope,
+          },
+        });
+        const replicaReplicaSession = await replica.openReplicationSession({
+          host: replicaNode.url,
+          scope: {
+            service: "kv",
+            prefix: scope,
+          },
+        });
+
+        const authorityTransport = await openTransportSession(
+          authorityAuthoritySession
+        );
+        const authorityTransportFromReplica = await openTransportSession(
+          replicaAuthoritySession
+        );
+        const replicaTransport = await openTransportSession(replicaReplicaSession);
+
+        expect(typeof authorityTransport?.serverDid).toBe("string");
+        expect(authorityTransport?.serverDid.length ?? 0).toBeGreaterThan(0);
+        expect(authorityTransportFromReplica?.serverDid).toBe(
+          authorityTransport?.serverDid
+        );
+        expect(replicaTransport?.serverDid).toBeDefined();
+        expect(replicaTransport?.serverDid).not.toBe(authorityTransport?.serverDid);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/auth-session-serving-assessment.test.ts
+++ b/tests/node-sdk/replication/auth-session-serving-assessment.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openTransportSession,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Session Serving Assessment", () => {
+  test(
+    "reports canExport and role state from replication/session/open",
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("replication-session-serving");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-c", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-c");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/session-serving/${Date.now()}`;
+
+        const hostSession = await authority.openReplicationSession({
+          host: authorityNode.url,
+          scope: {
+            service: "kv",
+            prefix: scope,
+          },
+        });
+        const replicaSession = await replica.openReplicationSession({
+          host: replicaNode.url,
+          scope: {
+            service: "kv",
+            prefix: scope,
+          },
+        });
+
+        const hostTransport = await openTransportSession(hostSession);
+        const replicaTransport = await openTransportSession(replicaSession);
+
+        expect(hostTransport?.serverDid).toBeDefined();
+        expect(replicaTransport?.serverDid).toBeDefined();
+        expect(hostTransport?.serverDid.length ?? 0).toBeGreaterThan(0);
+        expect(replicaTransport?.serverDid.length ?? 0).toBeGreaterThan(0);
+        expect(replicaTransport?.serverDid).not.toBe(hostTransport?.serverDid);
+
+        expect(hostTransport?.rolesEnabled).toEqual(["host"]);
+        expect(replicaTransport?.rolesEnabled).toEqual(["replica"]);
+        expect(hostTransport?.canExport).toBe(true);
+        expect(hostTransport?.peerServing).toBe(true);
+        expect(replicaTransport?.canExport).toBe(false);
+        expect(replicaTransport?.peerServing).toBe(false);
+        expect(typeof hostTransport?.recon).toBe("boolean");
+        expect(typeof hostTransport?.authSync).toBe("boolean");
+        expect(typeof replicaTransport?.recon).toBe("boolean");
+        expect(typeof replicaTransport?.authSync).toBe("boolean");
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/auth-session.test.ts
+++ b/tests/node-sdk/replication/auth-session.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openTransportSession,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Session Auth", () => {
+  test(
+    "opens a short-lived replication session and requires Replication-Session for KV export",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("replication-session-kv");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+
+        await authority.signIn();
+        expect(authority.spaceId).toBeDefined();
+
+        const scope = `replication/session-auth/kv/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const putResult = await authority.kv.put(key, { createdAt: new Date().toISOString() });
+        expect(putResult.ok).toBe(true);
+
+        const unauthorized = await fetch(`${authorityNode.url}/replication/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            spaceId: authority.spaceId,
+            prefix: scope,
+          }),
+        });
+        expect(unauthorized.status).toBe(401);
+
+        const session = await authority.openReplicationSession({
+          host: authorityNode.url,
+          scope: {
+            service: "kv",
+            prefix: scope,
+          },
+        });
+        const transport = await openTransportSession(session);
+        expect(session.host).toBe(authorityNode.url);
+        expect(session.spaceId).toBe(authority.spaceId);
+        expect(transport?.service).toBe("kv");
+        expect(transport?.prefix).toBe(scope);
+        expect(typeof transport?.sessionToken).toBe("string");
+        expect((transport?.sessionToken.length ?? 0)).toBeGreaterThan(0);
+
+        const authorized = await fetch(`${authorityNode.url}/replication/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": transport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: authority.spaceId,
+            prefix: scope,
+          }),
+        });
+        expect(authorized.status).toBe(200);
+
+        const exportBody = await authorized.json() as {
+          sequences: Array<{ events: Array<unknown> }>;
+        };
+        expect(exportBody.sequences.length).toBeGreaterThan(0);
+        expect(exportBody.sequences[0]?.events.length ?? 0).toBeGreaterThan(0);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+
+  test(
+    "opens a short-lived replication session and requires Replication-Session for SQL export",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("replication-session-sql");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+
+        await authority.signIn();
+        expect(authority.spaceId).toBeDefined();
+
+        const dbName = `replication_auth_${Date.now()}`;
+        const tableName = `items_auth_${Date.now()}`;
+        const sql = authority.sql.db(dbName);
+
+        const createResult = await sql.execute(
+          `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL)`
+        );
+        expect(createResult.ok).toBe(true);
+
+        const insertResult = await sql.execute(
+          `INSERT INTO ${tableName} (id, name) VALUES (?, ?)`,
+          ["item-1", "camera"]
+        );
+        expect(insertResult.ok).toBe(true);
+
+        const unauthorized = await fetch(`${authorityNode.url}/replication/sql/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            spaceId: authority.spaceId,
+            dbName,
+          }),
+        });
+        expect(unauthorized.status).toBe(401);
+
+        const session = await authority.openReplicationSession({
+          host: authorityNode.url,
+          scope: {
+            service: "sql",
+            dbName,
+          },
+        });
+        const transport = await openTransportSession(session);
+        expect(session.host).toBe(authorityNode.url);
+        expect(session.spaceId).toBe(authority.spaceId);
+        expect(transport?.service).toBe("sql");
+        expect(transport?.dbName).toBe(dbName);
+        expect(typeof transport?.sessionToken).toBe("string");
+        expect((transport?.sessionToken.length ?? 0)).toBeGreaterThan(0);
+
+        const authorized = await fetch(`${authorityNode.url}/replication/sql/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": transport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: authority.spaceId,
+            dbName,
+          }),
+        });
+        expect(authorized.status).toBe(200);
+
+        const exportBody = await authorized.json() as { snapshot: number[] };
+        expect(exportBody.snapshot.length).toBeGreaterThan(0);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/cluster.ts
+++ b/tests/node-sdk/replication/cluster.ts
@@ -62,6 +62,8 @@ const DEFAULT_PROMETHEUS_PORT_START = 8510;
 const PORT_RANGE_START = 8000;
 const PORT_RANGE_END = 8999;
 
+let clusterLeaseTail = Promise.resolve();
+
 const DEFAULT_NODES: ClusterNodeConfig[] = [
   { name: "node-a", role: "authority", port: 8010 },
   { name: "node-b", role: "host", port: 8011 },
@@ -70,6 +72,17 @@ const DEFAULT_NODES: ClusterNodeConfig[] = [
 
 interface AssignedClusterNodeConfig extends ClusterNodeConfig {
   prometheusPort: number;
+}
+
+async function acquireClusterLease(): Promise<() => void> {
+  let release: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const previous = clusterLeaseTail;
+  clusterLeaseTail = clusterLeaseTail.then(() => current);
+  await previous;
+  return () => release?.();
 }
 
 function replicationRoleEnv(role: ClusterNodeRole): "host" | "replica" {
@@ -386,6 +399,14 @@ async function startNode(
 export async function startCluster(
   options: ClusterOptions = {}
 ): Promise<RunningCluster> {
+  let releaseClusterLease: (() => void) | null = await acquireClusterLease();
+  const releaseLease = () => {
+    if (!releaseClusterLease) {
+      return;
+    }
+    releaseClusterLease();
+    releaseClusterLease = null;
+  };
   const clusterTmpRoot =
     process.env.TC_REPLICATION_TMPDIR ?? process.env.TMPDIR ?? tmpdir();
   const rootDir =
@@ -442,6 +463,7 @@ export async function startCluster(
     }
   } catch (error) {
     await Promise.all(nodes.map((node) => stopProcess(node.process)));
+    releaseLease();
     throw new Error(
       `Cluster startup failed. Preserved logs and data at ${rootDir}. ${String(error)}`
     );
@@ -458,8 +480,12 @@ export async function startCluster(
       return await startNodeByName(nodeName);
     },
     async stop() {
-      await Promise.all(nodes.map((node) => stopProcess(node.process)));
-      await rm(rootDir, { recursive: true, force: true });
+      try {
+        await Promise.all(nodes.map((node) => stopProcess(node.process)));
+        await rm(rootDir, { recursive: true, force: true });
+      } finally {
+        releaseLease();
+      }
     },
     async restartNode(nodeName: string) {
       await stopNodeByName(nodeName);

--- a/tests/node-sdk/replication/cluster.ts
+++ b/tests/node-sdk/replication/cluster.ts
@@ -72,6 +72,10 @@ interface AssignedClusterNodeConfig extends ClusterNodeConfig {
   prometheusPort: number;
 }
 
+function replicationRoleEnv(role: ClusterNodeRole): "host" | "replica" {
+  return role === "replica" ? "replica" : "host";
+}
+
 function repoRootFromThisFile(): string {
   return resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 }
@@ -311,6 +315,12 @@ async function startNode(
     TINYCLOUD_STORAGE_DATADIR: dataDir,
     TINYCLOUD_STORAGE_DATABASE: `sqlite:${join(dataDir, "caps.db")}`,
     TINYCLOUD_KEYS_TYPE: "Static",
+    TINYCLOUD_REPLICATION_ROLE:
+      config.env?.TINYCLOUD_REPLICATION_ROLE ?? replicationRoleEnv(config.role),
+    ...(config.role === "replica" &&
+    config.env?.TINYCLOUD_REPLICATION_PEER_SERVING === undefined
+      ? { TINYCLOUD_REPLICATION_PEER_SERVING: "false" }
+      : {}),
     TINYCLOUD_KEYS_SECRET:
       config.env?.TINYCLOUD_KEYS_SECRET ??
       base64UrlSecret(config.port - DEFAULT_NODES[0].port + 1),

--- a/tests/node-sdk/replication/cluster.ts
+++ b/tests/node-sdk/replication/cluster.ts
@@ -1,0 +1,459 @@
+import { once } from "node:events";
+import { createWriteStream } from "node:fs";
+import { access, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { createServer } from "node:net";
+import {
+  spawn,
+  spawnSync,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export type ClusterNodeRole = "authority" | "host" | "replica";
+
+export interface ClusterNodeConfig {
+  name: string;
+  role: ClusterNodeRole;
+  port: number;
+  env?: Record<string, string>;
+}
+
+export interface RunningNode {
+  name: string;
+  role: ClusterNodeRole;
+  port: number;
+  url: string;
+  rootDir: string;
+  stdoutLogPath: string;
+  stderrLogPath: string;
+  env: Record<string, string>;
+  process: ChildProcessWithoutNullStreams;
+}
+
+export interface ClusterOptions {
+  nodeRepo?: string;
+  nodeBin?: string;
+  cargoTargetDir?: string;
+  rootDir?: string;
+  startupTimeoutMs?: number;
+  healthPollMs?: number;
+  nodes?: ClusterNodeConfig[];
+  env?: Record<string, string>;
+}
+
+export interface RunningCluster {
+  rootDir: string;
+  nodeBin: string;
+  nodes: RunningNode[];
+  stopNode(nodeName: string): Promise<RunningNode>;
+  startNode(nodeName: string): Promise<RunningNode>;
+  stop(): Promise<void>;
+  restartNode(nodeName: string): Promise<RunningNode>;
+}
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 45_000;
+const DEFAULT_HEALTH_POLL_MS = 250;
+const DEFAULT_PROMETHEUS_PORT_OFFSET = 100;
+const DEFAULT_CARGO_BUILD_JOBS = "8";
+const DEFAULT_NODE_PORT_START = 8010;
+const DEFAULT_PROMETHEUS_PORT_START = 8510;
+const PORT_RANGE_START = 8000;
+const PORT_RANGE_END = 8999;
+
+const DEFAULT_NODES: ClusterNodeConfig[] = [
+  { name: "node-a", role: "authority", port: 8010 },
+  { name: "node-b", role: "host", port: 8011 },
+  { name: "node-c", role: "replica", port: 8012 },
+];
+
+interface AssignedClusterNodeConfig extends ClusterNodeConfig {
+  prometheusPort: number;
+}
+
+function repoRootFromThisFile(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+}
+
+function bootstrapTinycloudRepoCandidate(): string {
+  return resolve(
+    repoRootFromThisFile(),
+    "../../../tinycloud-node/feat/replication-e2e-bootstrap"
+  );
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isPortAvailable(port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+async function findAvailablePort(
+  preferredPort: number,
+  usedPorts: Set<number>,
+  start = PORT_RANGE_START,
+  end = PORT_RANGE_END
+): Promise<number> {
+  for (let offset = 0; offset <= end - start; offset += 1) {
+    const candidate =
+      start + ((preferredPort - start + offset + (end - start + 1)) % (end - start + 1));
+    if (usedPorts.has(candidate)) {
+      continue;
+    }
+    if (await isPortAvailable(candidate)) {
+      usedPorts.add(candidate);
+      return candidate;
+    }
+  }
+
+  throw new Error(`Could not find a free port in ${start}-${end}`);
+}
+
+async function assignClusterPorts(
+  configs: ClusterNodeConfig[]
+): Promise<AssignedClusterNodeConfig[]> {
+  const usedPorts = new Set<number>();
+  const assigned: AssignedClusterNodeConfig[] = [];
+
+  for (let index = 0; index < configs.length; index += 1) {
+    const config = configs[index];
+    const port = await findAvailablePort(
+      config.port ?? DEFAULT_NODE_PORT_START + index,
+      usedPorts
+    );
+    const prometheusPort = await findAvailablePort(
+      DEFAULT_PROMETHEUS_PORT_START + index * DEFAULT_PROMETHEUS_PORT_OFFSET,
+      usedPorts
+    );
+    assigned.push({
+      ...config,
+      port,
+      prometheusPort,
+    });
+  }
+
+  return assigned;
+}
+
+async function resolveNodeRepo(options: ClusterOptions): Promise<string> {
+  if (options.nodeRepo) {
+    return resolve(options.nodeRepo);
+  }
+
+  if (process.env.TC_REPLICATION_NODE_REPO) {
+    return resolve(process.env.TC_REPLICATION_NODE_REPO);
+  }
+
+  const candidate = bootstrapTinycloudRepoCandidate();
+  if (await pathExists(candidate)) {
+    return candidate;
+  }
+
+  throw new Error(
+    "Could not resolve tinycloud-node repo path. Set TC_REPLICATION_NODE_REPO or pass nodeRepo explicitly."
+  );
+}
+
+async function resolveNodeBinary(options: ClusterOptions): Promise<string> {
+  if (options.nodeBin) {
+    return resolve(options.nodeBin);
+  }
+
+  if (process.env.TC_REPLICATION_NODE_BIN) {
+    return resolve(process.env.TC_REPLICATION_NODE_BIN);
+  }
+
+  const nodeRepo = await resolveNodeRepo(options);
+  const cargoTargetDir = resolve(
+    options.cargoTargetDir ??
+      process.env.TC_REPLICATION_CARGO_TARGET_DIR ??
+      join(nodeRepo, ".replication-target")
+  );
+  const binaryPath = join(cargoTargetDir, "debug", "tinycloud");
+
+  if (!(await pathExists(binaryPath))) {
+    const build = spawnSync("cargo", ["build", "-j", DEFAULT_CARGO_BUILD_JOBS, "--bin", "tinycloud"], {
+      cwd: nodeRepo,
+      env: {
+        ...process.env,
+        CARGO_TARGET_DIR: cargoTargetDir,
+        CARGO_INCREMENTAL: "0",
+        CARGO_PROFILE_DEV_DEBUG: "0",
+        OPENSSL_NO_VENDOR: "1",
+      },
+      stdio: "inherit",
+    });
+
+    if (build.status !== 0) {
+      throw new Error(
+        `Failed to build tinycloud binary in ${nodeRepo} using target dir ${cargoTargetDir}`
+      );
+    }
+  }
+
+  if (!(await pathExists(binaryPath))) {
+    throw new Error(`tinycloud binary not found at ${binaryPath}`);
+  }
+
+  return binaryPath;
+}
+
+function base64UrlSecret(seedByte: number): string {
+  return Buffer.alloc(32, seedByte).toString("base64url");
+}
+
+async function waitForHealthy(
+  url: string,
+  timeoutMs: number,
+  pollMs: number
+): Promise<void> {
+  const start = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const health = await fetch(`${url}/healthz`, {
+        signal: AbortSignal.timeout(2_000),
+      });
+      const info = await fetch(`${url}/info`, {
+        signal: AbortSignal.timeout(2_000),
+      });
+
+      if (health.ok && info.ok) {
+        return;
+      }
+
+      lastError = new Error(
+        `health=${health.status} info=${info.status} while waiting for ${url}`
+      );
+    } catch (error) {
+      lastError = error;
+    }
+
+    await Bun.sleep(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`);
+}
+
+async function stopProcess(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs = 5_000
+): Promise<void> {
+  if (child.exitCode !== null || child.killed) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+
+  const exited = Promise.race([
+    once(child, "exit"),
+    Bun.sleep(timeoutMs).then(() => null),
+  ]);
+
+  const result = await exited;
+  if (result === null && child.exitCode === null) {
+    child.kill("SIGKILL");
+    await once(child, "exit");
+  }
+}
+
+async function readLogTail(path: string, maxChars = 4_000): Promise<string | null> {
+  try {
+    const content = await readFile(path, "utf8");
+    return content.slice(-maxChars);
+  } catch {
+    return null;
+  }
+}
+
+async function startNode(
+  nodeBin: string,
+  clusterRootDir: string,
+  config: AssignedClusterNodeConfig,
+  inheritedEnv: Record<string, string>
+): Promise<RunningNode> {
+  const nodeRootDir = join(clusterRootDir, config.name);
+  const dataDir = join(nodeRootDir, "data");
+  const blocksDir = join(nodeRootDir, "blocks");
+  const logsDir = join(nodeRootDir, "logs");
+  const stdoutLogPath = join(logsDir, "stdout.log");
+  const stderrLogPath = join(logsDir, "stderr.log");
+
+  await mkdir(dataDir, { recursive: true });
+  await mkdir(blocksDir, { recursive: true });
+  await mkdir(logsDir, { recursive: true });
+
+  const env: Record<string, string> = {
+    ...process.env,
+    ...inheritedEnv,
+    ...config.env,
+    ROCKET_ADDRESS: "127.0.0.1",
+    ROCKET_PORT: String(config.port),
+    TINYCLOUD_PROMETHEUS_PORT: String(config.prometheusPort),
+    TINYCLOUD_STORAGE_BLOCKS_TYPE: "Local",
+    TINYCLOUD_STORAGE_BLOCKS_PATH: blocksDir,
+    TINYCLOUD_STORAGE_DATADIR: dataDir,
+    TINYCLOUD_STORAGE_DATABASE: `sqlite:${join(dataDir, "caps.db")}`,
+    TINYCLOUD_KEYS_TYPE: "Static",
+    TINYCLOUD_KEYS_SECRET:
+      config.env?.TINYCLOUD_KEYS_SECRET ??
+      base64UrlSecret(config.port - DEFAULT_NODES[0].port + 1),
+  };
+
+  const child = spawn(nodeBin, [], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout.pipe(createWriteStream(stdoutLogPath, { flags: "a" }));
+  child.stderr.pipe(createWriteStream(stderrLogPath, { flags: "a" }));
+
+  const node: RunningNode = {
+    name: config.name,
+    role: config.role,
+    port: config.port,
+    url: `http://127.0.0.1:${config.port}`,
+    rootDir: nodeRootDir,
+    stdoutLogPath,
+    stderrLogPath,
+    env,
+    process: child,
+  };
+
+  const startupTimeoutMs = Number(
+    env.TC_REPLICATION_STARTUP_TIMEOUT_MS ?? DEFAULT_STARTUP_TIMEOUT_MS
+  );
+  const healthPollMs = Number(env.TC_REPLICATION_HEALTH_POLL_MS ?? DEFAULT_HEALTH_POLL_MS);
+
+  const startupResult = await Promise.race([
+    waitForHealthy(node.url, startupTimeoutMs, healthPollMs).then(() => ({
+      kind: "ready" as const,
+    })),
+    once(child, "exit").then(async ([code, signal]) => ({
+      kind: "exit" as const,
+      code,
+      signal,
+      stderrTail: await readLogTail(stderrLogPath),
+    })),
+  ]);
+
+  if (startupResult.kind === "exit") {
+    const stderrSection = startupResult.stderrTail
+      ? `\n--- stderr tail ---\n${startupResult.stderrTail}`
+      : "";
+    throw new Error(
+      `Node ${config.name} exited before becoming healthy at ${node.url} (code=${startupResult.code}, signal=${startupResult.signal ?? "none"}). Logs: ${stderrLogPath}${stderrSection}`
+    );
+  }
+
+  if (child.exitCode !== null || child.killed) {
+    const stderrTail = await readLogTail(stderrLogPath);
+    const stderrSection = stderrTail ? `\n--- stderr tail ---\n${stderrTail}` : "";
+    throw new Error(
+      `Node ${config.name} stopped before startup completed at ${node.url}. Logs: ${stderrLogPath}${stderrSection}`
+    );
+  }
+
+  return node;
+}
+
+export async function startCluster(
+  options: ClusterOptions = {}
+): Promise<RunningCluster> {
+  const clusterTmpRoot =
+    process.env.TC_REPLICATION_TMPDIR ?? process.env.TMPDIR ?? tmpdir();
+  const rootDir =
+    options.rootDir ??
+    (await mkdtemp(join(clusterTmpRoot, "tinycloud-replication-cluster-")));
+  const nodeBin = await resolveNodeBinary(options);
+  const nodes: RunningNode[] = [];
+  const stopNodeByName = async (nodeName: string): Promise<RunningNode> => {
+    const node = nodes.find((candidate) => candidate.name === nodeName);
+    if (!node) {
+      throw new Error(`Unknown cluster node: ${nodeName}`);
+    }
+
+    await stopProcess(node.process);
+    return node;
+  };
+  const startNodeByName = async (nodeName: string): Promise<RunningNode> => {
+    const node = nodes.find((candidate) => candidate.name === nodeName);
+    if (!node) {
+      throw new Error(`Unknown cluster node: ${nodeName}`);
+    }
+
+    if (node.process.exitCode === null && !node.process.killed) {
+      return node;
+    }
+
+    const prometheusPort = Number(node.env.TINYCLOUD_PROMETHEUS_PORT);
+    if (!Number.isFinite(prometheusPort)) {
+      throw new Error(
+        `Cluster node ${nodeName} is missing a valid TINYCLOUD_PROMETHEUS_PORT`
+      );
+    }
+
+    const started = await startNode(nodeBin, rootDir, {
+      name: node.name,
+      role: node.role,
+      port: node.port,
+      prometheusPort,
+      env: {
+        TINYCLOUD_KEYS_SECRET: node.env.TINYCLOUD_KEYS_SECRET,
+      },
+    }, node.env);
+
+    node.process = started.process;
+    node.env = started.env;
+    return node;
+  };
+
+  try {
+    const configs = await assignClusterPorts(options.nodes ?? DEFAULT_NODES);
+    for (const config of configs) {
+      const node = await startNode(nodeBin, rootDir, config, options.env ?? {});
+      nodes.push(node);
+    }
+  } catch (error) {
+    await Promise.all(nodes.map((node) => stopProcess(node.process)));
+    throw new Error(
+      `Cluster startup failed. Preserved logs and data at ${rootDir}. ${String(error)}`
+    );
+  }
+
+  return {
+    rootDir,
+    nodeBin,
+    nodes,
+    async stopNode(nodeName: string) {
+      return await stopNodeByName(nodeName);
+    },
+    async startNode(nodeName: string) {
+      return await startNodeByName(nodeName);
+    },
+    async stop() {
+      await Promise.all(nodes.map((node) => stopProcess(node.process)));
+      await rm(rootDir, { recursive: true, force: true });
+    },
+    async restartNode(nodeName: string) {
+      await stopNodeByName(nodeName);
+      return await startNodeByName(nodeName);
+    },
+  };
+}

--- a/tests/node-sdk/replication/delegation-baseline.test.ts
+++ b/tests/node-sdk/replication/delegation-baseline.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Delegation Baseline", () => {
+  test(
+    "creates a live delegation on one node and uses it from another",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("delegation-baseline");
+        const alice = createClusterClient(cluster, "node-a", prefix);
+        const bob = createClusterClient(cluster, "node-b", prefix);
+
+        await alice.signIn();
+        await bob.signIn();
+
+        expect(alice.spaceId).toBeDefined();
+        expect(bob.spaceId).toBeDefined();
+        expect(alice.spaceId).toBe(bob.spaceId);
+
+        const sharedPath = `replication/delegation-baseline/${Date.now()}`;
+        const delegation = await alice.createDelegation({
+          path: sharedPath,
+          actions: [
+            "tinycloud.kv/get",
+            "tinycloud.kv/put",
+            "tinycloud.kv/list",
+            "tinycloud.kv/metadata",
+          ],
+          delegateDID: bob.did,
+          includePublicSpace: false,
+        });
+
+        const delegatedAccess = await bob.useDelegation(delegation);
+        expect(delegatedAccess.spaceId).toBe(alice.spaceId);
+        expect(delegatedAccess.path).toBe(sharedPath);
+
+        const noteKey = "message.txt";
+        const noteValue = {
+          owner: "alice",
+          writer: "bob",
+          sharedAt: new Date().toISOString(),
+        };
+
+        const putResult = await delegatedAccess.kv.put(noteKey, noteValue);
+        expect(putResult.ok).toBe(true);
+
+        const delegatedGet = await delegatedAccess.kv.get<typeof noteValue>(noteKey);
+        expect(delegatedGet.ok).toBe(true);
+        if (!delegatedGet.ok) {
+          throw new Error(delegatedGet.error.message);
+        }
+        expect(delegatedGet.data.data).toEqual(noteValue);
+
+        const aliceGet = await alice.kv.get<typeof noteValue>(
+          `${sharedPath}/${noteKey}`
+        );
+        expect(aliceGet.ok).toBe(true);
+        if (!aliceGet.ok) {
+          throw new Error(aliceGet.error.message);
+        }
+        expect(aliceGet.data.data).toEqual(noteValue);
+
+        const listResult = await delegatedAccess.kv.list();
+        expect(listResult.ok).toBe(true);
+        if (!listResult.ok) {
+          throw new Error(listResult.error.message);
+        }
+        expect(listResult.data.keys).toContain(`${sharedPath}/${noteKey}`);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -138,6 +138,30 @@ export interface KvReconSplitResponse {
   children: KvReconSplitChild[];
 }
 
+export interface KvReconSplitCompareRequest {
+  peerUrl: string;
+  spaceId: string;
+  prefix?: string;
+}
+
+export interface KvReconSplitChildComparison {
+  prefix: string;
+  status: "match" | "local-missing" | "peer-missing" | "mismatch";
+  localItemCount: number;
+  peerItemCount: number;
+  localFingerprint: string;
+  peerFingerprint: string;
+  leaf: boolean;
+}
+
+export interface KvReconSplitCompareResponse {
+  spaceId: string;
+  prefix?: string;
+  peerUrl: string;
+  matches: boolean;
+  children: KvReconSplitChildComparison[];
+}
+
 export interface KvReconCompareResponse {
   spaceId: string;
   prefix?: string;
@@ -584,6 +608,40 @@ export async function reconSplitFromPeer(
   }
 
   return (await response.json()) as KvReconSplitResponse;
+}
+
+export async function reconSplitCompareFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: KvReconSplitCompareRequest,
+  sessions: ReplicationPullSessions
+): Promise<KvReconSplitCompareResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
+  const response = await fetch(`${node.url}/replication/recon/split/compare`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...targetHeaders,
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `KV recon split compare failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvReconSplitCompareResponse;
 }
 
 export async function reconCompareFromPeer(

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -2,6 +2,7 @@ import { Wallet } from "ethers";
 import {
   TinyCloudNode,
   type KVServiceConfig,
+  type SQLServiceConfig,
   type TinyCloudReplicationSession,
 } from "@tinycloud/node-sdk";
 import type { RunningCluster, RunningNode } from "./cluster";
@@ -466,6 +467,7 @@ export function createClusterClient(
   key = REPLICATION_TEST_KEY,
   options: {
     kvConfig?: KVServiceConfig;
+    sqlConfig?: SQLServiceConfig;
   } = {}
 ): TinyCloudNode {
   const node = getClusterNode(cluster, nodeName);
@@ -474,6 +476,7 @@ export function createClusterClient(
     host: node.url,
     prefix,
     kvConfig: options.kvConfig,
+    sqlConfig: options.sqlConfig,
     autoCreateSpace: true,
     defaultActions: replicationDefaultActions(),
   });

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -189,11 +189,13 @@ export async function openTransportSession(
           spaceId: session.spaceId,
           service: "kv",
           prefix: session.scope.prefix,
+          supportingDelegations: session.supportingDelegations,
         }
       : {
           spaceId: session.spaceId,
           service: "sql",
           dbName: session.scope.dbName,
+          supportingDelegations: session.supportingDelegations,
         };
 
   const response = await fetch(`${session.host}/replication/session/open`, {

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -147,6 +147,61 @@ export interface KvStateCompareResponse {
   items: KvStateCompareItem[];
 }
 
+export interface KvPeerMissingPlanItem {
+  key: string;
+  kind: string;
+  localInvocationId?: string | null;
+  peerStatus: "present" | "deleted" | "absent";
+  peerSeq?: number | null;
+  peerInvocationId?: string | null;
+  peerDeletedInvocationId?: string | null;
+  peerValueHash?: string | null;
+  action: "keep" | "prune-delete" | "quarantine-absent";
+}
+
+export interface KvPeerMissingPlanResponse {
+  spaceId: string;
+  prefix?: string;
+  peerUrl: string;
+  peerHostRole: boolean;
+  startAfter?: string;
+  limit?: number;
+  hasMore?: boolean;
+  nextStartAfter?: string | null;
+  keepCount: number;
+  pruneDeleteCount: number;
+  quarantineAbsentCount: number;
+  items: KvPeerMissingPlanItem[];
+}
+
+export interface KvPeerMissingApplyItem {
+  key: string;
+  action: "keep" | "prune-delete" | "quarantine-absent";
+  result: string;
+  localInvocationId?: string | null;
+  peerStatus: "present" | "deleted" | "absent";
+  peerDeletedInvocationId?: string | null;
+  appliedSequences: number;
+  appliedEvents: number;
+}
+
+export interface KvPeerMissingApplyResponse {
+  spaceId: string;
+  prefix?: string;
+  peerUrl: string;
+  peerHostRole: boolean;
+  startAfter?: string;
+  limit?: number;
+  hasMore?: boolean;
+  nextStartAfter?: string | null;
+  attemptedItems: number;
+  prunedDeletes: number;
+  quarantined: number;
+  alreadyQuarantined: number;
+  kept: number;
+  items: KvPeerMissingApplyItem[];
+}
+
 export interface KvReconItem {
   key: string;
   kind: string;
@@ -742,6 +797,74 @@ export async function kvStateCompareFromPeer(
   }
 
   return (await response.json()) as KvStateCompareResponse;
+}
+
+export async function peerMissingPlanFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: KvStateCompareRequest,
+  sessions: ReplicationPullSessions
+): Promise<KvPeerMissingPlanResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
+  const response = await fetch(`${node.url}/replication/peer-missing/plan`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...targetHeaders,
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Peer-missing plan failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvPeerMissingPlanResponse;
+}
+
+export async function peerMissingApplyFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: KvStateCompareRequest,
+  sessions: ReplicationPullSessions
+): Promise<KvPeerMissingApplyResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
+  const response = await fetch(`${node.url}/replication/peer-missing/apply`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...targetHeaders,
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Peer-missing apply failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvPeerMissingApplyResponse;
 }
 
 export async function reconSplitFromPeer(

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -1,6 +1,7 @@
 import { Wallet } from "ethers";
 import {
   TinyCloudNode,
+  type KVServiceConfig,
   type TinyCloudReplicationSession,
 } from "@tinycloud/node-sdk";
 import type { RunningCluster, RunningNode } from "./cluster";
@@ -398,13 +399,17 @@ export function createClusterClient(
   cluster: RunningCluster,
   nodeName: string,
   prefix: string,
-  key = REPLICATION_TEST_KEY
+  key = REPLICATION_TEST_KEY,
+  options: {
+    kvConfig?: KVServiceConfig;
+  } = {}
 ): TinyCloudNode {
   const node = getClusterNode(cluster, nodeName);
   return new TinyCloudNode({
     privateKey: key,
     host: node.url,
     prefix,
+    kvConfig: options.kvConfig,
     autoCreateSpace: true,
     defaultActions: replicationDefaultActions(),
   });

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -121,6 +121,8 @@ export interface KvReconCompareRequest {
 export interface KvReconSplitRequest {
   spaceId: string;
   prefix?: string;
+  childStartAfter?: string;
+  childLimit?: number;
 }
 
 export interface KvReconSplitChild {
@@ -133,8 +135,12 @@ export interface KvReconSplitChild {
 export interface KvReconSplitResponse {
   spaceId: string;
   prefix?: string;
+  childStartAfter?: string;
+  childLimit?: number;
   itemCount: number;
   fingerprint: string;
+  hasMore?: boolean;
+  nextChildStartAfter?: string | null;
   children: KvReconSplitChild[];
 }
 
@@ -142,6 +148,8 @@ export interface KvReconSplitCompareRequest {
   peerUrl: string;
   spaceId: string;
   prefix?: string;
+  childStartAfter?: string;
+  childLimit?: number;
 }
 
 export interface KvReconSplitReconcileRequest {
@@ -166,7 +174,11 @@ export interface KvReconSplitCompareResponse {
   spaceId: string;
   prefix?: string;
   peerUrl: string;
+  childStartAfter?: string;
+  childLimit?: number;
   matches: boolean;
+  hasMore?: boolean;
+  nextChildStartAfter?: string | null;
   children: KvReconSplitChildComparison[];
 }
 

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -174,10 +174,38 @@ export interface KvPeerMissingPlanResponse {
   items: KvPeerMissingPlanItem[];
 }
 
+export interface KvPeerMissingQuarantineRequest {
+  spaceId: string;
+  prefix?: string;
+  startAfter?: string;
+  limit?: number;
+}
+
+export interface KvPeerMissingQuarantineItem {
+  key: string;
+  peerUrl: string;
+  localInvocationId: string;
+  peerStatus: "present" | "deleted" | "absent";
+  peerInvocationId?: string | null;
+  peerDeletedInvocationId?: string | null;
+  quarantinedAt: number;
+}
+
+export interface KvPeerMissingQuarantineResponse {
+  spaceId: string;
+  prefix?: string;
+  startAfter?: string;
+  limit?: number;
+  hasMore?: boolean;
+  nextStartAfter?: string | null;
+  items: KvPeerMissingQuarantineItem[];
+}
+
 export interface KvPeerMissingApplyItem {
   key: string;
   action: "keep" | "prune-delete" | "quarantine-absent";
   result: string;
+  clearedQuarantine: boolean;
   localInvocationId?: string | null;
   peerStatus: "present" | "deleted" | "absent";
   peerDeletedInvocationId?: string | null;
@@ -198,6 +226,7 @@ export interface KvPeerMissingApplyResponse {
   prunedDeletes: number;
   quarantined: number;
   alreadyQuarantined: number;
+  clearedQuarantine: number;
   kept: number;
   items: KvPeerMissingApplyItem[];
 }
@@ -865,6 +894,35 @@ export async function peerMissingApplyFromPeer(
   }
 
   return (await response.json()) as KvPeerMissingApplyResponse;
+}
+
+export async function peerMissingQuarantineFromLocal(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: KvPeerMissingQuarantineRequest,
+  session: TinyCloudReplicationSession
+): Promise<KvPeerMissingQuarantineResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const headers = await buildSessionHeaders("Replication-Session", session);
+  const response = await fetch(
+    `${node.url}/replication/peer-missing/quarantine`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify(request),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Peer-missing quarantine export failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvPeerMissingQuarantineResponse;
 }
 
 export async function reconSplitFromPeer(

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -96,6 +96,57 @@ export interface KvReconExportRequest {
   limit?: number;
 }
 
+export interface KvStateRequest {
+  spaceId: string;
+  prefix?: string;
+  keys: string[];
+}
+
+export interface KvStateStatusItem {
+  key: string;
+  status: "present" | "deleted" | "absent";
+  seq?: number;
+  invocationId?: string | null;
+  deletedInvocationId?: string | null;
+  valueHash?: string | null;
+}
+
+export interface KvStateResponse {
+  spaceId: string;
+  prefix?: string;
+  items: KvStateStatusItem[];
+}
+
+export interface KvStateCompareRequest {
+  peerUrl: string;
+  spaceId: string;
+  prefix?: string;
+  startAfter?: string;
+  limit?: number;
+}
+
+export interface KvStateCompareItem {
+  key: string;
+  kind: string;
+  localInvocationId?: string | null;
+  peerStatus: "present" | "deleted" | "absent";
+  peerSeq?: number | null;
+  peerInvocationId?: string | null;
+  peerDeletedInvocationId?: string | null;
+  peerValueHash?: string | null;
+}
+
+export interface KvStateCompareResponse {
+  spaceId: string;
+  prefix?: string;
+  peerUrl: string;
+  startAfter?: string;
+  limit?: number;
+  hasMore?: boolean;
+  nextStartAfter?: string | null;
+  items: KvStateCompareItem[];
+}
+
 export interface KvReconItem {
   key: string;
   kind: string;
@@ -631,6 +682,66 @@ export async function reconExportFromPeer(
   }
 
   return (await response.json()) as KvReconExportResponse;
+}
+
+export async function kvStateFromPeer(
+  cluster: RunningCluster,
+  sourceNodeName: string,
+  request: KvStateRequest,
+  session?: TinyCloudReplicationSession
+): Promise<KvStateResponse> {
+  const node = getClusterNode(cluster, sourceNodeName);
+  const headers = await buildSessionHeaders("Replication-Session", session);
+  const response = await fetch(`${node.url}/replication/kv/state`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `KV state export failed on ${sourceNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvStateResponse;
+}
+
+export async function kvStateCompareFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: KvStateCompareRequest,
+  sessions: ReplicationPullSessions
+): Promise<KvStateCompareResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
+  const response = await fetch(`${node.url}/replication/kv/state/compare`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...targetHeaders,
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `KV state compare failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvStateCompareResponse;
 }
 
 export async function reconSplitFromPeer(

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -144,6 +144,13 @@ export interface KvReconSplitCompareRequest {
   prefix?: string;
 }
 
+export interface KvReconSplitReconcileRequest {
+  peerUrl: string;
+  spaceId: string;
+  prefix?: string;
+  childLimit?: number;
+}
+
 export interface KvReconSplitChildComparison {
   prefix: string;
   status: "match" | "local-missing" | "peer-missing" | "mismatch";
@@ -160,6 +167,24 @@ export interface KvReconSplitCompareResponse {
   peerUrl: string;
   matches: boolean;
   children: KvReconSplitChildComparison[];
+}
+
+export interface KvReconSplitReconcileChildResult {
+  prefix: string;
+  beforeStatus: "match" | "local-missing" | "peer-missing" | "mismatch";
+  afterStatus: "match" | "local-missing" | "peer-missing" | "mismatch";
+  appliedSequences: number;
+  appliedEvents: number;
+}
+
+export interface KvReconSplitReconcileResponse {
+  spaceId: string;
+  prefix?: string;
+  peerUrl: string;
+  matches: boolean;
+  attemptedChildren: number;
+  reconciledChildren: number;
+  children: KvReconSplitReconcileChildResult[];
 }
 
 export interface KvReconCompareResponse {
@@ -642,6 +667,40 @@ export async function reconSplitCompareFromPeer(
   }
 
   return (await response.json()) as KvReconSplitCompareResponse;
+}
+
+export async function reconcileSplitFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: KvReconSplitReconcileRequest,
+  sessions: ReplicationPullSessions
+): Promise<KvReconSplitReconcileResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
+  const response = await fetch(`${node.url}/replication/reconcile/split`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...targetHeaders,
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `KV split reconcile failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvReconSplitReconcileResponse;
 }
 
 export async function reconCompareFromPeer(

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -89,6 +89,24 @@ export interface SqlReplicationExportRequest {
   dbName: string;
 }
 
+export interface KvReconExportRequest {
+  spaceId: string;
+  prefix?: string;
+}
+
+export interface KvReconItem {
+  key: string;
+  kind: string;
+  seq?: number;
+  invocationId?: string;
+}
+
+export interface KvReconExportResponse {
+  spaceId: string;
+  prefix?: string;
+  items: KvReconItem[];
+}
+
 export interface SqlReplicationExportResponse {
   spaceId: string;
   dbName: string;
@@ -467,4 +485,30 @@ export async function exportSqlFromPeer(
   }
 
   return (await response.json()) as SqlReplicationExportResponse;
+}
+
+export async function reconExportFromPeer(
+  cluster: RunningCluster,
+  sourceNodeName: string,
+  request: KvReconExportRequest,
+  session?: TinyCloudReplicationSession
+): Promise<KvReconExportResponse> {
+  const node = getClusterNode(cluster, sourceNodeName);
+  const headers = await buildSessionHeaders("Replication-Session", session);
+  const response = await fetch(`${node.url}/replication/recon/export`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `KV recon export failed on ${sourceNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvReconExportResponse;
 }

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -22,6 +22,15 @@ export interface ReplicationReconcileRequest {
   limit?: number;
 }
 
+export interface AuthReplicationReconcileRequest {
+  peerUrl: string;
+  spaceId: string;
+  service: "kv" | "sql";
+  prefix?: string;
+  dbName?: string;
+  supportingDelegations?: string[];
+}
+
 export interface ReplicationExportRequest {
   spaceId: string;
   prefix?: string;
@@ -44,6 +53,16 @@ export interface ReplicationApplyResponse {
   appliedSequences: number;
   appliedEvents: number;
   appliedUntilSeq?: number;
+}
+
+export interface AuthReplicationApplyResponse {
+  spaceId: string;
+  peerUrl?: string;
+  service: string;
+  prefix?: string;
+  dbName?: string;
+  importedDelegations: number;
+  importedRevocations: number;
 }
 
 export interface SqlReplicationReconcileRequest {
@@ -184,19 +203,27 @@ export async function openTransportSession(
   }
 
   const body =
-    session.scope.service === "kv"
+    session.scope.service === "auth"
       ? {
           spaceId: session.spaceId,
-          service: "kv",
-          prefix: session.scope.prefix,
+          service: "auth",
+          prefix: null,
+          dbName: null,
           supportingDelegations: session.supportingDelegations,
         }
-      : {
-          spaceId: session.spaceId,
-          service: "sql",
-          dbName: session.scope.dbName,
-          supportingDelegations: session.supportingDelegations,
-        };
+      : session.scope.service === "kv"
+        ? {
+            spaceId: session.spaceId,
+            service: "kv",
+            prefix: session.scope.prefix,
+            supportingDelegations: session.supportingDelegations,
+          }
+        : {
+            spaceId: session.spaceId,
+            service: "sql",
+            dbName: session.scope.dbName,
+            supportingDelegations: session.supportingDelegations,
+          };
 
   const response = await fetch(`${session.host}/replication/session/open`, {
     method: "POST",
@@ -275,6 +302,32 @@ export async function reconcileFromPeer(
   }
 
   return (await response.json()) as ReplicationApplyResponse;
+}
+
+export async function reconcileAuthFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: AuthReplicationReconcileRequest,
+  session?: TinyCloudReplicationSession
+): Promise<AuthReplicationApplyResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const peerHeaders = await buildSessionHeaders(session);
+  const response = await fetch(`${node.url}/replication/auth/reconcile`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Auth replication reconcile failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as AuthReplicationApplyResponse;
 }
 
 export async function reconcileSqlFromPeer(

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -232,6 +232,11 @@ export interface ReplicationSessionOpenResponse {
   spaceId: string;
   service: string;
   serverDid: string;
+  rolesEnabled: string[];
+  peerServing: boolean;
+  canExport: boolean;
+  recon: boolean;
+  authSync: boolean;
   prefix?: string;
   dbName?: string;
   expiresAt: string;

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -118,6 +118,26 @@ export interface KvReconCompareRequest {
   limit?: number;
 }
 
+export interface KvReconSplitRequest {
+  spaceId: string;
+  prefix?: string;
+}
+
+export interface KvReconSplitChild {
+  prefix: string;
+  itemCount: number;
+  fingerprint: string;
+  leaf: boolean;
+}
+
+export interface KvReconSplitResponse {
+  spaceId: string;
+  prefix?: string;
+  itemCount: number;
+  fingerprint: string;
+  children: KvReconSplitChild[];
+}
+
 export interface KvReconCompareResponse {
   spaceId: string;
   prefix?: string;
@@ -538,6 +558,32 @@ export async function reconExportFromPeer(
   }
 
   return (await response.json()) as KvReconExportResponse;
+}
+
+export async function reconSplitFromPeer(
+  cluster: RunningCluster,
+  sourceNodeName: string,
+  request: KvReconSplitRequest,
+  session?: TinyCloudReplicationSession
+): Promise<KvReconSplitResponse> {
+  const node = getClusterNode(cluster, sourceNodeName);
+  const headers = await buildSessionHeaders("Replication-Session", session);
+  const response = await fetch(`${node.url}/replication/recon/split`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `KV recon split failed on ${sourceNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvReconSplitResponse;
 }
 
 export async function reconCompareFromPeer(

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -1,0 +1,356 @@
+import { Wallet } from "ethers";
+import {
+  TinyCloudNode,
+  type TinyCloudReplicationSession,
+} from "@tinycloud/node-sdk";
+import type { RunningCluster, RunningNode } from "./cluster";
+
+export const REPLICATION_TEST_KEY =
+  process.env.TC_TEST_PRIVATE_KEY ??
+  "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+export interface WaitForConditionOptions {
+  timeoutMs?: number;
+  pollMs?: number;
+}
+
+export interface ReplicationReconcileRequest {
+  peerUrl: string;
+  spaceId: string;
+  prefix?: string;
+  sinceSeq?: number;
+  limit?: number;
+}
+
+export interface ReplicationExportRequest {
+  spaceId: string;
+  prefix?: string;
+  sinceSeq?: number;
+  limit?: number;
+}
+
+export interface ReplicationExportResponse {
+  spaceId: string;
+  prefix?: string;
+  requestedSinceSeq?: number;
+  exportedUntilSeq?: number;
+  sequences: unknown[];
+}
+
+export interface ReplicationApplyResponse {
+  spaceId: string;
+  requestedSinceSeq?: number;
+  peerUrl?: string;
+  appliedSequences: number;
+  appliedEvents: number;
+  appliedUntilSeq?: number;
+}
+
+export interface SqlReplicationReconcileRequest {
+  peerUrl: string;
+  spaceId: string;
+  dbName: string;
+}
+
+function replicationDefaultActions(): Record<string, Record<string, string[]>> {
+  return {
+    space: {
+      "": ["tinycloud.space/sync"],
+    },
+  };
+}
+
+export interface SqlReplicationApplyResponse {
+  spaceId: string;
+  dbName: string;
+  peerUrl?: string;
+  snapshotBytes: number;
+}
+
+export interface SqlReplicationExportRequest {
+  spaceId: string;
+  dbName: string;
+}
+
+export interface SqlReplicationExportResponse {
+  spaceId: string;
+  dbName: string;
+  snapshot: number[];
+}
+
+export interface ReplicationSessionOpenResponse {
+  sessionToken: string;
+  spaceId: string;
+  service: string;
+  prefix?: string;
+  dbName?: string;
+  expiresAt: string;
+}
+
+export function getClusterNode(
+  cluster: RunningCluster,
+  nodeName: string
+): RunningNode {
+  const node = cluster.nodes.find((candidate) => candidate.name === nodeName);
+  if (!node) {
+    throw new Error(`Unknown cluster node: ${nodeName}`);
+  }
+  return node;
+}
+
+export function createClusterClient(
+  cluster: RunningCluster,
+  nodeName: string,
+  prefix: string,
+  key = REPLICATION_TEST_KEY
+): TinyCloudNode {
+  const node = getClusterNode(cluster, nodeName);
+  return new TinyCloudNode({
+    privateKey: key,
+    host: node.url,
+    prefix,
+    autoCreateSpace: true,
+    defaultActions: replicationDefaultActions(),
+  });
+}
+
+export function createRandomClusterClient(
+  cluster: RunningCluster,
+  nodeName: string,
+  prefix: string
+): TinyCloudNode {
+  return createClusterClient(
+    cluster,
+    nodeName,
+    prefix,
+    Wallet.createRandom().privateKey.slice(2)
+  );
+}
+
+export async function waitForCondition(
+  label: string,
+  predicate: () => Promise<boolean>,
+  options: WaitForConditionOptions = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const pollMs = options.pollMs ?? 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) {
+      return;
+    }
+    await Bun.sleep(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for condition: ${label}`);
+}
+
+export function uniqueReplicationPrefix(baseName: string): string {
+  return `replication-${baseName}-${Date.now()}`;
+}
+
+function normalizeHeaders(
+  headers: Record<string, string> | [string, string][]
+): Record<string, string> {
+  return Array.isArray(headers) ? Object.fromEntries(headers) : { ...headers };
+}
+
+const transportSessionCache = new WeakMap<
+  TinyCloudReplicationSession,
+  ReplicationSessionOpenResponse
+>();
+
+function transportSessionIsFresh(
+  session: ReplicationSessionOpenResponse | undefined
+): session is ReplicationSessionOpenResponse {
+  if (!session) {
+    return false;
+  }
+
+  return new Date(session.expiresAt).getTime() > Date.now() + 1_000;
+}
+
+export async function openTransportSession(
+  session: TinyCloudReplicationSession | undefined
+): Promise<ReplicationSessionOpenResponse | undefined> {
+  if (!session) {
+    return undefined;
+  }
+
+  const cached = transportSessionCache.get(session);
+  if (transportSessionIsFresh(cached)) {
+    return cached;
+  }
+
+  const body =
+    session.scope.service === "kv"
+      ? {
+          spaceId: session.spaceId,
+          service: "kv",
+          prefix: session.scope.prefix,
+        }
+      : {
+          spaceId: session.spaceId,
+          service: "sql",
+          dbName: session.scope.dbName,
+        };
+
+  const response = await fetch(`${session.host}/replication/session/open`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...normalizeHeaders(session.delegationHeader),
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Replication session open failed on ${session.host}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  const opened = (await response.json()) as ReplicationSessionOpenResponse;
+  transportSessionCache.set(session, opened);
+  return opened;
+}
+
+async function buildSessionHeaders(
+  session: TinyCloudReplicationSession | undefined
+): Promise<Record<string, string>> {
+  const opened = await openTransportSession(session);
+  return opened ? { "Replication-Session": opened.sessionToken } : {};
+}
+
+export async function exportFromPeer(
+  cluster: RunningCluster,
+  sourceNodeName: string,
+  request: ReplicationExportRequest,
+  session?: TinyCloudReplicationSession
+): Promise<ReplicationExportResponse> {
+  const node = getClusterNode(cluster, sourceNodeName);
+  const headers = await buildSessionHeaders(session);
+  const response = await fetch(`${node.url}/replication/export`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Replication export failed on ${sourceNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as ReplicationExportResponse;
+}
+
+export async function reconcileFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: ReplicationReconcileRequest,
+  session?: TinyCloudReplicationSession
+): Promise<ReplicationApplyResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const peerHeaders = await buildSessionHeaders(session);
+  const response = await fetch(`${node.url}/replication/reconcile`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Replication reconcile failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as ReplicationApplyResponse;
+}
+
+export async function reconcileSqlFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: SqlReplicationReconcileRequest,
+  session?: TinyCloudReplicationSession
+): Promise<SqlReplicationApplyResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const peerHeaders = await buildSessionHeaders(session);
+  const response = await fetch(`${node.url}/replication/sql/reconcile`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `SQL replication reconcile failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as SqlReplicationApplyResponse;
+}
+
+export async function openKvReplicationSession(
+  client: TinyCloudNode,
+  host: string,
+  prefix?: string
+): Promise<TinyCloudReplicationSession> {
+  return client.openReplicationSession({
+    host,
+    scope: {
+      service: "kv",
+      prefix: prefix ?? "",
+    },
+  });
+}
+
+export async function openSqlReplicationSession(
+  client: TinyCloudNode,
+  host: string,
+  dbName: string
+): Promise<TinyCloudReplicationSession> {
+  return client.openReplicationSession({
+    host,
+    scope: {
+      service: "sql",
+      dbName,
+    },
+  });
+}
+
+export async function exportSqlFromPeer(
+  cluster: RunningCluster,
+  sourceNodeName: string,
+  request: SqlReplicationExportRequest,
+  session?: TinyCloudReplicationSession
+): Promise<SqlReplicationExportResponse> {
+  const node = getClusterNode(cluster, sourceNodeName);
+  const headers = await buildSessionHeaders(session);
+  const response = await fetch(`${node.url}/replication/sql/export`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `SQL replication export failed on ${sourceNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as SqlReplicationExportResponse;
+}

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -156,6 +156,7 @@ export interface KvReconSplitReconcileRequest {
   peerUrl: string;
   spaceId: string;
   prefix?: string;
+  childStartAfter?: string;
   childLimit?: number;
   maxDepth?: number;
 }
@@ -194,7 +195,11 @@ export interface KvReconSplitReconcileResponse {
   spaceId: string;
   prefix?: string;
   peerUrl: string;
+  childStartAfter?: string;
+  childLimit?: number;
   matches: boolean;
+  hasMore?: boolean;
+  nextChildStartAfter?: string | null;
   attemptedChildren: number;
   reconciledChildren: number;
   children: KvReconSplitReconcileChildResult[];

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -63,6 +63,7 @@ export interface SqlReplicationReconcileRequest {
   peerUrl: string;
   spaceId: string;
   dbName: string;
+  sinceSeq?: number;
 }
 
 export interface ReplicationPullSessions {
@@ -82,12 +83,16 @@ export interface SqlReplicationApplyResponse {
   spaceId: string;
   dbName: string;
   peerUrl?: string;
-  snapshotBytes: number;
+  mode?: "snapshot" | "changeset";
+  changesetBytes?: number;
+  snapshotBytes?: number;
+  appliedUntilSeq?: number;
 }
 
 export interface SqlReplicationExportRequest {
   spaceId: string;
   dbName: string;
+  sinceSeq?: number;
 }
 
 export interface KvReconExportRequest {
@@ -362,7 +367,45 @@ export interface KvReconCompareResponse {
 export interface SqlReplicationExportResponse {
   spaceId: string;
   dbName: string;
-  snapshot: number[];
+  mode?: "snapshot" | "changeset";
+  requestedSinceSeq?: number;
+  exportedUntilSeq?: number;
+  changeset?: number[];
+  changesetBytes?: number;
+  snapshot?: number[];
+  snapshotBytes?: number;
+  snapshotReason?: string;
+}
+
+type SqlReplicationPayloadShape = {
+  mode?: "snapshot" | "changeset";
+  changeset?: number[];
+  snapshot?: number[];
+  changesetBytes?: number;
+  snapshotBytes?: number;
+};
+
+export function sqlReplicationMode(
+  response: SqlReplicationPayloadShape
+): "snapshot" | "changeset" {
+  if (response.mode) {
+    return response.mode;
+  }
+  if (response.changeset && response.changeset.length > 0) {
+    return "changeset";
+  }
+  return "snapshot";
+}
+
+export function sqlReplicationBytes(
+  response: SqlReplicationPayloadShape
+): { changesetBytes: number; snapshotBytes: number } {
+  return {
+    changesetBytes:
+      response.changesetBytes ?? response.changeset?.length ?? 0,
+    snapshotBytes:
+      response.snapshotBytes ?? response.snapshot?.length ?? 0,
+  };
 }
 
 export interface ReplicationSessionOpenResponse {

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -25,10 +25,6 @@ export interface ReplicationReconcileRequest {
 export interface AuthReplicationReconcileRequest {
   peerUrl: string;
   spaceId: string;
-  service: "kv" | "sql";
-  prefix?: string;
-  dbName?: string;
-  supportingDelegations?: string[];
 }
 
 export interface ReplicationExportRequest {
@@ -58,9 +54,6 @@ export interface ReplicationApplyResponse {
 export interface AuthReplicationApplyResponse {
   spaceId: string;
   peerUrl?: string;
-  service: string;
-  prefix?: string;
-  dbName?: string;
   importedDelegations: number;
   importedRevocations: number;
 }
@@ -69,6 +62,11 @@ export interface SqlReplicationReconcileRequest {
   peerUrl: string;
   spaceId: string;
   dbName: string;
+}
+
+export interface ReplicationPullSessions {
+  target: TinyCloudReplicationSession;
+  peer: TinyCloudReplicationSession;
 }
 
 function replicationDefaultActions(): Record<string, Record<string, string[]>> {
@@ -104,6 +102,10 @@ export interface ReplicationSessionOpenResponse {
   prefix?: string;
   dbName?: string;
   expiresAt: string;
+}
+
+export interface RequestTransportSessionOptions {
+  supportingDelegations?: string[] | null;
 }
 
 export function getClusterNode(
@@ -202,37 +204,7 @@ export async function openTransportSession(
     return cached;
   }
 
-  const body =
-    session.scope.service === "auth"
-      ? {
-          spaceId: session.spaceId,
-          service: "auth",
-          prefix: null,
-          dbName: null,
-          supportingDelegations: session.supportingDelegations,
-        }
-      : session.scope.service === "kv"
-        ? {
-            spaceId: session.spaceId,
-            service: "kv",
-            prefix: session.scope.prefix,
-            supportingDelegations: session.supportingDelegations,
-          }
-        : {
-            spaceId: session.spaceId,
-            service: "sql",
-            dbName: session.scope.dbName,
-            supportingDelegations: session.supportingDelegations,
-          };
-
-  const response = await fetch(`${session.host}/replication/session/open`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      ...normalizeHeaders(session.delegationHeader),
-    },
-    body: JSON.stringify(body),
-  });
+  const response = await requestTransportSession(session);
 
   if (!response.ok) {
     throw new Error(
@@ -245,11 +217,62 @@ export async function openTransportSession(
   return opened;
 }
 
+export async function requestTransportSession(
+  session: TinyCloudReplicationSession | undefined,
+  options: RequestTransportSessionOptions = {}
+): Promise<Response | undefined> {
+  if (!session) {
+    return undefined;
+  }
+
+  const body =
+    session.scope.service === "auth"
+      ? {
+          spaceId: session.spaceId,
+          service: "auth",
+          prefix: null,
+          dbName: null,
+        }
+      : session.scope.service === "kv"
+        ? {
+            spaceId: session.spaceId,
+            service: "kv",
+            prefix: session.scope.prefix,
+          }
+        : {
+            spaceId: session.spaceId,
+            service: "sql",
+            dbName: session.scope.dbName,
+          };
+
+  const supportingDelegations =
+    options.supportingDelegations === undefined
+      ? session.supportingDelegations
+      : options.supportingDelegations;
+  const requestBody =
+    supportingDelegations === null
+      ? body
+      : {
+          ...body,
+          supportingDelegations,
+        };
+
+  return fetch(`${session.host}/replication/session/open`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...normalizeHeaders(session.delegationHeader),
+    },
+    body: JSON.stringify(requestBody),
+  });
+}
+
 async function buildSessionHeaders(
+  headerName: string,
   session: TinyCloudReplicationSession | undefined
 ): Promise<Record<string, string>> {
   const opened = await openTransportSession(session);
-  return opened ? { "Replication-Session": opened.sessionToken } : {};
+  return opened ? { [headerName]: opened.sessionToken } : {};
 }
 
 export async function exportFromPeer(
@@ -259,7 +282,7 @@ export async function exportFromPeer(
   session?: TinyCloudReplicationSession
 ): Promise<ReplicationExportResponse> {
   const node = getClusterNode(cluster, sourceNodeName);
-  const headers = await buildSessionHeaders(session);
+  const headers = await buildSessionHeaders("Replication-Session", session);
   const response = await fetch(`${node.url}/replication/export`, {
     method: "POST",
     headers: {
@@ -282,14 +305,22 @@ export async function reconcileFromPeer(
   cluster: RunningCluster,
   targetNodeName: string,
   request: ReplicationReconcileRequest,
-  session?: TinyCloudReplicationSession
+  sessions: ReplicationPullSessions
 ): Promise<ReplicationApplyResponse> {
   const node = getClusterNode(cluster, targetNodeName);
-  const peerHeaders = await buildSessionHeaders(session);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
   const response = await fetch(`${node.url}/replication/reconcile`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
+      ...targetHeaders,
       ...peerHeaders,
     },
     body: JSON.stringify(request),
@@ -308,14 +339,22 @@ export async function reconcileAuthFromPeer(
   cluster: RunningCluster,
   targetNodeName: string,
   request: AuthReplicationReconcileRequest,
-  session?: TinyCloudReplicationSession
+  sessions: ReplicationPullSessions
 ): Promise<AuthReplicationApplyResponse> {
   const node = getClusterNode(cluster, targetNodeName);
-  const peerHeaders = await buildSessionHeaders(session);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
   const response = await fetch(`${node.url}/replication/auth/reconcile`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
+      ...targetHeaders,
       ...peerHeaders,
     },
     body: JSON.stringify(request),
@@ -334,14 +373,22 @@ export async function reconcileSqlFromPeer(
   cluster: RunningCluster,
   targetNodeName: string,
   request: SqlReplicationReconcileRequest,
-  session?: TinyCloudReplicationSession
+  sessions: ReplicationPullSessions
 ): Promise<SqlReplicationApplyResponse> {
   const node = getClusterNode(cluster, targetNodeName);
-  const peerHeaders = await buildSessionHeaders(session);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
   const response = await fetch(`${node.url}/replication/sql/reconcile`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
+      ...targetHeaders,
       ...peerHeaders,
     },
     body: JSON.stringify(request),
@@ -370,6 +417,18 @@ export async function openKvReplicationSession(
   });
 }
 
+export async function openAuthReplicationSession(
+  client: TinyCloudNode,
+  host: string
+): Promise<TinyCloudReplicationSession> {
+  return client.openReplicationSession({
+    host,
+    scope: {
+      service: "auth",
+    },
+  });
+}
+
 export async function openSqlReplicationSession(
   client: TinyCloudNode,
   host: string,
@@ -391,7 +450,7 @@ export async function exportSqlFromPeer(
   session?: TinyCloudReplicationSession
 ): Promise<SqlReplicationExportResponse> {
   const node = getClusterNode(cluster, sourceNodeName);
-  const headers = await buildSessionHeaders(session);
+  const headers = await buildSessionHeaders("Replication-Session", session);
   const response = await fetch(`${node.url}/replication/sql/export`, {
     method: "POST",
     headers: {

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -149,6 +149,7 @@ export interface KvReconSplitReconcileRequest {
   spaceId: string;
   prefix?: string;
   childLimit?: number;
+  maxDepth?: number;
 }
 
 export interface KvReconSplitChildComparison {

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -97,7 +97,6 @@ export interface KvReconExportRequest {
 export interface KvReconItem {
   key: string;
   kind: string;
-  seq?: number;
   invocationId?: string;
 }
 
@@ -105,6 +104,24 @@ export interface KvReconExportResponse {
   spaceId: string;
   prefix?: string;
   items: KvReconItem[];
+}
+
+export interface KvReconCompareRequest {
+  peerUrl: string;
+  spaceId: string;
+  prefix?: string;
+}
+
+export interface KvReconCompareResponse {
+  spaceId: string;
+  prefix?: string;
+  peerUrl: string;
+  matches: boolean;
+  localItemCount: number;
+  peerItemCount: number;
+  localFingerprint: string;
+  peerFingerprint: string;
+  firstMismatchKey?: string | null;
 }
 
 export interface SqlReplicationExportResponse {
@@ -511,4 +528,38 @@ export async function reconExportFromPeer(
   }
 
   return (await response.json()) as KvReconExportResponse;
+}
+
+export async function reconCompareFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: KvReconCompareRequest,
+  sessions: ReplicationPullSessions
+): Promise<KvReconCompareResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const targetHeaders = await buildSessionHeaders(
+    "Replication-Session",
+    sessions.target
+  );
+  const peerHeaders = await buildSessionHeaders(
+    "Peer-Replication-Session",
+    sessions.peer
+  );
+  const response = await fetch(`${node.url}/replication/recon/compare`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...targetHeaders,
+      ...peerHeaders,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `KV recon compare failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as KvReconCompareResponse;
 }

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -92,6 +92,8 @@ export interface SqlReplicationExportRequest {
 export interface KvReconExportRequest {
   spaceId: string;
   prefix?: string;
+  startAfter?: string;
+  limit?: number;
 }
 
 export interface KvReconItem {
@@ -103,6 +105,8 @@ export interface KvReconItem {
 export interface KvReconExportResponse {
   spaceId: string;
   prefix?: string;
+  hasMore?: boolean;
+  nextStartAfter?: string | null;
   items: KvReconItem[];
 }
 
@@ -110,6 +114,8 @@ export interface KvReconCompareRequest {
   peerUrl: string;
   spaceId: string;
   prefix?: string;
+  startAfter?: string;
+  limit?: number;
 }
 
 export interface KvReconCompareResponse {
@@ -121,6 +127,10 @@ export interface KvReconCompareResponse {
   peerItemCount: number;
   localFingerprint: string;
   peerFingerprint: string;
+  localHasMore?: boolean;
+  peerHasMore?: boolean;
+  localNextStartAfter?: string | null;
+  peerNextStartAfter?: string | null;
   firstMismatchKey?: string | null;
 }
 

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -231,6 +231,7 @@ export interface ReplicationSessionOpenResponse {
   sessionToken: string;
   spaceId: string;
   service: string;
+  serverDid: string;
   prefix?: string;
   dbName?: string;
   expiresAt: string;

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -163,6 +163,7 @@ export interface KvPeerMissingPlanResponse {
   spaceId: string;
   prefix?: string;
   peerUrl: string;
+  peerServerDid: string;
   peerHostRole: boolean;
   startAfter?: string;
   limit?: number;
@@ -217,6 +218,7 @@ export interface KvPeerMissingApplyResponse {
   spaceId: string;
   prefix?: string;
   peerUrl: string;
+  peerServerDid: string;
   peerHostRole: boolean;
   startAfter?: string;
   limit?: number;

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -104,6 +104,7 @@ export interface SqlReplicationApplyResponse {
   dbName: string;
   peerUrl?: string;
   mode?: "snapshot" | "changeset";
+  snapshotReason?: string | null;
   changesetBytes?: number;
   snapshotBytes?: number;
   appliedUntilSeq?: number;

--- a/tests/node-sdk/replication/helpers.ts
+++ b/tests/node-sdk/replication/helpers.ts
@@ -66,6 +66,26 @@ export interface SqlReplicationReconcileRequest {
   sinceSeq?: number;
 }
 
+export interface ReplicationNotifyRequest {
+  spaceId: string;
+  service: "kv" | "sql";
+  prefix?: string;
+  dbName?: string;
+  lastSeenSeq?: number;
+  timeoutMs?: number;
+}
+
+export interface ReplicationNotifyResponse {
+  spaceId: string;
+  service: "kv" | "sql";
+  prefix?: string;
+  dbName?: string;
+  lastSeenSeq?: number;
+  latestSeq: number;
+  dirty: boolean;
+  timedOut: boolean;
+}
+
 export interface ReplicationPullSessions {
   target: TinyCloudReplicationSession;
   peer: TinyCloudReplicationSession;
@@ -790,6 +810,32 @@ export async function exportSqlFromPeer(
   }
 
   return (await response.json()) as SqlReplicationExportResponse;
+}
+
+export async function notifyReplicationFromPeer(
+  cluster: RunningCluster,
+  targetNodeName: string,
+  request: ReplicationNotifyRequest,
+  session: TinyCloudReplicationSession
+): Promise<ReplicationNotifyResponse> {
+  const node = getClusterNode(cluster, targetNodeName);
+  const headers = await buildSessionHeaders("Replication-Session", session);
+  const response = await fetch(`${node.url}/replication/notify/poll`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Replication notify failed on ${targetNodeName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  return (await response.json()) as ReplicationNotifyResponse;
 }
 
 export async function reconExportFromPeer(

--- a/tests/node-sdk/replication/kv-baseline.test.ts
+++ b/tests/node-sdk/replication/kv-baseline.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication KV Baseline", () => {
+  test(
+    "round-trips KV data through a live node with the real SDK",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-baseline");
+        const alice = createClusterClient(cluster, "node-a", prefix);
+        await alice.signIn();
+
+        const key = "replication/kv-baseline/profile.json";
+        const value = {
+          name: "Alice",
+          role: "authority-writer",
+          createdAt: new Date().toISOString(),
+        };
+
+        const putResult = await alice.kv.put(key, value);
+        expect(putResult.ok).toBe(true);
+
+        const getResult = await alice.kv.get<typeof value>(key);
+        expect(getResult.ok).toBe(true);
+        if (!getResult.ok) {
+          throw new Error(getResult.error.message);
+        }
+        expect(getResult.data.data).toEqual(value);
+
+        const listResult = await alice.kv.list({
+          prefix: "replication/kv-baseline",
+        });
+        expect(listResult.ok).toBe(true);
+        if (!listResult.ok) {
+          throw new Error(listResult.error.message);
+        }
+        expect(listResult.data.keys).toContain(key);
+
+        const deleteResult = await alice.kv.delete(key);
+        expect(deleteResult.ok).toBe(true);
+
+        const missingResult = await alice.kv.get(key);
+        expect(missingResult.ok).toBe(false);
+        if (missingResult.ok) {
+          throw new Error("Expected deleted key lookup to fail");
+        }
+        expect(missingResult.error.code).toBe("KV_NOT_FOUND");
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-canonical-commit.test.ts
+++ b/tests/node-sdk/replication/kv-canonical-commit.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  kvStateFromPeer,
+  openKvReplicationSession,
+  reconCompareFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication KV Canonical Commit", () => {
+  test(
+    "keeps replica-authored KV writes visible locally while canonical state catches up through authority reconciliation",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster({
+        nodes: [
+          { name: "node-a", role: "authority", port: 8010 },
+          { name: "node-b", role: "host", port: 8011 },
+          {
+            name: "node-c",
+            role: "replica",
+            port: 8012,
+            env: {
+              TINYCLOUD_REPLICATION_PEER_SERVING: "true",
+            },
+          },
+        ],
+      });
+      try {
+        const prefix = uniqueReplicationPrefix("kv-canonical-commit");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const downstream = createClusterClient(cluster, "node-b", prefix);
+        const authoringReplica = createClusterClient(cluster, "node-c", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const downstreamNode = getClusterNode(cluster, "node-b");
+        const authoringNode = getClusterNode(cluster, "node-c");
+
+        await authority.signIn();
+        await downstream.signIn();
+        await authoringReplica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(downstream.spaceId).toBe(authority.spaceId);
+        expect(authoringReplica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/kv-canonical-commit/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const value = {
+          owner: "alice",
+          stage: "replica-local",
+          createdAt: new Date().toISOString(),
+        };
+
+        const writeResult = await authoringReplica.kv.put(key, value);
+        expect(writeResult.ok).toBe(true);
+
+        const localGet = await authoringReplica.kv.get<typeof value>(key);
+        expect(localGet.ok).toBe(true);
+        if (!localGet.ok) {
+          throw new Error(localGet.error.message);
+        }
+        expect(localGet.data.data).toEqual(value);
+
+        const localList = await authoringReplica.kv.list({ prefix: scope });
+        expect(localList.ok).toBe(true);
+        if (!localList.ok) {
+          throw new Error(localList.error.message);
+        }
+        expect(localList.data.keys).toContain(key);
+
+        const authoritySession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
+        const replicaSession = await openKvReplicationSession(
+          authoringReplica,
+          authoringNode.url,
+          scope
+        );
+
+        const authorityStateBefore = await kvStateFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scope,
+            keys: [key],
+          },
+          authoritySession
+        );
+        expect(authorityStateBefore.items).toHaveLength(1);
+        expect(authorityStateBefore.items[0]?.status).toBe("absent");
+
+        const authorityReconBefore = await reconCompareFromPeer(
+          cluster,
+          "node-a",
+          {
+            peerUrl: authoringNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          { target: authoritySession, peer: replicaSession }
+        );
+        expect(authorityReconBefore.matches).toBe(false);
+        expect(authorityReconBefore.localItemCount).toBe(0);
+        expect(authorityReconBefore.peerItemCount).toBeGreaterThan(0);
+
+        const authorityCatchup = await reconcileFromPeer(
+          cluster,
+          "node-a",
+          {
+            peerUrl: authoringNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          { target: authoritySession, peer: replicaSession }
+        );
+        expect(authorityCatchup.appliedSequences).toBeGreaterThan(0);
+        expect(authorityCatchup.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("authority sees replica-authored KV write", async () => {
+          const result = await authority.kv.get<typeof value>(key);
+          return result.ok && result.data.data.stage === value.stage;
+        });
+
+        const authorityRead = await authority.kv.get<typeof value>(key);
+        expect(authorityRead.ok).toBe(true);
+        if (!authorityRead.ok) {
+          throw new Error(authorityRead.error.message);
+        }
+        expect(authorityRead.data.data).toEqual(value);
+
+        const downstreamSession = await openKvReplicationSession(
+          downstream,
+          downstreamNode.url,
+          scope
+        );
+        const downstreamCatchup = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          { target: downstreamSession, peer: authoritySession }
+        );
+        expect(downstreamCatchup.appliedSequences).toBeGreaterThan(0);
+        expect(downstreamCatchup.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("downstream sees canonical KV write", async () => {
+          const result = await downstream.kv.get<typeof value>(key);
+          return result.ok && result.data.data.stage === value.stage;
+        });
+
+        const downstreamRead = await downstream.kv.get<typeof value>(key);
+        expect(downstreamRead.ok).toBe(true);
+        if (!downstreamRead.ok) {
+          throw new Error(downstreamRead.error.message);
+        }
+        expect(downstreamRead.data.data).toEqual(value);
+
+        const downstreamRecon = await reconCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          { target: downstreamSession, peer: authoritySession }
+        );
+        expect(downstreamRecon.matches).toBe(true);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-canonical-commit.test.ts
+++ b/tests/node-sdk/replication/kv-canonical-commit.test.ts
@@ -13,7 +13,7 @@ import {
 
 describe("Replication KV Canonical Commit", () => {
   test(
-    "keeps replica-authored KV writes visible locally while canonical state catches up through authority reconciliation",
+    "keeps replica-authored KV writes provisional until canonical state catches up through authority reconciliation",
     { timeout: 600_000 },
     async () => {
       const cluster = await startCluster({
@@ -58,19 +58,38 @@ describe("Replication KV Canonical Commit", () => {
         const writeResult = await authoringReplica.kv.put(key, value);
         expect(writeResult.ok).toBe(true);
 
-        const localGet = await authoringReplica.kv.get<typeof value>(key);
-        expect(localGet.ok).toBe(true);
-        if (!localGet.ok) {
-          throw new Error(localGet.error.message);
+        const localCanonicalGet = await authoringReplica.kv.get<typeof value>(key);
+        expect(localCanonicalGet.ok).toBe(false);
+        if (localCanonicalGet.ok) {
+          throw new Error("Expected canonical read to stay absent before authority commit");
         }
-        expect(localGet.data.data).toEqual(value);
+        expect(localCanonicalGet.error.code).toBe("KV_NOT_FOUND");
 
-        const localList = await authoringReplica.kv.list({ prefix: scope });
-        expect(localList.ok).toBe(true);
-        if (!localList.ok) {
-          throw new Error(localList.error.message);
+        const localCanonicalList = await authoringReplica.kv.list({ prefix: scope });
+        expect(localCanonicalList.ok).toBe(true);
+        if (!localCanonicalList.ok) {
+          throw new Error(localCanonicalList.error.message);
         }
-        expect(localList.data.keys).toContain(key);
+        expect(localCanonicalList.data.keys).not.toContain(key);
+
+        const localProvisionalGet = await authoringReplica.kv.get<typeof value>(key, {
+          readMode: "provisional",
+        });
+        expect(localProvisionalGet.ok).toBe(true);
+        if (!localProvisionalGet.ok) {
+          throw new Error(localProvisionalGet.error.message);
+        }
+        expect(localProvisionalGet.data.data).toEqual(value);
+
+        const localProvisionalList = await authoringReplica.kv.list({
+          prefix: scope,
+          readMode: "provisional",
+        });
+        expect(localProvisionalList.ok).toBe(true);
+        if (!localProvisionalList.ok) {
+          throw new Error(localProvisionalList.error.message);
+        }
+        expect(localProvisionalList.data.keys).toContain(key);
 
         const authoritySession = await openKvReplicationSession(
           authority,
@@ -106,9 +125,9 @@ describe("Replication KV Canonical Commit", () => {
           },
           { target: authoritySession, peer: replicaSession }
         );
-        expect(authorityReconBefore.matches).toBe(false);
+        expect(authorityReconBefore.matches).toBe(true);
         expect(authorityReconBefore.localItemCount).toBe(0);
-        expect(authorityReconBefore.peerItemCount).toBeGreaterThan(0);
+        expect(authorityReconBefore.peerItemCount).toBe(0);
 
         const authorityCatchup = await reconcileFromPeer(
           cluster,

--- a/tests/node-sdk/replication/kv-delete-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-delete-reconcile.test.ts
@@ -19,8 +19,12 @@ describe("Replication KV Delete Reconcile", () => {
         const writer = createClusterClient(cluster, "node-a", prefix);
         const reader = createClusterClient(cluster, "node-b", prefix);
         const writerNode = cluster.nodes.find((node) => node.name === "node-a");
+        const readerNode = cluster.nodes.find((node) => node.name === "node-b");
         if (!writerNode) {
           throw new Error("node-a missing from cluster");
+        }
+        if (!readerNode) {
+          throw new Error("node-b missing from cluster");
         }
 
         await writer.signIn();
@@ -45,11 +49,16 @@ describe("Replication KV Delete Reconcile", () => {
           writerNode.url,
           scope
         );
+        const targetSession = await openKvReplicationSession(
+          reader,
+          readerNode.url,
+          scope
+        );
         const firstPass = await reconcileFromPeer(cluster, "node-b", {
           peerUrl: writerNode.url,
           spaceId: writer.spaceId!,
           prefix: scope,
-        }, reconcileSession);
+        }, { target: targetSession, peer: reconcileSession });
 
         expect(firstPass.spaceId).toBe(writer.spaceId);
         expect(firstPass.peerUrl).toBe(writerNode.url);
@@ -71,7 +80,7 @@ describe("Replication KV Delete Reconcile", () => {
           spaceId: writer.spaceId!,
           prefix: scope,
           sinceSeq: firstPass.appliedUntilSeq,
-        }, reconcileSession);
+        }, { target: targetSession, peer: reconcileSession });
 
         expect(secondPass.spaceId).toBe(writer.spaceId);
         expect(secondPass.peerUrl).toBe(writerNode.url);

--- a/tests/node-sdk/replication/kv-delete-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-delete-reconcile.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication KV Delete Reconcile", () => {
+  test(
+    "pulls a real KV delete from one live node into another live node",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-delete-reconcile");
+        const writer = createClusterClient(cluster, "node-a", prefix);
+        const reader = createClusterClient(cluster, "node-b", prefix);
+        const writerNode = cluster.nodes.find((node) => node.name === "node-a");
+        if (!writerNode) {
+          throw new Error("node-a missing from cluster");
+        }
+
+        await writer.signIn();
+        await reader.signIn();
+
+        expect(writer.spaceId).toBeDefined();
+        expect(reader.spaceId).toBe(writer.spaceId);
+
+        const scope = `replication/kv-delete-reconcile/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const value = {
+          owner: "alice",
+          deletedBy: "node-a",
+          createdAt: new Date().toISOString(),
+        };
+
+        const putResult = await writer.kv.put(key, value);
+        expect(putResult.ok).toBe(true);
+
+        const reconcileSession = await openKvReplicationSession(
+          writer,
+          writerNode.url,
+          scope
+        );
+        const firstPass = await reconcileFromPeer(cluster, "node-b", {
+          peerUrl: writerNode.url,
+          spaceId: writer.spaceId!,
+          prefix: scope,
+        }, reconcileSession);
+
+        expect(firstPass.spaceId).toBe(writer.spaceId);
+        expect(firstPass.peerUrl).toBe(writerNode.url);
+        expect(firstPass.appliedSequences).toBeGreaterThan(0);
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+
+        const replicatedGet = await reader.kv.get<typeof value>(key);
+        expect(replicatedGet.ok).toBe(true);
+        if (!replicatedGet.ok) {
+          throw new Error(replicatedGet.error.message);
+        }
+        expect(replicatedGet.data.data).toEqual(value);
+
+        const deleteResult = await writer.kv.delete(key);
+        expect(deleteResult.ok).toBe(true);
+
+        const secondPass = await reconcileFromPeer(cluster, "node-b", {
+          peerUrl: writerNode.url,
+          spaceId: writer.spaceId!,
+          prefix: scope,
+          sinceSeq: firstPass.appliedUntilSeq,
+        }, reconcileSession);
+
+        expect(secondPass.spaceId).toBe(writer.spaceId);
+        expect(secondPass.peerUrl).toBe(writerNode.url);
+        expect(secondPass.appliedSequences).toBeGreaterThan(0);
+        expect(secondPass.appliedEvents).toBeGreaterThan(0);
+
+        const deletedResult = await reader.kv.get(key);
+        expect(deletedResult.ok).toBe(false);
+        if (deletedResult.ok) {
+          throw new Error("Expected deleted key lookup to fail on node-b");
+        }
+        expect(deletedResult.error.code).toBe("KV_NOT_FOUND");
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-offline-provisional.test.ts
+++ b/tests/node-sdk/replication/kv-offline-provisional.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe("Replication KV Offline Provisional", () => {
   test(
-    "keeps a node-c authored KV write visible locally before later convergence",
+    "keeps a node-c authored KV write visible provisionally before later convergence",
     { timeout: 600_000 },
     async () => {
       const cluster = await startCluster({
@@ -56,7 +56,16 @@ describe("Replication KV Offline Provisional", () => {
         const writeResult = await authoringReplica.kv.put(key, initialValue);
         expect(writeResult.ok).toBe(true);
 
-        const localResult = await authoringReplica.kv.get<typeof initialValue>(key);
+        const localCanonical = await authoringReplica.kv.get<typeof initialValue>(key);
+        expect(localCanonical.ok).toBe(false);
+        if (localCanonical.ok) {
+          throw new Error("Expected canonical replica read to stay absent before reconcile");
+        }
+        expect(localCanonical.error.code).toBe("KV_NOT_FOUND");
+
+        const localResult = await authoringReplica.kv.get<typeof initialValue>(key, {
+          readMode: "provisional",
+        });
         expect(localResult.ok).toBe(true);
         if (!localResult.ok) {
           throw new Error(localResult.error.message);

--- a/tests/node-sdk/replication/kv-offline-provisional.test.ts
+++ b/tests/node-sdk/replication/kv-offline-provisional.test.ts
@@ -14,7 +14,20 @@ describe("Replication KV Offline Provisional", () => {
     "keeps a node-c authored KV write visible locally before later convergence",
     { timeout: 600_000 },
     async () => {
-      const cluster = await startCluster();
+      const cluster = await startCluster({
+        nodes: [
+          { name: "node-a", role: "authority", port: 8010 },
+          { name: "node-b", role: "host", port: 8011 },
+          {
+            name: "node-c",
+            role: "replica",
+            port: 8012,
+            env: {
+              TINYCLOUD_REPLICATION_PEER_SERVING: "true",
+            },
+          },
+        ],
+      });
       try {
         const prefix = uniqueReplicationPrefix("kv-offline-provisional");
         const authority = createClusterClient(cluster, "node-a", prefix);

--- a/tests/node-sdk/replication/kv-offline-provisional.test.ts
+++ b/tests/node-sdk/replication/kv-offline-provisional.test.ts
@@ -34,6 +34,7 @@ describe("Replication KV Offline Provisional", () => {
         const replica = createClusterClient(cluster, "node-b", prefix);
         const authoringReplica = createClusterClient(cluster, "node-c", prefix);
         const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
         const authoringNode = getClusterNode(cluster, "node-c");
 
         await authority.signIn();
@@ -74,11 +75,16 @@ describe("Replication KV Offline Provisional", () => {
           authoringNode.url,
           scope
         );
+        const authorityTargetSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
         const firstPass = await reconcileFromPeer(cluster, "node-a", {
           peerUrl: authoringNode.url,
           spaceId: authority.spaceId!,
           prefix: scope,
-        }, authorityReconcileSession);
+        }, { target: authorityTargetSession, peer: authorityReconcileSession });
 
         expect(firstPass.appliedSequences).toBeGreaterThan(0);
         expect(firstPass.appliedEvents).toBeGreaterThan(0);
@@ -100,11 +106,16 @@ describe("Replication KV Offline Provisional", () => {
           authorityNode.url,
           scope
         );
+        const replicaTargetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scope
+        );
         const secondPass = await reconcileFromPeer(cluster, "node-b", {
           peerUrl: authorityNode.url,
           spaceId: authority.spaceId!,
           prefix: scope,
-        }, replicaReconcileSession);
+        }, { target: replicaTargetSession, peer: replicaReconcileSession });
 
         expect(secondPass.appliedSequences).toBeGreaterThan(0);
         expect(secondPass.appliedEvents).toBeGreaterThan(0);

--- a/tests/node-sdk/replication/kv-offline-provisional.test.ts
+++ b/tests/node-sdk/replication/kv-offline-provisional.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication KV Offline Provisional", () => {
+  test(
+    "keeps a node-c authored KV write visible locally before later convergence",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-offline-provisional");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authoringReplica = createClusterClient(cluster, "node-c", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const authoringNode = getClusterNode(cluster, "node-c");
+
+        await authority.signIn();
+        await replica.signIn();
+        await authoringReplica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+        expect(authoringReplica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/kv-offline-provisional/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const initialValue = {
+          owner: "alice",
+          stage: "node-c-local",
+          createdAt: new Date().toISOString(),
+        };
+
+        const writeResult = await authoringReplica.kv.put(key, initialValue);
+        expect(writeResult.ok).toBe(true);
+
+        const localResult = await authoringReplica.kv.get<typeof initialValue>(key);
+        expect(localResult.ok).toBe(true);
+        if (!localResult.ok) {
+          throw new Error(localResult.error.message);
+        }
+        expect(localResult.data.data).toEqual(initialValue);
+
+        const authorityBefore = await authority.kv.get(key);
+        expect(authorityBefore.ok).toBe(false);
+        if (authorityBefore.ok) {
+          throw new Error("Expected node-a to miss the node-c-local write before reconcile");
+        }
+        expect(authorityBefore.error.code).toBe("KV_NOT_FOUND");
+
+        const authorityReconcileSession = await openKvReplicationSession(
+          authoringReplica,
+          authoringNode.url,
+          scope
+        );
+        const firstPass = await reconcileFromPeer(cluster, "node-a", {
+          peerUrl: authoringNode.url,
+          spaceId: authority.spaceId!,
+          prefix: scope,
+        }, authorityReconcileSession);
+
+        expect(firstPass.appliedSequences).toBeGreaterThan(0);
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("node-a sees the node-c authored KV write", async () => {
+          const result = await authority.kv.get<typeof initialValue>(key);
+          return result.ok && result.data.data.stage === "node-c-local";
+        });
+
+        const authorityAfter = await authority.kv.get<typeof initialValue>(key);
+        expect(authorityAfter.ok).toBe(true);
+        if (!authorityAfter.ok) {
+          throw new Error(authorityAfter.error.message);
+        }
+        expect(authorityAfter.data.data).toEqual(initialValue);
+
+        const replicaReconcileSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
+        const secondPass = await reconcileFromPeer(cluster, "node-b", {
+          peerUrl: authorityNode.url,
+          spaceId: authority.spaceId!,
+          prefix: scope,
+        }, replicaReconcileSession);
+
+        expect(secondPass.appliedSequences).toBeGreaterThan(0);
+        expect(secondPass.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("node-b converges on the node-c authored KV write", async () => {
+          const result = await replica.kv.get<typeof initialValue>(key);
+          return result.ok && result.data.data.stage === "node-c-local";
+        });
+
+        const replicaAfter = await replica.kv.get<typeof initialValue>(key);
+        expect(replicaAfter.ok).toBe(true);
+        if (!replicaAfter.ok) {
+          throw new Error(replicaAfter.error.message);
+        }
+        expect(replicaAfter.data.data).toEqual(initialValue);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-peer-missing-apply.test.ts
+++ b/tests/node-sdk/replication/kv-peer-missing-apply.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  peerMissingApplyFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication Peer Missing Apply", () => {
+  test(
+    "applies delete-backed actions and persists absent keys as quarantine records",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("peer-missing-apply");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/peer-missing-apply/${Date.now()}`;
+        const deletedKey = `${scope}/deleted.json`;
+        const localOnlyKey = `${scope}/local-only.json`;
+
+        expect(
+          await authority.kv.put(deletedKey, { state: "deleted-on-peer" })
+        ).toMatchObject({ ok: true });
+
+        const firstPass = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+        await waitForCondition("replica has initial delete candidate key", async () => {
+          const result = await replica.kv.get(deletedKey);
+          return result.ok;
+        });
+
+        expect(await authority.kv.delete(deletedKey)).toMatchObject({ ok: true });
+        expect(await replica.kv.put(localOnlyKey, { state: "local-only" })).toMatchObject({
+          ok: true,
+        });
+
+        const apply = await peerMissingApplyFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(apply.spaceId).toBe(authority.spaceId);
+        expect(apply.prefix).toBe(scope);
+        expect(apply.peerUrl).toBe(authorityNode.url);
+        expect(apply.peerHostRole).toBe(true);
+        expect(apply.prunedDeletes).toBeGreaterThanOrEqual(1);
+        expect(apply.quarantined).toBeGreaterThanOrEqual(1);
+        expect(apply.alreadyQuarantined).toBe(0);
+
+        await waitForCondition("replica no longer serves delete-backed key", async () => {
+          const result = await replica.kv.get(deletedKey);
+          return !result.ok;
+        });
+
+        const deletedResult = await replica.kv.get(deletedKey);
+        expect(deletedResult.ok).toBe(false);
+
+        const localOnlyResult = await replica.kv.get<{ state: string }>(localOnlyKey);
+        expect(localOnlyResult.ok).toBe(true);
+        if (!localOnlyResult.ok) {
+          throw new Error(localOnlyResult.error.message);
+        }
+        expect(localOnlyResult.data.data.state).toBe("local-only");
+
+        const repeatApply = await peerMissingApplyFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(repeatApply.prunedDeletes).toBe(0);
+        expect(repeatApply.quarantined).toBe(0);
+        expect(repeatApply.alreadyQuarantined).toBeGreaterThanOrEqual(1);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-peer-missing-apply.test.ts
+++ b/tests/node-sdk/replication/kv-peer-missing-apply.test.ts
@@ -3,8 +3,11 @@ import { startCluster } from "./cluster";
 import {
   createClusterClient,
   getClusterNode,
+  openAuthReplicationSession,
   openKvReplicationSession,
+  openTransportSession,
   peerMissingApplyFromPeer,
+  reconcileAuthFromPeer,
   reconcileFromPeer,
   uniqueReplicationPrefix,
   waitForCondition,
@@ -62,6 +65,25 @@ describe("Replication Peer Missing Apply", () => {
           ok: true,
         });
 
+        await reconcileAuthFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+          },
+          {
+            target: await openAuthReplicationSession(replica, replicaNode.url),
+            peer: await openAuthReplicationSession(authority, authorityNode.url),
+          }
+        );
+
+        const peerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
+        const peerTransport = await openTransportSession(peerSession);
         const apply = await peerMissingApplyFromPeer(
           cluster,
           "node-b",
@@ -72,13 +94,14 @@ describe("Replication Peer Missing Apply", () => {
           },
           {
             target: await openKvReplicationSession(replica, replicaNode.url, scope),
-            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+            peer: peerSession,
           }
         );
 
         expect(apply.spaceId).toBe(authority.spaceId);
         expect(apply.prefix).toBe(scope);
         expect(apply.peerUrl).toBe(authorityNode.url);
+        expect(apply.peerServerDid).toBe(peerTransport?.serverDid);
         expect(apply.peerHostRole).toBe(true);
         expect(apply.prunedDeletes).toBeGreaterThanOrEqual(1);
         expect(apply.quarantined).toBeGreaterThanOrEqual(1);

--- a/tests/node-sdk/replication/kv-peer-missing-apply.test.ts
+++ b/tests/node-sdk/replication/kv-peer-missing-apply.test.ts
@@ -116,11 +116,20 @@ describe("Replication Peer Missing Apply", () => {
         expect(deletedResult.ok).toBe(false);
 
         const localOnlyResult = await replica.kv.get<{ state: string }>(localOnlyKey);
-        expect(localOnlyResult.ok).toBe(true);
-        if (!localOnlyResult.ok) {
-          throw new Error(localOnlyResult.error.message);
+        expect(localOnlyResult.ok).toBe(false);
+        if (localOnlyResult.ok) {
+          throw new Error("Expected canonical read to hide quarantined key");
         }
-        expect(localOnlyResult.data.data.state).toBe("local-only");
+        expect(localOnlyResult.error.code).toBe("KV_NOT_FOUND");
+
+        const provisionalLocalOnly = await replica.kv.get<{ state: string }>(localOnlyKey, {
+          readMode: "provisional",
+        });
+        expect(provisionalLocalOnly.ok).toBe(true);
+        if (!provisionalLocalOnly.ok) {
+          throw new Error(provisionalLocalOnly.error.message);
+        }
+        expect(provisionalLocalOnly.data.data.state).toBe("local-only");
 
         const repeatApply = await peerMissingApplyFromPeer(
           cluster,

--- a/tests/node-sdk/replication/kv-peer-missing-plan.test.ts
+++ b/tests/node-sdk/replication/kv-peer-missing-plan.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  peerMissingPlanFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+function itemsByKey(
+  items: {
+    key: string;
+    action: "keep" | "prune-delete" | "quarantine-absent";
+    peerStatus: "present" | "deleted" | "absent";
+  }[]
+) {
+  return new Map(items.map((item) => [item.key, item]));
+}
+
+describe("Replication Peer Missing Plan", () => {
+  test(
+    "classifies peer-missing outcomes as keep, prune-delete, and quarantine-absent",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("peer-missing-plan");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/peer-missing-plan/${Date.now()}`;
+        const presentKey = `${scope}/present.json`;
+        const deletedKey = `${scope}/deleted.json`;
+        const localOnlyKey = `${scope}/local-only.json`;
+
+        expect(await authority.kv.put(presentKey, { state: "present" })).toMatchObject({
+          ok: true,
+        });
+        expect(
+          await authority.kv.put(deletedKey, { state: "deleted-on-peer" })
+        ).toMatchObject({ ok: true });
+
+        const firstPass = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+        await waitForCondition("replica has initial authority keys", async () => {
+          const present = await replica.kv.get(presentKey);
+          const deleted = await replica.kv.get(deletedKey);
+          return present.ok && deleted.ok;
+        });
+
+        expect(await authority.kv.delete(deletedKey)).toMatchObject({ ok: true });
+        expect(await replica.kv.put(localOnlyKey, { state: "local-only" })).toMatchObject({
+          ok: true,
+        });
+
+        const plan = await peerMissingPlanFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(plan.spaceId).toBe(authority.spaceId);
+        expect(plan.prefix).toBe(scope);
+        expect(plan.peerUrl).toBe(authorityNode.url);
+        expect(plan.peerHostRole).toBe(true);
+        expect(plan.pruneDeleteCount).toBeGreaterThanOrEqual(1);
+        expect(plan.quarantineAbsentCount).toBeGreaterThanOrEqual(1);
+        expect(plan.keepCount).toBeGreaterThanOrEqual(1);
+
+        const items = itemsByKey(plan.items);
+        expect(items.get(presentKey)?.peerStatus).toBe("present");
+        expect(items.get(presentKey)?.action).toBe("keep");
+        expect(items.get(deletedKey)?.peerStatus).toBe("deleted");
+        expect(items.get(deletedKey)?.action).toBe("prune-delete");
+        expect(items.get(localOnlyKey)?.peerStatus).toBe("absent");
+        expect(items.get(localOnlyKey)?.action).toBe("quarantine-absent");
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+
+  test(
+    "rejects authority-mode planning against a peer-serving replica that is not a host",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster({
+        nodes: [
+          { name: "node-a", role: "authority", port: 8010 },
+          { name: "node-b", role: "host", port: 8011 },
+          {
+            name: "node-c",
+            role: "replica",
+            port: 8012,
+            env: {
+              TINYCLOUD_REPLICATION_PEER_SERVING: "true",
+            },
+          },
+        ],
+      });
+      try {
+        const prefix = uniqueReplicationPrefix("peer-missing-host-only");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const host = createClusterClient(cluster, "node-b", prefix);
+        const replica = createClusterClient(cluster, "node-c", prefix);
+        const replicaNode = getClusterNode(cluster, "node-c");
+        const hostNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await host.signIn();
+        await replica.signIn();
+
+        expect(host.spaceId).toBe(authority.spaceId);
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/peer-missing-host-only/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        expect(await replica.kv.put(key, { state: "replica-only" })).toMatchObject({
+          ok: true,
+        });
+
+        let message = "";
+        try {
+          await peerMissingPlanFromPeer(
+            cluster,
+            "node-b",
+            {
+              peerUrl: replicaNode.url,
+              spaceId: authority.spaceId!,
+              prefix: scope,
+            },
+            {
+              target: await openKvReplicationSession(host, hostNode.url, scope),
+              peer: await openKvReplicationSession(replica, replicaNode.url, scope),
+            }
+          );
+        } catch (error) {
+          message = String(error);
+        }
+
+        expect(message).toContain("403");
+        expect(message).toContain("host-role");
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-peer-missing-plan.test.ts
+++ b/tests/node-sdk/replication/kv-peer-missing-plan.test.ts
@@ -3,8 +3,11 @@ import { startCluster } from "./cluster";
 import {
   createClusterClient,
   getClusterNode,
+  openAuthReplicationSession,
   openKvReplicationSession,
+  openTransportSession,
   peerMissingPlanFromPeer,
+  reconcileAuthFromPeer,
   reconcileFromPeer,
   uniqueReplicationPrefix,
   waitForCondition,
@@ -77,6 +80,25 @@ describe("Replication Peer Missing Plan", () => {
           ok: true,
         });
 
+        await reconcileAuthFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+          },
+          {
+            target: await openAuthReplicationSession(replica, replicaNode.url),
+            peer: await openAuthReplicationSession(authority, authorityNode.url),
+          }
+        );
+
+        const peerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
+        const peerTransport = await openTransportSession(peerSession);
         const plan = await peerMissingPlanFromPeer(
           cluster,
           "node-b",
@@ -87,13 +109,14 @@ describe("Replication Peer Missing Plan", () => {
           },
           {
             target: await openKvReplicationSession(replica, replicaNode.url, scope),
-            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+            peer: peerSession,
           }
         );
 
         expect(plan.spaceId).toBe(authority.spaceId);
         expect(plan.prefix).toBe(scope);
         expect(plan.peerUrl).toBe(authorityNode.url);
+        expect(plan.peerServerDid).toBe(peerTransport?.serverDid);
         expect(plan.peerHostRole).toBe(true);
         expect(plan.pruneDeleteCount).toBeGreaterThanOrEqual(1);
         expect(plan.quarantineAbsentCount).toBeGreaterThanOrEqual(1);
@@ -113,41 +136,25 @@ describe("Replication Peer Missing Plan", () => {
   );
 
   test(
-    "rejects authority-mode planning against a peer-serving replica that is not a host",
+    "requires the peer host delegation to be present in the local auth DAG",
     { timeout: 600_000 },
     async () => {
-      const cluster = await startCluster({
-        nodes: [
-          { name: "node-a", role: "authority", port: 8010 },
-          { name: "node-b", role: "host", port: 8011 },
-          {
-            name: "node-c",
-            role: "replica",
-            port: 8012,
-            env: {
-              TINYCLOUD_REPLICATION_PEER_SERVING: "true",
-            },
-          },
-        ],
-      });
+      const cluster = await startCluster();
       try {
-        const prefix = uniqueReplicationPrefix("peer-missing-host-only");
+        const prefix = uniqueReplicationPrefix("peer-missing-auth-dag");
         const authority = createClusterClient(cluster, "node-a", prefix);
         const host = createClusterClient(cluster, "node-b", prefix);
-        const replica = createClusterClient(cluster, "node-c", prefix);
-        const replicaNode = getClusterNode(cluster, "node-c");
+        const authorityNode = getClusterNode(cluster, "node-a");
         const hostNode = getClusterNode(cluster, "node-b");
 
         await authority.signIn();
         await host.signIn();
-        await replica.signIn();
 
         expect(host.spaceId).toBe(authority.spaceId);
-        expect(replica.spaceId).toBe(authority.spaceId);
 
-        const scope = `replication/peer-missing-host-only/${Date.now()}`;
+        const scope = `replication/peer-missing-auth-dag/${Date.now()}`;
         const key = `${scope}/profile.json`;
-        expect(await replica.kv.put(key, { state: "replica-only" })).toMatchObject({
+        expect(await host.kv.put(key, { state: "host-local-only" })).toMatchObject({
           ok: true,
         });
 
@@ -157,21 +164,59 @@ describe("Replication Peer Missing Plan", () => {
             cluster,
             "node-b",
             {
-              peerUrl: replicaNode.url,
+              peerUrl: authorityNode.url,
               spaceId: authority.spaceId!,
               prefix: scope,
             },
             {
               target: await openKvReplicationSession(host, hostNode.url, scope),
-              peer: await openKvReplicationSession(replica, replicaNode.url, scope),
+              peer: await openKvReplicationSession(authority, authorityNode.url, scope),
             }
           );
         } catch (error) {
           message = String(error);
         }
 
-        expect(message).toContain("403");
-        expect(message).toContain("host-role");
+        expect(message).toContain("tinycloud.space/host");
+
+        const authPull = await reconcileAuthFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+          },
+          {
+            target: await openAuthReplicationSession(host, hostNode.url),
+            peer: await openAuthReplicationSession(authority, authorityNode.url),
+          }
+        );
+
+        expect(authPull.importedDelegations).toBeGreaterThanOrEqual(1);
+
+        const peerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
+        const peerTransport = await openTransportSession(peerSession);
+        const plan = await peerMissingPlanFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(host, hostNode.url, scope),
+            peer: peerSession,
+          }
+        );
+
+        expect(plan.peerServerDid).toBe(peerTransport?.serverDid);
+        expect(plan.peerHostRole).toBe(true);
+        expect(plan.items.some((item) => item.key === key)).toBe(true);
       } finally {
         await cluster.stop();
       }

--- a/tests/node-sdk/replication/kv-peer-missing-quarantine.test.ts
+++ b/tests/node-sdk/replication/kv-peer-missing-quarantine.test.ts
@@ -17,9 +17,17 @@ function quarantineKeys(items: { key: string }[]) {
   return new Set(items.map((item) => item.key));
 }
 
+function expectKvNotFound(result: { ok: boolean; error?: { code: string; message: string } }) {
+  expect(result.ok).toBe(false);
+  if (result.ok || !result.error) {
+    throw new Error("Expected KV lookup to fail");
+  }
+  expect(result.error.code).toBe("KV_NOT_FOUND");
+}
+
 describe("Replication Peer Missing Quarantine", () => {
   test(
-    "lists quarantined keys and clears them after keep and prune-delete resolution",
+    "hides quarantined keys in canonical reads and reveals them with provisional reads",
     { timeout: 600_000 },
     async () => {
       const cluster = await startCluster();
@@ -91,6 +99,49 @@ describe("Replication Peer Missing Quarantine", () => {
         expect(beforeKeys.has(keepKey)).toBe(true);
         expect(beforeKeys.has(pruneKey)).toBe(true);
 
+        const canonicalKeep = await replica.kv.get(keepKey);
+        expectKvNotFound(canonicalKeep);
+
+        const provisionalKeep = await replica.kv.get<{ state: string }>(keepKey, {
+          readMode: "provisional",
+        });
+        expect(provisionalKeep.ok).toBe(true);
+        if (!provisionalKeep.ok) {
+          throw new Error(provisionalKeep.error.message);
+        }
+        expect(provisionalKeep.data.data.state).toBe("local-only-keep");
+
+        const canonicalList = await replica.kv.list({ prefix: scope });
+        expect(canonicalList.ok).toBe(true);
+        if (!canonicalList.ok) {
+          throw new Error(canonicalList.error.message);
+        }
+        expect(canonicalList.data.keys).not.toContain(keepKey);
+        expect(canonicalList.data.keys).not.toContain(pruneKey);
+
+        const provisionalList = await replica.kv.list({
+          prefix: scope,
+          readMode: "provisional",
+        });
+        expect(provisionalList.ok).toBe(true);
+        if (!provisionalList.ok) {
+          throw new Error(provisionalList.error.message);
+        }
+        expect(provisionalList.data.keys).toEqual(
+          expect.arrayContaining([keepKey, pruneKey])
+        );
+
+        const canonicalHead = await replica.kv.head(pruneKey);
+        expectKvNotFound(canonicalHead);
+
+        const provisionalHead = await replica.kv.head(pruneKey, {
+          readMode: "provisional",
+        });
+        expect(provisionalHead.ok).toBe(true);
+        if (!provisionalHead.ok) {
+          throw new Error(provisionalHead.error.message);
+        }
+
         const authorityPull = await reconcileFromPeer(
           cluster,
           "node-a",
@@ -147,6 +198,10 @@ describe("Replication Peer Missing Quarantine", () => {
 
         const keepResult = await replica.kv.get<{ state: string }>(keepKey);
         expect(keepResult.ok).toBe(true);
+        if (!keepResult.ok) {
+          throw new Error(keepResult.error.message);
+        }
+        expect(keepResult.data.data.state).toBe("local-only-keep");
 
         const quarantineAfter = await peerMissingQuarantineFromLocal(
           cluster,

--- a/tests/node-sdk/replication/kv-peer-missing-quarantine.test.ts
+++ b/tests/node-sdk/replication/kv-peer-missing-quarantine.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  peerMissingApplyFromPeer,
+  peerMissingQuarantineFromLocal,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+function quarantineKeys(items: { key: string }[]) {
+  return new Set(items.map((item) => item.key));
+}
+
+describe("Replication Peer Missing Quarantine", () => {
+  test(
+    "lists quarantined keys and clears them after keep and prune-delete resolution",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("peer-missing-quarantine");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/peer-missing-quarantine/${Date.now()}`;
+        const keepKey = `${scope}/keep.json`;
+        const pruneKey = `${scope}/prune.json`;
+
+        expect(await replica.kv.put(keepKey, { state: "local-only-keep" })).toMatchObject({
+          ok: true,
+        });
+        expect(await replica.kv.put(pruneKey, { state: "local-only-prune" })).toMatchObject({
+          ok: true,
+        });
+
+        const firstApply = await peerMissingApplyFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(firstApply.quarantined).toBeGreaterThanOrEqual(2);
+        expect(firstApply.clearedQuarantine).toBe(0);
+
+        const quarantineBefore = await peerMissingQuarantineFromLocal(
+          cluster,
+          "node-b",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          await openKvReplicationSession(replica, replicaNode.url, scope)
+        );
+
+        const beforeKeys = quarantineKeys(quarantineBefore.items);
+        expect(beforeKeys.has(keepKey)).toBe(true);
+        expect(beforeKeys.has(pruneKey)).toBe(true);
+
+        const authorityPull = await reconcileFromPeer(
+          cluster,
+          "node-a",
+          {
+            peerUrl: replicaNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(authority, authorityNode.url, scope),
+            peer: await openKvReplicationSession(replica, replicaNode.url, scope),
+          }
+        );
+
+        expect(authorityPull.appliedEvents).toBeGreaterThan(0);
+        await waitForCondition("authority now sees replica-authored keys", async () => {
+          const keep = await authority.kv.get(keepKey);
+          const prune = await authority.kv.get(pruneKey);
+          return keep.ok && prune.ok;
+        });
+
+        expect(await authority.kv.delete(pruneKey)).toMatchObject({ ok: true });
+
+        const secondApply = await peerMissingApplyFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(secondApply.kept).toBeGreaterThanOrEqual(1);
+        expect(secondApply.prunedDeletes).toBeGreaterThanOrEqual(1);
+        expect(secondApply.clearedQuarantine).toBeGreaterThanOrEqual(2);
+
+        const appliedItems = new Map(
+          secondApply.items.map((item) => [item.key, item])
+        );
+        expect(appliedItems.get(keepKey)?.action).toBe("keep");
+        expect(appliedItems.get(keepKey)?.clearedQuarantine).toBe(true);
+        expect(appliedItems.get(pruneKey)?.action).toBe("prune-delete");
+        expect(appliedItems.get(pruneKey)?.clearedQuarantine).toBe(true);
+
+        await waitForCondition("replica no longer serves prune key", async () => {
+          const result = await replica.kv.get(pruneKey);
+          return !result.ok;
+        });
+
+        const keepResult = await replica.kv.get<{ state: string }>(keepKey);
+        expect(keepResult.ok).toBe(true);
+
+        const quarantineAfter = await peerMissingQuarantineFromLocal(
+          cluster,
+          "node-b",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          await openKvReplicationSession(replica, replicaNode.url, scope)
+        );
+
+        expect(quarantineAfter.items).toHaveLength(0);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-peer-missing-quarantine.test.ts
+++ b/tests/node-sdk/replication/kv-peer-missing-quarantine.test.ts
@@ -3,9 +3,11 @@ import { startCluster } from "./cluster";
 import {
   createClusterClient,
   getClusterNode,
+  openAuthReplicationSession,
   openKvReplicationSession,
   peerMissingApplyFromPeer,
   peerMissingQuarantineFromLocal,
+  reconcileAuthFromPeer,
   reconcileFromPeer,
   uniqueReplicationPrefix,
   waitForCondition,
@@ -44,6 +46,19 @@ describe("Replication Peer Missing Quarantine", () => {
         expect(await replica.kv.put(pruneKey, { state: "local-only-prune" })).toMatchObject({
           ok: true,
         });
+
+        await reconcileAuthFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+          },
+          {
+            target: await openAuthReplicationSession(replica, replicaNode.url),
+            peer: await openAuthReplicationSession(authority, authorityNode.url),
+          }
+        );
 
         const firstApply = await peerMissingApplyFromPeer(
           cluster,

--- a/tests/node-sdk/replication/kv-peer-serving-enforcement.test.ts
+++ b/tests/node-sdk/replication/kv-peer-serving-enforcement.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  openTransportSession,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Peer Serving Enforcement", () => {
+  test(
+    "allows host export and denies replica export unless peer serving is enabled",
+    { timeout: 600_000 },
+    async () => {
+      const prefix = uniqueReplicationPrefix("peer-serving-default");
+      const scope = `replication/peer-serving/default/${Date.now()}`;
+      const key = `${scope}/profile.json`;
+
+      const defaultCluster = await startCluster();
+      try {
+        const host = createClusterClient(defaultCluster, "node-b", prefix);
+        const replica = createClusterClient(defaultCluster, "node-c", prefix);
+        const hostNode = getClusterNode(defaultCluster, "node-b");
+        const replicaNode = getClusterNode(defaultCluster, "node-c");
+
+        const hostInfoResponse = await fetch(`${hostNode.url}/info`);
+        const replicaInfoResponse = await fetch(`${replicaNode.url}/info`);
+        expect(hostInfoResponse.ok).toBe(true);
+        expect(replicaInfoResponse.ok).toBe(true);
+
+        const hostInfo = (await hostInfoResponse.json()) as {
+          rolesEnabled: string[];
+          replication: { peerServing: boolean };
+        };
+        const replicaInfo = (await replicaInfoResponse.json()) as {
+          rolesEnabled: string[];
+          replication: { peerServing: boolean };
+        };
+        expect(hostInfo.rolesEnabled).toEqual(["host"]);
+        expect(hostInfo.replication.peerServing).toBe(true);
+        expect(replicaInfo.rolesEnabled).toEqual(["replica"]);
+        expect(replicaInfo.replication.peerServing).toBe(false);
+
+        await host.signIn();
+        await replica.signIn();
+
+        expect(host.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(host.spaceId);
+
+        const putResult = await host.kv.put(key, {
+          owner: "alice",
+          relayedBy: "node-b",
+          createdAt: new Date().toISOString(),
+        });
+        expect(putResult.ok).toBe(true);
+
+        const hostSession = await openKvReplicationSession(
+          host,
+          hostNode.url,
+          scope
+        );
+        const hostTransport = await openTransportSession(hostSession);
+        const hostExport = await fetch(`${hostNode.url}/replication/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": hostTransport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: host.spaceId,
+            prefix: scope,
+          }),
+        });
+        expect(hostExport.status).toBe(200);
+
+        const replicaSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scope
+        );
+        const replicaTransport = await openTransportSession(replicaSession);
+        const replicaExport = await fetch(`${replicaNode.url}/replication/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": replicaTransport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: replica.spaceId,
+            prefix: scope,
+          }),
+        });
+        expect(replicaExport.status).toBe(403);
+        expect(await replicaExport.text()).toContain("peerServing");
+      } finally {
+        await defaultCluster.stop();
+      }
+
+      const enabledCluster = await startCluster({
+        nodes: [
+          { name: "node-a", role: "authority", port: 8010 },
+          { name: "node-b", role: "host", port: 8011 },
+          {
+            name: "node-c",
+            role: "replica",
+            port: 8012,
+            env: {
+              TINYCLOUD_REPLICATION_PEER_SERVING: "true",
+            },
+          },
+        ],
+      });
+      try {
+        const authority = createClusterClient(enabledCluster, "node-a", prefix);
+        const replica = createClusterClient(enabledCluster, "node-c", prefix);
+        const replicaNode = getClusterNode(enabledCluster, "node-c");
+        const replicaInfoResponse = await fetch(`${replicaNode.url}/info`);
+        expect(replicaInfoResponse.ok).toBe(true);
+        const replicaInfo = (await replicaInfoResponse.json()) as {
+          rolesEnabled: string[];
+          replication: { peerServing: boolean };
+        };
+        expect(replicaInfo.rolesEnabled).toEqual(["replica"]);
+        expect(replicaInfo.replication.peerServing).toBe(true);
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const putResult = await replica.kv.put(key, {
+          owner: "alice",
+          relayedBy: "node-c",
+          createdAt: new Date().toISOString(),
+        });
+        expect(putResult.ok).toBe(true);
+
+        const replicaSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scope
+        );
+        const replicaTransport = await openTransportSession(replicaSession);
+        const replicaExport = await fetch(`${replicaNode.url}/replication/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": replicaTransport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: replica.spaceId,
+            prefix: scope,
+          }),
+        });
+        expect(replicaExport.status).toBe(200);
+
+        const exportBody = (await replicaExport.json()) as {
+          sequences: Array<{ events: Array<unknown> }>;
+        };
+        expect(exportBody.sequences.length).toBeGreaterThan(0);
+        expect(exportBody.sequences[0]?.events.length ?? 0).toBeGreaterThan(0);
+      } finally {
+        await enabledCluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-peer-serving-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-peer-serving-reconcile.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication KV Peer Serving Reconcile", () => {
+  test(
+    "pulls a real KV value through node-b into node-c",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-peer-serving-reconcile");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const host = createClusterClient(cluster, "node-b", prefix);
+        const replica = createClusterClient(cluster, "node-c", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const hostNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await host.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(host.spaceId).toBe(authority.spaceId);
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/kv-peer-serving-reconcile/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const value = {
+          owner: "alice",
+          relayedBy: "node-b",
+          createdAt: new Date().toISOString(),
+        };
+
+        const putResult = await authority.kv.put(key, value);
+        expect(putResult.ok).toBe(true);
+
+        const hostReconcileSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
+        const firstPass = await reconcileFromPeer(cluster, "node-b", {
+          peerUrl: authorityNode.url,
+          spaceId: authority.spaceId!,
+          prefix: scope,
+        }, hostReconcileSession);
+        expect(firstPass.appliedSequences).toBeGreaterThan(0);
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+
+        const replicaReconcileSession = await openKvReplicationSession(
+          host,
+          hostNode.url,
+          scope
+        );
+        const secondPass = await reconcileFromPeer(cluster, "node-c", {
+          peerUrl: hostNode.url,
+          spaceId: authority.spaceId!,
+          prefix: scope,
+        }, replicaReconcileSession);
+        expect(secondPass.appliedSequences).toBeGreaterThan(0);
+        expect(secondPass.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("replicated KV available on node-c", async () => {
+          const getResult = await replica.kv.get<typeof value>(key);
+          return getResult.ok;
+        });
+
+        const replicaGet = await replica.kv.get<typeof value>(key);
+        expect(replicaGet.ok).toBe(true);
+        if (!replicaGet.ok) {
+          throw new Error(replicaGet.error.message);
+        }
+        expect(replicaGet.data.data).toEqual(value);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-peer-serving-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-peer-serving-reconcile.test.ts
@@ -22,6 +22,7 @@ describe("Replication KV Peer Serving Reconcile", () => {
         const replica = createClusterClient(cluster, "node-c", prefix);
         const authorityNode = getClusterNode(cluster, "node-a");
         const hostNode = getClusterNode(cluster, "node-b");
+        const replicaNode = getClusterNode(cluster, "node-c");
 
         await authority.signIn();
         await host.signIn();
@@ -47,11 +48,16 @@ describe("Replication KV Peer Serving Reconcile", () => {
           authorityNode.url,
           scope
         );
+        const hostTargetSession = await openKvReplicationSession(
+          host,
+          hostNode.url,
+          scope
+        );
         const firstPass = await reconcileFromPeer(cluster, "node-b", {
           peerUrl: authorityNode.url,
           spaceId: authority.spaceId!,
           prefix: scope,
-        }, hostReconcileSession);
+        }, { target: hostTargetSession, peer: hostReconcileSession });
         expect(firstPass.appliedSequences).toBeGreaterThan(0);
         expect(firstPass.appliedEvents).toBeGreaterThan(0);
 
@@ -60,11 +66,16 @@ describe("Replication KV Peer Serving Reconcile", () => {
           hostNode.url,
           scope
         );
+        const replicaTargetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scope
+        );
         const secondPass = await reconcileFromPeer(cluster, "node-c", {
           peerUrl: hostNode.url,
           spaceId: authority.spaceId!,
           prefix: scope,
-        }, replicaReconcileSession);
+        }, { target: replicaTargetSession, peer: replicaReconcileSession });
         expect(secondPass.appliedSequences).toBeGreaterThan(0);
         expect(secondPass.appliedEvents).toBeGreaterThan(0);
 

--- a/tests/node-sdk/replication/kv-quarantine-visibility.test.ts
+++ b/tests/node-sdk/replication/kv-quarantine-visibility.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openAuthReplicationSession,
+  openKvReplicationSession,
+  peerMissingApplyFromPeer,
+  reconcileAuthFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication KV Quarantine Visibility", () => {
+  test(
+    "defaults reads to canonical visibility and allows provisional overrides for quarantined keys",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-quarantine-visibility");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const canonicalReplica = createClusterClient(cluster, "node-b", prefix);
+        const provisionalReplica = createClusterClient(cluster, "node-b", prefix, undefined, {
+          kvConfig: { readMode: "provisional" },
+        });
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await canonicalReplica.signIn();
+        await provisionalReplica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(canonicalReplica.spaceId).toBe(authority.spaceId);
+        expect(provisionalReplica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/kv-quarantine-visibility/${Date.now()}`;
+        const key = `${scope}/local-only.json`;
+        const value = {
+          stage: "local-only",
+          createdAt: new Date().toISOString(),
+        };
+
+        expect(await canonicalReplica.kv.put(key, value)).toMatchObject({ ok: true });
+
+        await reconcileAuthFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+          },
+          {
+            target: await openAuthReplicationSession(canonicalReplica, replicaNode.url),
+            peer: await openAuthReplicationSession(authority, authorityNode.url),
+          }
+        );
+
+        const firstApply = await peerMissingApplyFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(canonicalReplica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(firstApply.quarantined).toBeGreaterThanOrEqual(1);
+
+        const canonicalGet = await canonicalReplica.kv.get(key);
+        expect(canonicalGet.ok).toBe(false);
+        if (canonicalGet.ok) {
+          throw new Error("Expected canonical read to hide quarantined key");
+        }
+        expect(canonicalGet.error.code).toBe("KV_NOT_FOUND");
+
+        const canonicalHead = await canonicalReplica.kv.head(key);
+        expect(canonicalHead.ok).toBe(false);
+        if (canonicalHead.ok) {
+          throw new Error("Expected canonical head to hide quarantined key");
+        }
+        expect(canonicalHead.error.code).toBe("KV_NOT_FOUND");
+
+        const canonicalList = await canonicalReplica.kv.list({ prefix: scope });
+        expect(canonicalList.ok).toBe(true);
+        if (!canonicalList.ok) {
+          throw new Error(canonicalList.error.message);
+        }
+        expect(canonicalList.data.keys).not.toContain(key);
+
+        const provisionalGet = await canonicalReplica.kv.get<typeof value>(key, {
+          readMode: "provisional",
+        });
+        expect(provisionalGet.ok).toBe(true);
+        if (!provisionalGet.ok) {
+          throw new Error(provisionalGet.error.message);
+        }
+        expect(provisionalGet.data.data).toEqual(value);
+
+        const provisionalHead = await canonicalReplica.kv.head(key, {
+          readMode: "provisional",
+        });
+        expect(provisionalHead.ok).toBe(true);
+
+        const provisionalList = await canonicalReplica.kv.list({
+          prefix: scope,
+          readMode: "provisional",
+        });
+        expect(provisionalList.ok).toBe(true);
+        if (!provisionalList.ok) {
+          throw new Error(provisionalList.error.message);
+        }
+        expect(provisionalList.data.keys).toContain(key);
+
+        const configuredProvisionalGet = await provisionalReplica.kv.get<typeof value>(key);
+        expect(configuredProvisionalGet.ok).toBe(true);
+        if (!configuredProvisionalGet.ok) {
+          throw new Error(configuredProvisionalGet.error.message);
+        }
+        expect(configuredProvisionalGet.data.data).toEqual(value);
+
+        const authorityPull = await reconcileFromPeer(
+          cluster,
+          "node-a",
+          {
+            peerUrl: replicaNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(authority, authorityNode.url, scope),
+            peer: await openKvReplicationSession(canonicalReplica, replicaNode.url, scope),
+          }
+        );
+        expect(authorityPull.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("authority sees quarantined key before keep resolution", async () => {
+          const result = await authority.kv.get<typeof value>(key);
+          return result.ok && result.data.data.stage === value.stage;
+        });
+
+        const secondApply = await peerMissingApplyFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(canonicalReplica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+        expect(secondApply.kept).toBeGreaterThanOrEqual(1);
+        expect(secondApply.clearedQuarantine).toBeGreaterThanOrEqual(1);
+
+        await waitForCondition("canonical reads show key again after quarantine clears", async () => {
+          const result = await canonicalReplica.kv.get<typeof value>(key);
+          return result.ok && result.data.data.stage === value.stage;
+        });
+
+        const finalCanonicalList = await canonicalReplica.kv.list({ prefix: scope });
+        expect(finalCanonicalList.ok).toBe(true);
+        if (!finalCanonicalList.ok) {
+          throw new Error(finalCanonicalList.error.message);
+        }
+        expect(finalCanonicalList.data.keys).toContain(key);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-quarantine-visibility.test.ts
+++ b/tests/node-sdk/replication/kv-quarantine-visibility.test.ts
@@ -7,7 +7,6 @@ import {
   openKvReplicationSession,
   peerMissingApplyFromPeer,
   reconcileAuthFromPeer,
-  reconcileFromPeer,
   uniqueReplicationPrefix,
   waitForCondition,
 } from "./helpers";
@@ -126,17 +125,15 @@ describe("Replication KV Quarantine Visibility", () => {
         }
         expect(configuredProvisionalGet.data.data).toEqual(value);
 
-        const authorityPull = await reconcileFromPeer(
-          cluster,
-          "node-a",
+        const authorityPull = await authority.reconcileKvFromPeer(
+          {
+            target: await openKvReplicationSession(authority, authorityNode.url, scope),
+            peer: await openKvReplicationSession(canonicalReplica, replicaNode.url, scope),
+          },
           {
             peerUrl: replicaNode.url,
             spaceId: authority.spaceId!,
             prefix: scope,
-          },
-          {
-            target: await openKvReplicationSession(authority, authorityNode.url, scope),
-            peer: await openKvReplicationSession(canonicalReplica, replicaNode.url, scope),
           }
         );
         expect(authorityPull.appliedEvents).toBeGreaterThan(0);

--- a/tests/node-sdk/replication/kv-recon-compare.test.ts
+++ b/tests/node-sdk/replication/kv-recon-compare.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconCompareFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication KV Recon Compare", () => {
+  test(
+    "reports mismatch before replay reconcile, match after reconcile, and keeps prefixes isolated",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-compare");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon-compare/${Date.now()}`;
+        const primaryScope = `${scopeRoot}/primary`;
+        const siblingScope = `${scopeRoot}/sibling`;
+        const primaryKey = `${primaryScope}/profile.json`;
+        const siblingKey = `${siblingScope}/profile.json`;
+
+        const primaryValue = {
+          owner: "alice",
+          scope: "primary",
+          createdAt: new Date().toISOString(),
+        };
+        const siblingValue = {
+          owner: "alice",
+          scope: "sibling",
+          createdAt: new Date().toISOString(),
+        };
+
+        const primaryWrite = await authority.kv.put(primaryKey, primaryValue);
+        expect(primaryWrite.ok).toBe(true);
+        const siblingWrite = await authority.kv.put(siblingKey, siblingValue);
+        expect(siblingWrite.ok).toBe(true);
+
+        const targetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          primaryScope
+        );
+        const peerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          primaryScope
+        );
+        const beforeCompare = await reconCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          { target: targetSession, peer: peerSession }
+        );
+
+        expect(beforeCompare.spaceId).toBe(authority.spaceId);
+        expect(beforeCompare.prefix).toBe(primaryScope);
+        expect(beforeCompare.peerUrl).toBe(authorityNode.url);
+        expect(beforeCompare.matches).toBe(false);
+        expect(beforeCompare.localFingerprint).not.toBe(beforeCompare.peerFingerprint);
+        expect(beforeCompare.peerItemCount).toBeGreaterThan(0);
+        expect(beforeCompare.firstMismatchKey).toBeDefined();
+        expect(beforeCompare.firstMismatchKey?.startsWith(primaryScope)).toBe(true);
+
+        const reconcileResult = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          { target: targetSession, peer: peerSession }
+        );
+        expect(reconcileResult.appliedSequences).toBeGreaterThan(0);
+        expect(reconcileResult.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("primary KV available on node-b", async () => {
+          const result = await replica.kv.get<typeof primaryValue>(primaryKey);
+          return result.ok && result.data.data.scope === "primary";
+        });
+
+        const postTargetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          primaryScope
+        );
+        const postPeerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          primaryScope
+        );
+        const afterCompare = await reconCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          { target: postTargetSession, peer: postPeerSession }
+        );
+
+        expect(afterCompare.matches).toBe(true);
+        expect(afterCompare.localItemCount).toBe(afterCompare.peerItemCount);
+        expect(afterCompare.localFingerprint).toBe(afterCompare.peerFingerprint);
+        expect(afterCompare.firstMismatchKey).toBeNull();
+
+        const siblingTargetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          siblingScope
+        );
+        const siblingPeerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          siblingScope
+        );
+        const siblingCompare = await reconCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: siblingScope,
+          },
+          { target: siblingTargetSession, peer: siblingPeerSession }
+        );
+
+        expect(siblingCompare.matches).toBe(false);
+        expect(siblingCompare.peerItemCount).toBeGreaterThan(0);
+        expect(siblingCompare.firstMismatchKey).toBeDefined();
+        expect(siblingCompare.firstMismatchKey?.startsWith(siblingScope)).toBe(true);
+        expect(
+          siblingCompare.firstMismatchKey?.startsWith(primaryScope)
+        ).toBe(false);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-recon-export.test.ts
+++ b/tests/node-sdk/replication/kv-recon-export.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconExportFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+type ReconItem = {
+  key: string;
+  kind: string;
+  invocationId?: string;
+};
+
+function normalizeReconInventory(items: ReconItem[]): ReconItem[] {
+  return items.map(({ key, kind, invocationId }) => ({
+    key,
+    kind,
+    invocationId,
+  }));
+}
+
+describe("Replication KV Recon Export", () => {
+  test(
+    "exports the same scoped KV inventory after replay reconcile and ignores sibling prefixes",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-export");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon/${Date.now()}`;
+        const primaryScope = `${scopeRoot}/primary`;
+        const siblingScope = `${scopeRoot}/sibling`;
+        const primaryKey = `${primaryScope}/profile.json`;
+        const siblingKey = `${siblingScope}/profile.json`;
+
+        const primaryValue = {
+          owner: "alice",
+          scope: "primary",
+          createdAt: new Date().toISOString(),
+        };
+        const siblingValue = {
+          owner: "alice",
+          scope: "sibling",
+          createdAt: new Date().toISOString(),
+        };
+
+        const primaryWrite = await authority.kv.put(primaryKey, primaryValue);
+        expect(primaryWrite.ok).toBe(true);
+        const siblingWrite = await authority.kv.put(siblingKey, siblingValue);
+        expect(siblingWrite.ok).toBe(true);
+
+        const peerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          primaryScope
+        );
+        const targetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          primaryScope
+        );
+        const firstPass = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          { target: targetSession, peer: peerSession }
+        );
+
+        expect(firstPass.appliedSequences).toBeGreaterThan(0);
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("primary KV available on node-b", async () => {
+          const result = await replica.kv.get<typeof primaryValue>(primaryKey);
+          return result.ok && result.data.data.scope === "primary";
+        });
+
+        const authorityReconSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          primaryScope
+        );
+        const replicaReconSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          primaryScope
+        );
+        const authorityRecon = await reconExportFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          authorityReconSession
+        );
+        const replicaRecon = await reconExportFromPeer(
+          cluster,
+          "node-b",
+          {
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          replicaReconSession
+        );
+
+        expect(authorityRecon.spaceId).toBe(authority.spaceId);
+        expect(replicaRecon.spaceId).toBe(authority.spaceId);
+        expect(authorityRecon.prefix).toBe(primaryScope);
+        expect(replicaRecon.prefix).toBe(primaryScope);
+
+        const normalizedAuthorityRecon = normalizeReconInventory(
+          authorityRecon.items as ReconItem[]
+        );
+        const normalizedReplicaRecon = normalizeReconInventory(
+          replicaRecon.items as ReconItem[]
+        );
+
+        expect(normalizedReplicaRecon).toEqual(normalizedAuthorityRecon);
+        expect(normalizedAuthorityRecon.length).toBeGreaterThan(0);
+        expect(normalizedAuthorityRecon.every((item) => item.key.startsWith(primaryScope))).toBe(
+          true
+        );
+        expect(
+          normalizedAuthorityRecon.every((item) => !item.key.startsWith(siblingScope))
+        ).toBe(true);
+
+        const authorityReconRepeat = await reconExportFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          authorityReconSession
+        );
+        expect(
+          normalizeReconInventory(authorityReconRepeat.items as ReconItem[])
+        ).toEqual(normalizedAuthorityRecon);
+
+        const siblingRecon = await reconExportFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: siblingScope,
+          },
+          await openKvReplicationSession(authority, authorityNode.url, siblingScope)
+        );
+        expect(siblingRecon.items.length).toBeGreaterThan(0);
+        expect(
+          siblingRecon.items.every((item) => item.key.startsWith(siblingScope))
+        ).toBe(true);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-recon-split-compare.test.ts
+++ b/tests/node-sdk/replication/kv-recon-split-compare.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconSplitCompareFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+function childStatusMap(
+  children: {
+    prefix: string;
+    status: "match" | "local-missing" | "peer-missing" | "mismatch";
+    localItemCount: number;
+    peerItemCount: number;
+  }[]
+) {
+  return new Map(children.map((child) => [child.prefix, child]));
+}
+
+describe("Replication KV Recon Split Compare", () => {
+  test(
+    "shows which child prefixes still need replay and converges after the remaining child is reconciled",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-split-compare");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon-split-compare/${Date.now()}`;
+        const primaryScope = `${scopeRoot}/primary`;
+        const siblingScope = `${scopeRoot}/sibling`;
+        const primaryProfileKey = `${primaryScope}/profile.json`;
+        const primaryAssetKey = `${primaryScope}/assets/avatar.json`;
+        const siblingProfileKey = `${siblingScope}/profile.json`;
+
+        expect(
+          await authority.kv.put(primaryProfileKey, {
+            owner: "alice",
+            scope: "primary",
+            kind: "profile",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(primaryAssetKey, {
+            owner: "alice",
+            scope: "primary",
+            kind: "asset",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(siblingProfileKey, {
+            owner: "alice",
+            scope: "sibling",
+            kind: "profile",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+
+        const primaryReconcile = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, primaryScope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, primaryScope),
+          }
+        );
+        expect(primaryReconcile.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("primary KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(primaryProfileKey);
+          return result.ok && result.data.data.scope === "primary";
+        });
+
+        const partialCompare = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scopeRoot),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scopeRoot),
+          }
+        );
+
+        const partialChildren = childStatusMap(partialCompare.children);
+        expect(partialCompare.matches).toBe(false);
+        expect(partialChildren.get(primaryScope)?.status).toBe("match");
+        expect(partialChildren.get(primaryScope)?.localItemCount).toBe(2);
+        expect(partialChildren.get(primaryScope)?.peerItemCount).toBe(2);
+        expect(partialChildren.get(siblingScope)?.status).toBe("local-missing");
+        expect(partialChildren.get(siblingScope)?.localItemCount).toBe(0);
+        expect(partialChildren.get(siblingScope)?.peerItemCount).toBe(1);
+
+        const siblingReconcile = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: siblingScope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, siblingScope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, siblingScope),
+          }
+        );
+        expect(siblingReconcile.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("sibling KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(siblingProfileKey);
+          return result.ok && result.data.data.scope === "sibling";
+        });
+
+        const convergedCompare = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scopeRoot),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scopeRoot),
+          }
+        );
+
+        expect(convergedCompare.matches).toBe(true);
+        expect(
+          convergedCompare.children.every((child) => child.status === "match")
+        ).toBe(true);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-recon-split-grandchild.test.ts
+++ b/tests/node-sdk/replication/kv-recon-split-grandchild.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconSplitCompareFromPeer,
+  reconcileSplitFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+function splitChildMap(
+  children: {
+    prefix: string;
+    beforeStatus: "match" | "local-missing" | "peer-missing" | "mismatch";
+    afterStatus: "match" | "local-missing" | "peer-missing" | "mismatch";
+    appliedSequences: number;
+    appliedEvents: number;
+  }[]
+) {
+  return new Map(children.map((child) => [child.prefix, child]));
+}
+
+function compareChildMap(
+  children: {
+    prefix: string;
+    status: "match" | "local-missing" | "peer-missing" | "mismatch";
+    localItemCount: number;
+    peerItemCount: number;
+  }[]
+) {
+  return new Map(children.map((child) => [child.prefix, child]));
+}
+
+describe("Replication KV Split-Driven Grandchild Replay", () => {
+  test(
+    "pages deeper mismatched grandchild prefixes before replaying a coarse child scope",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-split-grandchild");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon-split-grandchild/${Date.now()}`;
+        const coarseScope = `${scopeRoot}/library`;
+        const chapterAScope = `${coarseScope}/chapter-a`;
+        const chapterBScope = `${coarseScope}/chapter-b`;
+        const chapterAProfileKey = `${chapterAScope}/profile.json`;
+        const chapterAAssetKey = `${chapterAScope}/assets/cover.json`;
+        const chapterBProfileKey = `${chapterBScope}/profile.json`;
+
+        expect(
+          await authority.kv.put(chapterAProfileKey, {
+            owner: "alice",
+            scope: "chapter-a",
+            kind: "profile",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(chapterAAssetKey, {
+            owner: "alice",
+            scope: "chapter-a",
+            kind: "asset",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(chapterBProfileKey, {
+            owner: "alice",
+            scope: "chapter-b",
+            kind: "profile",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+
+        const rootTargetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scopeRoot
+        );
+        const rootPeerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scopeRoot
+        );
+        const coarseTargetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          coarseScope
+        );
+        const coarsePeerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          coarseScope
+        );
+
+        const rootBefore = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        const rootBeforeChildren = compareChildMap(rootBefore.children);
+        expect(rootBefore.matches).toBe(false);
+        expect(rootBeforeChildren.get(coarseScope)?.status).toBe(
+          "local-missing"
+        );
+        expect(rootBeforeChildren.get(coarseScope)?.localItemCount).toBe(0);
+        expect(rootBeforeChildren.get(coarseScope)?.peerItemCount).toBe(3);
+
+        const coarseBefore = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: coarseScope,
+          },
+          {
+            target: coarseTargetSession,
+            peer: coarsePeerSession,
+          }
+        );
+        const coarseBeforeChildren = compareChildMap(coarseBefore.children);
+        expect(coarseBefore.matches).toBe(false);
+        expect(coarseBeforeChildren.get(chapterAScope)?.status).toBe(
+          "local-missing"
+        );
+        expect(coarseBeforeChildren.get(chapterAScope)?.peerItemCount).toBe(2);
+        expect(coarseBeforeChildren.get(chapterBScope)?.status).toBe(
+          "local-missing"
+        );
+        expect(coarseBeforeChildren.get(chapterBScope)?.peerItemCount).toBe(1);
+
+        const firstSplitReconcile = await reconcileSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childLimit: 1,
+            maxDepth: 2,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+
+        expect(firstSplitReconcile.spaceId).toBe(authority.spaceId);
+        expect(firstSplitReconcile.peerUrl).toBe(authorityNode.url);
+        expect(firstSplitReconcile.prefix).toBe(scopeRoot);
+        expect(firstSplitReconcile.matches).toBe(false);
+        expect(firstSplitReconcile.attemptedChildren).toBe(1);
+        expect(firstSplitReconcile.reconciledChildren).toBe(0);
+
+        const firstSplitChildren = splitChildMap(firstSplitReconcile.children);
+        expect(firstSplitChildren.get(coarseScope)?.beforeStatus).toBe(
+          "local-missing"
+        );
+        expect(firstSplitChildren.get(coarseScope)?.afterStatus).toBe("mismatch");
+        expect(
+          firstSplitChildren.get(coarseScope)?.appliedSequences
+        ).toBeGreaterThan(0);
+        expect(firstSplitChildren.get(coarseScope)?.appliedEvents).toBeGreaterThan(
+          0
+        );
+
+        await waitForCondition("chapter-a KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(
+            chapterAProfileKey
+          );
+          return result.ok && result.data.data.scope === "chapter-a";
+        });
+
+        const chapterBBefore = await replica.kv.get<{ scope: string }>(
+          chapterBProfileKey
+        );
+        expect(chapterBBefore.ok).toBe(false);
+
+        const rootAfterFirst = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        const rootAfterFirstChildren = compareChildMap(rootAfterFirst.children);
+        expect(rootAfterFirst.matches).toBe(false);
+        expect(rootAfterFirstChildren.get(coarseScope)?.status).toBe("mismatch");
+
+        const coarseAfterFirst = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: coarseScope,
+          },
+          {
+            target: coarseTargetSession,
+            peer: coarsePeerSession,
+          }
+        );
+        const coarseAfterFirstChildren = compareChildMap(coarseAfterFirst.children);
+        expect(coarseAfterFirst.matches).toBe(false);
+        expect(coarseAfterFirstChildren.get(chapterAScope)?.status).toBe(
+          "match"
+        );
+        expect(coarseAfterFirstChildren.get(chapterBScope)?.status).toBe(
+          "local-missing"
+        );
+
+        const secondSplitReconcile = await reconcileSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childLimit: 1,
+            maxDepth: 2,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+
+        expect(secondSplitReconcile.spaceId).toBe(authority.spaceId);
+        expect(secondSplitReconcile.peerUrl).toBe(authorityNode.url);
+        expect(secondSplitReconcile.prefix).toBe(scopeRoot);
+        expect(secondSplitReconcile.matches).toBe(true);
+        expect(secondSplitReconcile.attemptedChildren).toBe(1);
+        expect(secondSplitReconcile.reconciledChildren).toBe(1);
+
+        const secondSplitChildren = splitChildMap(secondSplitReconcile.children);
+        expect(secondSplitChildren.get(coarseScope)?.beforeStatus).toBe(
+          "mismatch"
+        );
+        expect(secondSplitChildren.get(coarseScope)?.afterStatus).toBe("match");
+        expect(
+          secondSplitChildren.get(coarseScope)?.appliedSequences
+        ).toBeGreaterThan(0);
+        expect(secondSplitChildren.get(coarseScope)?.appliedEvents).toBeGreaterThan(
+          0
+        );
+
+        await waitForCondition("chapter-b KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(
+            chapterBProfileKey
+          );
+          return result.ok && result.data.data.scope === "chapter-b";
+        });
+
+        const coarseAfterSecond = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: coarseScope,
+          },
+          {
+            target: coarseTargetSession,
+            peer: coarsePeerSession,
+          }
+        );
+        const rootAfterSecond = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        expect(coarseAfterSecond.matches).toBe(true);
+        expect(
+          coarseAfterSecond.children.every((child) => child.status === "match")
+        ).toBe(true);
+        expect(rootAfterSecond.matches).toBe(true);
+        expect(
+          rootAfterSecond.children.every((child) => child.status === "match")
+        ).toBe(true);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-recon-split-pagination.test.ts
+++ b/tests/node-sdk/replication/kv-recon-split-pagination.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconSplitCompareFromPeer,
+  reconSplitFromPeer,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+function childPrefixMap(
+  children: {
+    prefix: string;
+  }[]
+) {
+  return new Map(children.map((child) => [child.prefix, child]));
+}
+
+describe("Replication KV Split Child Pagination", () => {
+  test(
+    "pages wide child lists deterministically with childStartAfter and childLimit",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-split-pagination");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon-split-pagination/${Date.now()}`;
+        const childScopes = [
+          `${scopeRoot}/alpha`,
+          `${scopeRoot}/bravo`,
+          `${scopeRoot}/charlie`,
+          `${scopeRoot}/delta`,
+        ];
+
+        for (const [index, childScope] of childScopes.entries()) {
+          const write = await authority.kv.put(`${childScope}/profile.json`, {
+            owner: "alice",
+            scope: childScope,
+            ordinal: index,
+            createdAt: new Date().toISOString(),
+          });
+          expect(write.ok).toBe(true);
+        }
+
+        const targetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scopeRoot
+        );
+        const peerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scopeRoot
+        );
+
+        const firstSplitPage = await reconSplitFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childLimit: 2,
+          },
+          peerSession
+        );
+        expect(firstSplitPage.hasMore).toBe(true);
+        expect(firstSplitPage.childStartAfter ?? null).toBeNull();
+        expect(firstSplitPage.childLimit).toBe(2);
+        expect(firstSplitPage.nextChildStartAfter).toBeDefined();
+        expect(firstSplitPage.children.length).toBe(2);
+        expect(firstSplitPage.children.map((child) => child.prefix)).toEqual([
+          childScopes[0],
+          childScopes[1],
+        ]);
+
+        const secondSplitPage = await reconSplitFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childStartAfter: firstSplitPage.nextChildStartAfter ?? undefined,
+            childLimit: 2,
+          },
+          peerSession
+        );
+        expect(secondSplitPage.hasMore).toBe(false);
+        expect(secondSplitPage.childStartAfter).toBe(
+          firstSplitPage.nextChildStartAfter ?? undefined
+        );
+        expect(secondSplitPage.childLimit).toBe(2);
+        expect(secondSplitPage.nextChildStartAfter ?? null).toBeNull();
+        expect(secondSplitPage.children.length).toBe(2);
+        expect(secondSplitPage.children.map((child) => child.prefix)).toEqual([
+          childScopes[2],
+          childScopes[3],
+        ]);
+
+        const pagePrefixes = childPrefixMap([
+          ...firstSplitPage.children,
+          ...secondSplitPage.children,
+        ]);
+        expect(pagePrefixes.size).toBe(4);
+        expect([...pagePrefixes.keys()]).toEqual(
+          childScopes.sort()
+        );
+
+        const firstComparePage = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childLimit: 2,
+          },
+          {
+            target: targetSession,
+            peer: peerSession,
+          }
+        );
+        expect(firstComparePage.matches).toBe(false);
+        expect(firstComparePage.hasMore).toBe(true);
+        expect(firstComparePage.childStartAfter ?? null).toBeNull();
+        expect(firstComparePage.childLimit).toBe(2);
+        expect(firstComparePage.nextChildStartAfter).toBeDefined();
+        expect(firstComparePage.children.length).toBe(2);
+        expect(firstComparePage.children.map((child) => child.prefix)).toEqual([
+          childScopes[0],
+          childScopes[1],
+        ]);
+        expect(
+          firstComparePage.children.every(
+            (child) => child.status === "local-missing"
+          )
+        ).toBe(true);
+
+        const secondComparePage = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childStartAfter: firstComparePage.nextChildStartAfter ?? undefined,
+            childLimit: 2,
+          },
+          {
+            target: targetSession,
+            peer: peerSession,
+          }
+        );
+        expect(secondComparePage.matches).toBe(false);
+        expect(secondComparePage.hasMore).toBe(false);
+        expect(secondComparePage.childStartAfter).toBe(
+          firstComparePage.nextChildStartAfter ?? undefined
+        );
+        expect(secondComparePage.childLimit).toBe(2);
+        expect(secondComparePage.nextChildStartAfter ?? null).toBeNull();
+        expect(secondComparePage.children.length).toBe(2);
+        expect(secondComparePage.children.map((child) => child.prefix)).toEqual([
+          childScopes[2],
+          childScopes[3],
+        ]);
+        expect(
+          secondComparePage.children.every(
+            (child) => child.status === "local-missing"
+          )
+        ).toBe(true);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-recon-split-reconcile-pagination.test.ts
+++ b/tests/node-sdk/replication/kv-recon-split-reconcile-pagination.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconSplitCompareFromPeer,
+  reconcileSplitFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+function childStatusMap(
+  children: {
+    prefix: string;
+    status: "match" | "local-missing" | "peer-missing" | "mismatch";
+    localItemCount: number;
+    peerItemCount: number;
+  }[]
+) {
+  return new Map(children.map((child) => [child.prefix, child]));
+}
+
+function splitChildResultMap(
+  children: {
+    prefix: string;
+    beforeStatus: "match" | "local-missing" | "peer-missing" | "mismatch";
+    afterStatus: "match" | "local-missing" | "peer-missing" | "mismatch";
+    appliedSequences: number;
+    appliedEvents: number;
+  }[]
+) {
+  return new Map(children.map((child) => [child.prefix, child]));
+}
+
+describe("Replication KV Split-Driven Reconcile Pagination", () => {
+  test(
+    "pages wide child reconcile deterministically without changing peer-missing semantics",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-split-reconcile-pagination");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon-split-reconcile-pagination/${Date.now()}`;
+        const childScopes = [
+          `${scopeRoot}/alpha`,
+          `${scopeRoot}/bravo`,
+          `${scopeRoot}/charlie`,
+          `${scopeRoot}/delta`,
+        ];
+        const peerMissingScope = `${scopeRoot}/zulu`;
+
+        for (const [index, childScope] of childScopes.entries()) {
+          const write = await authority.kv.put(`${childScope}/profile.json`, {
+            owner: "alice",
+            scope: childScope,
+            ordinal: index,
+            createdAt: new Date().toISOString(),
+          });
+          expect(write.ok).toBe(true);
+        }
+
+        const peerOnlyWrite = await replica.kv.put(`${peerMissingScope}/profile.json`, {
+          owner: "alice",
+          scope: peerMissingScope,
+          kind: "peer-only",
+          createdAt: new Date().toISOString(),
+        });
+        expect(peerOnlyWrite.ok).toBe(true);
+
+        const rootTargetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scopeRoot
+        );
+        const rootPeerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scopeRoot
+        );
+
+        const compareBefore = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        const compareBeforeChildren = childStatusMap(compareBefore.children);
+        expect(compareBefore.matches).toBe(false);
+        expect(compareBeforeChildren.get(childScopes[0])?.status).toBe(
+          "local-missing"
+        );
+        expect(compareBeforeChildren.get(childScopes[1])?.status).toBe(
+          "local-missing"
+        );
+        expect(compareBeforeChildren.get(childScopes[2])?.status).toBe(
+          "local-missing"
+        );
+        expect(compareBeforeChildren.get(childScopes[3])?.status).toBe(
+          "local-missing"
+        );
+        expect(compareBeforeChildren.get(peerMissingScope)?.status).toBe(
+          "peer-missing"
+        );
+
+        const firstSplitReconcile = await reconcileSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childLimit: 2,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        expect(firstSplitReconcile.matches).toBe(false);
+        expect(firstSplitReconcile.childStartAfter ?? null).toBeNull();
+        expect(firstSplitReconcile.childLimit).toBe(2);
+        expect(firstSplitReconcile.hasMore).toBe(true);
+        expect(firstSplitReconcile.nextChildStartAfter).toBeDefined();
+        expect(firstSplitReconcile.children.length).toBe(2);
+
+        const firstSplitChildren = splitChildResultMap(firstSplitReconcile.children);
+        expect(firstSplitChildren.get(childScopes[0])?.beforeStatus).toBe(
+          "local-missing"
+        );
+        expect(firstSplitChildren.get(childScopes[0])?.afterStatus).toBe("match");
+        expect(firstSplitChildren.get(childScopes[1])?.beforeStatus).toBe(
+          "local-missing"
+        );
+        expect(firstSplitChildren.get(childScopes[1])?.afterStatus).toBe("match");
+
+        await waitForCondition("first page children available on node-b", async () => {
+          const first = await replica.kv.get<{ scope: string }>(
+            `${childScopes[0]}/profile.json`
+          );
+          const second = await replica.kv.get<{ scope: string }>(
+            `${childScopes[1]}/profile.json`
+          );
+          return (
+            first.ok &&
+            second.ok &&
+            first.data.data.scope === childScopes[0] &&
+            second.data.data.scope === childScopes[1]
+          );
+        });
+        const secondPageCursor = firstSplitReconcile.nextChildStartAfter;
+        expect(secondPageCursor).toBeDefined();
+
+        const secondSplitReconcile = await reconcileSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childStartAfter: secondPageCursor === null ? undefined : secondPageCursor,
+            childLimit: 2,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        expect(secondSplitReconcile.matches).toBe(false);
+        expect(secondSplitReconcile.childStartAfter).toBe(secondPageCursor);
+        expect(secondSplitReconcile.childLimit).toBe(2);
+        expect(secondSplitReconcile.hasMore).toBe(true);
+        expect(secondSplitReconcile.nextChildStartAfter).toBeDefined();
+        expect(secondSplitReconcile.children.length).toBe(2);
+
+        const secondSplitChildren = splitChildResultMap(secondSplitReconcile.children);
+        expect(secondSplitChildren.get(childScopes[2])?.beforeStatus).toBe(
+          "local-missing"
+        );
+        expect(secondSplitChildren.get(childScopes[2])?.afterStatus).toBe("match");
+        expect(secondSplitChildren.get(childScopes[3])?.beforeStatus).toBe(
+          "local-missing"
+        );
+        expect(secondSplitChildren.get(childScopes[3])?.afterStatus).toBe("match");
+
+        await waitForCondition("second page children available on node-b", async () => {
+          const third = await replica.kv.get<{ scope: string }>(
+            `${childScopes[2]}/profile.json`
+          );
+          const fourth = await replica.kv.get<{ scope: string }>(
+            `${childScopes[3]}/profile.json`
+          );
+          return (
+            third.ok &&
+            fourth.ok &&
+            third.data.data.scope === childScopes[2] &&
+            fourth.data.data.scope === childScopes[3]
+          );
+        });
+        const thirdPageCursor = secondSplitReconcile.nextChildStartAfter;
+        expect(thirdPageCursor).toBeDefined();
+
+        const thirdSplitReconcile = await reconcileSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childStartAfter: thirdPageCursor === null ? undefined : thirdPageCursor,
+            childLimit: 2,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        expect(thirdSplitReconcile.matches).toBe(false);
+        expect(thirdSplitReconcile.childStartAfter).toBe(thirdPageCursor);
+        expect(thirdSplitReconcile.childLimit).toBe(2);
+        expect(thirdSplitReconcile.hasMore).toBe(false);
+        expect(thirdSplitReconcile.nextChildStartAfter ?? null).toBeNull();
+        expect(thirdSplitReconcile.children.length).toBe(1);
+        expect(thirdSplitReconcile.attemptedChildren).toBe(0);
+        expect(thirdSplitReconcile.reconciledChildren).toBe(0);
+
+        const thirdSplitChildren = splitChildResultMap(thirdSplitReconcile.children);
+        expect(thirdSplitChildren.get(peerMissingScope)?.beforeStatus).toBe(
+          "peer-missing"
+        );
+        expect(thirdSplitChildren.get(peerMissingScope)?.afterStatus).toBe(
+          "peer-missing"
+        );
+        expect(thirdSplitChildren.get(peerMissingScope)?.appliedSequences).toBe(0);
+        expect(thirdSplitChildren.get(peerMissingScope)?.appliedEvents).toBe(0);
+
+        const compareAfter = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        const compareAfterChildren = childStatusMap(compareAfter.children);
+        expect(compareAfter.matches).toBe(false);
+        expect(compareAfterChildren.get(childScopes[0])?.status).toBe("match");
+        expect(compareAfterChildren.get(childScopes[1])?.status).toBe("match");
+        expect(compareAfterChildren.get(childScopes[2])?.status).toBe("match");
+        expect(compareAfterChildren.get(childScopes[3])?.status).toBe("match");
+        expect(compareAfterChildren.get(peerMissingScope)?.status).toBe(
+          "peer-missing"
+        );
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-recon-split-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-recon-split-reconcile.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconSplitCompareFromPeer,
+  reconcileFromPeer,
+  reconcileSplitFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+function splitChildMap(
+  children: {
+    prefix: string;
+    beforeStatus: "match" | "local-missing" | "peer-missing" | "mismatch";
+    afterStatus: "match" | "local-missing" | "peer-missing" | "mismatch";
+    appliedSequences: number;
+    appliedEvents: number;
+  }[]
+) {
+  return new Map(children.map((child) => [child.prefix, child]));
+}
+
+describe("Replication KV Split-Driven Replay", () => {
+  test(
+    "replays only the remaining missing child after one child has already been reconciled",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-split-reconcile");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon-split-reconcile/${Date.now()}`;
+        const primaryScope = `${scopeRoot}/primary`;
+        const siblingScope = `${scopeRoot}/sibling`;
+        const primaryProfileKey = `${primaryScope}/profile.json`;
+        const primaryAssetKey = `${primaryScope}/assets/avatar.json`;
+        const siblingProfileKey = `${siblingScope}/profile.json`;
+
+        expect(
+          await authority.kv.put(primaryProfileKey, {
+            owner: "alice",
+            scope: "primary",
+            kind: "profile",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(primaryAssetKey, {
+            owner: "alice",
+            scope: "primary",
+            kind: "asset",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(siblingProfileKey, {
+            owner: "alice",
+            scope: "sibling",
+            kind: "profile",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+
+        const primaryReconcile = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          {
+            target: await openKvReplicationSession(
+              replica,
+              replicaNode.url,
+              primaryScope
+            ),
+            peer: await openKvReplicationSession(
+              authority,
+              authorityNode.url,
+              primaryScope
+            ),
+          }
+        );
+        expect(primaryReconcile.appliedSequences).toBeGreaterThan(0);
+        expect(primaryReconcile.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("primary KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(
+            primaryProfileKey
+          );
+          return result.ok && result.data.data.scope === "primary";
+        });
+
+        const rootTargetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scopeRoot
+        );
+        const rootPeerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scopeRoot
+        );
+
+        const compareBefore = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        const compareBeforeChildren = splitChildMap(compareBefore.children);
+        expect(compareBefore.matches).toBe(false);
+        expect(compareBeforeChildren.get(primaryScope)?.status).toBe("match");
+        expect(compareBeforeChildren.get(primaryScope)?.localItemCount).toBe(2);
+        expect(compareBeforeChildren.get(primaryScope)?.peerItemCount).toBe(2);
+        expect(compareBeforeChildren.get(siblingScope)?.status).toBe(
+          "local-missing"
+        );
+        expect(compareBeforeChildren.get(siblingScope)?.localItemCount).toBe(0);
+        expect(compareBeforeChildren.get(siblingScope)?.peerItemCount).toBe(1);
+
+        const splitReconcile = await reconcileSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childLimit: 10,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+
+        expect(splitReconcile.spaceId).toBe(authority.spaceId);
+        expect(splitReconcile.peerUrl).toBe(authorityNode.url);
+        expect(splitReconcile.prefix).toBe(scopeRoot);
+        expect(splitReconcile.matches).toBe(true);
+        expect(splitReconcile.attemptedChildren).toBe(1);
+        expect(splitReconcile.reconciledChildren).toBe(1);
+
+        const splitChildren = splitChildMap(splitReconcile.children);
+        expect(splitChildren.get(primaryScope)?.beforeStatus).toBe("match");
+        expect(splitChildren.get(primaryScope)?.afterStatus).toBe("match");
+        expect(splitChildren.get(primaryScope)?.appliedSequences).toBe(0);
+        expect(splitChildren.get(primaryScope)?.appliedEvents).toBe(0);
+        expect(splitChildren.get(siblingScope)?.beforeStatus).toBe(
+          "local-missing"
+        );
+        expect(splitChildren.get(siblingScope)?.afterStatus).toBe("match");
+        expect(splitChildren.get(siblingScope)?.appliedSequences).toBeGreaterThan(
+          0
+        );
+        expect(splitChildren.get(siblingScope)?.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("sibling KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(
+            siblingProfileKey
+          );
+          return result.ok && result.data.data.scope === "sibling";
+        });
+
+        const compareAfter = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        expect(compareAfter.matches).toBe(true);
+        expect(
+          compareAfter.children.every((child) => child.status === "match")
+        ).toBe(true);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-recon-split-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-recon-split-reconcile.test.ts
@@ -5,7 +5,6 @@ import {
   getClusterNode,
   openKvReplicationSession,
   reconSplitCompareFromPeer,
-  reconcileFromPeer,
   reconcileSplitFromPeer,
   uniqueReplicationPrefix,
   waitForCondition,
@@ -74,37 +73,6 @@ describe("Replication KV Split-Driven Replay", () => {
           })
         ).toMatchObject({ ok: true });
 
-        const primaryReconcile = await reconcileFromPeer(
-          cluster,
-          "node-b",
-          {
-            peerUrl: authorityNode.url,
-            spaceId: authority.spaceId!,
-            prefix: primaryScope,
-          },
-          {
-            target: await openKvReplicationSession(
-              replica,
-              replicaNode.url,
-              primaryScope
-            ),
-            peer: await openKvReplicationSession(
-              authority,
-              authorityNode.url,
-              primaryScope
-            ),
-          }
-        );
-        expect(primaryReconcile.appliedSequences).toBeGreaterThan(0);
-        expect(primaryReconcile.appliedEvents).toBeGreaterThan(0);
-
-        await waitForCondition("primary KV available on node-b", async () => {
-          const result = await replica.kv.get<{ scope: string }>(
-            primaryProfileKey
-          );
-          return result.ok && result.data.data.scope === "primary";
-        });
-
         const rootTargetSession = await openKvReplicationSession(
           replica,
           replicaNode.url,
@@ -131,8 +99,10 @@ describe("Replication KV Split-Driven Replay", () => {
         );
         const compareBeforeChildren = splitChildMap(compareBefore.children);
         expect(compareBefore.matches).toBe(false);
-        expect(compareBeforeChildren.get(primaryScope)?.status).toBe("match");
-        expect(compareBeforeChildren.get(primaryScope)?.localItemCount).toBe(2);
+        expect(compareBeforeChildren.get(primaryScope)?.status).toBe(
+          "local-missing"
+        );
+        expect(compareBeforeChildren.get(primaryScope)?.localItemCount).toBe(0);
         expect(compareBeforeChildren.get(primaryScope)?.peerItemCount).toBe(2);
         expect(compareBeforeChildren.get(siblingScope)?.status).toBe(
           "local-missing"
@@ -140,14 +110,14 @@ describe("Replication KV Split-Driven Replay", () => {
         expect(compareBeforeChildren.get(siblingScope)?.localItemCount).toBe(0);
         expect(compareBeforeChildren.get(siblingScope)?.peerItemCount).toBe(1);
 
-        const splitReconcile = await reconcileSplitFromPeer(
+        const firstSplitReconcile = await reconcileSplitFromPeer(
           cluster,
           "node-b",
           {
             peerUrl: authorityNode.url,
             spaceId: authority.spaceId!,
             prefix: scopeRoot,
-            childLimit: 10,
+            childLimit: 1,
           },
           {
             target: rootTargetSession,
@@ -155,14 +125,87 @@ describe("Replication KV Split-Driven Replay", () => {
           }
         );
 
-        expect(splitReconcile.spaceId).toBe(authority.spaceId);
-        expect(splitReconcile.peerUrl).toBe(authorityNode.url);
-        expect(splitReconcile.prefix).toBe(scopeRoot);
-        expect(splitReconcile.matches).toBe(true);
-        expect(splitReconcile.attemptedChildren).toBe(1);
-        expect(splitReconcile.reconciledChildren).toBe(1);
+        expect(firstSplitReconcile.spaceId).toBe(authority.spaceId);
+        expect(firstSplitReconcile.peerUrl).toBe(authorityNode.url);
+        expect(firstSplitReconcile.prefix).toBe(scopeRoot);
+        expect(firstSplitReconcile.matches).toBe(false);
+        expect(firstSplitReconcile.attemptedChildren).toBe(1);
+        expect(firstSplitReconcile.reconciledChildren).toBe(1);
 
-        const splitChildren = splitChildMap(splitReconcile.children);
+        const firstSplitChildren = splitChildMap(firstSplitReconcile.children);
+        expect(firstSplitChildren.get(primaryScope)?.beforeStatus).toBe(
+          "local-missing"
+        );
+        expect(firstSplitChildren.get(primaryScope)?.afterStatus).toBe("match");
+        expect(
+          firstSplitChildren.get(primaryScope)?.appliedSequences
+        ).toBeGreaterThan(0);
+        expect(firstSplitChildren.get(primaryScope)?.appliedEvents).toBeGreaterThan(
+          0
+        );
+        expect(firstSplitChildren.get(siblingScope)?.beforeStatus).toBe(
+          "local-missing"
+        );
+        expect(firstSplitChildren.get(siblingScope)?.afterStatus).toBe(
+          "local-missing"
+        );
+        expect(firstSplitChildren.get(siblingScope)?.appliedSequences).toBe(0);
+        expect(firstSplitChildren.get(siblingScope)?.appliedEvents).toBe(0);
+
+        await waitForCondition("primary KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(
+            primaryProfileKey
+          );
+          return result.ok && result.data.data.scope === "primary";
+        });
+
+        const compareAfterFirst = await reconSplitCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+        const compareAfterFirstChildren = splitChildMap(
+          compareAfterFirst.children
+        );
+        expect(compareAfterFirst.matches).toBe(false);
+        expect(compareAfterFirstChildren.get(primaryScope)?.status).toBe(
+          "match"
+        );
+        expect(compareAfterFirstChildren.get(siblingScope)?.status).toBe(
+          "local-missing"
+        );
+
+        const secondSplitReconcile = await reconcileSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+            childLimit: 1,
+          },
+          {
+            target: rootTargetSession,
+            peer: rootPeerSession,
+          }
+        );
+
+        expect(secondSplitReconcile.spaceId).toBe(authority.spaceId);
+        expect(secondSplitReconcile.peerUrl).toBe(authorityNode.url);
+        expect(secondSplitReconcile.prefix).toBe(scopeRoot);
+        expect(secondSplitReconcile.matches).toBe(true);
+        expect(secondSplitReconcile.attemptedChildren).toBe(1);
+        expect(secondSplitReconcile.reconciledChildren).toBe(1);
+
+        const splitChildren = splitChildMap(secondSplitReconcile.children);
         expect(splitChildren.get(primaryScope)?.beforeStatus).toBe("match");
         expect(splitChildren.get(primaryScope)?.afterStatus).toBe("match");
         expect(splitChildren.get(primaryScope)?.appliedSequences).toBe(0);
@@ -174,7 +217,9 @@ describe("Replication KV Split-Driven Replay", () => {
         expect(splitChildren.get(siblingScope)?.appliedSequences).toBeGreaterThan(
           0
         );
-        expect(splitChildren.get(siblingScope)?.appliedEvents).toBeGreaterThan(0);
+        expect(splitChildren.get(siblingScope)?.appliedEvents).toBeGreaterThan(
+          0
+        );
 
         await waitForCondition("sibling KV available on node-b", async () => {
           const result = await replica.kv.get<{ scope: string }>(

--- a/tests/node-sdk/replication/kv-recon-split-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-recon-split-reconcile.test.ts
@@ -128,9 +128,14 @@ describe("Replication KV Split-Driven Replay", () => {
         expect(firstSplitReconcile.spaceId).toBe(authority.spaceId);
         expect(firstSplitReconcile.peerUrl).toBe(authorityNode.url);
         expect(firstSplitReconcile.prefix).toBe(scopeRoot);
+        expect(firstSplitReconcile.childStartAfter ?? null).toBeNull();
+        expect(firstSplitReconcile.childLimit).toBe(1);
         expect(firstSplitReconcile.matches).toBe(false);
+        expect(firstSplitReconcile.hasMore).toBe(true);
+        expect(firstSplitReconcile.nextChildStartAfter).toBeDefined();
         expect(firstSplitReconcile.attemptedChildren).toBe(1);
         expect(firstSplitReconcile.reconciledChildren).toBe(1);
+        expect(firstSplitReconcile.children.length).toBe(1);
 
         const firstSplitChildren = splitChildMap(firstSplitReconcile.children);
         expect(firstSplitChildren.get(primaryScope)?.beforeStatus).toBe(
@@ -143,14 +148,7 @@ describe("Replication KV Split-Driven Replay", () => {
         expect(firstSplitChildren.get(primaryScope)?.appliedEvents).toBeGreaterThan(
           0
         );
-        expect(firstSplitChildren.get(siblingScope)?.beforeStatus).toBe(
-          "local-missing"
-        );
-        expect(firstSplitChildren.get(siblingScope)?.afterStatus).toBe(
-          "local-missing"
-        );
-        expect(firstSplitChildren.get(siblingScope)?.appliedSequences).toBe(0);
-        expect(firstSplitChildren.get(siblingScope)?.appliedEvents).toBe(0);
+        expect(firstSplitChildren.has(siblingScope)).toBe(false);
 
         await waitForCondition("primary KV available on node-b", async () => {
           const result = await replica.kv.get<{ scope: string }>(
@@ -182,6 +180,8 @@ describe("Replication KV Split-Driven Replay", () => {
         expect(compareAfterFirstChildren.get(siblingScope)?.status).toBe(
           "local-missing"
         );
+        const secondPageCursor = firstSplitReconcile.nextChildStartAfter;
+        expect(secondPageCursor).toBeDefined();
 
         const secondSplitReconcile = await reconcileSplitFromPeer(
           cluster,
@@ -190,6 +190,7 @@ describe("Replication KV Split-Driven Replay", () => {
             peerUrl: authorityNode.url,
             spaceId: authority.spaceId!,
             prefix: scopeRoot,
+            childStartAfter: secondPageCursor === null ? undefined : secondPageCursor,
             childLimit: 1,
           },
           {
@@ -201,15 +202,16 @@ describe("Replication KV Split-Driven Replay", () => {
         expect(secondSplitReconcile.spaceId).toBe(authority.spaceId);
         expect(secondSplitReconcile.peerUrl).toBe(authorityNode.url);
         expect(secondSplitReconcile.prefix).toBe(scopeRoot);
+        expect(secondSplitReconcile.childStartAfter).toBe(secondPageCursor);
+        expect(secondSplitReconcile.childLimit).toBe(1);
         expect(secondSplitReconcile.matches).toBe(true);
+        expect(secondSplitReconcile.hasMore).toBe(false);
+        expect(secondSplitReconcile.nextChildStartAfter ?? null).toBeNull();
         expect(secondSplitReconcile.attemptedChildren).toBe(1);
         expect(secondSplitReconcile.reconciledChildren).toBe(1);
+        expect(secondSplitReconcile.children.length).toBe(1);
 
         const splitChildren = splitChildMap(secondSplitReconcile.children);
-        expect(splitChildren.get(primaryScope)?.beforeStatus).toBe("match");
-        expect(splitChildren.get(primaryScope)?.afterStatus).toBe("match");
-        expect(splitChildren.get(primaryScope)?.appliedSequences).toBe(0);
-        expect(splitChildren.get(primaryScope)?.appliedEvents).toBe(0);
         expect(splitChildren.get(siblingScope)?.beforeStatus).toBe(
           "local-missing"
         );
@@ -220,6 +222,7 @@ describe("Replication KV Split-Driven Replay", () => {
         expect(splitChildren.get(siblingScope)?.appliedEvents).toBeGreaterThan(
           0
         );
+        expect(splitChildren.has(primaryScope)).toBe(false);
 
         await waitForCondition("sibling KV available on node-b", async () => {
           const result = await replica.kv.get<{ scope: string }>(

--- a/tests/node-sdk/replication/kv-recon-split.test.ts
+++ b/tests/node-sdk/replication/kv-recon-split.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconSplitFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+function childMap(children: { prefix: string; fingerprint: string; itemCount: number }[]) {
+  return new Map(children.map((child) => [child.prefix, child]));
+}
+
+describe("Replication KV Recon Split", () => {
+  test(
+    "summarizes immediate child scopes so partial replay can isolate the remaining mismatch",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-split");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon-split/${Date.now()}`;
+        const primaryScope = `${scopeRoot}/primary`;
+        const siblingScope = `${scopeRoot}/sibling`;
+        const primaryKey = `${primaryScope}/profile.json`;
+        const primaryAssetKey = `${primaryScope}/assets/avatar.json`;
+        const siblingKey = `${siblingScope}/profile.json`;
+
+        expect(
+          await authority.kv.put(primaryKey, {
+            owner: "alice",
+            scope: "primary",
+            kind: "profile",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(primaryAssetKey, {
+            owner: "alice",
+            scope: "primary",
+            kind: "asset",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(siblingKey, {
+            owner: "alice",
+            scope: "sibling",
+            kind: "profile",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+
+        const authorityBefore = await reconSplitFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          await openKvReplicationSession(authority, authorityNode.url, scopeRoot)
+        );
+        const replicaBefore = await reconSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          await openKvReplicationSession(replica, replicaNode.url, scopeRoot)
+        );
+
+        expect(authorityBefore.itemCount).toBe(3);
+        expect(authorityBefore.children.map((child) => child.prefix)).toEqual([
+          primaryScope,
+          siblingScope,
+        ]);
+        expect(replicaBefore.itemCount).toBe(0);
+        expect(replicaBefore.children).toEqual([]);
+
+        const primaryReconcile = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, primaryScope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, primaryScope),
+          }
+        );
+        expect(primaryReconcile.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("primary KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(primaryKey);
+          return result.ok && result.data.data.scope === "primary";
+        });
+
+        const authorityPartial = await reconSplitFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          await openKvReplicationSession(authority, authorityNode.url, scopeRoot)
+        );
+        const replicaPartial = await reconSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          await openKvReplicationSession(replica, replicaNode.url, scopeRoot)
+        );
+
+        const authorityPartialChildren = childMap(authorityPartial.children);
+        const replicaPartialChildren = childMap(replicaPartial.children);
+        expect(replicaPartial.fingerprint).not.toBe(authorityPartial.fingerprint);
+        expect(replicaPartialChildren.has(primaryScope)).toBe(true);
+        expect(replicaPartialChildren.has(siblingScope)).toBe(false);
+        expect(replicaPartialChildren.get(primaryScope)?.itemCount).toBe(2);
+        expect(replicaPartialChildren.get(primaryScope)?.fingerprint).toBe(
+          authorityPartialChildren.get(primaryScope)?.fingerprint
+        );
+
+        const siblingReconcile = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: siblingScope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, siblingScope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, siblingScope),
+          }
+        );
+        expect(siblingReconcile.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("sibling KV available on node-b", async () => {
+          const result = await replica.kv.get<{ scope: string }>(siblingKey);
+          return result.ok && result.data.data.scope === "sibling";
+        });
+
+        const authorityFinal = await reconSplitFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          await openKvReplicationSession(authority, authorityNode.url, scopeRoot)
+        );
+        const replicaFinal = await reconSplitFromPeer(
+          cluster,
+          "node-b",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scopeRoot,
+          },
+          await openKvReplicationSession(replica, replicaNode.url, scopeRoot)
+        );
+
+        expect(replicaFinal.itemCount).toBe(authorityFinal.itemCount);
+        expect(replicaFinal.fingerprint).toBe(authorityFinal.fingerprint);
+        expect(replicaFinal.children).toEqual(authorityFinal.children);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-recon-window.test.ts
+++ b/tests/node-sdk/replication/kv-recon-window.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconCompareFromPeer,
+  reconExportFromPeer,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+  type KvReconCompareRequest,
+  type KvReconCompareResponse,
+  type KvReconExportRequest,
+  type KvReconExportResponse,
+  type KvReconItem,
+  type ReplicationPullSessions,
+} from "./helpers";
+import type { RunningCluster } from "./cluster";
+
+type ReconItemSummary = Pick<KvReconItem, "key" | "kind" | "invocationId">;
+
+function normalizeReconItems(items: KvReconItem[]): ReconItemSummary[] {
+  return items.map(({ key, kind, invocationId }) => ({
+    key,
+    kind,
+    invocationId,
+  }));
+}
+
+async function collectReconExportPages(
+  cluster: RunningCluster,
+  nodeName: string,
+  request: KvReconExportRequest,
+  session: Parameters<typeof reconExportFromPeer>[3]
+): Promise<KvReconExportResponse[]> {
+  const pages: KvReconExportResponse[] = [];
+  let startAfter = request.startAfter;
+
+  for (;;) {
+    const page = await reconExportFromPeer(
+      cluster,
+      nodeName,
+      {
+        ...request,
+        startAfter,
+      },
+      session
+    );
+    pages.push(page);
+
+    if (!page.hasMore) {
+      expect(page.nextStartAfter ?? null).toBeNull();
+      break;
+    }
+
+    expect(page.nextStartAfter).toBeDefined();
+    expect(page.nextStartAfter).not.toBe(startAfter);
+    startAfter = page.nextStartAfter ?? undefined;
+  }
+
+  return pages;
+}
+
+async function collectReconComparePages(
+  cluster: Awaited<ReturnType<typeof startCluster>>,
+  nodeName: string,
+  request: KvReconCompareRequest,
+  sessions: ReplicationPullSessions
+): Promise<KvReconCompareResponse[]> {
+  const pages: KvReconCompareResponse[] = [];
+  let startAfter = request.startAfter;
+
+  for (;;) {
+    const page = await reconCompareFromPeer(
+      cluster,
+      nodeName,
+      {
+        ...request,
+        startAfter,
+      },
+      sessions
+    );
+    pages.push(page);
+
+    if (!page.localHasMore && !page.peerHasMore) {
+      expect(page.localNextStartAfter ?? null).toBeNull();
+      expect(page.peerNextStartAfter ?? null).toBeNull();
+      break;
+    }
+
+    expect(page.localHasMore).toBe(page.peerHasMore);
+    expect(page.localNextStartAfter).toBe(page.peerNextStartAfter);
+    expect(page.localNextStartAfter).not.toBe(startAfter);
+    startAfter = page.localNextStartAfter ?? undefined;
+  }
+
+  return pages;
+}
+
+describe("Replication KV Recon Windows", () => {
+  test(
+    "traverses bounded windows after reconcile and keeps sibling prefixes isolated",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-recon-window");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scopeRoot = `replication/kv-recon-window/${Date.now()}`;
+        const primaryScope = `${scopeRoot}/primary`;
+        const siblingScope = `${scopeRoot}/sibling`;
+
+        const primaryEntries = [
+          { key: `${primaryScope}/alpha.json`, value: { scope: "primary", name: "alpha" } },
+          { key: `${primaryScope}/bravo.json`, value: { scope: "primary", name: "bravo" } },
+          { key: `${primaryScope}/charlie.json`, value: { scope: "primary", name: "charlie" } },
+          { key: `${primaryScope}/delta.json`, value: { scope: "primary", name: "delta" } },
+        ];
+        const siblingEntries = [
+          { key: `${siblingScope}/echo.json`, value: { scope: "sibling", name: "echo" } },
+          { key: `${siblingScope}/foxtrot.json`, value: { scope: "sibling", name: "foxtrot" } },
+          { key: `${siblingScope}/golf.json`, value: { scope: "sibling", name: "golf" } },
+        ];
+
+        for (const entry of [...primaryEntries, ...siblingEntries]) {
+          const write = await authority.kv.put(entry.key, {
+            ...entry.value,
+            createdAt: new Date().toISOString(),
+          });
+          expect(write.ok).toBe(true);
+        }
+
+        const targetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          primaryScope
+        );
+        const peerSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          primaryScope
+        );
+        const reconcileResult = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+          },
+          { target: targetSession, peer: peerSession }
+        );
+
+        expect(reconcileResult.appliedSequences).toBeGreaterThan(0);
+        expect(reconcileResult.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("primary KV available on node-b", async () => {
+          const result = await replica.kv.get(primaryEntries[0].key);
+          return result.ok && result.data.data.scope === "primary";
+        });
+
+        const primaryComparePages = await collectReconComparePages(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+            limit: 2,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, primaryScope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, primaryScope),
+          }
+        );
+
+        expect(primaryComparePages.length).toBeGreaterThan(1);
+        expect(primaryComparePages.every((page) => page.matches)).toBe(true);
+        expect(
+          primaryComparePages.every((page) => page.localItemCount === page.peerItemCount)
+        ).toBe(true);
+        expect(primaryComparePages[0].localHasMore).toBe(true);
+        expect(primaryComparePages[0].peerHasMore).toBe(true);
+        expect(primaryComparePages[0].localNextStartAfter).toBe(
+          primaryComparePages[0].peerNextStartAfter
+        );
+        expect(
+          primaryComparePages[primaryComparePages.length - 1].localHasMore
+        ).toBe(false);
+        expect(
+          primaryComparePages[primaryComparePages.length - 1].peerHasMore
+        ).toBe(false);
+
+        const authorityExportPages = await collectReconExportPages(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+            limit: 2,
+          },
+          await openKvReplicationSession(authority, authorityNode.url, primaryScope)
+        );
+        const replicaExportPages = await collectReconExportPages(
+          cluster,
+          "node-b",
+          {
+            spaceId: authority.spaceId!,
+            prefix: primaryScope,
+            limit: 2,
+          },
+          await openKvReplicationSession(replica, replicaNode.url, primaryScope)
+        );
+
+        expect(authorityExportPages.length).toBeGreaterThan(1);
+        expect(replicaExportPages.length).toBeGreaterThan(1);
+        expect(authorityExportPages[0].hasMore).toBe(true);
+        expect(replicaExportPages[0].hasMore).toBe(true);
+        expect(
+          authorityExportPages[authorityExportPages.length - 1].hasMore
+        ).toBe(false);
+        expect(replicaExportPages[replicaExportPages.length - 1].hasMore).toBe(false);
+
+        const authorityItems = authorityExportPages.flatMap((page) => page.items);
+        const replicaItems = replicaExportPages.flatMap((page) => page.items);
+
+        expect(normalizeReconItems(replicaItems)).toEqual(
+          normalizeReconItems(authorityItems)
+        );
+        expect(authorityItems.length).toBeGreaterThan(0);
+        expect(
+          authorityItems.every((item) => item.key.startsWith(primaryScope))
+        ).toBe(true);
+        expect(authorityItems.every((item) => !item.key.startsWith(siblingScope))).toBe(
+          true
+        );
+        expect(
+          replicaItems.every((item) => item.key.startsWith(primaryScope))
+        ).toBe(true);
+        expect(replicaItems.every((item) => !item.key.startsWith(siblingScope))).toBe(
+          true
+        );
+
+        const siblingCompare = await reconCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: siblingScope,
+            limit: 1,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, siblingScope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, siblingScope),
+          }
+        );
+
+        expect(siblingCompare.matches).toBe(false);
+        expect(siblingCompare.peerItemCount).toBeGreaterThan(0);
+        expect(siblingCompare.peerHasMore).toBe(true);
+        expect(siblingCompare.localHasMore).toBe(false);
+        expect(siblingCompare.firstMismatchKey).toBeDefined();
+        expect(siblingCompare.firstMismatchKey?.startsWith(siblingScope)).toBe(true);
+        expect(siblingCompare.firstMismatchKey?.startsWith(primaryScope)).toBe(false);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-reconcile.test.ts
@@ -5,7 +5,6 @@ import {
   exportFromPeer,
   getClusterNode,
   openKvReplicationSession,
-  reconcileFromPeer,
   uniqueReplicationPrefix,
   waitForCondition,
 } from "./helpers";
@@ -63,11 +62,14 @@ describe("Replication KV Reconcile", () => {
         expect(exportResult.prefix).toBe(scope);
         expect(exportResult.sequences.length).toBeGreaterThan(0);
 
-        const firstPass = await reconcileFromPeer(cluster, "node-b", {
-          peerUrl: authorityNode.url,
-          spaceId: authority.spaceId!,
-          prefix: scope,
-        }, { target: targetSession, peer: exportSession });
+        const firstPass = await replica.reconcileKvFromPeer(
+          { target: targetSession, peer: exportSession },
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          }
+        );
 
         expect(firstPass.spaceId).toBe(authority.spaceId);
         expect(firstPass.peerUrl).toBe(authorityNode.url);
@@ -93,12 +95,15 @@ describe("Replication KV Reconcile", () => {
         }
         expect(replicaList.data.keys).toContain(key);
 
-        const secondPass = await reconcileFromPeer(cluster, "node-b", {
-          peerUrl: authorityNode.url,
-          spaceId: authority.spaceId!,
-          prefix: scope,
-          sinceSeq: firstPass.appliedUntilSeq,
-        }, { target: targetSession, peer: exportSession });
+        const secondPass = await replica.reconcileKvFromPeer(
+          { target: targetSession, peer: exportSession },
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+            sinceSeq: firstPass.appliedUntilSeq,
+          }
+        );
 
         expect(secondPass.appliedSequences).toBe(0);
         expect(secondPass.appliedEvents).toBe(0);

--- a/tests/node-sdk/replication/kv-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-reconcile.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  exportFromPeer,
+  getClusterNode,
+  openKvReplicationSession,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication KV Reconcile", () => {
+  test(
+    "pulls real KV data from one live node into another live node",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-reconcile");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/kv-reconcile/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const value = {
+          owner: "alice",
+          replicatedTo: "node-b",
+          createdAt: new Date().toISOString(),
+        };
+
+        const putResult = await authority.kv.put(key, value);
+        expect(putResult.ok).toBe(true);
+
+        const exportSession = await openKvReplicationSession(
+          authority,
+          authorityNode.url,
+          scope
+        );
+        const exportResult = await exportFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          exportSession
+        );
+        expect(exportResult.spaceId).toBe(authority.spaceId);
+        expect(exportResult.prefix).toBe(scope);
+        expect(exportResult.sequences.length).toBeGreaterThan(0);
+
+        const firstPass = await reconcileFromPeer(cluster, "node-b", {
+          peerUrl: authorityNode.url,
+          spaceId: authority.spaceId!,
+          prefix: scope,
+        }, exportSession);
+
+        expect(firstPass.spaceId).toBe(authority.spaceId);
+        expect(firstPass.peerUrl).toBe(authorityNode.url);
+        expect(firstPass.appliedSequences).toBeGreaterThan(0);
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("replicated KV available on node-b", async () => {
+          const getResult = await replica.kv.get<typeof value>(key);
+          return getResult.ok;
+        });
+
+        const replicaGet = await replica.kv.get<typeof value>(key);
+        expect(replicaGet.ok).toBe(true);
+        if (!replicaGet.ok) {
+          throw new Error(replicaGet.error.message);
+        }
+        expect(replicaGet.data.data).toEqual(value);
+
+        const replicaList = await replica.kv.list({ prefix: scope });
+        expect(replicaList.ok).toBe(true);
+        if (!replicaList.ok) {
+          throw new Error(replicaList.error.message);
+        }
+        expect(replicaList.data.keys).toContain(key);
+
+        const secondPass = await reconcileFromPeer(cluster, "node-b", {
+          peerUrl: authorityNode.url,
+          spaceId: authority.spaceId!,
+          prefix: scope,
+          sinceSeq: firstPass.appliedUntilSeq,
+        }, exportSession);
+
+        expect(secondPass.appliedSequences).toBe(0);
+        expect(secondPass.appliedEvents).toBe(0);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-reconcile.test.ts
+++ b/tests/node-sdk/replication/kv-reconcile.test.ts
@@ -21,6 +21,7 @@ describe("Replication KV Reconcile", () => {
         const authority = createClusterClient(cluster, "node-a", prefix);
         const replica = createClusterClient(cluster, "node-b", prefix);
         const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
 
         await authority.signIn();
         await replica.signIn();
@@ -44,6 +45,11 @@ describe("Replication KV Reconcile", () => {
           authorityNode.url,
           scope
         );
+        const targetSession = await openKvReplicationSession(
+          replica,
+          replicaNode.url,
+          scope
+        );
         const exportResult = await exportFromPeer(
           cluster,
           "node-a",
@@ -61,7 +67,7 @@ describe("Replication KV Reconcile", () => {
           peerUrl: authorityNode.url,
           spaceId: authority.spaceId!,
           prefix: scope,
-        }, exportSession);
+        }, { target: targetSession, peer: exportSession });
 
         expect(firstPass.spaceId).toBe(authority.spaceId);
         expect(firstPass.peerUrl).toBe(authorityNode.url);
@@ -92,7 +98,7 @@ describe("Replication KV Reconcile", () => {
           spaceId: authority.spaceId!,
           prefix: scope,
           sinceSeq: firstPass.appliedUntilSeq,
-        }, exportSession);
+        }, { target: targetSession, peer: exportSession });
 
         expect(secondPass.appliedSequences).toBe(0);
         expect(secondPass.appliedEvents).toBe(0);

--- a/tests/node-sdk/replication/kv-restart-catchup.test.ts
+++ b/tests/node-sdk/replication/kv-restart-catchup.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openKvReplicationSession,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication KV Restart Catch-up", () => {
+  test(
+    "catches up a restarted node after writes land while it is offline",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-restart-catchup");
+        const writer = createClusterClient(cluster, "node-a", prefix);
+        const reader = createClusterClient(cluster, "node-b", prefix);
+        const writerNode = getClusterNode(cluster, "node-a");
+
+        await writer.signIn();
+        await reader.signIn();
+
+        expect(writer.spaceId).toBeDefined();
+        expect(reader.spaceId).toBe(writer.spaceId);
+
+        const scope = `replication/kv-restart-catchup/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const initialValue = {
+          owner: "alice",
+          stage: "before-restart",
+          createdAt: new Date().toISOString(),
+        };
+        const updatedValue = {
+          owner: "alice",
+          stage: "after-restart",
+          updatedAt: new Date().toISOString(),
+        };
+
+        const firstWrite = await writer.kv.put(key, initialValue);
+        expect(firstWrite.ok).toBe(true);
+
+        const initialReconcileSession = await openKvReplicationSession(
+          writer,
+          writerNode.url,
+          scope
+        );
+        const firstPass = await reconcileFromPeer(cluster, "node-b", {
+          peerUrl: writerNode.url,
+          spaceId: writer.spaceId!,
+          prefix: scope,
+        }, initialReconcileSession);
+
+        expect(firstPass.appliedSequences).toBeGreaterThan(0);
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+
+        const beforeRestart = await reader.kv.get<typeof initialValue>(key);
+        expect(beforeRestart.ok).toBe(true);
+        if (!beforeRestart.ok) {
+          throw new Error(beforeRestart.error.message);
+        }
+        expect(beforeRestart.data.data).toEqual(initialValue);
+
+        await cluster.stopNode("node-b");
+
+        const secondWrite = await writer.kv.put(key, updatedValue);
+        expect(secondWrite.ok).toBe(true);
+
+        await cluster.startNode("node-b");
+
+        const restartedReader = createClusterClient(cluster, "node-b", prefix);
+        await restartedReader.signIn();
+        expect(restartedReader.spaceId).toBe(writer.spaceId);
+
+        const persistedResult = await restartedReader.kv.get<typeof initialValue>(key);
+        expect(persistedResult.ok).toBe(true);
+        if (!persistedResult.ok) {
+          throw new Error(persistedResult.error.message);
+        }
+        expect(persistedResult.data.data).toEqual(initialValue);
+
+        const restartedReconcileSession = await openKvReplicationSession(
+          writer,
+          writerNode.url,
+          scope
+        );
+        const secondPass = await reconcileFromPeer(cluster, "node-b", {
+          peerUrl: writerNode.url,
+          spaceId: writer.spaceId!,
+          prefix: scope,
+          sinceSeq: firstPass.appliedUntilSeq,
+        }, restartedReconcileSession);
+
+        expect(secondPass.appliedSequences).toBeGreaterThan(0);
+        expect(secondPass.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("updated KV available on restarted node-b", async () => {
+          const result = await restartedReader.kv.get<typeof updatedValue>(key);
+          return result.ok && result.data.data.stage === "after-restart";
+        });
+
+        const restartedResult = await restartedReader.kv.get<typeof updatedValue>(key);
+        expect(restartedResult.ok).toBe(true);
+        if (!restartedResult.ok) {
+          throw new Error(restartedResult.error.message);
+        }
+        expect(restartedResult.data.data).toEqual(updatedValue);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-restart-catchup.test.ts
+++ b/tests/node-sdk/replication/kv-restart-catchup.test.ts
@@ -20,6 +20,7 @@ describe("Replication KV Restart Catch-up", () => {
         const writer = createClusterClient(cluster, "node-a", prefix);
         const reader = createClusterClient(cluster, "node-b", prefix);
         const writerNode = getClusterNode(cluster, "node-a");
+        const readerNode = getClusterNode(cluster, "node-b");
 
         await writer.signIn();
         await reader.signIn();
@@ -48,11 +49,16 @@ describe("Replication KV Restart Catch-up", () => {
           writerNode.url,
           scope
         );
+        const initialTargetSession = await openKvReplicationSession(
+          reader,
+          readerNode.url,
+          scope
+        );
         const firstPass = await reconcileFromPeer(cluster, "node-b", {
           peerUrl: writerNode.url,
           spaceId: writer.spaceId!,
           prefix: scope,
-        }, initialReconcileSession);
+        }, { target: initialTargetSession, peer: initialReconcileSession });
 
         expect(firstPass.appliedSequences).toBeGreaterThan(0);
         expect(firstPass.appliedEvents).toBeGreaterThan(0);
@@ -87,12 +93,17 @@ describe("Replication KV Restart Catch-up", () => {
           writerNode.url,
           scope
         );
+        const restartedTargetSession = await openKvReplicationSession(
+          restartedReader,
+          readerNode.url,
+          scope
+        );
         const secondPass = await reconcileFromPeer(cluster, "node-b", {
           peerUrl: writerNode.url,
           spaceId: writer.spaceId!,
           prefix: scope,
           sinceSeq: firstPass.appliedUntilSeq,
-        }, restartedReconcileSession);
+        }, { target: restartedTargetSession, peer: restartedReconcileSession });
 
         expect(secondPass.appliedSequences).toBeGreaterThan(0);
         expect(secondPass.appliedEvents).toBeGreaterThan(0);

--- a/tests/node-sdk/replication/kv-state-compare.test.ts
+++ b/tests/node-sdk/replication/kv-state-compare.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  kvStateCompareFromPeer,
+  openKvReplicationSession,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+function compareByKey(
+  items: {
+    key: string;
+    kind: string;
+    localInvocationId?: string | null;
+    peerStatus: "present" | "deleted" | "absent";
+    peerSeq?: number | null;
+    peerInvocationId?: string | null;
+    peerDeletedInvocationId?: string | null;
+    peerValueHash?: string | null;
+  }[]
+) {
+  return new Map(items.map((item) => [item.key, item]));
+}
+
+describe("Replication KV State Compare", () => {
+  test(
+    "compares local visible keys against peer state without pruning them",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-state-compare");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/kv-state-compare/${Date.now()}`;
+        const presentKey = `${scope}/present.json`;
+        const deletedKey = `${scope}/deleted.json`;
+        const localOnlyKey = `${scope}/local-only.json`;
+
+        expect(
+          await authority.kv.put(presentKey, {
+            owner: "alice",
+            state: "present",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+        expect(
+          await authority.kv.put(deletedKey, {
+            owner: "alice",
+            state: "deleted-on-peer",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+
+        const firstPass = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(firstPass.appliedSequences).toBeGreaterThan(0);
+        expect(firstPass.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("replica sees authority keys before divergence", async () => {
+          const present = await replica.kv.get<{ state: string }>(presentKey);
+          const deleted = await replica.kv.get<{ state: string }>(deletedKey);
+          return (
+            present.ok &&
+            present.data.data.state === "present" &&
+            deleted.ok &&
+            deleted.data.data.state === "deleted-on-peer"
+          );
+        });
+
+        expect(await authority.kv.delete(deletedKey)).toMatchObject({ ok: true });
+        expect(
+          await replica.kv.put(localOnlyKey, {
+            owner: "bob",
+            state: "local-only",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+
+        const authorityLocalOnly = await authority.kv.get(localOnlyKey);
+        expect(authorityLocalOnly.ok).toBe(false);
+        if (authorityLocalOnly.ok) {
+          throw new Error("expected authority host to miss the replica local-only key");
+        }
+
+        const compare = await kvStateCompareFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(compare.spaceId).toBe(authority.spaceId);
+        expect(compare.prefix).toBe(scope);
+        expect(compare.peerUrl).toBe(authorityNode.url);
+        expect(compare.items.length).toBeGreaterThanOrEqual(3);
+
+        const items = compareByKey(compare.items);
+        const present = items.get(presentKey);
+        const deleted = items.get(deletedKey);
+        const localOnly = items.get(localOnlyKey);
+
+        expect(present?.peerStatus).toBe("present");
+        expect(typeof present?.localInvocationId).toBe("string");
+        expect(typeof present?.peerInvocationId).toBe("string");
+        expect(typeof present?.peerValueHash).toBe("string");
+
+        expect(deleted?.peerStatus).toBe("deleted");
+        expect(typeof deleted?.localInvocationId).toBe("string");
+        expect(typeof deleted?.peerInvocationId).toBe("string");
+        expect(typeof deleted?.peerDeletedInvocationId).toBe("string");
+        expect(deleted?.peerValueHash ?? null).toBeNull();
+
+        expect(localOnly?.peerStatus).toBe("absent");
+        expect(typeof localOnly?.localInvocationId).toBe("string");
+        expect(localOnly?.peerSeq ?? null).toBeNull();
+        expect(localOnly?.peerInvocationId ?? null).toBeNull();
+        expect(localOnly?.peerDeletedInvocationId ?? null).toBeNull();
+        expect(localOnly?.peerValueHash ?? null).toBeNull();
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-state.test.ts
+++ b/tests/node-sdk/replication/kv-state.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  kvStateFromPeer,
+  openKvReplicationSession,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+function stateByKey(
+  items: {
+    key: string;
+    status: "present" | "deleted" | "absent";
+    seq?: number;
+    invocationId?: string | null;
+    deletedInvocationId?: string | null;
+    valueHash?: string | null;
+  }[]
+) {
+  return new Map(items.map((item) => [item.key, item]));
+}
+
+describe("Replication KV State", () => {
+  test(
+    "distinguishes present, deleted, and absent keys over an authenticated replication session",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-state");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const scope = `replication/kv-state/${Date.now()}`;
+        const presentKey = `${scope}/profile.json`;
+        const deletedKey = `${scope}/deleted.json`;
+        const absentKey = `${scope}/never-seen.json`;
+
+        expect(
+          await authority.kv.put(presentKey, {
+            owner: "alice",
+            kind: "present",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+
+        expect(
+          await authority.kv.put(deletedKey, {
+            owner: "alice",
+            kind: "deleted",
+            createdAt: new Date().toISOString(),
+          })
+        ).toMatchObject({ ok: true });
+
+        expect(await authority.kv.delete(deletedKey)).toMatchObject({ ok: true });
+
+        const session = await openKvReplicationSession(
+          replica,
+          authorityNode.url,
+          scope
+        );
+        const response = await kvStateFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            prefix: scope,
+            keys: [presentKey, deletedKey, absentKey],
+          },
+          session
+        );
+
+        expect(response.spaceId).toBe(authority.spaceId);
+        expect(response.prefix).toBe(scope);
+        expect(response.items).toHaveLength(3);
+
+        const items = stateByKey(response.items);
+        const present = items.get(presentKey);
+        const deleted = items.get(deletedKey);
+        const absent = items.get(absentKey);
+
+        expect(present?.status).toBe("present");
+        expect(present?.seq).toBeGreaterThan(0);
+        expect(typeof present?.invocationId).toBe("string");
+        expect(present?.deletedInvocationId ?? null).toBeNull();
+        expect(typeof present?.valueHash).toBe("string");
+
+        expect(deleted?.status).toBe("deleted");
+        expect(deleted?.seq).toBeGreaterThan(0);
+        expect(typeof deleted?.invocationId).toBe("string");
+        expect(typeof deleted?.deletedInvocationId).toBe("string");
+        expect(deleted?.valueHash ?? null).toBeNull();
+
+        expect(absent?.status).toBe("absent");
+        expect(absent?.seq ?? null).toBeNull();
+        expect(absent?.invocationId ?? null).toBeNull();
+        expect(absent?.deletedInvocationId ?? null).toBeNull();
+        expect(absent?.valueHash ?? null).toBeNull();
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/kv-warm-sync.test.ts
+++ b/tests/node-sdk/replication/kv-warm-sync.test.ts
@@ -3,7 +3,6 @@ import { startCluster } from "./cluster";
 import {
   createClusterClient,
   getClusterNode,
-  notifyReplicationFromPeer,
   openKvReplicationSession,
   reconcileFromPeer,
   uniqueReplicationPrefix,
@@ -57,18 +56,13 @@ describe("Replication KV Warm Sync", () => {
           authorityNode.url,
           scope
         );
-        const notifyPromise = notifyReplicationFromPeer(
-          cluster,
-          "node-a",
-          {
-            spaceId: authority.spaceId!,
-            service: "kv",
-            prefix: scope,
-            lastSeenSeq: 0,
-            timeoutMs: 30_000,
-          },
-          notifySession
-        );
+        const notifyPromise = authority.notifyReplication(notifySession, {
+          spaceId: authority.spaceId!,
+          service: "kv",
+          prefix: scope,
+          lastSeenSeq: 0,
+          timeoutMs: 30_000,
+        });
 
         expect(await authority.kv.put(key, value)).toMatchObject({ ok: true });
 

--- a/tests/node-sdk/replication/kv-warm-sync.test.ts
+++ b/tests/node-sdk/replication/kv-warm-sync.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  notifyReplicationFromPeer,
+  openKvReplicationSession,
+  reconcileFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+async function replicationNotificationsEnabled(nodeUrl: string): Promise<boolean> {
+  const response = await fetch(`${nodeUrl}/replication/info`);
+  if (!response.ok) {
+    throw new Error(`Failed to load replication info from ${nodeUrl}: ${response.status}`);
+  }
+  const info = (await response.json()) as {
+    capabilities?: { notifications?: boolean };
+  };
+  return info.capabilities?.notifications ?? false;
+}
+
+describe("Replication KV Warm Sync", () => {
+  test(
+    "uses authenticated notify long-poll to mark a KV scope dirty before reconcile",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("kv-warm-sync");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        if (!(await replicationNotificationsEnabled(authorityNode.url))) {
+          throw new Error("replication notifications are not enabled on the authority node");
+        }
+
+        const scope = `replication/kv-warm-sync/${Date.now()}`;
+        const key = `${scope}/profile.json`;
+        const value = {
+          owner: "alice",
+          stage: "notify-warm-sync",
+          createdAt: new Date().toISOString(),
+        };
+
+        const notifySession = await openKvReplicationSession(
+          replica,
+          authorityNode.url,
+          scope
+        );
+        const notifyPromise = notifyReplicationFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            service: "kv",
+            prefix: scope,
+            lastSeenSeq: 0,
+            timeoutMs: 30_000,
+          },
+          notifySession
+        );
+
+        expect(await authority.kv.put(key, value)).toMatchObject({ ok: true });
+
+        const notification = await notifyPromise;
+        expect(notification.spaceId).toBe(authority.spaceId!);
+        expect(notification.service).toBe("kv");
+        expect(notification.prefix).toBe(scope);
+        expect(notification.dirty).toBe(true);
+        expect(notification.timedOut).toBe(false);
+        expect(notification.latestSeq).toBeGreaterThan(0);
+
+        const reconcileResult = await reconcileFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            prefix: scope,
+          },
+          {
+            target: await openKvReplicationSession(replica, replicaNode.url, scope),
+            peer: await openKvReplicationSession(authority, authorityNode.url, scope),
+          }
+        );
+
+        expect(reconcileResult.appliedSequences).toBeGreaterThan(0);
+        expect(reconcileResult.appliedEvents).toBeGreaterThan(0);
+
+        await waitForCondition("replica reconciles KV scope after notify", async () => {
+          const result = await replica.kv.get<typeof value>(key);
+          return result.ok && result.data.data.stage === value.stage;
+        });
+
+        const warmed = await replica.kv.get<typeof value>(key);
+        expect(warmed.ok).toBe(true);
+        if (!warmed.ok) {
+          throw new Error(warmed.error.message);
+        }
+        expect(warmed.data.data).toEqual(value);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/smoke.test.ts
+++ b/tests/node-sdk/replication/smoke.test.ts
@@ -44,7 +44,7 @@ describe("Replication Cluster Smoke", () => {
             recon: true,
             authSync: true,
             authoredFactExchange: true,
-            notifications: false,
+            notifications: true,
             snapshots: true,
           });
           expect(replication).toMatchObject({
@@ -58,10 +58,11 @@ describe("Replication Cluster Smoke", () => {
               recon: true,
               authSync: true,
               authoredFactExchange: true,
-              notifications: false,
+              notifications: true,
               snapshots: true,
             },
           });
+          expect(typeof replication.capabilities.notifications).toBe("boolean");
           expect(Array.isArray(replication.endpoints)).toBe(true);
           expect(replication.endpoints).toContain("GET /replication/info");
           expect(replication.endpoints).toContain(
@@ -86,6 +87,9 @@ describe("Replication Cluster Smoke", () => {
           expect(replication.endpoints).toContain(
             "POST /replication/sql/reconcile"
           );
+          if (replication.capabilities.notifications) {
+            expect(replication.endpoints).toContain("POST /replication/notify/poll");
+          }
         }
       } finally {
         await cluster.stop();

--- a/tests/node-sdk/replication/smoke.test.ts
+++ b/tests/node-sdk/replication/smoke.test.ts
@@ -41,7 +41,7 @@ describe("Replication Cluster Smoke", () => {
             supported: true,
             enabled: true,
             peerServing: node.role === "replica" ? false : true,
-            recon: false,
+            recon: true,
             authSync: true,
             authoredFactExchange: true,
             notifications: false,
@@ -55,7 +55,7 @@ describe("Replication Cluster Smoke", () => {
               supported: true,
               enabled: true,
               peerServing: node.role === "replica" ? false : true,
-              recon: false,
+              recon: true,
               authSync: true,
               authoredFactExchange: true,
               notifications: false,
@@ -74,6 +74,9 @@ describe("Replication Cluster Smoke", () => {
             "POST /replication/auth/reconcile"
           );
           expect(replication.endpoints).toContain("POST /replication/export");
+          expect(replication.endpoints).toContain(
+            "POST /replication/recon/export"
+          );
           expect(replication.endpoints).toContain(
             "POST /replication/reconcile"
           );

--- a/tests/node-sdk/replication/smoke.test.ts
+++ b/tests/node-sdk/replication/smoke.test.ts
@@ -26,7 +26,10 @@ describe("Replication Cluster Smoke", () => {
           expect(Array.isArray(info.features)).toBe(true);
           expect(info.features).toContain("replication");
           expect(info.rolesSupported).toContain("host");
-          expect(info.rolesEnabled).toContain("host");
+          expect(info.rolesSupported).toContain("replica");
+          expect(info.rolesEnabled).toEqual([
+            node.role === "replica" ? "replica" : "host",
+          ]);
           expect(info.services).toMatchObject({
             kv: true,
             delegation: true,
@@ -37,6 +40,7 @@ describe("Replication Cluster Smoke", () => {
           expect(info.replication).toMatchObject({
             supported: true,
             enabled: true,
+            peerServing: node.role === "replica" ? false : true,
             recon: false,
             authSync: false,
             authoredFactExchange: true,
@@ -50,6 +54,7 @@ describe("Replication Cluster Smoke", () => {
             capabilities: {
               supported: true,
               enabled: true,
+              peerServing: node.role === "replica" ? false : true,
               recon: false,
               authSync: false,
               authoredFactExchange: true,

--- a/tests/node-sdk/replication/smoke.test.ts
+++ b/tests/node-sdk/replication/smoke.test.ts
@@ -42,7 +42,7 @@ describe("Replication Cluster Smoke", () => {
             enabled: true,
             peerServing: node.role === "replica" ? false : true,
             recon: false,
-            authSync: false,
+            authSync: true,
             authoredFactExchange: true,
             notifications: false,
             snapshots: false,
@@ -56,7 +56,7 @@ describe("Replication Cluster Smoke", () => {
               enabled: true,
               peerServing: node.role === "replica" ? false : true,
               recon: false,
-              authSync: false,
+              authSync: true,
               authoredFactExchange: true,
               notifications: false,
               snapshots: false,
@@ -66,6 +66,12 @@ describe("Replication Cluster Smoke", () => {
           expect(replication.endpoints).toContain("GET /replication/info");
           expect(replication.endpoints).toContain(
             "POST /replication/session/open"
+          );
+          expect(replication.endpoints).toContain(
+            "POST /replication/auth/export"
+          );
+          expect(replication.endpoints).toContain(
+            "POST /replication/auth/reconcile"
           );
           expect(replication.endpoints).toContain("POST /replication/export");
           expect(replication.endpoints).toContain(

--- a/tests/node-sdk/replication/smoke.test.ts
+++ b/tests/node-sdk/replication/smoke.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication Cluster Smoke", () => {
+  test(
+    "boots three nodes and exposes /info",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        expect(cluster.nodes).toHaveLength(3);
+
+        for (const node of cluster.nodes) {
+          const response = await fetch(`${node.url}/info`);
+          const replicationResponse = await fetch(`${node.url}/replication/info`);
+          expect(response.ok).toBe(true);
+          expect(replicationResponse.ok).toBe(true);
+
+          const info = await response.json();
+          const replication = await replicationResponse.json();
+          expect(typeof info.version).toBe("string");
+          expect(Array.isArray(info.features)).toBe(true);
+          expect(info.features).toContain("replication");
+          expect(info.rolesSupported).toContain("host");
+          expect(info.rolesEnabled).toContain("host");
+          expect(info.services).toMatchObject({
+            kv: true,
+            delegation: true,
+            sharing: true,
+            sql: true,
+            duckdb: true,
+          });
+          expect(info.replication).toMatchObject({
+            supported: true,
+            enabled: true,
+            recon: false,
+            authSync: false,
+            authoredFactExchange: true,
+            notifications: false,
+            snapshots: false,
+          });
+          expect(replication).toMatchObject({
+            routeMounted: true,
+            protocolReady: true,
+            requiresAuth: true,
+            capabilities: {
+              supported: true,
+              enabled: true,
+              recon: false,
+              authSync: false,
+              authoredFactExchange: true,
+              notifications: false,
+              snapshots: false,
+            },
+          });
+          expect(Array.isArray(replication.endpoints)).toBe(true);
+          expect(replication.endpoints).toContain("GET /replication/info");
+          expect(replication.endpoints).toContain(
+            "POST /replication/session/open"
+          );
+          expect(replication.endpoints).toContain("POST /replication/export");
+          expect(replication.endpoints).toContain(
+            "POST /replication/reconcile"
+          );
+          expect(replication.endpoints).toContain(
+            "POST /replication/sql/export"
+          );
+          expect(replication.endpoints).toContain(
+            "POST /replication/sql/reconcile"
+          );
+        }
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+
+  test(
+    "same user and prefix map to the same space across hosts",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("same-space");
+        const aliceOnAuthority = createClusterClient(cluster, "node-a", prefix);
+        const aliceOnHost = createClusterClient(cluster, "node-b", prefix);
+
+        await aliceOnAuthority.signIn();
+        await aliceOnHost.signIn();
+
+        expect(aliceOnAuthority.spaceId).toBeDefined();
+        expect(aliceOnHost.spaceId).toBeDefined();
+        expect(aliceOnAuthority.spaceId).toBe(aliceOnHost.spaceId);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/smoke.test.ts
+++ b/tests/node-sdk/replication/smoke.test.ts
@@ -45,7 +45,7 @@ describe("Replication Cluster Smoke", () => {
             authSync: true,
             authoredFactExchange: true,
             notifications: false,
-            snapshots: false,
+            snapshots: true,
           });
           expect(replication).toMatchObject({
             routeMounted: true,
@@ -59,7 +59,7 @@ describe("Replication Cluster Smoke", () => {
               authSync: true,
               authoredFactExchange: true,
               notifications: false,
-              snapshots: false,
+              snapshots: true,
             },
           });
           expect(Array.isArray(replication.endpoints)).toBe(true);

--- a/tests/node-sdk/replication/sql-baseline.test.ts
+++ b/tests/node-sdk/replication/sql-baseline.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication SQL Baseline", () => {
+  test(
+    "executes SQLite-backed SQL through a live node with the real SDK",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("sql-baseline");
+        const alice = createClusterClient(cluster, "node-a", prefix);
+        await alice.signIn();
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_baseline_${suffix}`;
+        const tableName = `items_sql_baseline_${suffix}`;
+        const sql = alice.sql.db(dbName);
+
+        const createResult = await sql.execute(
+          `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL, quantity INTEGER NOT NULL)`
+        );
+        expect(createResult.ok).toBe(true);
+
+        const insertResult = await sql.execute(
+          `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+          ["item-1", "camera", 2]
+        );
+        expect(insertResult.ok).toBe(true);
+        if (!insertResult.ok) {
+          throw new Error(insertResult.error.message);
+        }
+        expect(insertResult.data.changes).toBe(1);
+
+        const queryResult = await sql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(queryResult.ok).toBe(true);
+        if (!queryResult.ok) {
+          throw new Error(queryResult.error.message);
+        }
+
+        expect(queryResult.data.rowCount).toBe(1);
+        expect(queryResult.data.columns).toEqual(["id", "name", "quantity"]);
+        expect(queryResult.data.rows[0]).toEqual(["item-1", "camera", 2]);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-conflict-fallback.test.ts
+++ b/tests/node-sdk/replication/sql-conflict-fallback.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  sqlReplicationBytes,
+  sqlReplicationMode,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication SQL Conflict Fallback", () => {
+  test(
+    "falls back to a snapshot when an incremental SQL changeset conflicts with local replica state",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("sql-conflict-fallback");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_conflict_fallback_${suffix}`;
+        const tableName = `items_sql_conflict_fallback_${suffix}`;
+        const authoritySql = authority.sql.db(dbName);
+        const replicaSql = replica.sql.db(dbName);
+
+        expect(
+          (
+            await authoritySql.execute(
+              `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL, quantity INTEGER NOT NULL)`
+            )
+          ).ok
+        ).toBe(true);
+        expect(
+          (
+            await authoritySql.execute(
+              `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+              ["item-1", "camera", 2]
+            )
+          ).ok
+        ).toBe(true);
+
+        const peerSession = await openSqlReplicationSession(
+          authority,
+          authorityNode.url,
+          dbName
+        );
+        const targetSession = await openSqlReplicationSession(
+          replica,
+          replicaNode.url,
+          dbName
+        );
+
+        const baselineApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          { target: targetSession, peer: peerSession }
+        );
+
+        expect(sqlReplicationMode(baselineApply)).toBe("snapshot");
+        expect(sqlReplicationBytes(baselineApply).snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("replica sees baseline SQL row", async () => {
+          const query = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return query.ok && query.data.rowCount === 1;
+        });
+
+        expect(
+          (
+            await replicaSql.execute(
+              `UPDATE ${tableName} SET name = ?, quantity = ? WHERE id = ?`,
+              ["replica-local", 9, "item-1"]
+            )
+          ).ok
+        ).toBe(true);
+
+        expect(
+          (
+            await authoritySql.execute(
+              `UPDATE ${tableName} SET name = ?, quantity = ? WHERE id = ?`,
+              ["authority-canonical", 4, "item-1"]
+            )
+          ).ok
+        ).toBe(true);
+
+        const fallbackApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+            sinceSeq: baselineApply.appliedUntilSeq,
+          },
+          { target: targetSession, peer: peerSession }
+        );
+
+        expect(sqlReplicationMode(fallbackApply)).toBe("snapshot");
+        expect(sqlReplicationBytes(fallbackApply).snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("replica falls back to authority snapshot", async () => {
+          const query = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return (
+            query.ok &&
+            query.data.rowCount === 1 &&
+            query.data.rows[0][1] === "authority-canonical" &&
+            query.data.rows[0][2] === 4
+          );
+        });
+
+        const finalQuery = await replicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(finalQuery.ok).toBe(true);
+        if (!finalQuery.ok) {
+          throw new Error(finalQuery.error.message);
+        }
+        expect(finalQuery.data.rows[0]).toEqual([
+          "item-1",
+          "authority-canonical",
+          4,
+        ]);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-conflict-fallback.test.ts
+++ b/tests/node-sdk/replication/sql-conflict-fallback.test.ts
@@ -76,6 +76,7 @@ describe("Replication SQL Conflict Fallback", () => {
 
         expect(sqlReplicationMode(baselineApply)).toBe("snapshot");
         expect(sqlReplicationBytes(baselineApply).snapshotBytes).toBeGreaterThan(0);
+        expect(baselineApply.snapshotReason).toBe("initial-sync");
 
         await waitForCondition("replica sees baseline SQL row", async () => {
           const query = await replicaSql.query(
@@ -117,6 +118,7 @@ describe("Replication SQL Conflict Fallback", () => {
 
         expect(sqlReplicationMode(fallbackApply)).toBe("snapshot");
         expect(sqlReplicationBytes(fallbackApply).snapshotBytes).toBeGreaterThan(0);
+        expect(fallbackApply.snapshotReason).toBe("changeset-conflict");
 
         await waitForCondition("replica falls back to authority snapshot", async () => {
           const query = await replicaSql.query(

--- a/tests/node-sdk/replication/sql-incremental-reconcile.test.ts
+++ b/tests/node-sdk/replication/sql-incremental-reconcile.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  exportSqlFromPeer,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  sqlReplicationBytes,
+  sqlReplicationMode,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication SQL Incremental Reconcile", () => {
+  test(
+    "uses a snapshot baseline and then accepts a later sinceSeq export for incremental SQL changes",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("sql-incremental");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_incremental_${suffix}`;
+        const tableName = `items_sql_incremental_${suffix}`;
+        const authoritySql = authority.sql.db(dbName);
+        const replicaSql = replica.sql.db(dbName);
+
+        const createResult = await authoritySql.execute(
+          `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL, quantity INTEGER NOT NULL)`
+        );
+        expect(createResult.ok).toBe(true);
+
+        const firstInsert = await authoritySql.execute(
+          `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+          ["item-1", "camera", 2]
+        );
+        expect(firstInsert.ok).toBe(true);
+
+        const exportSession = await openSqlReplicationSession(
+          authority,
+          authorityNode.url,
+          dbName
+        );
+        const targetSession = await openSqlReplicationSession(
+          replica,
+          replicaNode.url,
+          dbName
+        );
+
+        const baselineApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          { target: targetSession, peer: exportSession }
+        );
+
+        expect(sqlReplicationMode(baselineApply)).toBe("snapshot");
+        expect(sqlReplicationBytes(baselineApply).snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("replica sees baseline SQL row", async () => {
+          const query = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return query.ok && query.data.rowCount === 1;
+        });
+
+        const baselineSeq = baselineApply.appliedUntilSeq ?? 0;
+
+        const updateResult = await authoritySql.execute(
+          `UPDATE ${tableName} SET name = ?, quantity = ? WHERE id = ?`,
+          ["camera-pro", 4, "item-1"]
+        );
+        expect(updateResult.ok).toBe(true);
+
+        const secondInsert = await authoritySql.execute(
+          `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+          ["item-2", "tripod", 1]
+        );
+        expect(secondInsert.ok).toBe(true);
+
+        const incrementalExportResponse = await exportSqlFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            dbName,
+            sinceSeq: baselineSeq,
+          },
+          exportSession
+        );
+        if (incrementalExportResponse.requestedSinceSeq !== undefined) {
+          expect(incrementalExportResponse.requestedSinceSeq).toBe(baselineSeq);
+        }
+        const incrementalMode =
+          incrementalExportResponse.mode ?? sqlReplicationMode(incrementalExportResponse);
+        const incrementalBytes = sqlReplicationBytes(incrementalExportResponse);
+        expect(
+          incrementalBytes.changesetBytes + incrementalBytes.snapshotBytes
+        ).toBeGreaterThan(0);
+        if (incrementalMode === "changeset") {
+          expect(incrementalBytes.changesetBytes).toBeGreaterThan(0);
+        } else {
+          expect(incrementalBytes.snapshotBytes).toBeGreaterThan(0);
+        }
+
+        const incrementalApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+            sinceSeq: baselineSeq,
+          },
+          { target: targetSession, peer: exportSession }
+        );
+
+        expect(incrementalApply.appliedUntilSeq ?? baselineSeq).toBeGreaterThanOrEqual(
+          baselineSeq
+        );
+        const incrementalApplyBytes = sqlReplicationBytes(incrementalApply);
+        expect(
+          incrementalApplyBytes.snapshotBytes + incrementalApplyBytes.changesetBytes
+        ).toBeGreaterThan(0);
+
+        await waitForCondition("replica sees incremental SQL changes", async () => {
+          const query = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id IN (?, ?) ORDER BY id`,
+            ["item-1", "item-2"]
+          );
+          return (
+            query.ok &&
+            query.data.rowCount === 2 &&
+            query.data.rows[0][1] === "camera-pro" &&
+            query.data.rows[0][2] === 4 &&
+            query.data.rows[1][1] === "tripod" &&
+            query.data.rows[1][2] === 1
+          );
+        });
+
+        const replicaQuery = await replicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} ORDER BY id`
+        );
+        expect(replicaQuery.ok).toBe(true);
+        if (!replicaQuery.ok) {
+          throw new Error(replicaQuery.error.message);
+        }
+        expect(replicaQuery.data.rowCount).toBe(2);
+        expect(replicaQuery.data.rows).toEqual([
+          ["item-1", "camera-pro", 4],
+          ["item-2", "tripod", 1],
+        ]);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-incremental-reconcile.test.ts
+++ b/tests/node-sdk/replication/sql-incremental-reconcile.test.ts
@@ -72,6 +72,7 @@ describe("Replication SQL Incremental Reconcile", () => {
 
         expect(sqlReplicationMode(baselineApply)).toBe("snapshot");
         expect(sqlReplicationBytes(baselineApply).snapshotBytes).toBeGreaterThan(0);
+        expect(baselineApply.snapshotReason).toBe("initial-sync");
 
         await waitForCondition("replica sees baseline SQL row", async () => {
           const query = await replicaSql.query(
@@ -139,6 +140,9 @@ describe("Replication SQL Incremental Reconcile", () => {
         expect(
           incrementalApplyBytes.snapshotBytes + incrementalApplyBytes.changesetBytes
         ).toBeGreaterThan(0);
+        if (sqlReplicationMode(incrementalApply) === "changeset") {
+          expect(incrementalApply.snapshotReason).toBeNull();
+        }
 
         await waitForCondition("replica sees incremental SQL changes", async () => {
           const query = await replicaSql.query(

--- a/tests/node-sdk/replication/sql-peer-serving-enforcement.test.ts
+++ b/tests/node-sdk/replication/sql-peer-serving-enforcement.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openSqlReplicationSession,
+  openTransportSession,
+  sqlReplicationBytes,
+  uniqueReplicationPrefix,
+} from "./helpers";
+
+describe("Replication SQL Peer Serving Enforcement", () => {
+  test(
+    "allows host SQL export and denies replica SQL export unless peer serving is enabled",
+    { timeout: 600_000 },
+    async () => {
+      const prefix = uniqueReplicationPrefix("sql-peer-serving-default");
+      const suffix = Date.now().toString(36);
+      const dbName = `sql_peer_serving_${suffix}`;
+      const tableName = `items_${suffix}`;
+
+      const defaultCluster = await startCluster();
+      try {
+        const host = createClusterClient(defaultCluster, "node-b", prefix);
+        const replica = createClusterClient(defaultCluster, "node-c", prefix);
+        const hostNode = getClusterNode(defaultCluster, "node-b");
+        const replicaNode = getClusterNode(defaultCluster, "node-c");
+
+        const hostInfoResponse = await fetch(`${hostNode.url}/info`);
+        const replicaInfoResponse = await fetch(`${replicaNode.url}/info`);
+        expect(hostInfoResponse.ok).toBe(true);
+        expect(replicaInfoResponse.ok).toBe(true);
+
+        const hostInfo = (await hostInfoResponse.json()) as {
+          rolesEnabled: string[];
+          replication: { peerServing: boolean };
+        };
+        const replicaInfo = (await replicaInfoResponse.json()) as {
+          rolesEnabled: string[];
+          replication: { peerServing: boolean };
+        };
+        expect(hostInfo.rolesEnabled).toEqual(["host"]);
+        expect(hostInfo.replication.peerServing).toBe(true);
+        expect(replicaInfo.rolesEnabled).toEqual(["replica"]);
+        expect(replicaInfo.replication.peerServing).toBe(false);
+
+        await host.signIn();
+        await replica.signIn();
+
+        expect(host.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(host.spaceId);
+
+        const hostSql = host.sql.db(dbName);
+        expect(
+          (await hostSql.execute(
+            `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, label TEXT NOT NULL)`
+          )).ok
+        ).toBe(true);
+        expect(
+          (
+            await hostSql.execute(
+              `INSERT INTO ${tableName} (id, label) VALUES (?, ?)`,
+              ["item-1", "host-export"]
+            )
+          ).ok
+        ).toBe(true);
+
+        const hostSession = await openSqlReplicationSession(host, hostNode.url, dbName);
+        const hostTransport = await openTransportSession(hostSession);
+        const hostExport = await fetch(`${hostNode.url}/replication/sql/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": hostTransport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: host.spaceId,
+            dbName,
+          }),
+        });
+        expect(hostExport.status).toBe(200);
+        const hostExportBody = (await hostExport.json()) as {
+          mode?: "snapshot" | "changeset";
+          snapshotReason?: string | null;
+          snapshot?: number[];
+          changeset?: number[];
+        };
+        expect(hostExportBody.mode).toBe("snapshot");
+        expect(hostExportBody.snapshotReason).toBe("initial-sync");
+        expect(sqlReplicationBytes(hostExportBody).snapshotBytes).toBeGreaterThan(0);
+
+        const replicaSql = replica.sql.db(dbName);
+        expect(
+          (await replicaSql.execute(
+            `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, label TEXT NOT NULL)`
+          )).ok
+        ).toBe(true);
+        expect(
+          (
+            await replicaSql.execute(
+              `INSERT INTO ${tableName} (id, label) VALUES (?, ?)`,
+              ["item-local", "replica-export"]
+            )
+          ).ok
+        ).toBe(true);
+
+        const replicaSession = await openSqlReplicationSession(
+          replica,
+          replicaNode.url,
+          dbName
+        );
+        const replicaTransport = await openTransportSession(replicaSession);
+        const replicaExport = await fetch(`${replicaNode.url}/replication/sql/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": replicaTransport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: replica.spaceId,
+            dbName,
+          }),
+        });
+        expect(replicaExport.status).toBe(403);
+        expect(await replicaExport.text()).toContain("peerServing");
+      } finally {
+        await defaultCluster.stop();
+      }
+
+      const enabledCluster = await startCluster({
+        nodes: [
+          { name: "node-a", role: "authority", port: 8010 },
+          { name: "node-b", role: "host", port: 8011 },
+          {
+            name: "node-c",
+            role: "replica",
+            port: 8012,
+            env: {
+              TINYCLOUD_REPLICATION_PEER_SERVING: "true",
+            },
+          },
+        ],
+      });
+      try {
+        const authority = createClusterClient(enabledCluster, "node-a", prefix);
+        const replica = createClusterClient(enabledCluster, "node-c", prefix);
+        const replicaNode = getClusterNode(enabledCluster, "node-c");
+
+        const replicaInfoResponse = await fetch(`${replicaNode.url}/info`);
+        expect(replicaInfoResponse.ok).toBe(true);
+        const replicaInfo = (await replicaInfoResponse.json()) as {
+          rolesEnabled: string[];
+          replication: { peerServing: boolean };
+        };
+        expect(replicaInfo.rolesEnabled).toEqual(["replica"]);
+        expect(replicaInfo.replication.peerServing).toBe(true);
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const replicaSql = replica.sql.db(dbName);
+        expect(
+          (await replicaSql.execute(
+            `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, label TEXT NOT NULL)`
+          )).ok
+        ).toBe(true);
+        expect(
+          (
+            await replicaSql.execute(
+              `INSERT INTO ${tableName} (id, label) VALUES (?, ?)`,
+              ["item-local", "replica-export"]
+            )
+          ).ok
+        ).toBe(true);
+
+        const replicaSession = await openSqlReplicationSession(
+          replica,
+          replicaNode.url,
+          dbName
+        );
+        const replicaTransport = await openTransportSession(replicaSession);
+        const replicaExport = await fetch(`${replicaNode.url}/replication/sql/export`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Replication-Session": replicaTransport!.sessionToken,
+          },
+          body: JSON.stringify({
+            spaceId: replica.spaceId,
+            dbName,
+          }),
+        });
+        expect(replicaExport.status).toBe(200);
+        const replicaExportBody = (await replicaExport.json()) as {
+          mode?: "snapshot" | "changeset";
+          snapshot?: number[];
+          changeset?: number[];
+        };
+        expect(sqlReplicationBytes(replicaExportBody).snapshotBytes).toBeGreaterThan(0);
+      } finally {
+        await enabledCluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-peer-serving-reconcile.test.ts
+++ b/tests/node-sdk/replication/sql-peer-serving-reconcile.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  sqlReplicationBytes,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication SQL Peer Serving Reconcile", () => {
+  test(
+    "pulls SQL changes through a peer-serving replica into a host",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster({
+        nodes: [
+          { name: "node-a", role: "authority", port: 8210 },
+          { name: "node-b", role: "host", port: 8211 },
+          {
+            name: "node-c",
+            role: "replica",
+            port: 8212,
+            env: {
+              TINYCLOUD_REPLICATION_PEER_SERVING: "true",
+            },
+          },
+        ],
+      });
+      try {
+        const prefix = uniqueReplicationPrefix("sql-peer-serving-reconcile");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const host = createClusterClient(cluster, "node-b", prefix);
+        const replica = createClusterClient(cluster, "node-c", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const hostNode = getClusterNode(cluster, "node-b");
+        const replicaNode = getClusterNode(cluster, "node-c");
+
+        await authority.signIn();
+        await host.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(host.spaceId).toBe(authority.spaceId);
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_peer_serving_reconcile_${suffix}`;
+        const tableName = `items_sql_peer_serving_reconcile_${suffix}`;
+        const authoritySql = authority.sql.db(dbName);
+        const hostSql = host.sql.db(dbName);
+        const replicaSql = replica.sql.db(dbName);
+
+        expect(
+          (
+            await authoritySql.execute(
+              `CREATE TABLE IF NOT EXISTS ${tableName} (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                quantity INTEGER NOT NULL
+              )`
+            )
+          ).ok
+        ).toBe(true);
+        expect(
+          (
+            await authoritySql.execute(
+              `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+              ["item-1", "camera", 2]
+            )
+          ).ok
+        ).toBe(true);
+
+        const seedReplicaApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-c",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          {
+            target: await openSqlReplicationSession(replica, replicaNode.url, dbName),
+            peer: await openSqlReplicationSession(authority, authorityNode.url, dbName),
+          }
+        );
+
+        expect(
+          sqlReplicationBytes(seedReplicaApply).snapshotBytes +
+            sqlReplicationBytes(seedReplicaApply).changesetBytes
+        ).toBeGreaterThan(0);
+
+        await waitForCondition("peer-serving replica sees baseline SQL row", async () => {
+          const query = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return query.ok && query.data.rowCount === 1;
+        });
+
+        expect(
+          (
+            await authoritySql.execute(
+              `UPDATE ${tableName} SET name = ?, quantity = ? WHERE id = ?`,
+              ["camera-pro", 4, "item-1"]
+            )
+          ).ok
+        ).toBe(true);
+
+        const seedReplicaUpdate = await reconcileSqlFromPeer(
+          cluster,
+          "node-c",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+            sinceSeq: seedReplicaApply.appliedUntilSeq,
+          },
+          {
+            target: await openSqlReplicationSession(replica, replicaNode.url, dbName),
+            peer: await openSqlReplicationSession(authority, authorityNode.url, dbName),
+          }
+        );
+
+        expect(seedReplicaUpdate.appliedUntilSeq).toBeGreaterThan(
+          seedReplicaApply.appliedUntilSeq ?? 0
+        );
+
+        await waitForCondition(
+          "peer-serving replica sees updated SQL row before relaying it",
+          async () => {
+            const query = await replicaSql.query(
+              `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+              ["item-1"]
+            );
+            return (
+              query.ok &&
+              query.data.rowCount === 1 &&
+              query.data.rows[0][1] === "camera-pro" &&
+              query.data.rows[0][2] === 4
+            );
+          }
+        );
+
+        const hostApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: replicaNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          {
+            target: await openSqlReplicationSession(host, hostNode.url, dbName),
+            peer: await openSqlReplicationSession(replica, replicaNode.url, dbName),
+          }
+        );
+
+        expect(
+          sqlReplicationBytes(hostApply).snapshotBytes +
+            sqlReplicationBytes(hostApply).changesetBytes
+        ).toBeGreaterThan(0);
+
+        await waitForCondition("host catches SQL changes through the replica", async () => {
+          const query = await hostSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return (
+            query.ok &&
+            query.data.rowCount === 1 &&
+            query.data.rows[0][1] === "camera-pro" &&
+            query.data.rows[0][2] === 4
+          );
+        });
+
+        const hostQuery = await hostSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(hostQuery.ok).toBe(true);
+        if (!hostQuery.ok) {
+          throw new Error(hostQuery.error.message);
+        }
+        expect(hostQuery.data.rows[0]).toEqual(["item-1", "camera-pro", 4]);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-read-mode.test.ts
+++ b/tests/node-sdk/replication/sql-read-mode.test.ts
@@ -126,14 +126,31 @@ describe("Replication SQL Read Mode", () => {
         }
         expect(provisionalDefault.data.rows).toEqual([["item-local", "replica-camera", 1]]);
 
+        const authorityPull = await reconcileSqlFromPeer(
+          cluster,
+          "node-a",
+          {
+            peerUrl: replicaNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+            sinceSeq: baselineApply.appliedUntilSeq,
+          },
+          {
+            target: await openSqlReplicationSession(authority, authorityNode.url, dbName),
+            peer: await openSqlReplicationSession(canonicalReplica, replicaNode.url, dbName),
+          }
+        );
         expect(
-          (
-            await authoritySql.execute(
-              `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
-              ["item-local", "replica-camera", 1]
-            )
-          ).ok
-        ).toBe(true);
+          (authorityPull.snapshotBytes ?? 0) + (authorityPull.changesetBytes ?? 0)
+        ).toBeGreaterThan(0);
+
+        await waitForCondition("authority sees replica-authored row", async () => {
+          const result = await authoritySql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-local"]
+          );
+          return result.ok && result.data.rowCount === 1;
+        });
 
         const replicaCatchup = await reconcileSqlFromPeer(
           cluster,

--- a/tests/node-sdk/replication/sql-read-mode.test.ts
+++ b/tests/node-sdk/replication/sql-read-mode.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication SQL Read Mode", () => {
+  test(
+    "defaults SQL reads to canonical visibility and allows provisional reads until canonicalization converges",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster({
+        nodes: [
+          { name: "node-a", role: "authority", port: 8010 },
+          { name: "node-b", role: "host", port: 8011 },
+          {
+            name: "node-c",
+            role: "replica",
+            port: 8012,
+            env: { TINYCLOUD_REPLICATION_PEER_SERVING: "true" },
+          },
+        ],
+      });
+      try {
+        const prefix = uniqueReplicationPrefix("sql-read-mode");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const canonicalReplica = createClusterClient(cluster, "node-c", prefix);
+        const provisionalReplica = createClusterClient(
+          cluster,
+          "node-c",
+          prefix,
+          undefined,
+          { sqlConfig: { readMode: "provisional" } }
+        );
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-c");
+
+        await authority.signIn();
+        await canonicalReplica.signIn();
+        await provisionalReplica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(canonicalReplica.spaceId).toBe(authority.spaceId);
+        expect(provisionalReplica.spaceId).toBe(authority.spaceId);
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_read_mode_${suffix}`;
+        const tableName = `items_sql_read_mode_${suffix}`;
+        const authoritySql = authority.sql.db(dbName);
+        const canonicalReplicaSql = canonicalReplica.sql.db(dbName);
+        const provisionalReplicaSql = provisionalReplica.sql.db(dbName);
+
+        expect(
+          (
+            await authoritySql.execute(
+              `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL, quantity INTEGER NOT NULL)`
+            )
+          ).ok
+        ).toBe(true);
+
+        const baselineApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-c",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          {
+            target: await openSqlReplicationSession(canonicalReplica, replicaNode.url, dbName),
+            peer: await openSqlReplicationSession(authority, authorityNode.url, dbName),
+          }
+        );
+        expect(baselineApply.snapshotBytes ?? 0).toBeGreaterThan(0);
+
+        await waitForCondition("replica sees canonical schema", async () => {
+          const result = await canonicalReplicaSql.query(
+            `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+            [tableName]
+          );
+          return result.ok && result.data.rowCount === 1;
+        });
+
+        expect(
+          (
+            await canonicalReplicaSql.execute(
+              `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+              ["item-local", "replica-camera", 1]
+            )
+          ).ok
+        ).toBe(true);
+
+        const canonicalBefore = await canonicalReplicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-local"]
+        );
+        expect(canonicalBefore.ok).toBe(true);
+        if (!canonicalBefore.ok) {
+          throw new Error(canonicalBefore.error.message);
+        }
+        expect(canonicalBefore.data.rowCount).toBe(0);
+
+        const provisionalOverride = await canonicalReplicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-local"],
+          { readMode: "provisional" }
+        );
+        expect(provisionalOverride.ok).toBe(true);
+        if (!provisionalOverride.ok) {
+          throw new Error(provisionalOverride.error.message);
+        }
+        expect(provisionalOverride.data.rows).toEqual([["item-local", "replica-camera", 1]]);
+
+        const provisionalDefault = await provisionalReplicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-local"]
+        );
+        expect(provisionalDefault.ok).toBe(true);
+        if (!provisionalDefault.ok) {
+          throw new Error(provisionalDefault.error.message);
+        }
+        expect(provisionalDefault.data.rows).toEqual([["item-local", "replica-camera", 1]]);
+
+        expect(
+          (
+            await authoritySql.execute(
+              `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+              ["item-local", "replica-camera", 1]
+            )
+          ).ok
+        ).toBe(true);
+
+        const replicaCatchup = await reconcileSqlFromPeer(
+          cluster,
+          "node-c",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+            sinceSeq: baselineApply.appliedUntilSeq,
+          },
+          {
+            target: await openSqlReplicationSession(canonicalReplica, replicaNode.url, dbName),
+            peer: await openSqlReplicationSession(authority, authorityNode.url, dbName),
+          }
+        );
+        expect(
+          (replicaCatchup.snapshotBytes ?? 0) + (replicaCatchup.changesetBytes ?? 0)
+        ).toBeGreaterThan(0);
+
+        await waitForCondition("canonical SQL view converges after authority round-trip", async () => {
+          const result = await canonicalReplicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-local"]
+          );
+          return result.ok && result.data.rowCount === 1;
+        });
+
+        const canonicalAfter = await canonicalReplicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-local"]
+        );
+        expect(canonicalAfter.ok).toBe(true);
+        if (!canonicalAfter.ok) {
+          throw new Error(canonicalAfter.error.message);
+        }
+        expect(canonicalAfter.data.rows).toEqual([["item-local", "replica-camera", 1]]);
+
+        const provisionalAfter = await canonicalReplicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-local"],
+          { readMode: "provisional" }
+        );
+        expect(provisionalAfter.ok).toBe(true);
+        if (!provisionalAfter.ok) {
+          throw new Error(provisionalAfter.error.message);
+        }
+        expect(provisionalAfter.data.rows).toEqual([["item-local", "replica-camera", 1]]);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-reconcile.test.ts
+++ b/tests/node-sdk/replication/sql-reconcile.test.ts
@@ -6,6 +6,7 @@ import {
   getClusterNode,
   openSqlReplicationSession,
   reconcileSqlFromPeer,
+  sqlReplicationBytes,
   uniqueReplicationPrefix,
   waitForCondition,
 } from "./helpers";
@@ -78,7 +79,7 @@ describe("Replication SQL Reconcile", () => {
         expect(reconcileResult.spaceId).toBe(authority.spaceId);
         expect(reconcileResult.dbName).toBe(dbName);
         expect(reconcileResult.peerUrl).toBe(authorityNode.url);
-        expect(reconcileResult.snapshotBytes).toBeGreaterThan(0);
+        expect(sqlReplicationBytes(reconcileResult).snapshotBytes).toBeGreaterThan(0);
 
         await waitForCondition("replicated SQL row available on node-b", async () => {
           const queryResult = await replicaSql.query(
@@ -110,7 +111,10 @@ describe("Replication SQL Reconcile", () => {
           spaceId: authority.spaceId!,
           dbName,
         }, { target: targetSession, peer: exportSession });
-        expect(secondPass.snapshotBytes).toBeGreaterThan(0);
+        const secondPassBytes = sqlReplicationBytes(secondPass);
+        expect(
+          secondPassBytes.snapshotBytes + secondPassBytes.changesetBytes
+        ).toBeGreaterThan(0);
 
         await waitForCondition("updated SQL row available on node-b", async () => {
           const queryResult = await replicaSql.query(
@@ -146,7 +150,10 @@ describe("Replication SQL Reconcile", () => {
           spaceId: authority.spaceId!,
           dbName,
         }, { target: targetSession, peer: exportSession });
-        expect(thirdPass.snapshotBytes).toBeGreaterThan(0);
+        const thirdPassBytes = sqlReplicationBytes(thirdPass);
+        expect(
+          thirdPassBytes.snapshotBytes + thirdPassBytes.changesetBytes
+        ).toBeGreaterThan(0);
 
         await waitForCondition("deleted SQL row removed from node-b", async () => {
           const queryResult = await replicaSql.query(

--- a/tests/node-sdk/replication/sql-reconcile.test.ts
+++ b/tests/node-sdk/replication/sql-reconcile.test.ts
@@ -21,6 +21,7 @@ describe("Replication SQL Reconcile", () => {
         const authority = createClusterClient(cluster, "node-a", prefix);
         const replica = createClusterClient(cluster, "node-b", prefix);
         const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
 
         await authority.signIn();
         await replica.signIn();
@@ -50,6 +51,11 @@ describe("Replication SQL Reconcile", () => {
           authorityNode.url,
           dbName
         );
+        const targetSession = await openSqlReplicationSession(
+          replica,
+          replicaNode.url,
+          dbName
+        );
         const exportResult = await exportSqlFromPeer(
           cluster,
           "node-a",
@@ -67,7 +73,7 @@ describe("Replication SQL Reconcile", () => {
           peerUrl: authorityNode.url,
           spaceId: authority.spaceId!,
           dbName,
-        }, exportSession);
+        }, { target: targetSession, peer: exportSession });
 
         expect(reconcileResult.spaceId).toBe(authority.spaceId);
         expect(reconcileResult.dbName).toBe(dbName);
@@ -103,7 +109,7 @@ describe("Replication SQL Reconcile", () => {
           peerUrl: authorityNode.url,
           spaceId: authority.spaceId!,
           dbName,
-        }, exportSession);
+        }, { target: targetSession, peer: exportSession });
         expect(secondPass.snapshotBytes).toBeGreaterThan(0);
 
         await waitForCondition("updated SQL row available on node-b", async () => {
@@ -139,7 +145,7 @@ describe("Replication SQL Reconcile", () => {
           peerUrl: authorityNode.url,
           spaceId: authority.spaceId!,
           dbName,
-        }, exportSession);
+        }, { target: targetSession, peer: exportSession });
         expect(thirdPass.snapshotBytes).toBeGreaterThan(0);
 
         await waitForCondition("deleted SQL row removed from node-b", async () => {

--- a/tests/node-sdk/replication/sql-reconcile.test.ts
+++ b/tests/node-sdk/replication/sql-reconcile.test.ts
@@ -5,7 +5,6 @@ import {
   exportSqlFromPeer,
   getClusterNode,
   openSqlReplicationSession,
-  reconcileSqlFromPeer,
   sqlReplicationBytes,
   uniqueReplicationPrefix,
   waitForCondition,
@@ -70,11 +69,14 @@ describe("Replication SQL Reconcile", () => {
         expect(exportResult.dbName).toBe(dbName);
         expect(exportResult.snapshot.length).toBeGreaterThan(0);
 
-        const reconcileResult = await reconcileSqlFromPeer(cluster, "node-b", {
-          peerUrl: authorityNode.url,
-          spaceId: authority.spaceId!,
-          dbName,
-        }, { target: targetSession, peer: exportSession });
+        const reconcileResult = await replica.reconcileSqlFromPeer(
+          { target: targetSession, peer: exportSession },
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          }
+        );
 
         expect(reconcileResult.spaceId).toBe(authority.spaceId);
         expect(reconcileResult.dbName).toBe(dbName);
@@ -107,11 +109,14 @@ describe("Replication SQL Reconcile", () => {
         );
         expect(updateResult.ok).toBe(true);
 
-        const secondPass = await reconcileSqlFromPeer(cluster, "node-b", {
-          peerUrl: authorityNode.url,
-          spaceId: authority.spaceId!,
-          dbName,
-        }, { target: targetSession, peer: exportSession });
+        const secondPass = await replica.reconcileSqlFromPeer(
+          { target: targetSession, peer: exportSession },
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          }
+        );
         const secondPassBytes = sqlReplicationBytes(secondPass);
         expect(
           secondPassBytes.snapshotBytes + secondPassBytes.changesetBytes
@@ -146,11 +151,14 @@ describe("Replication SQL Reconcile", () => {
         );
         expect(deleteResult.ok).toBe(true);
 
-        const thirdPass = await reconcileSqlFromPeer(cluster, "node-b", {
-          peerUrl: authorityNode.url,
-          spaceId: authority.spaceId!,
-          dbName,
-        }, { target: targetSession, peer: exportSession });
+        const thirdPass = await replica.reconcileSqlFromPeer(
+          { target: targetSession, peer: exportSession },
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          }
+        );
         const thirdPassBytes = sqlReplicationBytes(thirdPass);
         expect(
           thirdPassBytes.snapshotBytes + thirdPassBytes.changesetBytes

--- a/tests/node-sdk/replication/sql-reconcile.test.ts
+++ b/tests/node-sdk/replication/sql-reconcile.test.ts
@@ -80,6 +80,7 @@ describe("Replication SQL Reconcile", () => {
         expect(reconcileResult.dbName).toBe(dbName);
         expect(reconcileResult.peerUrl).toBe(authorityNode.url);
         expect(sqlReplicationBytes(reconcileResult).snapshotBytes).toBeGreaterThan(0);
+        expect(reconcileResult.snapshotReason).toBe("initial-sync");
 
         await waitForCondition("replicated SQL row available on node-b", async () => {
           const queryResult = await replicaSql.query(

--- a/tests/node-sdk/replication/sql-reconcile.test.ts
+++ b/tests/node-sdk/replication/sql-reconcile.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  exportSqlFromPeer,
+  getClusterNode,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication SQL Reconcile", () => {
+  test(
+    "pulls real SQLite insert, update, and delete changes from one live node into another live node",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("sql-reconcile");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_reconcile_${suffix}`;
+        const tableName = `items_sql_reconcile_${suffix}`;
+        const authoritySql = authority.sql.db(dbName);
+        const replicaSql = replica.sql.db(dbName);
+
+        const createResult = await authoritySql.execute(
+          `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL, quantity INTEGER NOT NULL)`
+        );
+        expect(createResult.ok).toBe(true);
+
+        const insertResult = await authoritySql.execute(
+          `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+          ["item-1", "camera", 2]
+        );
+        expect(insertResult.ok).toBe(true);
+
+        const exportSession = await openSqlReplicationSession(
+          authority,
+          authorityNode.url,
+          dbName
+        );
+        const exportResult = await exportSqlFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          exportSession
+        );
+        expect(exportResult.spaceId).toBe(authority.spaceId);
+        expect(exportResult.dbName).toBe(dbName);
+        expect(exportResult.snapshot.length).toBeGreaterThan(0);
+
+        const reconcileResult = await reconcileSqlFromPeer(cluster, "node-b", {
+          peerUrl: authorityNode.url,
+          spaceId: authority.spaceId!,
+          dbName,
+        }, exportSession);
+
+        expect(reconcileResult.spaceId).toBe(authority.spaceId);
+        expect(reconcileResult.dbName).toBe(dbName);
+        expect(reconcileResult.peerUrl).toBe(authorityNode.url);
+        expect(reconcileResult.snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("replicated SQL row available on node-b", async () => {
+          const queryResult = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return queryResult.ok && queryResult.data.rowCount === 1;
+        });
+
+        const replicaQuery = await replicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(replicaQuery.ok).toBe(true);
+        if (!replicaQuery.ok) {
+          throw new Error(replicaQuery.error.message);
+        }
+        expect(replicaQuery.data.columns).toEqual(["id", "name", "quantity"]);
+        expect(replicaQuery.data.rows[0]).toEqual(["item-1", "camera", 2]);
+
+        const updateResult = await authoritySql.execute(
+          `UPDATE ${tableName} SET name = ?, quantity = ? WHERE id = ?`,
+          ["camera-pro", 4, "item-1"]
+        );
+        expect(updateResult.ok).toBe(true);
+
+        const secondPass = await reconcileSqlFromPeer(cluster, "node-b", {
+          peerUrl: authorityNode.url,
+          spaceId: authority.spaceId!,
+          dbName,
+        }, exportSession);
+        expect(secondPass.snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("updated SQL row available on node-b", async () => {
+          const queryResult = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return (
+            queryResult.ok &&
+            queryResult.data.rowCount === 1 &&
+            queryResult.data.rows[0][1] === "camera-pro" &&
+            queryResult.data.rows[0][2] === 4
+          );
+        });
+
+        const updatedReplicaQuery = await replicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(updatedReplicaQuery.ok).toBe(true);
+        if (!updatedReplicaQuery.ok) {
+          throw new Error(updatedReplicaQuery.error.message);
+        }
+        expect(updatedReplicaQuery.data.rows[0]).toEqual(["item-1", "camera-pro", 4]);
+
+        const deleteResult = await authoritySql.execute(
+          `DELETE FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(deleteResult.ok).toBe(true);
+
+        const thirdPass = await reconcileSqlFromPeer(cluster, "node-b", {
+          peerUrl: authorityNode.url,
+          spaceId: authority.spaceId!,
+          dbName,
+        }, exportSession);
+        expect(thirdPass.snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("deleted SQL row removed from node-b", async () => {
+          const queryResult = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return queryResult.ok && queryResult.data.rowCount === 0;
+        });
+
+        const deletedReplicaQuery = await replicaSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(deletedReplicaQuery.ok).toBe(true);
+        if (!deletedReplicaQuery.ok) {
+          throw new Error(deletedReplicaQuery.error.message);
+        }
+        expect(deletedReplicaQuery.data.rowCount).toBe(0);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-restart-cursor.test.ts
+++ b/tests/node-sdk/replication/sql-restart-cursor.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  sqlReplicationBytes,
+  sqlReplicationMode,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication SQL Restart Cursor", () => {
+  test(
+    "persists the SQL peer cursor across node restart and resumes with an incremental changeset",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("sql-restart-cursor");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_restart_cursor_${suffix}`;
+        const tableName = `items_sql_restart_cursor_${suffix}`;
+        const authoritySql = authority.sql.db(dbName);
+
+        expect(
+          (
+            await authoritySql.execute(
+              `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL, quantity INTEGER NOT NULL)`
+            )
+          ).ok
+        ).toBe(true);
+        expect(
+          (
+            await authoritySql.execute(
+              `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+              ["item-1", "camera", 2]
+            )
+          ).ok
+        ).toBe(true);
+
+        const baselinePeerSession = await openSqlReplicationSession(
+          authority,
+          authorityNode.url,
+          dbName
+        );
+        const baselineTargetSession = await openSqlReplicationSession(
+          replica,
+          replicaNode.url,
+          dbName
+        );
+
+        const baselineApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          { target: baselineTargetSession, peer: baselinePeerSession }
+        );
+
+        expect(sqlReplicationMode(baselineApply)).toBe("snapshot");
+        expect(sqlReplicationBytes(baselineApply).snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("replica sees baseline SQL row", async () => {
+          const query = await replica.sql.db(dbName).query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return query.ok && query.data.rowCount === 1;
+        });
+
+        await cluster.stopNode("node-b");
+
+        expect(
+          (
+            await authoritySql.execute(
+              `UPDATE ${tableName} SET name = ?, quantity = ? WHERE id = ?`,
+              ["camera-pro", 4, "item-1"]
+            )
+          ).ok
+        ).toBe(true);
+        expect(
+          (
+            await authoritySql.execute(
+              `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+              ["item-2", "tripod", 1]
+            )
+          ).ok
+        ).toBe(true);
+
+        await cluster.startNode("node-b");
+
+        const restartedReplica = createClusterClient(cluster, "node-b", prefix);
+        await restartedReplica.signIn();
+        expect(restartedReplica.spaceId).toBe(authority.spaceId);
+
+        const peerSession = await openSqlReplicationSession(
+          authority,
+          authorityNode.url,
+          dbName
+        );
+        const targetSession = await openSqlReplicationSession(
+          restartedReplica,
+          replicaNode.url,
+          dbName
+        );
+
+        const resumedApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          { target: targetSession, peer: peerSession }
+        );
+
+        expect(sqlReplicationMode(resumedApply)).toBe("changeset");
+        expect(sqlReplicationBytes(resumedApply).changesetBytes).toBeGreaterThan(0);
+        expect(sqlReplicationBytes(resumedApply).snapshotBytes).toBe(0);
+        expect(resumedApply.appliedUntilSeq).toBeGreaterThan(
+          baselineApply.appliedUntilSeq ?? 0
+        );
+
+        await waitForCondition(
+          "restarted replica catches up using incremental SQL changeset",
+          async () => {
+            const query = await restartedReplica.sql.db(dbName).query(
+              `SELECT id, name, quantity FROM ${tableName} ORDER BY id`
+            );
+            return (
+              query.ok &&
+              query.data.rowCount === 2 &&
+              query.data.rows[0][1] === "camera-pro" &&
+              query.data.rows[0][2] === 4 &&
+              query.data.rows[1][1] === "tripod" &&
+              query.data.rows[1][2] === 1
+            );
+          }
+        );
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-schema-drift.test.ts
+++ b/tests/node-sdk/replication/sql-schema-drift.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication SQL Schema Drift", () => {
+  test(
+    "lets the authority snapshot override divergent local SQL schema on node-b",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("sql-schema-drift");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const drifted = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+
+        await authority.signIn();
+        await drifted.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(drifted.spaceId).toBe(authority.spaceId);
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_schema_drift_${suffix}`;
+        const tableName = `items_sql_schema_drift_${suffix}`;
+        const authoritySql = authority.sql.db(dbName);
+        const driftedSql = drifted.sql.db(dbName);
+
+        const localCreate = await driftedSql.execute(
+          `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, label TEXT NOT NULL, local_only INTEGER NOT NULL)`
+        );
+        expect(localCreate.ok).toBe(true);
+
+        const localInsert = await driftedSql.execute(
+          `INSERT INTO ${tableName} (id, label, local_only) VALUES (?, ?, ?)`,
+          ["local-1", "replica-only", 1]
+        );
+        expect(localInsert.ok).toBe(true);
+
+        const authorityCreate = await authoritySql.execute(
+          `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL, quantity INTEGER NOT NULL)`
+        );
+        expect(authorityCreate.ok).toBe(true);
+
+        const authorityInsert = await authoritySql.execute(
+          `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+          ["item-1", "camera", 2]
+        );
+        expect(authorityInsert.ok).toBe(true);
+
+        await waitForCondition("node-b sees divergent local SQL state", async () => {
+          const result = await driftedSql.query(
+            `SELECT id, label, local_only FROM ${tableName} WHERE id = ?`,
+            ["local-1"]
+          );
+          return result.ok && result.data.rowCount === 1;
+        });
+
+        const localDriftQuery = await driftedSql.query(
+          `SELECT id, label, local_only FROM ${tableName} WHERE id = ?`,
+          ["local-1"]
+        );
+        expect(localDriftQuery.ok).toBe(true);
+        if (!localDriftQuery.ok) {
+          throw new Error(localDriftQuery.error.message);
+        }
+        expect(localDriftQuery.data.rows[0]).toEqual(["local-1", "replica-only", 1]);
+
+        const reconcileSession = await openSqlReplicationSession(
+          authority,
+          authorityNode.url,
+          dbName
+        );
+        const reconcileResult = await reconcileSqlFromPeer(cluster, "node-b", {
+          peerUrl: authorityNode.url,
+          spaceId: authority.spaceId!,
+          dbName,
+        }, reconcileSession);
+
+        expect(reconcileResult.spaceId).toBe(authority.spaceId);
+        expect(reconcileResult.dbName).toBe(dbName);
+        expect(reconcileResult.peerUrl).toBe(authorityNode.url);
+        expect(reconcileResult.snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("authority snapshot overrides node-b drift", async () => {
+          const result = await driftedSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return (
+            result.ok &&
+            result.data.rowCount === 1 &&
+            result.data.rows[0][1] === "camera" &&
+            result.data.rows[0][2] === 2
+          );
+        });
+
+        const canonicalQuery = await driftedSql.query(
+          `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(canonicalQuery.ok).toBe(true);
+        if (!canonicalQuery.ok) {
+          throw new Error(canonicalQuery.error.message);
+        }
+        expect(canonicalQuery.data.columns).toEqual(["id", "name", "quantity"]);
+        expect(canonicalQuery.data.rows[0]).toEqual(["item-1", "camera", 2]);
+
+        const driftColumnQuery = await driftedSql.query(
+          `SELECT id, label, local_only FROM ${tableName} WHERE id = ?`,
+          ["item-1"]
+        );
+        expect(driftColumnQuery.ok).toBe(false);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-schema-drift.test.ts
+++ b/tests/node-sdk/replication/sql-schema-drift.test.ts
@@ -20,6 +20,7 @@ describe("Replication SQL Schema Drift", () => {
         const authority = createClusterClient(cluster, "node-a", prefix);
         const drifted = createClusterClient(cluster, "node-b", prefix);
         const authorityNode = getClusterNode(cluster, "node-a");
+        const driftedNode = getClusterNode(cluster, "node-b");
 
         await authority.signIn();
         await drifted.signIn();
@@ -78,11 +79,16 @@ describe("Replication SQL Schema Drift", () => {
           authorityNode.url,
           dbName
         );
+        const targetSession = await openSqlReplicationSession(
+          drifted,
+          driftedNode.url,
+          dbName
+        );
         const reconcileResult = await reconcileSqlFromPeer(cluster, "node-b", {
           peerUrl: authorityNode.url,
           spaceId: authority.spaceId!,
           dbName,
-        }, reconcileSession);
+        }, { target: targetSession, peer: reconcileSession });
 
         expect(reconcileResult.spaceId).toBe(authority.spaceId);
         expect(reconcileResult.dbName).toBe(dbName);

--- a/tests/node-sdk/replication/sql-schema-fallback.test.ts
+++ b/tests/node-sdk/replication/sql-schema-fallback.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  sqlReplicationBytes,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+describe("Replication SQL Schema Fallback", () => {
+  test(
+    "falls back to snapshot reconciliation after an authority-side schema change",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("sql-schema-fallback");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        const suffix = Date.now();
+        const dbName = `replication_sql_schema_fallback_${suffix}`;
+        const tableName = `items_sql_schema_fallback_${suffix}`;
+        const authoritySql = authority.sql.db(dbName);
+        const replicaSql = replica.sql.db(dbName);
+
+        const createResult = await authoritySql.execute(
+          `CREATE TABLE IF NOT EXISTS ${tableName} (id TEXT PRIMARY KEY, name TEXT NOT NULL, quantity INTEGER NOT NULL)`
+        );
+        expect(createResult.ok).toBe(true);
+
+        const insertResult = await authoritySql.execute(
+          `INSERT INTO ${tableName} (id, name, quantity) VALUES (?, ?, ?)`,
+          ["item-1", "camera", 2]
+        );
+        expect(insertResult.ok).toBe(true);
+
+        const exportSession = await openSqlReplicationSession(
+          authority,
+          authorityNode.url,
+          dbName
+        );
+        const targetSession = await openSqlReplicationSession(
+          replica,
+          replicaNode.url,
+          dbName
+        );
+
+        const baselineApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          { target: targetSession, peer: exportSession }
+        );
+
+        expect(sqlReplicationBytes(baselineApply).snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("replica sees baseline SQL row", async () => {
+          const query = await replicaSql.query(
+            `SELECT id, name, quantity FROM ${tableName} WHERE id = ?`,
+            ["item-1"]
+          );
+          return query.ok && query.data.rowCount === 1;
+        });
+
+        const baselineSeq = baselineApply.appliedUntilSeq ?? 0;
+
+        const addColumnResult = await authoritySql.execute(
+          `ALTER TABLE ${tableName} ADD COLUMN status TEXT NOT NULL DEFAULT 'active'`
+        );
+        expect(addColumnResult.ok).toBe(true);
+
+        const updateResult = await authoritySql.execute(
+          `UPDATE ${tableName} SET status = ? WHERE id = ?`,
+          ["updated", "item-1"]
+        );
+        expect(updateResult.ok).toBe(true);
+
+        const secondInsert = await authoritySql.execute(
+          `INSERT INTO ${tableName} (id, name, quantity, status) VALUES (?, ?, ?, ?)`,
+          ["item-2", "tripod", 1, "new"]
+        );
+        expect(secondInsert.ok).toBe(true);
+
+        const fallbackApply = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+            sinceSeq: baselineSeq,
+          },
+          { target: targetSession, peer: exportSession }
+        );
+
+        if (fallbackApply.mode !== undefined) {
+          expect(fallbackApply.mode).toBe("snapshot");
+        }
+        expect(sqlReplicationBytes(fallbackApply).snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("replica sees schema fallback snapshot", async () => {
+          const query = await replicaSql.query(
+            `SELECT id, name, quantity, status FROM ${tableName} ORDER BY id`
+          );
+          return (
+            query.ok &&
+            query.data.rowCount === 2 &&
+            query.data.rows[0][0] === "item-1" &&
+            query.data.rows[0][3] === "updated" &&
+            query.data.rows[1][0] === "item-2" &&
+            query.data.rows[1][3] === "new"
+          );
+        });
+
+        const replicaQuery = await replicaSql.query(
+          `SELECT id, name, quantity, status FROM ${tableName} ORDER BY id`
+        );
+        expect(replicaQuery.ok).toBe(true);
+        if (!replicaQuery.ok) {
+          throw new Error(replicaQuery.error.message);
+        }
+        expect(replicaQuery.data.rows).toEqual([
+          ["item-1", "camera", 2, "updated"],
+          ["item-2", "tripod", 1, "new"],
+        ]);
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-schema-fallback.test.ts
+++ b/tests/node-sdk/replication/sql-schema-fallback.test.ts
@@ -69,6 +69,7 @@ describe("Replication SQL Schema Fallback", () => {
         );
 
         expect(sqlReplicationBytes(baselineApply).snapshotBytes).toBeGreaterThan(0);
+        expect(baselineApply.snapshotReason).toBe("initial-sync");
 
         await waitForCondition("replica sees baseline SQL row", async () => {
           const query = await replicaSql.query(
@@ -113,6 +114,7 @@ describe("Replication SQL Schema Fallback", () => {
           expect(fallbackApply.mode).toBe("snapshot");
         }
         expect(sqlReplicationBytes(fallbackApply).snapshotBytes).toBeGreaterThan(0);
+        expect(fallbackApply.snapshotReason).toBe("schema-change");
 
         await waitForCondition("replica sees schema fallback snapshot", async () => {
           const query = await replicaSql.query(

--- a/tests/node-sdk/replication/sql-warm-sync.test.ts
+++ b/tests/node-sdk/replication/sql-warm-sync.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { startCluster } from "./cluster";
+import {
+  createClusterClient,
+  getClusterNode,
+  notifyReplicationFromPeer,
+  openSqlReplicationSession,
+  reconcileSqlFromPeer,
+  uniqueReplicationPrefix,
+  waitForCondition,
+} from "./helpers";
+
+async function replicationNotificationsEnabled(nodeUrl: string): Promise<boolean> {
+  const response = await fetch(`${nodeUrl}/replication/info`);
+  if (!response.ok) {
+    throw new Error(`Failed to load replication info from ${nodeUrl}: ${response.status}`);
+  }
+  const info = (await response.json()) as {
+    capabilities?: { notifications?: boolean };
+  };
+  return info.capabilities?.notifications ?? false;
+}
+
+describe("Replication SQL Warm Sync", () => {
+  test(
+    "uses authenticated notify long-poll to mark a SQL database dirty before reconcile",
+    { timeout: 600_000 },
+    async () => {
+      const cluster = await startCluster();
+      try {
+        const prefix = uniqueReplicationPrefix("sql-warm-sync");
+        const authority = createClusterClient(cluster, "node-a", prefix);
+        const replica = createClusterClient(cluster, "node-b", prefix);
+        const authorityNode = getClusterNode(cluster, "node-a");
+        const replicaNode = getClusterNode(cluster, "node-b");
+
+        await authority.signIn();
+        await replica.signIn();
+
+        expect(authority.spaceId).toBeDefined();
+        expect(replica.spaceId).toBe(authority.spaceId);
+
+        if (!(await replicationNotificationsEnabled(authorityNode.url))) {
+          throw new Error("replication notifications are not enabled on the authority node");
+        }
+
+        const suffix = Date.now().toString(36);
+        const dbName = `warm_sync_sql_${suffix}`;
+        const tableName = `items_${suffix}`;
+        const sql = authority.sql.db(dbName);
+        const replicaSql = replica.sql.db(dbName);
+
+        await sql.execute(`CREATE TABLE ${tableName} (id INTEGER PRIMARY KEY, label TEXT)`);
+
+        const notifySession = await openSqlReplicationSession(
+          replica,
+          authorityNode.url,
+          dbName
+        );
+        const baselineNotification = await notifyReplicationFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            service: "sql",
+            dbName,
+            lastSeenSeq: 0,
+            timeoutMs: 100,
+          },
+          notifySession
+        );
+        expect(baselineNotification.dirty).toBe(true);
+        expect(baselineNotification.latestSeq).toBeGreaterThan(0);
+        const notifyPromise = notifyReplicationFromPeer(
+          cluster,
+          "node-a",
+          {
+            spaceId: authority.spaceId!,
+            service: "sql",
+            dbName,
+            lastSeenSeq: baselineNotification.latestSeq,
+            timeoutMs: 30_000,
+          },
+          notifySession
+        );
+
+        await sql.execute(`INSERT INTO ${tableName} (id, label) VALUES (?, ?)`, [
+          1,
+          "notify-warm-sync",
+        ]);
+
+        const notification = await notifyPromise;
+        expect(notification.spaceId).toBe(authority.spaceId!);
+        expect(notification.service).toBe("sql");
+        expect(notification.dbName).toBe(dbName);
+        expect(notification.dirty).toBe(true);
+        expect(notification.timedOut).toBe(false);
+        expect(notification.latestSeq).toBeGreaterThan(0);
+
+        const reconcileResult = await reconcileSqlFromPeer(
+          cluster,
+          "node-b",
+          {
+            peerUrl: authorityNode.url,
+            spaceId: authority.spaceId!,
+            dbName,
+          },
+          {
+            target: await openSqlReplicationSession(replica, replicaNode.url, dbName),
+            peer: await openSqlReplicationSession(authority, authorityNode.url, dbName),
+          }
+        );
+
+        expect(reconcileResult.snapshotBytes).toBeGreaterThan(0);
+
+        await waitForCondition("replica reconciles SQL database after notify", async () => {
+          const result = await replicaSql.query<{ id: number; label: string }>(
+            `SELECT id, label FROM ${tableName} WHERE id = ?`,
+            [1]
+          );
+          return result.ok && result.data.rows[0]?.[1] === "notify-warm-sync";
+        });
+
+        const warmed = await replicaSql.query<{ id: number; label: string }>(
+          `SELECT id, label FROM ${tableName} WHERE id = ?`,
+          [1]
+        );
+        expect(warmed.ok).toBe(true);
+        if (!warmed.ok) {
+          throw new Error(warmed.error.message);
+        }
+        expect(warmed.data.rows[0]?.[1]).toBe("notify-warm-sync");
+      } finally {
+        await cluster.stop();
+      }
+    }
+  );
+});

--- a/tests/node-sdk/replication/sql-warm-sync.test.ts
+++ b/tests/node-sdk/replication/sql-warm-sync.test.ts
@@ -3,7 +3,6 @@ import { startCluster } from "./cluster";
 import {
   createClusterClient,
   getClusterNode,
-  notifyReplicationFromPeer,
   openSqlReplicationSession,
   reconcileSqlFromPeer,
   uniqueReplicationPrefix,
@@ -57,32 +56,25 @@ describe("Replication SQL Warm Sync", () => {
           authorityNode.url,
           dbName
         );
-        const baselineNotification = await notifyReplicationFromPeer(
-          cluster,
-          "node-a",
+        const baselineNotification = await authority.notifyReplication(
+          notifySession,
           {
             spaceId: authority.spaceId!,
             service: "sql",
             dbName,
             lastSeenSeq: 0,
             timeoutMs: 100,
-          },
-          notifySession
+          }
         );
         expect(baselineNotification.dirty).toBe(true);
         expect(baselineNotification.latestSeq).toBeGreaterThan(0);
-        const notifyPromise = notifyReplicationFromPeer(
-          cluster,
-          "node-a",
-          {
-            spaceId: authority.spaceId!,
-            service: "sql",
-            dbName,
-            lastSeenSeq: baselineNotification.latestSeq,
-            timeoutMs: 30_000,
-          },
-          notifySession
-        );
+        const notifyPromise = authority.notifyReplication(notifySession, {
+          spaceId: authority.spaceId!,
+          service: "sql",
+          dbName,
+          lastSeenSeq: baselineNotification.latestSeq,
+          timeoutMs: 30_000,
+        });
 
         await sql.execute(`INSERT INTO ${tableName} (id, label) VALUES (?, ?)`, [
           1,


### PR DESCRIPTION
## Summary
- add replication session support to `@tinycloud/node-sdk`
- add a live multi-node replication harness under `tests/node-sdk/replication`
- cover KV, SQLite, delegation, restart catch-up, peer-serving, offline/provisional, schema drift, and auth-session flows with real `tinycloud` processes

## Verification
- `bun run build` in `packages/node-sdk`
- `TC_REPLICATION_NODE_BIN=/mnt/HC_Volume_105362075/cargo-target/debug/tinycloud bun test replication/`

## Notes
- the replication suite uses real nodes only; no mocked transport or fake replication state
- the auth-session tests open short-lived transport sessions before export and reconcile
- the suite expects ports in the `8000-8999` range and a real `tinycloud` binary
