### PR TITLE
fix: re-export invokeAny from node-sdk-wasm

### DIFF
--- a/.changeset/reexport-invoke-any.md
+++ b/.changeset/reexport-invoke-any.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/node-sdk-wasm": patch
+"@tinycloud/web-sdk-wasm": patch
+---
+
+Re-export `invokeAny` from the node and web WASM bindings. Unblocks `@tinycloud/node-sdk@2.1.x`, which imports `invokeAny` at module load; against the published `@tinycloud/node-sdk-wasm@1.7.1` artifact (built before the symbol existed) consumers hit `SyntaxError: Export named 'invokeAny' not found in module '@tinycloud/node-sdk-wasm'`. The Rust source and TypeScript wrappers already expose `invokeAny` on master (PR #173); this changeset exists to trigger a new WASM release so the symbol reaches npm.


### PR DESCRIPTION
## Symptom

Downstream consumers bumping `@tinycloud/node-sdk` from `2.0.4` to `2.1.0-beta.0` hit a module-load failure in tests that import from `@tinycloud/node-sdk`:

```
SyntaxError: Export named 'invokeAny' not found in module
'@tinycloud/node-sdk-wasm@1.7.1/dist/index.js'
```

Verified this blocks e.g. the TinyCloudLabs listen app backend `delegations.test.ts`.

## Root cause

Timeline:

1. `0009729` (2026-04-09 16:48 UTC) — `chore: release stable packages` cut `@tinycloud/{node,web}-sdk-wasm@1.7.1` from a source tree that did **not** have `invokeAny`.
2. `61c031d` (2026-04-09 19:41 UTC, PR #173) — `feat: add write hooks sdk support and live tests through phase 4` added `invokeAny` to the Rust source (`packages/sdk-rs/src/lib.rs`) and to both TS wrapper re-export lists (`packages/sdk-rs/packages/{node,web}/src/index.ts`).
3. No WASM release has happened since — so the published `@tinycloud/node-sdk-wasm@1.7.1` artifact on npm still lacks the symbol, even though master is correct.

`@tinycloud/node-sdk@2.1.0-beta.0` was published with `import { ..., invokeAny, ... } from '@tinycloud/node-sdk-wasm'` at the top of `dist/index.d.cts`, pinned against the broken `1.7.1` artifact. Module load fails before any code runs.

## The fix

This PR adds a single changeset (`.changeset/reexport-invoke-any.md`) that patches both `@tinycloud/node-sdk-wasm` and `@tinycloud/web-sdk-wasm`. **No source changes are needed** — the Rust and TS already expose `invokeAny` on master. This PR exists solely to trigger a new WASM release so the symbol reaches npm.

On merge, `.github/workflows/changesets.yml` (beta job) will:
1. Install Rust + `wasm-pack`
2. Run `bun changeset version` → bump both WASM packages to `1.7.2-beta.0`
3. Run `bun run build` → rebuild `sdk-rs` via `wasm-pack`, producing fresh `node-sdk-wasm/` and `web-sdk-wasm/` output that includes `invokeAny` (because the Rust has `#[wasm_bindgen] pub fn invokeAny` at `packages/sdk-rs/src/lib.rs:38-44`)
4. Publish both WASM packages to npm under the `beta` dist-tag

Downstream consumers can then `bun add @tinycloud/node-sdk-wasm@beta` (or rely on the linked TS group picking up the new wasm via a subsequent beta bump) to pick up the fix.

## Scope and cascade

- **Linked group:** Per PR #181, `@tinycloud/{node,web}-sdk-wasm` are **no longer** in the `.changeset/config.json` `linked` group. This patch therefore does NOT cascade into the TS SDK family (`@tinycloud/{sdk-core,sdk-services,node-sdk,web-sdk}`), which is the documented and intended behavior — the WASM packages release on their own cadence per `docs/versioning.md`.
- **`updateInternalDependencies: "patch"`:** `bunx changeset status` shows the expected bump cascade into apps/CLI that list the wasm packages as deps (`@tinycloud/cli`, `@tinycloud/node-demo`, `openkey-vite`, `tinycloud-openkey-example-app`). This is normal internal-dependency tracking and does not affect published TS SDK versions.
- Both wasm packages are bumped (not just node) because they build from the same Rust crate and share the same gap; shipping only the node one would leave web consumers hitting the identical failure on their next `@tinycloud/web-sdk` beta.

## Why not a code change?

I verified end-to-end that the fix is already in code:

- `packages/sdk-rs/src/lib.rs:38-44` — `#[wasm_bindgen] #[allow(non_snake_case)] pub fn invokeAny(...)`
- `packages/sdk-rs/packages/node/src/index.ts:19` — `invokeAny` is in the explicit named re-export list
- `packages/sdk-rs/packages/web/src/index.ts:22` — `export import invokeAny = lib.invokeAny`

The `dist/index.js` that ships in `1.7.1` on npm does not have it because that artifact was built from a pre-#173 tree. Running `bun run build` on current master will produce a `dist/index.js` containing `invokeAny` without any code edit.

## Test plan

- [ ] CI beta job succeeds on merge and publishes `@tinycloud/node-sdk-wasm@1.7.2-beta.0` (or equivalent) to npm with `invokeAny` in the named export list of `dist/index.js` and `dist/index.d.ts`
- [ ] CI beta job also publishes `@tinycloud/web-sdk-wasm@1.7.2-beta.0` with the same fix
- [ ] Downstream `@tinycloud/node-sdk@2.1.x` module-loads cleanly against the new WASM beta (reproduce with the failing listen-app `delegations.test.ts`)
- [ ] No unintended bumps on the TS SDK linked group (verify with `bunx changeset status` on master post-merge; the linked group should only move due to the pre-existing `trigger-nonce-republish` and `write-hooks-phase2` changesets)