### PR TITLE
fix(ci): use NPM_CONFIG_TOKEN for npm publish auth

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -87,11 +87,11 @@ jobs:
           for dir in packages/sdk-core packages/node-sdk packages/web-sdk packages/sdk-services packages/cli packages/sdk-rs/packages/node packages/sdk-rs/packages/web; do
             if [ -f "$dir/package.json" ] && ! grep -q '"private"' "$dir/package.json"; then
               echo "Publishing $dir..."
-              (cd "$dir" && npm publish --access public --tag beta --token "${NPM_TOKEN}") || true
+              (cd "$dir" && npm publish --access public --tag beta)
             fi
           done
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit beta version bumps
         if: steps.check.outputs.pending != '0'
@@ -172,11 +172,11 @@ jobs:
           for dir in packages/sdk-core packages/node-sdk packages/web-sdk packages/sdk-services packages/cli packages/sdk-rs/packages/node packages/sdk-rs/packages/web; do
             if [ -f "$dir/package.json" ] && ! grep -q '"private"' "$dir/package.json"; then
               echo "Publishing $dir..."
-              (cd "$dir" && npm publish --access public --token "${NPM_TOKEN}") || true
+              (cd "$dir" && npm publish --access public)
             fi
           done
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Re-enter pre mode for next beta cycle
         run: bun changeset pre enter beta


### PR DESCRIPTION
## Problem

Both `npm publish` steps in `.github/workflows/changesets.yml` (beta and stable) were silently failing with `ENEEDAUTH`, while the workflow reported success. Three bugs combined to hide this:

1. `npm publish` does **not** accept a `--token` flag — it was silently ignored.
2. The publish loop was suffixed with `|| true`, swallowing the non-zero exit.
3. The step exported `NPM_TOKEN`, but `npm` does not read that env var. It reads `NPM_CONFIG_TOKEN` (or an `.npmrc` auth entry).

Net effect: every release built the packages, "published" them, committed version bumps, and tagged — but nothing ever hit the registry.

## Fix

Applied to **both** the beta and stable publish steps in `.github/workflows/changesets.yml`:

- Removed the bogus `--token "${NPM_TOKEN}"` flag from the `npm publish` invocation.
- Removed the `|| true` suffix so publish failures surface as workflow failures.
- Renamed the env var from `NPM_TOKEN` to `NPM_CONFIG_TOKEN` so `npm` picks it up automatically.

The per-package loop structure and the `resolve-workspace-versions` node script are unchanged.

## Scope

Only `.github/workflows/changesets.yml` is touched. No other changes.