### PR TITLE
fix(ci): use changeset publish to handle idempotent beta releases

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -48,6 +48,15 @@ jobs:
           COUNT=$(find .changeset -name '*.md' ! -name 'README.md' | wc -l)
           echo "pending=$COUNT" >> "$GITHUB_OUTPUT"
 
+      - name: List pending changesets
+        if: steps.check.outputs.pending != '0'
+        run: |
+          echo "## Pending changesets to consume:"
+          find .changeset -name '*.md' ! -name 'README.md' -exec basename {} \; | sort
+          echo ""
+          echo "## Current pre.json state:"
+          cat .changeset/pre.json
+
       - name: Version and build
         if: steps.check.outputs.pending != '0'
         run: |
@@ -67,7 +76,9 @@ jobs:
       - name: Publish beta to npm
         if: steps.check.outputs.pending != '0'
         run: |
-          # Resolve workspace:* to real versions before publishing
+          # Resolve workspace:* to real versions before publishing.
+          # Belt-and-suspenders: changeset publish also resolves internally,
+          # but keeping this script ensures consistency with the prior workflow.
           node -e '
             const fs = require("fs");
             const glob = require("child_process").execSync("find packages -name package.json -not -path */node_modules/*", {encoding:"utf8"}).trim().split("\n");
@@ -91,12 +102,12 @@ jobs:
               if (changed) { fs.writeFileSync(f, JSON.stringify(pkg, null, 2) + "\n"); console.log("Resolved workspace refs in", f); }
             }
           '
-          for dir in packages/sdk-core packages/node-sdk packages/web-sdk packages/sdk-services packages/cli packages/sdk-rs/packages/node packages/sdk-rs/packages/web; do
-            if [ -f "$dir/package.json" ] && ! grep -q '"private"' "$dir/package.json"; then
-              echo "Publishing $dir..."
-              (cd "$dir" && npm publish --access public --tag beta)
-            fi
-          done
+          # Use `changeset publish` instead of a hand-rolled loop so that
+          # already-published versions are skipped gracefully. The hand-rolled
+          # loop 403'd on sdk-core@2.1.0-beta.0 in the 2026-04-10 release after
+          # PR #182, aborting before the wasm packages (which actually needed
+          # publishing) were attempted.
+          bunx changeset publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -158,7 +169,9 @@ jobs:
 
       - name: Publish stable to npm
         run: |
-          # Resolve workspace:* to real versions before publishing
+          # Resolve workspace:* to real versions before publishing.
+          # Belt-and-suspenders: changeset publish also resolves internally,
+          # but keeping this script ensures consistency with the prior workflow.
           node -e '
             const fs = require("fs");
             const glob = require("child_process").execSync("find packages -name package.json -not -path */node_modules/*", {encoding:"utf8"}).trim().split("\n");
@@ -182,12 +195,10 @@ jobs:
               if (changed) { fs.writeFileSync(f, JSON.stringify(pkg, null, 2) + "\n"); console.log("Resolved workspace refs in", f); }
             }
           '
-          for dir in packages/sdk-core packages/node-sdk packages/web-sdk packages/sdk-services packages/cli packages/sdk-rs/packages/node packages/sdk-rs/packages/web; do
-            if [ -f "$dir/package.json" ] && ! grep -q '"private"' "$dir/package.json"; then
-              echo "Publishing $dir..."
-              (cd "$dir" && npm publish --access public)
-            fi
-          done
+          # Use `changeset publish` instead of a hand-rolled loop so that
+          # already-published versions are skipped gracefully, matching the
+          # beta job's behavior.
+          bunx changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Root cause

The hand-rolled publish loop in the beta/stable release jobs
unconditionally tried `npm publish` on every non-private package
in an explicit dir list. It had no idempotence: if any single
version already existed on npm, `set -e` aborted the loop and
later packages in the list never published.

This fired on 2026-04-10 after PR #182 merged:

1. `bun changeset version` bumped sdk-core et al to 2.1.0-beta.0
   (minor from the pre.json initialVersion 2.0.4) and node-sdk-wasm
   to 1.7.2-beta.0 (patch).
2. `@tinycloud/sdk-core@2.1.0-beta.0` was already on npm from before
   the 2.0.4 stable release.
3. The loop hit sdk-core first, got 403, and aborted. The wasm
   packages that actually needed publishing (to re-export invokeAny)
   were never reached.

## Fix

Replace the loop with `bunx changeset publish`, which is idempotent
by design: it reports "already published" for pre-existing versions
and continues to the next package.

Also adds a pre-version step that logs pending changesets and the
current pre.json to the workflow output, so future debugging can
immediately see what will be consumed.

## Not fixed by this PR

The stale pre.json drift from PR #181 is a separate concern — the
lead is tracking it independently. This PR only makes the publish
step robust to that kind of drift going forward.