### PR TITLE
fix(ci): use setup-node registry-url for npm publish auth

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -57,6 +57,13 @@ jobs:
         env:
           BUILD_SETUP_ENABLED: true
 
+      - name: Setup Node for npm publish
+        if: steps.check.outputs.pending != '0'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Publish beta to npm
         if: steps.check.outputs.pending != '0'
         run: |
@@ -91,7 +98,7 @@ jobs:
             fi
           done
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit beta version bumps
         if: steps.check.outputs.pending != '0'
@@ -143,6 +150,12 @@ jobs:
         env:
           BUILD_SETUP_ENABLED: true
 
+      - name: Setup Node for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Publish stable to npm
         run: |
           # Resolve workspace:* to real versions before publishing
@@ -176,7 +189,7 @@ jobs:
             fi
           done
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Re-enter pre mode for next beta cycle
         run: bun changeset pre enter beta

--- a/.github/workflows/raw-publish.yml
+++ b/.github/workflows/raw-publish.yml
@@ -91,6 +91,13 @@ jobs:
             fi
           done
 
+      - name: Setup Node for npm publish
+        if: ${{ !inputs.dry_run }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Publish to npm
         if: ${{ !inputs.dry_run }}
         run: |
@@ -117,7 +124,7 @@ jobs:
             fi
           done
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry run pack
         if: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Summary

- Adds `actions/setup-node@v4` with `registry-url` before each npm publish step in both `changesets.yml` (beta + stable jobs) and `raw-publish.yml`.
- Switches the publish step `env` from `NPM_CONFIG_TOKEN` to `NODE_AUTH_TOKEN`, which is the token the `setup-node`-generated `.npmrc` substitutes at runtime.

## Why

The previous `NPM_CONFIG_TOKEN` approach doesn't work for scoped package publishing. npm requires a registry-specific auth entry (`//registry.npmjs.org/:_authToken=...`) in `.npmrc`, which is exactly what `setup-node` with `registry-url` writes. This is the idiomatic GitHub Actions pattern for publishing to npm.

## Scope

- No changes to version numbers, workspace:* resolution, or any other publish logic.
- Bun is still used for install/build; `setup-node` is only added so `npm publish` has a valid `.npmrc`.

## Test plan

- [ ] Merge to master
- [ ] Trigger Raw Publish workflow with `dry_run=false` to confirm the beta actually publishes
- [ ] Verify `npm view @tinycloud/web-sdk dist-tags` shows the new beta