### PR TITLE
fix(ci): auto-detect npm dist-tag in raw-publish

### DIFF
--- a/.github/workflows/raw-publish.yml
+++ b/.github/workflows/raw-publish.yml
@@ -4,14 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'npm dist-tag (beta, latest, next)'
-        type: choice
-        options:
-          - beta
-          - latest
-          - next
-        default: 'beta'
-        required: true
+        description: 'npm dist-tag override (leave empty to auto-detect from version)'
+        type: string
+        default: ''
+        required: false
       dry_run:
         description: 'Dry run (pack + list, do not publish)'
         type: boolean
@@ -78,7 +74,20 @@ jobs:
             if [ -f "$dir/package.json" ] && ! grep -q '"private": true' "$dir/package.json"; then
               name=$(node -p "require('./$dir/package.json').name")
               version=$(node -p "require('./$dir/package.json').version")
-              echo "  - $name@$version"
+
+              # Auto-detect tag from version, or use override
+              if [ -n "${{ inputs.tag }}" ]; then
+                tag="${{ inputs.tag }}"
+              else
+                prerelease=$(echo "$version" | sed -n 's/.*-\([a-zA-Z]*\)\..*/\1/p')
+                if [ -n "$prerelease" ]; then
+                  tag="$prerelease"
+                else
+                  tag="latest"
+                fi
+              fi
+
+              echo "  - $name@$version (tag: $tag)"
             fi
           done
 
@@ -89,8 +98,22 @@ jobs:
             if [ -f "$dir/package.json" ] && ! grep -q '"private": true' "$dir/package.json"; then
               name=$(node -p "require('./$dir/package.json').name")
               version=$(node -p "require('./$dir/package.json').version")
-              echo "Publishing $name@$version with tag ${{ inputs.tag }}..."
-              (cd "$dir" && npm publish --access public --tag ${{ inputs.tag }})
+
+              # Auto-detect tag from version, or use override
+              if [ -n "${{ inputs.tag }}" ]; then
+                tag="${{ inputs.tag }}"
+              else
+                # Parse prerelease identifier from version (e.g. "2.0.3-beta.3" -> "beta")
+                prerelease=$(echo "$version" | sed -n 's/.*-\([a-zA-Z]*\)\..*/\1/p')
+                if [ -n "$prerelease" ]; then
+                  tag="$prerelease"
+                else
+                  tag="latest"
+                fi
+              fi
+
+              echo "Publishing $name@$version with tag $tag..."
+              (cd "$dir" && npm publish --access public --tag "$tag")
             fi
           done
         env:


### PR DESCRIPTION
## Summary
- Replaces the required `tag` choice input in `raw-publish.yml` with an optional string override that defaults to empty
- When no override is given, each package's dist-tag is auto-detected from its version string: prerelease identifier (e.g. `2.0.3-beta.3` -> `beta`) or `latest` for stable versions
- Users can still force a specific tag by filling in the `tag` input

## Why
Previously users had to manually pick `beta`/`latest`/`next` on every run, which was error-prone when packages in the monorepo were on different prerelease tracks. Parsing from the version keeps the tag consistent with the actual package version.

## Test plan
- [ ] Trigger workflow with empty `tag` input against a package on a `-beta.N` version and confirm it publishes to the `beta` dist-tag
- [ ] Trigger workflow with empty `tag` input against a stable version and confirm it publishes to `latest`
- [ ] Trigger workflow with an explicit `tag` override and confirm it wins over auto-detection
- [ ] Dry run path still lists packages and runs `npm pack --dry-run`