### PR TITLE
chore(release): 2.0.4 stable with SIWE nonce fix

### DIFF
--- a/.github/workflows/raw-publish.yml
+++ b/.github/workflows/raw-publish.yml
@@ -75,6 +75,12 @@ jobs:
               name=$(node -p "require('./$dir/package.json').name")
               version=$(node -p "require('./$dir/package.json').version")
 
+              # Skip if this version is already published
+              if npm view "$name@$version" version >/dev/null 2>&1; then
+                echo "  - $name@$version (SKIP — already published)"
+                continue
+              fi
+
               # Auto-detect tag from version, or use override
               if [ -n "${{ inputs.tag }}" ]; then
                 tag="${{ inputs.tag }}"
@@ -106,6 +112,12 @@ jobs:
               name=$(node -p "require('./$dir/package.json').name")
               version=$(node -p "require('./$dir/package.json').version")
 
+              # Skip if this version is already published
+              if npm view "$name@$version" version >/dev/null 2>&1; then
+                echo "Skipping $name@$version — already published"
+                continue
+              fi
+
               # Auto-detect tag from version, or use override
               if [ -n "${{ inputs.tag }}" ]; then
                 tag="${{ inputs.tag }}"
@@ -131,7 +143,16 @@ jobs:
         run: |
           for dir in packages/*/; do
             if [ -f "$dir/package.json" ] && ! grep -q '"private": true' "$dir/package.json"; then
-              echo "=== $dir ==="
+              name=$(node -p "require('./$dir/package.json').name")
+              version=$(node -p "require('./$dir/package.json').version")
+
+              # Skip if this version is already published
+              if npm view "$name@$version" version >/dev/null 2>&1; then
+                echo "=== $dir (SKIP — $name@$version already published) ==="
+                continue
+              fi
+
+              echo "=== $dir (would publish $name@$version) ==="
               (cd "$dir" && npm pack --dry-run)
             fi
           done

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/cli",
-  "version": "0.4.6-beta.0",
+  "version": "0.4.6",
   "description": "TinyCloud CLI - manage data, delegations, and nodes from the terminal",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -23,7 +23,7 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "@tinycloud/node-sdk": "2.0.4-beta.0",
+    "@tinycloud/node-sdk": "2.0.4",
     "@tinycloud/node-sdk-wasm": "1.7.1",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/node-sdk",
-  "version": "2.0.4-beta.0",
+  "version": "2.0.4",
   "description": "TinyCloud SDK for Node.js with configurable authorization strategies",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -32,7 +32,7 @@
     "test": "echo 'Tests are in tests/node-sdk workspace'"
   },
   "dependencies": {
-    "@tinycloud/sdk-core": "2.0.4-beta.0",
+    "@tinycloud/sdk-core": "2.0.4",
     "@tinycloud/node-sdk-wasm": "1.7.1",
     "siwe": "^3.0.0"
   },

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/sdk-core",
-  "version": "2.0.4-beta.0",
+  "version": "2.0.4",
   "description": "Core TinyCloud SDK - shared interfaces and TinyCloud class",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -24,7 +24,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@tinycloud/sdk-services": "2.0.3",
+    "@tinycloud/sdk-services": "2.0.4",
     "siwe": "^3.0.0",
     "zod": "^3.22.0",
     "zod-to-json-schema": "^3.22.0"

--- a/packages/sdk-services/package.json
+++ b/packages/sdk-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/sdk-services",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "TinyCloud SDK Services - Platform-agnostic service implementations",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/web-sdk",
-  "version": "2.0.4-beta.0",
+  "version": "2.0.4",
   "description": "A set of tools and utilities to help you build your app with TinyCloud.",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
@@ -38,8 +38,8 @@
     "@metamask/detect-provider": "^1.2.0",
     "@multiformats/multiaddr": "^13.0.1",
     "@multiformats/multiaddr-to-uri": "^12.0.0",
-    "@tinycloud/node-sdk": "2.0.4-beta.0",
-    "@tinycloud/sdk-core": "2.0.4-beta.0",
+    "@tinycloud/node-sdk": "2.0.4",
+    "@tinycloud/sdk-core": "2.0.4",
     "@tinycloud/web-sdk-wasm": "1.7.1",
     "axios": "^1.7.9",
     "ethers": "^5.7.2",


### PR DESCRIPTION
## Summary

- Manually bumps all non-private packages to a clean stable `2.0.4` (cli to `0.4.6`) so the SIWE nonce passthrough fix from tinycloud-node#43 + the WASM rev update finally lands on npm.
- Makes `raw-publish.yml` idempotent by checking `npm view <name>@<version>` before each publish and skipping with a log line if that version already exists. Applied to list, publish, and dry-run steps.

## Context

Previous publish runs left npm in an inconsistent state:

| Package | npm `latest` before this PR |
| --- | --- |
| `@tinycloud/cli` | 0.4.5 |
| `@tinycloud/node-sdk` | 2.0.3 |
| `@tinycloud/sdk-core` | 2.0.3 |
| `@tinycloud/sdk-services` | 2.0.3 (but master was still at `2.0.3` — collision) |
| `@tinycloud/web-sdk` | 2.0.1 (never caught up — loop aborted on collision) |

`web-sdk@2.0.1` is missing the nonce fix entirely. This PR picks a fresh minor-patch that cannot collide with any existing npm version, so the fix can actually ship.

## Version bumps

```
@tinycloud/sdk-services  2.0.3         -> 2.0.4
@tinycloud/sdk-core      2.0.4-beta.0  -> 2.0.4
@tinycloud/node-sdk      2.0.4-beta.0  -> 2.0.4
@tinycloud/web-sdk       2.0.4-beta.0  -> 2.0.4
@tinycloud/cli           0.4.6-beta.0  -> 0.4.6
```

Pinned internal deps updated to match:
- `sdk-core` -> `sdk-services@2.0.4`
- `node-sdk` -> `sdk-core@2.0.4`
- `web-sdk` -> `node-sdk@2.0.4`, `sdk-core@2.0.4`
- `cli` -> `node-sdk@2.0.4`

No changesets — this is a manual release bump to recover from the partial-publish state.

## Workflow idempotency

The publish loop now skips any `<name>@<version>` pair that already resolves via `npm view`. This means: re-running `raw-publish.yml` after a partial failure is safe, and anyone can dry-run the workflow to see exactly which packages would publish vs. skip.

## Test plan

- [ ] Merge and trigger `raw-publish.yml` with `dry_run=false`
- [ ] Verify `npm view @tinycloud/web-sdk dist-tags` shows `latest: 2.0.4`
- [ ] Verify `npm view @tinycloud/sdk-services@2.0.4 version` succeeds
- [ ] Confirm all 5 packages published cleanly with the `latest` tag