### PR TITLE
feat: manifest + capability-chain delegation

### DIFF
--- a/.changeset/capability-chain-manifest.md
+++ b/.changeset/capability-chain-manifest.md
@@ -1,0 +1,12 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk-wasm": patch
+"@tinycloud/web-sdk-wasm": patch
+---
+
+Add manifest and capability-chain primitives to `@tinycloud/sdk-core`, and re-export `parseRecapFromSiwe` from both WASM wrappers.
+
+- `@tinycloud/sdk-core` gains `Manifest`, `PermissionEntry`, `ResolvedCapabilities`, `resolveManifest`, `parseExpiry`, `expandActionShortNames`, default-tier constants, `isCapabilitySubset`, `parseRecapCapabilities`, `PermissionNotInManifestError`, and `SessionExpiredError`. These are the building blocks for the `delegateTo` / `requestPermissions` flow that will follow in `@tinycloud/node-sdk` and `@tinycloud/web-sdk`.
+- `@tinycloud/node-sdk-wasm` and `@tinycloud/web-sdk-wasm` re-export `parseRecapFromSiwe`, the new WASM export in `tinycloud-node` that decodes recap capabilities from a signed SIWE message.
+- The Rust rev in `packages/sdk-rs/Cargo.toml` is bumped to the commit that introduced `parseRecapFromSiwe`.
+- New `ms` dependency on `@tinycloud/sdk-core` for duration parsing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "cacaos"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
 dependencies = [
  "async-trait",
  "hex",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
 dependencies = [
  "hex",
  "http 1.4.0",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "siwe-recap"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
 dependencies = [
  "base64 0.22.1",
  "ipld-core",
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-auth"
 version = "1.2.1"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-rs"
 version = "1.2.1"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
 dependencies = [
  "async-trait",
  "hex",
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-wasm"
 version = "1.2.1"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=e0449685#e04496856a8c0dc2288d5e828754a24e6091fe82"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
 dependencies = [
  "aes-gcm",
  "chrono",

--- a/bun.lock
+++ b/bun.lock
@@ -165,7 +165,7 @@
     },
     "packages/cli": {
       "name": "@tinycloud/cli",
-      "version": "0.4.6-beta.0",
+      "version": "0.4.6",
       "bin": {
         "tc": "./bin/tc",
       },
@@ -185,7 +185,7 @@
     },
     "packages/node-sdk": {
       "name": "@tinycloud/node-sdk",
-      "version": "2.0.4-beta.0",
+      "version": "2.0.4",
       "dependencies": {
         "@tinycloud/node-sdk-wasm": "1.7.0",
         "@tinycloud/sdk-core": "2.0.3-beta.2",
@@ -199,14 +199,16 @@
     },
     "packages/sdk-core": {
       "name": "@tinycloud/sdk-core",
-      "version": "2.0.4-beta.0",
+      "version": "2.0.4",
       "dependencies": {
-        "@tinycloud/sdk-services": "2.0.2",
+        "@tinycloud/sdk-services": "2.0.4",
+        "ms": "^2.1.3",
         "siwe": "^3.0.0",
         "zod": "^3.22.0",
         "zod-to-json-schema": "^3.22.0",
       },
       "devDependencies": {
+        "@types/ms": "^0.7.34",
         "@types/node": "^20",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
@@ -243,7 +245,7 @@
     },
     "packages/sdk-services": {
       "name": "@tinycloud/sdk-services",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "zod": "^3.23.0",
       },
@@ -256,7 +258,7 @@
     },
     "packages/web-sdk": {
       "name": "@tinycloud/web-sdk",
-      "version": "2.0.4-beta.0",
+      "version": "2.0.4",
       "dependencies": {
         "@metamask/detect-provider": "^1.2.0",
         "@multiformats/multiaddr": "^13.0.1",
@@ -1801,7 +1803,7 @@
 
     "@types/minimatch": ["@types/minimatch@6.0.0", "", { "dependencies": { "minimatch": "*" } }, "sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA=="],
 
-    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+    "@types/ms": ["@types/ms@0.7.34", "", {}, "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="],
 
     "@types/node": ["@types/node@20.19.33", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw=="],
 
@@ -5590,6 +5592,8 @@
     "@tinycloud/web-sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@tufjs/models/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@types/debug/@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@typescript-eslint/experimental-utils/@typescript-eslint/utils": ["@typescript-eslint/utils@5.62.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@types/json-schema": "^7.0.9", "@types/semver": "^7.3.12", "@typescript-eslint/scope-manager": "5.62.0", "@typescript-eslint/types": "5.62.0", "@typescript-eslint/typescript-estree": "5.62.0", "eslint-scope": "^5.1.1", "semver": "^7.3.7" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ=="],
 

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf dist",
-    "test": "echo 'Tests are in tests/node-sdk workspace'"
+    "test": "bun test src/",
+    "test:integration": "echo 'Integration tests live in tests/node-sdk workspace'"
   },
   "dependencies": {
     "@tinycloud/sdk-core": "2.0.4",

--- a/packages/node-sdk/src/NodeWasmBindings.ts
+++ b/packages/node-sdk/src/NodeWasmBindings.ts
@@ -15,6 +15,7 @@ import {
   ensureEip55,
   makeSpaceId,
   createDelegation,
+  parseRecapFromSiwe,
   generateHostSIWEMessage,
   siweToDelegationHeaders,
   protocolVersion,
@@ -54,6 +55,7 @@ export class NodeWasmBindings implements IWasmBindings {
   ensureEip55 = ensureEip55;
   makeSpaceId = makeSpaceId;
   createDelegation = createDelegation;
+  parseRecapFromSiwe = parseRecapFromSiwe;
   generateHostSIWEMessage = generateHostSIWEMessage;
   siweToDelegationHeaders = siweToDelegationHeaders;
   protocolVersion = protocolVersion;

--- a/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Unit tests for {@link TinyCloudNode.delegateTo}.
+ *
+ * These tests stand up a TinyCloudNode in session-only mode with a fully
+ * mocked {@link IWasmBindings} so no real WASM is loaded and no server is
+ * contacted. A fake `tinyCloudSession` is attached directly to the
+ * internal auth shim so we can exercise the subset-check / wallet-path /
+ * expiry-check branches in isolation.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  PermissionNotInManifestError,
+  SessionExpiredError,
+  type PermissionEntry,
+  type IWasmBindings,
+  type ISessionManager,
+} from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a signed SIWE message string with a specific `Expiration Time`.
+ * Mirrors the fixture helper in delegateToHelpers.test.ts so both tests
+ * avoid depending on siwe-library output formatting.
+ */
+function buildSiwe(expirationTime: string | null): string {
+  const lines = [
+    "example.com wants you to sign in with your Ethereum account:",
+    "0x0000000000000000000000000000000000000001",
+    "",
+    "Sign-in statement",
+    "",
+    "URI: https://example.com",
+    "Version: 1",
+    "Chain ID: 1",
+    "Nonce: abcdefghij",
+    "Issued At: 2024-01-01T00:00:00.000Z",
+  ];
+  if (expirationTime !== null) {
+    lines.push(`Expiration Time: ${expirationTime}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Fake ISessionManager — enough for TinyCloudNode's constructor.
+ *
+ * The real WASM `TCWSessionManager.createSessionKey(id)` returns the same
+ * `id` back (the id is the caller-provided handle), and `jwk(id)` /
+ * `getDID(id)` are keyed off that id. The constructor code path is:
+ *
+ *   this.sessionKeyId = sessionManager.createSessionKey("default");
+ *   jwkStr = sessionManager.jwk(this.sessionKeyId);
+ *
+ * so our fake returns the id from createSessionKey, not a DID.
+ */
+function makeFakeSessionManager(): ISessionManager {
+  const keys = new Set<string>();
+  return {
+    createSessionKey(id: string): string {
+      keys.add(id);
+      return id;
+    },
+    renameSessionKeyId(oldId: string, newId: string): void {
+      if (keys.has(oldId)) {
+        keys.delete(oldId);
+        keys.add(newId);
+      }
+    },
+    getDID(keyId: string): string {
+      return `did:key:z6MkTest-${keyId}`;
+    },
+    jwk(keyId: string): string | undefined {
+      if (!keys.has(keyId)) {
+        return undefined;
+      }
+      return JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" });
+    },
+  };
+}
+
+/**
+ * A mocked IWasmBindings. Test callers override specific fields via the
+ * `overrides` param — we provide no-op defaults for everything the
+ * TinyCloudNode constructor touches.
+ */
+function makeFakeWasmBindings(
+  overrides: Partial<IWasmBindings> = {},
+): IWasmBindings {
+  const base: IWasmBindings = {
+    invoke: mock(() => Promise.resolve({} as any)) as any,
+    invokeAny: mock(() => Promise.resolve({} as any)) as any,
+    prepareSession: mock(() => ({})),
+    completeSessionSetup: mock(() => ({})),
+    ensureEip55: (a: string) => a,
+    makeSpaceId: (a: string, c: number, p: string) => `space://${a}:${c}:${p}`,
+    createDelegation: mock(() => ({
+      delegation: "fake-serialized-delegation",
+      cid: "bafyfake",
+      delegateDid: "did:pkh:eip155:1:0xDEAD",
+      path: "items/",
+      actions: ["tinycloud.kv/get"],
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+    })),
+    parseRecapFromSiwe: mock(() => [] as any[]),
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(),
+      privateKey: new Uint8Array(),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array()),
+    vault_sha256: mock(() => new Uint8Array()),
+    createSessionManager: makeFakeSessionManager,
+  };
+  return { ...base, ...overrides };
+}
+
+/**
+ * Install a fake session on a newly-constructed session-only TinyCloudNode
+ * so delegateTo can reach it via `this.auth?.tinyCloudSession`. The node
+ * starts session-only (no signer), so `this.auth` is null; we assign a
+ * minimal duck-typed stub that matches the `auth` shape delegateTo reads.
+ */
+function installFakeSession(
+  node: TinyCloudNode,
+  opts: {
+    siwe: string;
+    spaceId?: string;
+    address?: string;
+    chainId?: number;
+  },
+): void {
+  const fakeSession = {
+    address: opts.address ?? "0x0000000000000000000000000000000000000001",
+    chainId: opts.chainId ?? 1,
+    sessionKey: "default",
+    spaceId: opts.spaceId ?? "space://test",
+    delegationCid: "bafyparent",
+    delegationHeader: { Authorization: "Bearer parent" },
+    verificationMethod: "did:key:z6MkTestSession",
+    jwk: { kty: "OKP", crv: "Ed25519", x: "test" },
+    siwe: opts.siwe,
+    signature: "0xfake",
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (node as any).auth = { tinyCloudSession: fakeSession };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TinyCloudNode.delegateTo", () => {
+  const ALICE_DID = "did:pkh:eip155:1:0x0000000000000000000000000000000000000001";
+  const BOB_DID = "did:pkh:eip155:1:0x00000000000000000000000000000000000000BB";
+
+  const futureExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  test("no session → SessionExpiredError with epoch", async () => {
+    const wasm = makeFakeWasmBindings();
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    // Leave `auth` null — session-only with no attached session.
+
+    await expect(
+      node.delegateTo(BOB_DID, [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "items/",
+          actions: ["tinycloud.kv/get"],
+        },
+      ]),
+    ).rejects.toBeInstanceOf(SessionExpiredError);
+  });
+
+  test("expired session → SessionExpiredError with the expired date", async () => {
+    const wasm = makeFakeWasmBindings();
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    // Expiry in the past — clearly expired, well outside the 60s margin.
+    const pastIso = new Date(Date.now() - 60_000).toISOString();
+    installFakeSession(node, { siwe: buildSiwe(pastIso) });
+
+    await expect(
+      node.delegateTo(BOB_DID, [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "items/",
+          actions: ["tinycloud.kv/get"],
+        },
+      ]),
+    ).rejects.toBeInstanceOf(SessionExpiredError);
+  });
+
+  test("subset match → WASM path, no wallet prompt (prompted=false)", async () => {
+    // parseRecapFromSiwe returns the granted set (entire KV space); the
+    // test asserts delegateTo never touches prepareSession or the signer.
+    const grantedRaw = [
+      {
+        service: "kv", // short form — parseRecapCapabilities normalizes
+        space: "default",
+        path: "/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+
+    const parseSpy = mock(() => grantedRaw);
+    const createDelegationSpy = mock(() => ({
+      delegation: "fake-ucan-delegation",
+      cid: "bafyfakeucan",
+      delegateDid: BOB_DID,
+      path: "items/",
+      actions: ["tinycloud.kv/get"],
+      expiry: Math.floor((Date.now() + 3600_000) / 1000),
+    }));
+    const prepareSessionSpy = mock(() => ({}));
+
+    const wasm = makeFakeWasmBindings({
+      parseRecapFromSiwe: parseSpy as any,
+      createDelegation: createDelegationSpy as any,
+      prepareSession: prepareSessionSpy as any,
+    });
+
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+
+    const result = await node.delegateTo(BOB_DID, [
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "items/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ]);
+
+    expect(result.prompted).toBe(false);
+    expect(result.delegation.delegateDID).toBe(BOB_DID);
+    // WASM path was used.
+    expect(createDelegationSpy).toHaveBeenCalledTimes(1);
+    // Wallet path was NOT used.
+    expect(prepareSessionSpy).not.toHaveBeenCalled();
+  });
+
+  test("missing caps → PermissionNotInManifestError, no WASM or wallet call", async () => {
+    // Granted set covers kv/get only. Requesting kv/put should miss.
+    const parseSpy = mock(() => [
+      {
+        service: "kv",
+        space: "default",
+        path: "/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ]);
+    const createDelegationSpy = mock(() => ({}));
+    const prepareSessionSpy = mock(() => ({}));
+
+    const wasm = makeFakeWasmBindings({
+      parseRecapFromSiwe: parseSpy as any,
+      createDelegation: createDelegationSpy as any,
+      prepareSession: prepareSessionSpy as any,
+    });
+
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+
+    await expect(
+      node.delegateTo(BOB_DID, [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "items/",
+          actions: ["tinycloud.kv/put"],
+        },
+      ]),
+    ).rejects.toBeInstanceOf(PermissionNotInManifestError);
+
+    expect(createDelegationSpy).not.toHaveBeenCalled();
+    expect(prepareSessionSpy).not.toHaveBeenCalled();
+  });
+
+  test("multi-entry input throws a clear error", async () => {
+    const wasm = makeFakeWasmBindings();
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+
+    const entries: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "items/",
+        actions: ["tinycloud.kv/get"],
+      },
+      {
+        service: "tinycloud.sql",
+        space: "default",
+        path: "/",
+        actions: ["tinycloud.sql/read"],
+      },
+    ];
+
+    await expect(node.delegateTo(BOB_DID, entries)).rejects.toThrow(
+      /one permission entry per call/,
+    );
+  });
+
+  test("empty permissions array throws", async () => {
+    const wasm = makeFakeWasmBindings();
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+
+    await expect(node.delegateTo(BOB_DID, [])).rejects.toThrow(
+      /non-empty permissions array/,
+    );
+  });
+
+  test("forceWalletSign: true bypasses derivability check", async () => {
+    // No signer on the node → the wallet path will fail, but before it
+    // does we can assert the derivability check never fired. This is the
+    // cleanest way to verify the branch without mocking the full wallet
+    // activation stack (SIWE sign + activateSessionWithHost network call).
+    const parseSpy = mock(() => [
+      // Granting the full KV space — derivable, so the non-forced path
+      // would absolutely take the WASM route. forceWalletSign should
+      // still short-circuit past this.
+      {
+        service: "kv",
+        space: "default",
+        path: "/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ]);
+    const createDelegationSpy = mock(() => ({
+      delegation: "fake",
+      cid: "bafy",
+      delegateDid: BOB_DID,
+      path: "items/",
+      actions: ["tinycloud.kv/get"],
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+    }));
+
+    const wasm = makeFakeWasmBindings({
+      parseRecapFromSiwe: parseSpy as any,
+      createDelegation: createDelegationSpy as any,
+    });
+
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+
+    // Wallet path will fail at the session-only guard inside
+    // createDelegationWalletPath ("Cannot createDelegation() in session-
+    // only mode. Requires wallet mode."), which proves the forced path
+    // was taken.
+    await expect(
+      node.delegateTo(
+        BOB_DID,
+        [
+          {
+            service: "tinycloud.kv",
+            space: "default",
+            path: "items/",
+            actions: ["tinycloud.kv/get"],
+          },
+        ],
+        { forceWalletSign: true },
+      ),
+    ).rejects.toThrow(/session-only mode/);
+
+    // Derivability was never checked (parseRecapFromSiwe not called) and
+    // WASM createDelegation was not called either — we went straight to
+    // the wallet path.
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(createDelegationSpy).not.toHaveBeenCalled();
+  });
+
+  test("legacy createDelegation: derivable caps route through delegateTo fast path", async () => {
+    // Construct a session-only node, install a session granting full KV
+    // access, and call the legacy createDelegation method with a single
+    // service request. It should go through delegateTo → WASM path,
+    // returning a PortableDelegation without ever touching the wallet
+    // path (which would throw "session-only mode").
+    const parseSpy = mock(() => [
+      {
+        service: "kv",
+        space: "default",
+        path: "/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ]);
+    const createDelegationSpy = mock(() => ({
+      delegation: "fake-legacy-routed",
+      cid: "bafylegacy",
+      delegateDid: BOB_DID,
+      path: "items/",
+      actions: ["tinycloud.kv/get"],
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+    }));
+
+    const wasm = makeFakeWasmBindings({
+      parseRecapFromSiwe: parseSpy as any,
+      createDelegation: createDelegationSpy as any,
+    });
+
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+
+    // Legacy method bails in session-only mode before any routing, so we
+    // simulate the "signer present" state by attaching a minimal stub.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (node as any).signer = {
+      signMessage: async () => "0xfake",
+      getAddress: async () => "0x0000000000000000000000000000000000000001",
+      getChainId: async () => 1,
+    };
+
+    const result = await node.createDelegation({
+      path: "items/",
+      actions: ["tinycloud.kv/get"],
+      delegateDID: BOB_DID,
+    });
+
+    expect(result.delegateDID).toBe(BOB_DID);
+    // Subset check happened and WASM path was taken.
+    expect(parseSpy).toHaveBeenCalledTimes(1);
+    expect(createDelegationSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -75,6 +75,13 @@ import {
   CreateDelegationWasmResult,
   UnsupportedFeatureError,
   makePublicSpaceId,
+  // Capability-chain delegation
+  type PermissionEntry,
+  PermissionNotInManifestError,
+  SessionExpiredError,
+  expandActionShortNames,
+  isCapabilitySubset,
+  parseRecapCapabilities,
 } from "@tinycloud/sdk-core";
 import { NodeUserAuthorization } from "./authorization/NodeUserAuthorization";
 import { FileSessionStorage } from "./storage/FileSessionStorage";
@@ -82,6 +89,11 @@ import { MemorySessionStorage } from "./storage/MemorySessionStorage";
 import { PortableDelegation } from "./delegation";
 import { DelegatedAccess } from "./DelegatedAccess";
 import { WasmKeyProvider } from "./keys/WasmKeyProvider";
+import {
+  legacyParamsToPermissionEntries,
+  resolveExpiryMs,
+  extractSiweExpiration,
+} from "./delegateToHelpers";
 
 /** Default TinyCloud host */
 const DEFAULT_HOST = "https://node.tinycloud.xyz";
@@ -126,6 +138,37 @@ export interface TinyCloudNodeConfig {
   nonce?: string;
   /** Optional SIWE configuration overrides (e.g., nonce for server-provided nonces) */
   siweConfig?: SiweConfig;
+}
+
+/**
+ * Options for {@link TinyCloudNode.delegateTo}.
+ *
+ * `expiry` accepts either an ms-format duration string (e.g. `"7d"`, `"1h"`)
+ * or a raw number of milliseconds. When omitted, the default is 1 hour.
+ *
+ * `forceWalletSign` bypasses the derivability check and sends the
+ * delegation through the legacy wallet-signed SIWE path, which always
+ * triggers a wallet prompt. Used for testing, for explicit wallet
+ * confirmation flows, and by the legacy `createDelegation` fallback.
+ */
+export interface DelegateToOptions {
+  /** Override expiry. ms-format string ("7d", "1h") or raw milliseconds. */
+  expiry?: string | number;
+  /** Force the wallet-signed SIWE path even if the caps are derivable. Default false. */
+  forceWalletSign?: boolean;
+}
+
+/**
+ * Result of {@link TinyCloudNode.delegateTo}.
+ *
+ * `prompted` indicates whether a wallet prompt was shown — `true` for the
+ * legacy wallet path (always), `false` for the session-key UCAN path (never).
+ * Callers wiring single-prompt sign-in flows use this to assert that their
+ * capability chain was derivable.
+ */
+export interface DelegateToResult {
+  delegation: PortableDelegation;
+  prompted: boolean;
 }
 
 /**
@@ -1515,6 +1558,221 @@ export class TinyCloudNode {
     return this.delegationManager.checkPermission(path, action);
   }
 
+  // ===========================================================================
+  // Capability-chain delegation (spec: .claude/specs/capability-chain.md)
+  // ===========================================================================
+
+  /**
+   * Safety margin before the session's own expiry at which {@link delegateTo}
+   * will refuse to issue a derived delegation. Prevents issuing sub-delegations
+   * that would be invalid by the time the recipient used them. Spec: 60 seconds.
+   *
+   * @internal
+   */
+  private static readonly SESSION_EXPIRY_SAFETY_MARGIN_MS = 60_000;
+
+  /**
+   * Issue a delegation using the capability-chain flow.
+   *
+   * When the requested permissions are a subset of the current session's
+   * recap, the delegation is signed by the session key via WASM — no wallet
+   * prompt. When they are not, a {@link PermissionNotInManifestError} is
+   * raised so the caller can trigger an escalation flow (e.g.
+   * `TinyCloudWeb.requestPermissions`). Passing `forceWalletSign: true`
+   * bypasses the derivability check and always uses the wallet-signed SIWE
+   * path — used by the legacy `createDelegation` fallback and by callers
+   * that want explicit wallet confirmation.
+   *
+   * Current limitation: exactly one {@link PermissionEntry} per call. For
+   * multi-resource delegation, call `delegateTo` multiple times. This keeps
+   * each delegation a single `(spaceId, path)` grant, which matches the
+   * underlying `PortableDelegation` shape.
+   *
+   * @throws {@link SessionExpiredError} when there is no session or the
+   *   current session has expired (or will within the 60s safety margin).
+   * @throws {@link PermissionNotInManifestError} when the requested entries
+   *   are not a subset of the granted session capabilities and
+   *   `forceWalletSign` is not set.
+   */
+  async delegateTo(
+    did: string,
+    permissions: PermissionEntry[],
+    options?: DelegateToOptions,
+  ): Promise<DelegateToResult> {
+    // 1. Session validity check — fail fast with a clear error class so
+    //    callers can catch and trigger a fresh sign-in.
+    const session = this.auth?.tinyCloudSession;
+    if (!session) {
+      throw new SessionExpiredError(new Date(0));
+    }
+    const sessionExpiry = extractSiweExpiration(session.siwe);
+    if (sessionExpiry !== undefined) {
+      const now = Date.now();
+      const marginMs = TinyCloudNode.SESSION_EXPIRY_SAFETY_MARGIN_MS;
+      if (sessionExpiry.getTime() <= now + marginMs) {
+        throw new SessionExpiredError(sessionExpiry);
+      }
+    }
+
+    // 2. Require exactly one permission entry per call. The legacy
+    //    createDelegation API bundles actions across services for a single
+    //    (space, path), so we enforce the same cardinality here and let
+    //    callers loop for multi-entry scenarios.
+    if (!Array.isArray(permissions) || permissions.length === 0) {
+      throw new Error(
+        "delegateTo requires a non-empty permissions array",
+      );
+    }
+    if (permissions.length > 1) {
+      throw new Error(
+        "delegateTo currently supports one permission entry per call. " +
+          "Call delegateTo multiple times for multi-resource delegation.",
+      );
+    }
+    const entry = permissions[0];
+
+    // 3. Defensively expand any short-form action names into full URNs so
+    //    the subset check and downstream WASM call both see canonical form.
+    const expandedEntry: PermissionEntry = {
+      ...entry,
+      actions: expandActionShortNames(entry.service, entry.actions),
+    };
+
+    // 4. Compute expiration. `options.expiry` overrides the default 1h.
+    //    ms-format ("7d") or raw millisecond count both accepted.
+    const now = new Date();
+    const expiryMs = resolveExpiryMs(options?.expiry);
+    const expirationTime = new Date(now.getTime() + expiryMs);
+    // Cap expiry at the session's own expiry so we never emit a UCAN whose
+    // validity exceeds the parent chain.
+    let effectiveExpiration = expirationTime;
+    if (sessionExpiry !== undefined && sessionExpiry < expirationTime) {
+      effectiveExpiration = sessionExpiry;
+    }
+
+    // 5. forceWalletSign short-circuit → always legacy path.
+    if (options?.forceWalletSign) {
+      const delegation = await this.createDelegationLegacyWalletPath(
+        did,
+        expandedEntry,
+        effectiveExpiration,
+      );
+      return { delegation, prompted: true };
+    }
+
+    // 6. Derivability check. `parseRecapCapabilities` is a thin wrapper
+    //    around the injected WASM binding; the binding is required because
+    //    `IWasmBindings` declares `parseRecapFromSiwe` as mandatory. If the
+    //    runtime binding hasn't been updated, this call will surface a
+    //    clear TypeError rather than silently falling through.
+    const granted = parseRecapCapabilities(
+      (siwe: string) => this.wasmBindings.parseRecapFromSiwe(siwe),
+      session.siwe,
+    );
+    const requested: PermissionEntry[] = [expandedEntry];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+
+    if (!subset) {
+      throw new PermissionNotInManifestError(missing, granted);
+    }
+
+    // 7. Subset path — sign the sub-delegation with the session key via WASM.
+    //    No wallet prompt. `createDelegationWrapper` is the same path used
+    //    by SharingService today.
+    const delegation = await this.createDelegationViaWasmPath(
+      did,
+      expandedEntry,
+      effectiveExpiration,
+      session,
+    );
+    return { delegation, prompted: false };
+  }
+
+  /**
+   * Issue a delegation via the session-key UCAN WASM path.
+   *
+   * The caller has already verified the request is derivable from the
+   * current session; we just need to shape the inputs for
+   * {@link createDelegationWrapper}.
+   *
+   * @internal
+   */
+  private async createDelegationViaWasmPath(
+    did: string,
+    entry: PermissionEntry,
+    expirationTime: Date,
+    session: TinyCloudSession,
+  ): Promise<PortableDelegation> {
+    // Translate the manifest `space` field into the server-side spaceId.
+    // "default" resolves to the session's primary space; any other value
+    // is trusted as a raw space URI (this matches how the rest of the
+    // node-sdk treats `spaceIdOverride`).
+    const spaceId = entry.space === "default" ? session.spaceId : entry.space;
+
+    // Build ServiceSession from TinyCloudSession. This mirrors how
+    // SharingService hands sessions to createDelegationWrapper.
+    const serviceSession: ServiceSession = {
+      delegationHeader: session.delegationHeader,
+      delegationCid: session.delegationCid,
+      jwk: session.jwk,
+      spaceId,
+      verificationMethod: session.verificationMethod,
+    };
+
+    const expirationSecs = Math.floor(expirationTime.getTime() / 1000);
+    const result = this.createDelegationWrapper({
+      session: serviceSession,
+      delegateDID: did,
+      spaceId,
+      path: entry.path,
+      actions: entry.actions,
+      expirationSecs,
+    });
+
+    // Translate the WASM result into a PortableDelegation. We don't have a
+    // structured delegation header from the WASM path, so we synthesize one
+    // from the serialized delegation (the recipient decodes it via
+    // `deserializeDelegation`).
+    return {
+      cid: result.cid,
+      delegationHeader: { Authorization: `Bearer ${result.delegation}` },
+      spaceId,
+      path: entry.path,
+      actions: entry.actions,
+      disableSubDelegation: false,
+      expiry: result.expiry,
+      delegateDID: did,
+      ownerAddress: session.address,
+      chainId: session.chainId,
+      host: this.config.host,
+    };
+  }
+
+  /**
+   * Issue a delegation via the legacy wallet-signed SIWE path for a single
+   * {@link PermissionEntry}. Shares the implementation with the public
+   * `createDelegation` method via {@link createDelegationWalletPath} so
+   * both entry points hit exactly the same SIWE / signer / public-space
+   * logic without mutual recursion.
+   *
+   * @internal
+   */
+  private async createDelegationLegacyWalletPath(
+    delegateDID: string,
+    entry: PermissionEntry,
+    expirationTime: Date,
+  ): Promise<PortableDelegation> {
+    const spaceIdOverride = entry.space === "default" ? undefined : entry.space;
+    return this.createDelegationWalletPath({
+      path: entry.path,
+      actions: entry.actions,
+      delegateDID,
+      includePublicSpace: true,
+      expiryMs: Math.max(0, expirationTime.getTime() - Date.now()),
+      spaceIdOverride,
+    });
+  }
+
   /**
    * Create a delegation from this user to another user.
    *
@@ -1540,19 +1798,99 @@ export class TinyCloudNode {
     /** Include a companion delegation for the user's public space (default: true) */
     includePublicSpace?: boolean;
   }): Promise<PortableDelegation> {
+    // Legacy compatibility shim.
+    //
+    // Route through delegateTo so that callers whose requested capabilities
+    // are a subset of their current session get the session-key UCAN path
+    // (no wallet prompt). Fall back to the legacy wallet-sign path on
+    // PermissionNotInManifestError, preserving today's behaviour for
+    // callers that request scope outside their session.
+    //
+    // SessionExpiredError propagates — an expired session can't be fixed
+    // by re-signing the SIWE, the caller needs to run signIn() again.
+    if (!this.signer) {
+      throw new Error("Cannot createDelegation() in session-only mode. Requires wallet mode.");
+    }
+    if (!this.auth?.tinyCloudSession) {
+      throw new Error("Not signed in. Call signIn() first.");
+    }
+
+    // Resolve ENS names to PKH DIDs up front so both paths see the resolved
+    // DID. The wallet path mutates params further below; we do it here so
+    // the fast path (delegateTo) also picks up the resolved DID.
+    let resolvedDelegateDID = params.delegateDID;
+    if (resolvedDelegateDID.endsWith('.eth') && this.config.ensResolver) {
+      const address = await this.config.ensResolver.resolveAddress(resolvedDelegateDID);
+      if (!address) throw new Error(`Could not resolve ENS name: ${resolvedDelegateDID}`);
+      resolvedDelegateDID = `did:pkh:eip155:1:${address}`;
+    }
+
+    // Legacy params lump multiple services' actions under one path. The
+    // fast-path `delegateTo` emits one `PortableDelegation` per entry, so
+    // we only take the fast path when the legacy request contains actions
+    // for exactly one service. Multi-service legacy calls always go through
+    // the wallet path to preserve today's single-PortableDelegation return
+    // shape (with its `publicDelegation` companion for KV).
+    const entries = legacyParamsToPermissionEntries(
+      params.actions,
+      params.path,
+      params.spaceIdOverride,
+    );
+    if (entries.length === 1) {
+      try {
+        const result = await this.delegateTo(
+          resolvedDelegateDID,
+          [entries[0]],
+          params.expiryMs !== undefined
+            ? { expiry: params.expiryMs }
+            : undefined,
+        );
+        return result.delegation;
+      } catch (err) {
+        if (err instanceof PermissionNotInManifestError) {
+          // Expected — fall through to the wallet path below. Legacy
+          // callers that request scope outside their current session
+          // continue to see a wallet prompt, matching today's behaviour.
+        } else {
+          // SessionExpiredError and any other error class must propagate.
+          // An expired session can't be rescued by re-signing the SIWE
+          // here — the caller needs to run signIn() again.
+          throw err;
+        }
+      }
+    }
+
+    // Legacy wallet-signed SIWE path — same implementation as before the
+    // delegateTo refactor. Callers that request scope outside their
+    // current session land here and see the familiar wallet prompt.
+    return this.createDelegationWalletPath({
+      ...params,
+      delegateDID: resolvedDelegateDID,
+    });
+  }
+
+  /**
+   * Legacy wallet-signed SIWE delegation path. Lifted from the original
+   * `createDelegation` body verbatim so both the legacy public method and
+   * `delegateTo({ forceWalletSign: true })` hit the same code.
+   *
+   * @internal
+   */
+  private async createDelegationWalletPath(params: {
+    path: string;
+    actions: string[];
+    delegateDID: string;
+    disableSubDelegation?: boolean;
+    expiryMs?: number;
+    spaceIdOverride?: string;
+    includePublicSpace?: boolean;
+  }): Promise<PortableDelegation> {
     if (!this.signer) {
       throw new Error("Cannot createDelegation() in session-only mode. Requires wallet mode.");
     }
     const session = this.auth?.tinyCloudSession;
     if (!session) {
       throw new Error("Not signed in. Call signIn() first.");
-    }
-
-    // Resolve ENS names to PKH DIDs
-    if (params.delegateDID.endsWith('.eth') && this.config.ensResolver) {
-      const address = await this.config.ensResolver.resolveAddress(params.delegateDID);
-      if (!address) throw new Error(`Could not resolve ENS name: ${params.delegateDID}`);
-      params = { ...params, delegateDID: `did:pkh:eip155:1:${address}` };
     }
 
     // Build abilities for the delegation
@@ -1942,3 +2280,4 @@ export class TinyCloudNode {
     };
   }
 }
+

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -67,7 +67,35 @@ export type {
 } from "./authorization/strategies";
 
 // High-level API
-export { TinyCloudNode, TinyCloudNodeConfig } from "./TinyCloudNode";
+export {
+  TinyCloudNode,
+  TinyCloudNodeConfig,
+  type DelegateToOptions,
+  type DelegateToResult,
+} from "./TinyCloudNode";
+
+// Capability-chain primitives (spec: .claude/specs/capability-chain.md).
+// Re-exported here so TinyCloudWeb and other consumers can pass
+// `PermissionEntry[]` to `delegateTo` and catch the error classes without
+// also importing from `@tinycloud/sdk-core`.
+export {
+  type PermissionEntry,
+  type Manifest,
+  type ManifestDefaults,
+  type ManifestDelegation,
+  type ResolvedCapabilities,
+  type ResolvedDelegate,
+  type ResourceCapability,
+  PermissionNotInManifestError,
+  SessionExpiredError,
+  ManifestValidationError,
+  resolveManifest,
+  validateManifest,
+  loadManifest,
+  isCapabilitySubset,
+  expandActionShortNames,
+  parseExpiry,
+} from "@tinycloud/sdk-core";
 
 // Delegation
 export { DelegatedAccess } from "./DelegatedAccess";

--- a/packages/node-sdk/src/delegateToHelpers.test.ts
+++ b/packages/node-sdk/src/delegateToHelpers.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractSiweExpiration,
+  legacyParamsToPermissionEntries,
+  resolveExpiryMs,
+} from "./delegateToHelpers";
+
+describe("legacyParamsToPermissionEntries", () => {
+  test("groups actions by tinycloud.<service> prefix", () => {
+    const entries = legacyParamsToPermissionEntries(
+      [
+        "tinycloud.kv/get",
+        "tinycloud.kv/put",
+        "tinycloud.sql/read",
+      ],
+      "items/",
+      undefined,
+    );
+    // One entry per service, preserving the original action list order per
+    // service. Iteration order is insertion order on Map.
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({
+      service: "tinycloud.kv",
+      space: "default",
+      path: "items/",
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+    });
+    expect(entries[1]).toEqual({
+      service: "tinycloud.sql",
+      space: "default",
+      path: "items/",
+      actions: ["tinycloud.sql/read"],
+    });
+  });
+
+  test("uses spaceIdOverride when provided", () => {
+    const entries = legacyParamsToPermissionEntries(
+      ["tinycloud.kv/get"],
+      "/",
+      "space://custom",
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].space).toBe("space://custom");
+  });
+
+  test("drops action URNs without a slash", () => {
+    // Malformed URNs (no /) should be silently dropped to match how the
+    // wallet path also ignores unrecognised prefixes.
+    const entries = legacyParamsToPermissionEntries(
+      ["tinycloud.kv", "tinycloud.kv/get"],
+      "/",
+      undefined,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].actions).toEqual(["tinycloud.kv/get"]);
+  });
+
+  test("drops action URNs whose prefix is not tinycloud.*", () => {
+    const entries = legacyParamsToPermissionEntries(
+      ["other.ns/foo", "tinycloud.kv/get"],
+      "/",
+      undefined,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].service).toBe("tinycloud.kv");
+  });
+
+  test("empty actions returns empty array", () => {
+    expect(legacyParamsToPermissionEntries([], "/", undefined)).toEqual([]);
+  });
+});
+
+describe("resolveExpiryMs", () => {
+  test("undefined → 1 hour default", () => {
+    expect(resolveExpiryMs(undefined)).toBe(60 * 60 * 1000);
+  });
+
+  test("positive number passes through unchanged", () => {
+    expect(resolveExpiryMs(5000)).toBe(5000);
+    expect(resolveExpiryMs(7 * 24 * 60 * 60 * 1000)).toBe(
+      7 * 24 * 60 * 60 * 1000,
+    );
+  });
+
+  test("zero number throws", () => {
+    expect(() => resolveExpiryMs(0)).toThrow(/positive finite/);
+  });
+
+  test("negative number throws", () => {
+    expect(() => resolveExpiryMs(-1)).toThrow(/positive finite/);
+  });
+
+  test("NaN throws", () => {
+    expect(() => resolveExpiryMs(Number.NaN)).toThrow(/positive finite/);
+  });
+
+  test("ms-format string parses correctly", () => {
+    expect(resolveExpiryMs("7d")).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(resolveExpiryMs("1h")).toBe(60 * 60 * 1000);
+    expect(resolveExpiryMs("30m")).toBe(30 * 60 * 1000);
+  });
+
+  test("invalid duration string throws", () => {
+    expect(() => resolveExpiryMs("not-a-duration")).toThrow();
+  });
+});
+
+describe("extractSiweExpiration", () => {
+  // A minimal valid SIWE message. We build it by hand rather than using
+  // the `siwe` library's formatter so the tests don't depend on the
+  // formatter's exact output.
+  function buildSiwe(expirationTime: string | null): string {
+    const lines = [
+      "example.com wants you to sign in with your Ethereum account:",
+      "0x0000000000000000000000000000000000000001",
+      "",
+      "Sign-in statement",
+      "",
+      "URI: https://example.com",
+      "Version: 1",
+      "Chain ID: 1",
+      "Nonce: abcdefghij",
+      "Issued At: 2024-01-01T00:00:00.000Z",
+    ];
+    if (expirationTime !== null) {
+      lines.push(`Expiration Time: ${expirationTime}`);
+    }
+    return lines.join("\n");
+  }
+
+  test("returns the expiration as a Date when present", () => {
+    const result = extractSiweExpiration(buildSiwe("2025-01-01T00:00:00.000Z"));
+    expect(result).toBeInstanceOf(Date);
+    expect(result?.toISOString()).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  test("returns undefined when the SIWE has no Expiration Time line", () => {
+    const result = extractSiweExpiration(buildSiwe(null));
+    expect(result).toBeUndefined();
+  });
+
+  test("propagates parse errors for malformed SIWE", () => {
+    // A completely unparseable SIWE should throw (from inside SiweMessage)
+    // rather than silently returning undefined — a corrupted session is
+    // a bug we want to surface.
+    expect(() => extractSiweExpiration("garbage not-siwe")).toThrow();
+  });
+});

--- a/packages/node-sdk/src/delegateToHelpers.ts
+++ b/packages/node-sdk/src/delegateToHelpers.ts
@@ -1,0 +1,112 @@
+/**
+ * Internal helpers for TinyCloudNode.delegateTo and the legacy
+ * createDelegation compatibility shim. Exported from their own module so
+ * they are easy to unit-test without spinning up a full TinyCloudNode.
+ *
+ * None of these are part of the public API — the module path is not
+ * re-exported from `@tinycloud/node-sdk` or `@tinycloud/node-sdk/core`.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  type PermissionEntry,
+  parseExpiry,
+  SiweMessage,
+} from "@tinycloud/sdk-core";
+
+/**
+ * Convert legacy `createDelegation` params into one {@link PermissionEntry}
+ * per service. Groups action URNs by their `tinycloud.<service>` prefix and
+ * emits one entry per group. Actions whose prefix is not `tinycloud.*` are
+ * dropped (preserving the wallet-path behaviour, which also ignores
+ * unrecognised URN prefixes).
+ *
+ * Used by the legacy compatibility shim in `createDelegation` to hand off
+ * to `delegateTo` on the fast (subset) path.
+ */
+export function legacyParamsToPermissionEntries(
+  actions: readonly string[],
+  path: string,
+  spaceIdOverride: string | undefined,
+): PermissionEntry[] {
+  const byService = new Map<string, string[]>();
+  for (const a of actions) {
+    // Action URNs look like `tinycloud.kv/get`, `tinycloud.sql/read`, etc.
+    // Split on the first `/` to get the service namespace.
+    const slashIdx = a.indexOf("/");
+    if (slashIdx === -1) {
+      continue;
+    }
+    const service = a.slice(0, slashIdx);
+    if (!service.startsWith("tinycloud.")) {
+      continue;
+    }
+    const list = byService.get(service);
+    if (list === undefined) {
+      byService.set(service, [a]);
+    } else {
+      list.push(a);
+    }
+  }
+  const space = spaceIdOverride ?? "default";
+  const entries: PermissionEntry[] = [];
+  for (const [service, actionList] of byService) {
+    entries.push({
+      service,
+      space,
+      path,
+      actions: actionList,
+    });
+  }
+  return entries;
+}
+
+/**
+ * Resolve the `expiry` option of {@link DelegateToOptions} into a concrete
+ * millisecond duration from now. Default is 1 hour to match the existing
+ * `createDelegation` behaviour.
+ *
+ * Accepts:
+ *  - `undefined` → 1 hour
+ *  - `number` → raw milliseconds (must be positive + finite)
+ *  - `string` → parsed via {@link parseExpiry} (ms-format, e.g. `"7d"`)
+ */
+export function resolveExpiryMs(expiry: string | number | undefined): number {
+  if (expiry === undefined) {
+    return 60 * 60 * 1000;
+  }
+  if (typeof expiry === "number") {
+    if (!Number.isFinite(expiry) || expiry <= 0) {
+      throw new Error(
+        `delegateTo expiry must be a positive finite number (got ${expiry})`,
+      );
+    }
+    return expiry;
+  }
+  // string — parseExpiry throws ManifestValidationError on bad input.
+  return parseExpiry(expiry);
+}
+
+/**
+ * Extract the `expirationTime` field of a signed SIWE message as a `Date`.
+ *
+ * Returns `undefined` only when the SIWE genuinely has no `Expiration Time`
+ * line (RFC-4501 permits it). Propagates parse errors — the SDK always
+ * produces signed SIWEs during sign-in, so an unparseable `session.siwe`
+ * means something is actively wrong and we do not want to silently skip
+ * the expiry check.
+ */
+export function extractSiweExpiration(siwe: string): Date | undefined {
+  const parsed = new SiweMessage(siwe);
+  if (parsed.expirationTime === undefined || parsed.expirationTime === null) {
+    return undefined;
+  }
+  const d = new Date(parsed.expirationTime);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(
+      `Session SIWE has unparseable expirationTime: ${parsed.expirationTime}`,
+    );
+  }
+  return d;
+}

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -94,7 +94,32 @@ export type {
 } from "./authorization/strategies";
 
 // High-level API
-export { TinyCloudNode, TinyCloudNodeConfig } from "./TinyCloudNode";
+export {
+  TinyCloudNode,
+  TinyCloudNodeConfig,
+  type DelegateToOptions,
+  type DelegateToResult,
+} from "./TinyCloudNode";
+
+// Capability-chain primitives (spec: .claude/specs/capability-chain.md).
+export {
+  type PermissionEntry,
+  type Manifest,
+  type ManifestDefaults,
+  type ManifestDelegation,
+  type ResolvedCapabilities,
+  type ResolvedDelegate,
+  type ResourceCapability,
+  PermissionNotInManifestError,
+  SessionExpiredError,
+  ManifestValidationError,
+  resolveManifest,
+  validateManifest,
+  loadManifest,
+  isCapabilitySubset,
+  expandActionShortNames,
+  parseExpiry,
+} from "@tinycloud/sdk-core";
 
 // WASM bindings
 export { NodeWasmBindings } from "./NodeWasmBindings";

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -25,11 +25,13 @@
   },
   "dependencies": {
     "@tinycloud/sdk-services": "2.0.4",
+    "ms": "^2.1.3",
     "siwe": "^3.0.0",
     "zod": "^3.22.0",
     "zod-to-json-schema": "^3.22.0"
   },
   "devDependencies": {
+    "@types/ms": "^0.7.34",
     "@types/node": "^20",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0"

--- a/packages/sdk-core/src/capabilities.test.ts
+++ b/packages/sdk-core/src/capabilities.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Unit tests for the capability subset check and the parseRecapCapabilities
+ * wrapper.
+ *
+ * These tests do not touch the real WASM binding; they use stub
+ * ParseRecapFromSiwe functions to exercise the normalization layer.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  PermissionNotInManifestError,
+  SessionExpiredError,
+  isCapabilitySubset,
+  parseRecapCapabilities,
+  type WasmRecapEntry,
+} from "./capabilities";
+import type { PermissionEntry } from "./manifest";
+
+// ---------------------------------------------------------------------------
+// isCapabilitySubset — exact match
+// ---------------------------------------------------------------------------
+
+describe("isCapabilitySubset — exact match", () => {
+  const granted: PermissionEntry[] = [
+    {
+      service: "tinycloud.kv",
+      space: "tinycloud:pkh:eip155:1:0xabc:default",
+      path: "com.listen.app/",
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+    },
+  ];
+
+  it("accepts an exact subset of the granted caps", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "tinycloud:pkh:eip155:1:0xabc:default",
+        path: "com.listen.app/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(true);
+    expect(missing).toEqual([]);
+  });
+
+  it("accepts the exact same entry", () => {
+    const { subset } = isCapabilitySubset(granted, granted);
+    expect(subset).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCapabilitySubset — prefix containment
+// ---------------------------------------------------------------------------
+
+describe("isCapabilitySubset — prefix containment", () => {
+  const granted: PermissionEntry[] = [
+    {
+      service: "tinycloud.kv",
+      space: "s1",
+      path: "com.listen.app/",
+      actions: ["tinycloud.kv/get"],
+    },
+  ];
+
+  it("accepts a nested path under a trailing-slash prefix", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "com.listen.app/sub/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    expect(isCapabilitySubset(requested, granted).subset).toBe(true);
+  });
+
+  it("accepts an exact key under a trailing-slash prefix", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "com.listen.app/foo",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    expect(isCapabilitySubset(requested, granted).subset).toBe(true);
+  });
+
+  it("rejects a path outside the prefix", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "other.app/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(false);
+    expect(missing).toHaveLength(1);
+    expect(missing[0]?.path).toBe("other.app/");
+  });
+
+  it("treats / as matching everything", () => {
+    const grantedAll: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "anything/deep/nested",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    expect(isCapabilitySubset(requested, grantedAll).subset).toBe(true);
+  });
+
+  it("enforces exact match when granted path has no trailing slash", () => {
+    const exact: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "exact.key",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "exact.key.plus.more",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    expect(isCapabilitySubset(requested, exact).subset).toBe(false);
+    // And the positive case:
+    expect(
+      isCapabilitySubset(
+        [
+          {
+            service: "tinycloud.kv",
+            space: "s1",
+            path: "exact.key",
+            actions: ["tinycloud.kv/get"],
+          },
+        ],
+        exact
+      ).subset
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCapabilitySubset — action subset
+// ---------------------------------------------------------------------------
+
+describe("isCapabilitySubset — action subset", () => {
+  const granted: PermissionEntry[] = [
+    {
+      service: "tinycloud.kv",
+      space: "s1",
+      path: "app/",
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+    },
+  ];
+
+  it("accepts a proper subset of actions", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "app/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    expect(isCapabilitySubset(requested, granted).subset).toBe(true);
+  });
+
+  it("rejects when an action is missing", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "app/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/del"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(false);
+    expect(missing).toHaveLength(1);
+    expect(missing[0]?.actions).toContain("tinycloud.kv/del");
+  });
+
+  it("accepts short-name actions that expand to a granted URN", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "app/",
+        actions: ["get"], // expands to "tinycloud.kv/get"
+      },
+    ];
+    expect(isCapabilitySubset(requested, granted).subset).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCapabilitySubset — space and service mismatches
+// ---------------------------------------------------------------------------
+
+describe("isCapabilitySubset — space and service mismatches", () => {
+  const granted: PermissionEntry[] = [
+    {
+      service: "tinycloud.kv",
+      space: "space-a",
+      path: "app/",
+      actions: ["tinycloud.kv/get"],
+    },
+  ];
+
+  it("rejects a space mismatch", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "space-b",
+        path: "app/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(false);
+    expect(missing[0]?.space).toBe("space-b");
+  });
+
+  it("rejects a service mismatch", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.sql",
+        space: "space-a",
+        path: "app/",
+        actions: ["tinycloud.sql/read"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(false);
+    expect(missing[0]?.service).toBe("tinycloud.sql");
+  });
+
+  it("collects multiple missing entries in one pass", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "space-a",
+        path: "app/",
+        actions: ["tinycloud.kv/get"],
+      },
+      {
+        service: "tinycloud.sql",
+        space: "space-a",
+        path: "app/",
+        actions: ["tinycloud.sql/read"],
+      },
+      {
+        service: "tinycloud.kv",
+        space: "other-space",
+        path: "app/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(false);
+    expect(missing).toHaveLength(2);
+    const missingServices = missing.map((m) => `${m.service}|${m.space}`);
+    expect(missingServices).toContain("tinycloud.sql|space-a");
+    expect(missingServices).toContain("tinycloud.kv|other-space");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRecapCapabilities
+// ---------------------------------------------------------------------------
+
+describe("parseRecapCapabilities", () => {
+  it("normalizes short-form services to the long form", () => {
+    const stub = (): WasmRecapEntry[] => [
+      {
+        service: "kv",
+        space: "tinycloud:pkh:eip155:1:0xabc:default",
+        path: "com.listen.app/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+      {
+        service: "sql",
+        space: "tinycloud:pkh:eip155:1:0xabc:default",
+        path: "com.listen.app/",
+        actions: ["tinycloud.sql/read"],
+      },
+    ];
+    const entries = parseRecapCapabilities(stub, "stub-siwe");
+    expect(entries).toHaveLength(2);
+    const services = entries.map((e) => e.service).sort();
+    expect(services).toEqual(["tinycloud.kv", "tinycloud.sql"]);
+  });
+
+  it("passes long-form services through unchanged", () => {
+    const stub = (): WasmRecapEntry[] => [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const entries = parseRecapCapabilities(stub, "stub-siwe");
+    expect(entries[0]?.service).toBe("tinycloud.kv");
+  });
+
+  it("returns an empty array when the WASM binding returns an empty array", () => {
+    const stub = (): WasmRecapEntry[] => [];
+    expect(parseRecapCapabilities(stub, "")).toEqual([]);
+  });
+
+  it("sorts entries deterministically by (space, service, path)", () => {
+    const stub = (): WasmRecapEntry[] => [
+      {
+        service: "sql",
+        space: "space-b",
+        path: "app/",
+        actions: ["tinycloud.sql/read"],
+      },
+      {
+        service: "kv",
+        space: "space-a",
+        path: "app/",
+        actions: ["tinycloud.kv/get"],
+      },
+      {
+        service: "kv",
+        space: "space-a",
+        path: "other/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const entries = parseRecapCapabilities(stub, "stub-siwe");
+    expect(entries.map((e) => `${e.space}|${e.service}|${e.path}`)).toEqual([
+      "space-a|tinycloud.kv|app/",
+      "space-a|tinycloud.kv|other/",
+      "space-b|tinycloud.sql|app/",
+    ]);
+  });
+
+  it("hands off parsed entries to isCapabilitySubset cleanly", () => {
+    const stub = (): WasmRecapEntry[] => [
+      {
+        service: "kv",
+        space: "space-a",
+        path: "com.listen.app/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+    const granted = parseRecapCapabilities(stub, "stub-siwe");
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "space-a",
+        path: "com.listen.app/data",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    expect(isCapabilitySubset(requested, granted).subset).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+describe("PermissionNotInManifestError", () => {
+  it("exposes missing and granted on the instance", () => {
+    const missing: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s",
+        path: "p",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const granted: PermissionEntry[] = [];
+    const err = new PermissionNotInManifestError(missing, granted);
+    expect(err.name).toBe("PermissionNotInManifestError");
+    expect(err.missing).toEqual(missing);
+    expect(err.granted).toEqual(granted);
+    expect(err.message).toContain("Missing 1 entries");
+  });
+});
+
+describe("SessionExpiredError", () => {
+  it("exposes the expiredAt Date on the instance", () => {
+    const when = new Date("2024-01-01T00:00:00.000Z");
+    const err = new SessionExpiredError(when);
+    expect(err.name).toBe("SessionExpiredError");
+    expect(err.expiredAt).toEqual(when);
+    expect(err.message).toBe("Session expired at 2024-01-01T00:00:00.000Z");
+  });
+});

--- a/packages/sdk-core/src/capabilities.ts
+++ b/packages/sdk-core/src/capabilities.ts
@@ -1,0 +1,254 @@
+/**
+ * Capability subset checking and recap parsing.
+ *
+ * This module powers the capability-chain delegation flow. The key decision
+ * a `delegateTo` call has to make is: "are the requested capabilities a
+ * subset of what the current session already grants?"
+ *
+ * - If yes → issue the delegation via the session-key UCAN path (no wallet prompt).
+ * - If no → raise {@link PermissionNotInManifestError} so the caller can
+ *   trigger an escalation flow via `requestPermissions`.
+ *
+ * Canonical spec: `.claude/specs/capability-chain.md`.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  type PermissionEntry,
+  SERVICE_SHORT_TO_LONG,
+  expandActionShortNames,
+} from "./manifest";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a `delegateTo` call requests capabilities that the current
+ * session does not already grant. The caller can catch this and trigger
+ * `requestPermissions(missing)` to show an escalation modal.
+ */
+export class PermissionNotInManifestError extends Error {
+  public readonly missing: PermissionEntry[];
+  public readonly granted: PermissionEntry[];
+
+  constructor(missing: PermissionEntry[], granted: PermissionEntry[]) {
+    super(
+      `Requested capabilities exceed current session. Missing ${missing.length} entries.`
+    );
+    this.name = "PermissionNotInManifestError";
+    this.missing = missing;
+    this.granted = granted;
+  }
+}
+
+/**
+ * Thrown when the current session has expired (or will expire within the
+ * safety margin). The caller should trigger a fresh sign-in.
+ */
+export class SessionExpiredError extends Error {
+  public readonly expiredAt: Date;
+
+  constructor(expiredAt: Date) {
+    super(`Session expired at ${expiredAt.toISOString()}`);
+    this.name = "SessionExpiredError";
+    this.expiredAt = expiredAt;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subset check
+// ---------------------------------------------------------------------------
+
+export interface SubsetCheckResult {
+  /** True when every requested entry is covered by a granted entry. */
+  subset: boolean;
+  /** Entries the granted set does not cover (empty when `subset` is true). */
+  missing: PermissionEntry[];
+}
+
+/**
+ * Check whether `requested` is a strict subset of `granted`.
+ *
+ * Matching rules for each `requested[i]`:
+ * - `service` matches exactly.
+ * - `space` matches exactly.
+ * - Path containment:
+ *     - If `granted.path` ends with `/`, it covers any `requested.path` that
+ *       starts with `granted.path`.
+ *     - Otherwise, the paths must match exactly.
+ * - Action containment: every URN in `requested.actions` must appear in
+ *   `granted.actions` (set subset).
+ *
+ * Any `requested` entry that does not find a matching `granted` entry is
+ * added to `missing` and the overall result is non-subset.
+ *
+ * Both sides are expected to be in the canonical long-form shape (service
+ * starts with `tinycloud.`, actions are full URNs). Use {@link parseRecapCapabilities}
+ * or `expandActionShortNames` to normalize inputs first.
+ */
+export function isCapabilitySubset(
+  requested: readonly PermissionEntry[],
+  granted: readonly PermissionEntry[]
+): SubsetCheckResult {
+  const missing: PermissionEntry[] = [];
+
+  for (const req of requested) {
+    const match = granted.find((g) => canonicalizeEntryMatches(req, g));
+    if (match === undefined) {
+      missing.push(cloneEntry(req));
+      continue;
+    }
+    // `match` is confirmed to cover `req`; nothing to record.
+  }
+
+  return { subset: missing.length === 0, missing };
+}
+
+/**
+ * Returns true when `granted` fully covers `requested` — same service, same
+ * space, path containment per spec, and action set containment.
+ */
+function canonicalizeEntryMatches(
+  requested: PermissionEntry,
+  granted: PermissionEntry
+): boolean {
+  if (requested.service !== granted.service) {
+    return false;
+  }
+  if (requested.space !== granted.space) {
+    return false;
+  }
+  if (!pathContains(granted.path, requested.path)) {
+    return false;
+  }
+  // Normalize actions to full URN form on both sides before set comparison,
+  // so a caller passing short names ("get") against a granted entry with
+  // full URNs still behaves correctly.
+  const reqActions = new Set(
+    expandActionShortNames(requested.service, requested.actions)
+  );
+  const grantedActions = new Set(
+    expandActionShortNames(granted.service, granted.actions)
+  );
+  for (const a of reqActions) {
+    if (!grantedActions.has(a)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Path containment per spec:
+ * - `granted.path` ends with `/` → prefix match (requested starts with granted)
+ * - otherwise → exact string match
+ *
+ * The empty string is treated as "no path constraint" and matches anything.
+ * The single-character `"/"` also matches anything (it is a trailing-slash
+ * prefix of zero-length).
+ */
+function pathContains(grantedPath: string, requestedPath: string): boolean {
+  if (grantedPath === "" || grantedPath === "/") {
+    return true;
+  }
+  if (grantedPath.endsWith("/")) {
+    return requestedPath.startsWith(grantedPath);
+  }
+  return requestedPath === grantedPath;
+}
+
+function cloneEntry(entry: PermissionEntry): PermissionEntry {
+  return {
+    service: entry.service,
+    space: entry.space,
+    path: entry.path,
+    actions: [...entry.actions],
+    ...(entry.skipPrefix !== undefined ? { skipPrefix: entry.skipPrefix } : {}),
+    ...(entry.expiry !== undefined ? { expiry: entry.expiry } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recap parsing (WASM wrapper)
+// ---------------------------------------------------------------------------
+
+/**
+ * The raw shape returned from the WASM `parseRecapFromSiwe` export. The
+ * Rust layer encodes the service in the short form (e.g. `"kv"`) because
+ * that is what the SIWE recap resource URI actually contains. We normalize
+ * to the manifest long form (`"tinycloud.kv"`) in {@link parseRecapCapabilities}.
+ *
+ * @internal
+ */
+export interface WasmRecapEntry {
+  service: string;
+  space: string;
+  path: string;
+  actions: string[];
+}
+
+/**
+ * Signature of the WASM `parseRecapFromSiwe` export. Accepts the signed
+ * SIWE message string and returns an array of raw recap entries. Throws if
+ * the SIWE is malformed or the recap statement has been tampered.
+ *
+ * Exposed as an interface so the SDK can inject the web or node binding
+ * without `capabilities.ts` needing to know which.
+ */
+export type ParseRecapFromSiwe = (siweString: string) => WasmRecapEntry[];
+
+/**
+ * Parse a signed SIWE message into an array of {@link PermissionEntry}
+ * objects in the canonical long-form manifest shape.
+ *
+ * This is a thin wrapper around the WASM `parseRecapFromSiwe` export that:
+ * 1. Normalizes short-form services (`"kv"`) to long-form (`"tinycloud.kv"`).
+ * 2. Returns entries in a deterministic order (sorted by space, then service,
+ *    then path) so downstream equality checks are stable.
+ *
+ * Returns an empty array when the SIWE has no recap resource (plain auth
+ * SIWE); this matches the WASM function's behavior and the spec.
+ *
+ * @param parseWasm The WASM `parseRecapFromSiwe` binding.
+ * @param siwe The signed SIWE message string (exactly what `session.siwe` stores).
+ */
+export function parseRecapCapabilities(
+  parseWasm: ParseRecapFromSiwe,
+  siwe: string
+): PermissionEntry[] {
+  const raw = parseWasm(siwe);
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      "parseRecapFromSiwe returned a non-array value; wasm binding may be out of sync"
+    );
+  }
+  const normalized: PermissionEntry[] = raw.map((entry) => {
+    const longService =
+      SERVICE_SHORT_TO_LONG[entry.service] ??
+      // Unknown short names pass through. If the recap already contained a
+      // long-form service (e.g. a future tinycloud-node version emits long
+      // form directly), don't double-prefix.
+      (entry.service.startsWith("tinycloud.")
+        ? entry.service
+        : `tinycloud.${entry.service}`);
+    return {
+      service: longService,
+      space: entry.space,
+      path: entry.path,
+      actions: [...entry.actions],
+    };
+  });
+
+  // Sort for determinism (callers do equality checks on arrays of entries
+  // in tests; deterministic ordering keeps those stable).
+  normalized.sort((a, b) => {
+    if (a.space !== b.space) return a.space < b.space ? -1 : 1;
+    if (a.service !== b.service) return a.service < b.service ? -1 : 1;
+    if (a.path !== b.path) return a.path < b.path ? -1 : 1;
+    return 0;
+  });
+
+  return normalized;
+}

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -286,3 +286,44 @@ export {
   checkNodeInfo,
 } from "./version";
 export type { NodeInfo } from "./version";
+
+// Manifest types and resolution (capability chain delegation)
+export {
+  // Types
+  type Manifest,
+  type ManifestDefaults,
+  type ManifestDelegation,
+  type PermissionEntry,
+  type ResolvedCapabilities,
+  type ResolvedDelegate,
+  type ResourceCapability,
+  // Errors
+  ManifestValidationError,
+  // Constants
+  DEFAULT_DEFAULTS,
+  DEFAULT_EXPIRY,
+  SERVICE_LONG_TO_SHORT,
+  SERVICE_SHORT_TO_LONG,
+  // Functions
+  applyPrefix,
+  expandActionShortNames,
+  loadManifest,
+  normalizeDefaults,
+  parseExpiry,
+  resolveManifest,
+  validateManifest,
+} from "./manifest";
+
+// Capability subset checking and recap parsing
+export {
+  // Errors
+  PermissionNotInManifestError,
+  SessionExpiredError,
+  // Functions
+  isCapabilitySubset,
+  parseRecapCapabilities,
+  // Types
+  type ParseRecapFromSiwe,
+  type SubsetCheckResult,
+  type WasmRecapEntry,
+} from "./capabilities";

--- a/packages/sdk-core/src/manifest.test.ts
+++ b/packages/sdk-core/src/manifest.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Unit tests for the manifest module.
+ *
+ * Exercises validation, default tiers, prefix inheritance, duration
+ * parsing, expiry overrides, and delegation resolution.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  DEFAULT_EXPIRY,
+  ManifestValidationError,
+  applyPrefix,
+  expandActionShortNames,
+  normalizeDefaults,
+  parseExpiry,
+  resolveManifest,
+  validateManifest,
+  type Manifest,
+  type PermissionEntry,
+  type ResourceCapability,
+} from "./manifest";
+
+// ---------------------------------------------------------------------------
+// parseExpiry
+// ---------------------------------------------------------------------------
+
+describe("parseExpiry", () => {
+  it("parses ms-format duration strings", () => {
+    expect(parseExpiry("30d")).toBe(30 * 24 * 60 * 60 * 1000);
+    expect(parseExpiry("2h")).toBe(2 * 60 * 60 * 1000);
+    expect(parseExpiry("90m")).toBe(90 * 60 * 1000);
+    expect(parseExpiry("45s")).toBe(45 * 1000);
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseExpiry("")).toThrow(ManifestValidationError);
+  });
+
+  it("throws on garbage input", () => {
+    expect(() => parseExpiry("not-a-duration")).toThrow(
+      ManifestValidationError
+    );
+  });
+
+  it("throws on zero or negative durations", () => {
+    expect(() => parseExpiry("0s")).toThrow(ManifestValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandActionShortNames
+// ---------------------------------------------------------------------------
+
+describe("expandActionShortNames", () => {
+  it("prefixes short names with the service", () => {
+    expect(expandActionShortNames("tinycloud.kv", ["get", "put"])).toEqual([
+      "tinycloud.kv/get",
+      "tinycloud.kv/put",
+    ]);
+  });
+
+  it("passes already-expanded URNs through unchanged", () => {
+    expect(
+      expandActionShortNames("tinycloud.kv", ["tinycloud.kv/get", "list"])
+    ).toEqual(["tinycloud.kv/get", "tinycloud.kv/list"]);
+  });
+
+  it("handles arbitrary services", () => {
+    expect(
+      expandActionShortNames("tinycloud.sql", ["read", "ddl"])
+    ).toEqual(["tinycloud.sql/read", "tinycloud.sql/ddl"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyPrefix
+// ---------------------------------------------------------------------------
+
+describe("applyPrefix", () => {
+  it("joins prefix and path with a slash when path has no leading slash", () => {
+    expect(applyPrefix("com.listen.app", "data.sqlite", false)).toBe(
+      "com.listen.app/data.sqlite"
+    );
+  });
+
+  it("keeps the leading slash when path starts with /", () => {
+    expect(applyPrefix("com.listen.app", "/", false)).toBe("com.listen.app/");
+    expect(applyPrefix("com.listen.app", "/nested/", false)).toBe(
+      "com.listen.app/nested/"
+    );
+  });
+
+  it("returns the path unchanged when skipPrefix is true", () => {
+    expect(applyPrefix("com.listen.app", "global/", true)).toBe("global/");
+  });
+
+  it("returns the path unchanged when the prefix is empty", () => {
+    expect(applyPrefix("", "anything/", false)).toBe("anything/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeDefaults
+// ---------------------------------------------------------------------------
+
+describe("normalizeDefaults", () => {
+  it("defaults undefined to true", () => {
+    expect(normalizeDefaults(undefined)).toBe(true);
+  });
+
+  it("passes true and false through", () => {
+    expect(normalizeDefaults(true)).toBe(true);
+    expect(normalizeDefaults(false)).toBe(false);
+  });
+
+  it("recognizes admin and all after normalization", () => {
+    expect(normalizeDefaults("admin")).toBe("admin");
+    expect(normalizeDefaults("ADMIN")).toBe("admin");
+    expect(normalizeDefaults("  Admin  ")).toBe("admin");
+    expect(normalizeDefaults("all")).toBe("all");
+  });
+
+  it("falls back to true on unknown strings", () => {
+    expect(normalizeDefaults("super-admin")).toBe(true);
+    expect(normalizeDefaults("root")).toBe(true);
+    expect(normalizeDefaults("")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateManifest
+// ---------------------------------------------------------------------------
+
+describe("validateManifest", () => {
+  it("accepts a minimum-shape manifest", () => {
+    const m: Manifest = { id: "com.listen.app", name: "Listen" };
+    expect(() => validateManifest(m)).not.toThrow();
+  });
+
+  it("throws on missing id", () => {
+    expect(() => validateManifest({ name: "Listen" })).toThrow(
+      ManifestValidationError
+    );
+  });
+
+  it("throws on missing name", () => {
+    expect(() => validateManifest({ id: "com.listen.app" })).toThrow(
+      ManifestValidationError
+    );
+  });
+
+  it("throws on invalid top-level expiry", () => {
+    expect(() =>
+      validateManifest({ id: "a.b.c", name: "x", expiry: "forever" })
+    ).toThrow(ManifestValidationError);
+  });
+
+  it("throws on permission entry with empty actions", () => {
+    expect(() =>
+      validateManifest({
+        id: "a.b.c",
+        name: "x",
+        permissions: [
+          { service: "tinycloud.kv", space: "default", path: "/", actions: [] },
+        ],
+      })
+    ).toThrow(ManifestValidationError);
+  });
+
+  it("throws on delegation with missing `to`", () => {
+    expect(() =>
+      validateManifest({
+        id: "a.b.c",
+        name: "x",
+        delegations: [{ permissions: [] }] as unknown,
+      } as Manifest)
+    ).toThrow(ManifestValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveManifest — defaults
+// ---------------------------------------------------------------------------
+
+describe("resolveManifest — minimum manifest with defaults=true", () => {
+  const resolved = resolveManifest({ id: "com.listen.app", name: "Listen" });
+
+  it("copies the id", () => {
+    expect(resolved.id).toBe("com.listen.app");
+  });
+
+  it("defaults expiry to 30 days", () => {
+    expect(resolved.expiryMs).toBe(parseExpiry(DEFAULT_EXPIRY));
+  });
+
+  it("defaults includePublicSpace to true", () => {
+    expect(resolved.includePublicSpace).toBe(true);
+  });
+
+  it("includes the three standard default entries (kv, sql, capabilities)", () => {
+    const services = new Set(resolved.resources.map((r) => r.service));
+    expect(services.has("tinycloud.kv")).toBe(true);
+    expect(services.has("tinycloud.sql")).toBe(true);
+    expect(services.has("tinycloud.capabilities")).toBe(true);
+    // DuckDB must NOT be included in the standard tier.
+    expect(services.has("tinycloud.duckdb")).toBe(false);
+  });
+
+  it("applies the id as the default prefix", () => {
+    const kv = resolved.resources.find((r) => r.service === "tinycloud.kv");
+    expect(kv).toBeDefined();
+    expect(kv?.path).toBe("com.listen.app/");
+  });
+
+  it("expands action short names to full URNs", () => {
+    const kv = resolved.resources.find((r) => r.service === "tinycloud.kv");
+    expect(kv?.actions).toEqual([
+      "tinycloud.kv/get",
+      "tinycloud.kv/put",
+      "tinycloud.kv/del",
+      "tinycloud.kv/list",
+      "tinycloud.kv/metadata",
+    ]);
+  });
+
+  it("always includes capabilities:read in any non-false default", () => {
+    const caps = resolved.resources.find(
+      (r) => r.service === "tinycloud.capabilities"
+    );
+    expect(caps?.actions).toContain("tinycloud.capabilities/read");
+  });
+});
+
+describe("resolveManifest — defaults tiers", () => {
+  it("false produces no default resources", () => {
+    const resolved = resolveManifest({
+      id: "a.b.c",
+      name: "x",
+      defaults: false,
+    });
+    expect(resolved.resources).toEqual([]);
+  });
+
+  it("admin includes sql/ddl and capabilities/admin", () => {
+    const resolved = resolveManifest({
+      id: "a.b.c",
+      name: "x",
+      defaults: "admin",
+    });
+    const sql = resolved.resources.find((r) => r.service === "tinycloud.sql");
+    expect(sql?.actions).toContain("tinycloud.sql/ddl");
+    const caps = resolved.resources.find(
+      (r) => r.service === "tinycloud.capabilities"
+    );
+    expect(caps?.actions).toContain("tinycloud.capabilities/admin");
+    // DuckDB still opt-in.
+    expect(
+      resolved.resources.find((r) => r.service === "tinycloud.duckdb")
+    ).toBeUndefined();
+  });
+
+  it("all includes DuckDB", () => {
+    const resolved = resolveManifest({
+      id: "a.b.c",
+      name: "x",
+      defaults: "all",
+    });
+    const duckdb = resolved.resources.find(
+      (r) => r.service === "tinycloud.duckdb"
+    );
+    expect(duckdb).toBeDefined();
+    expect(duckdb?.actions).toEqual([
+      "tinycloud.duckdb/read",
+      "tinycloud.duckdb/write",
+    ]);
+  });
+
+  it("unknown defaults string silently falls back to true without throwing", () => {
+    const resolved = resolveManifest({
+      id: "a.b.c",
+      name: "x",
+      defaults: "super-admin" as unknown as Manifest["defaults"],
+    });
+    // Standard tier, not admin or all.
+    const sql = resolved.resources.find((r) => r.service === "tinycloud.sql");
+    expect(sql?.actions).not.toContain("tinycloud.sql/ddl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveManifest — prefix semantics
+// ---------------------------------------------------------------------------
+
+describe("resolveManifest — prefix semantics", () => {
+  it("skipPrefix: true leaves the path untouched", () => {
+    const resolved = resolveManifest({
+      id: "com.listen.app",
+      name: "x",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "shared/images/",
+          actions: ["get"],
+          skipPrefix: true,
+        },
+      ],
+    });
+    expect(resolved.resources[0]?.path).toBe("shared/images/");
+  });
+
+  it('prefix: "" disables prefix application globally', () => {
+    const resolved = resolveManifest({
+      id: "com.listen.app",
+      name: "x",
+      prefix: "",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "foo/",
+          actions: ["get"],
+        },
+      ],
+    });
+    expect(resolved.resources[0]?.path).toBe("foo/");
+  });
+
+  it("explicit prefix overrides the id", () => {
+    const resolved = resolveManifest({
+      id: "com.listen.app",
+      name: "x",
+      prefix: "other.prefix",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "data/",
+          actions: ["get"],
+        },
+      ],
+    });
+    expect(resolved.resources[0]?.path).toBe("other.prefix/data/");
+  });
+
+  it("delegations inherit prefix just like top-level permissions", () => {
+    const resolved = resolveManifest({
+      id: "com.listen.app",
+      name: "x",
+      defaults: false,
+      delegations: [
+        {
+          to: "did:pkh:eip155:1:0x0000000000000000000000000000000000000001",
+          permissions: [
+            {
+              service: "tinycloud.sql",
+              space: "default",
+              path: "data.sqlite",
+              actions: ["read"],
+            },
+          ],
+        },
+      ],
+    });
+    expect(resolved.additionalDelegates).toHaveLength(1);
+    const delegate = resolved.additionalDelegates[0]!;
+    expect(delegate.permissions[0]?.path).toBe("com.listen.app/data.sqlite");
+  });
+
+  it("delegations honor skipPrefix on individual permission entries", () => {
+    const resolved = resolveManifest({
+      id: "com.listen.app",
+      name: "x",
+      defaults: false,
+      delegations: [
+        {
+          to: "did:pkh:eip155:1:0x0000000000000000000000000000000000000001",
+          permissions: [
+            {
+              service: "tinycloud.kv",
+              space: "default",
+              path: "shared/",
+              actions: ["get"],
+              skipPrefix: true,
+            },
+          ],
+        },
+      ],
+    });
+    expect(resolved.additionalDelegates[0]?.permissions[0]?.path).toBe(
+      "shared/"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveManifest — expiry inheritance
+// ---------------------------------------------------------------------------
+
+describe("resolveManifest — expiry inheritance", () => {
+  it("uses manifest expiry as the session default", () => {
+    const resolved = resolveManifest({
+      id: "a.b.c",
+      name: "x",
+      expiry: "7d",
+      defaults: false,
+    });
+    expect(resolved.expiryMs).toBe(parseExpiry("7d"));
+  });
+
+  it("per-permission expiry overrides manifest expiry", () => {
+    const resolved = resolveManifest({
+      id: "a.b.c",
+      name: "x",
+      expiry: "7d",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "/",
+          actions: ["get"],
+          expiry: "1h",
+        },
+      ],
+    });
+    expect(resolved.resources[0]?.expiryMs).toBe(parseExpiry("1h"));
+  });
+
+  it("delegation expiry overrides manifest expiry and is inherited by its permissions", () => {
+    const resolved = resolveManifest({
+      id: "a.b.c",
+      name: "x",
+      expiry: "30d",
+      defaults: false,
+      delegations: [
+        {
+          to: "did:pkh:eip155:1:0x0000000000000000000000000000000000000001",
+          expiry: "1h",
+          permissions: [
+            {
+              service: "tinycloud.kv",
+              space: "default",
+              path: "/",
+              actions: ["get"],
+            },
+          ],
+        },
+      ],
+    });
+    const delegate = resolved.additionalDelegates[0]!;
+    expect(delegate.expiryMs).toBe(parseExpiry("1h"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composition example — backend addendum
+// ---------------------------------------------------------------------------
+
+describe("resolveManifest — end-to-end composition", () => {
+  it("matches the spec composition example", () => {
+    const appManifest: Manifest = {
+      id: "com.listen.app",
+      name: "Listen",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.sql",
+          space: "default",
+          path: "data.sqlite",
+          actions: ["read", "write"],
+        },
+      ],
+    };
+    const composed: Manifest = {
+      ...appManifest,
+      delegations: [
+        {
+          to: "did:pkh:eip155:1:0x000000000000000000000000000000000000dead",
+          name: "backend",
+          expiry: "7d",
+          permissions: [
+            {
+              service: "tinycloud.sql",
+              space: "default",
+              path: "data.sqlite",
+              actions: ["read", "write"],
+            },
+          ],
+        },
+      ],
+    };
+
+    const resolved = resolveManifest(composed);
+    expect(resolved.resources).toHaveLength(1);
+    expect(resolved.resources[0]?.path).toBe("com.listen.app/data.sqlite");
+
+    expect(resolved.additionalDelegates).toHaveLength(1);
+    const delegate = resolved.additionalDelegates[0]!;
+    expect(delegate.did).toBe(
+      "did:pkh:eip155:1:0x000000000000000000000000000000000000dead"
+    );
+    expect(delegate.expiryMs).toBe(parseExpiry("7d"));
+    expect(delegate.permissions[0]?.path).toBe("com.listen.app/data.sqlite");
+    expect(delegate.permissions[0]?.actions).toEqual([
+      "tinycloud.sql/read",
+      "tinycloud.sql/write",
+    ]);
+  });
+});

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -1,0 +1,632 @@
+/**
+ * TinyCloud App Manifest
+ *
+ * A declarative description of an app's identity and the capabilities it
+ * needs. The manifest drives the SIWE recap at sign-in time, enabling a
+ * single wallet prompt that covers the app's own permissions plus any
+ * pre-declared delegations.
+ *
+ * The SDK does NOT fetch external manifests. Apps compose their own manifest
+ * (optionally including backend or agent addenda) before handing it to the
+ * SDK.
+ *
+ * Canonical spec: `.claude/specs/manifest.md`.
+ *
+ * @packageDocumentation
+ */
+
+import ms from "ms";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single permission entry inside a manifest. This is the shape apps write
+ * in their `manifest.json` and the shape we compare against when performing
+ * the capability-subset derivability check in the delegation flow.
+ *
+ * `service` uses the long form (e.g. `"tinycloud.kv"`, `"tinycloud.sql"`)
+ * which matches the ability-namespace half of the full action URN.
+ */
+export interface PermissionEntry {
+  /** Service namespace, e.g. "tinycloud.kv", "tinycloud.sql", "tinycloud.duckdb", "tinycloud.capabilities". */
+  service: string;
+  /** "default" for the user's personal space, or a specific space id. */
+  space: string;
+  /**
+   * Service-specific path.
+   * - tinycloud.kv: hierarchical prefix. "/" = all, "foo/" = prefix match, "foo" = exact key
+   * - tinycloud.sql: database name/file (e.g. "data.sqlite") or "/" for all
+   * - tinycloud.duckdb: database name/file
+   * - tinycloud.capabilities: capability key URI or "/" for all
+   */
+  path: string;
+  /**
+   * Short action names (e.g. "get", "put", "read", "ddl"). The SDK expands
+   * these to full URNs (e.g. `tinycloud.kv/get`) during resolution.
+   * Already-expanded URNs are passed through unchanged.
+   */
+  actions: string[];
+  /** When true, the manifest prefix is NOT prepended to `path`. Default false. */
+  skipPrefix?: boolean;
+  /** Per-entry expiry override, ms-format. */
+  expiry?: string;
+}
+
+/**
+ * A pre-declared delegation that will be included in the main SIWE recap as
+ * an additional audience.
+ */
+export interface ManifestDelegation {
+  /** DID of the delegate (e.g. a backend's wallet DID). */
+  to: string;
+  /** Informational display name. Optional. */
+  name?: string;
+  /** Expiry override for this delegation, ms-format. Optional. */
+  expiry?: string;
+  /**
+   * Permissions to delegate. Same shape as the top-level `permissions`, and
+   * the manifest prefix is inherited identically (unless `skipPrefix: true`).
+   */
+  permissions: PermissionEntry[];
+}
+
+/**
+ * The valid values for `Manifest.defaults`.
+ *
+ * - `false` → no auto-included permissions
+ * - `true` → standard tier (KV + SQL read/write + capabilities:read)
+ * - `"admin"` → standard + SQL ddl + capabilities:admin
+ * - `"all"` → everything the SDK supports (including DuckDB)
+ *
+ * Unknown string values silently fall back to `true`. Values are normalized
+ * (lowercase + trim) before matching.
+ */
+export type ManifestDefaults = boolean | "admin" | "all";
+
+/**
+ * The raw manifest shape an app declares. See `.claude/specs/manifest.md`.
+ */
+export interface Manifest {
+  /** Schema version. Optional, defaults to 1. */
+  version?: number;
+  /** Bundle identifier — reverse DNS. Required. */
+  id: string;
+  /** Display name. Required. */
+  name: string;
+  /** One-line description. Optional. */
+  description?: string;
+  /** URL to app icon. Optional. */
+  icon?: string;
+  /** App version string. Optional. */
+  appVersion?: string;
+  /** Default expiry for permissions. ms-format ("30d", "2h", "1y"). Default "30d". */
+  expiry?: string;
+  /**
+   * Path prefix auto-prepended to permission paths. Optional, defaults to
+   * `id`. Set to `""` to disable entirely. Individual permissions can opt
+   * out with `skipPrefix: true`.
+   */
+  prefix?: string;
+  /**
+   * Default permission set to auto-include. Optional, defaults to `true`.
+   * See {@link ManifestDefaults}.
+   */
+  defaults?: ManifestDefaults | string;
+  /** Whether to include the public-space companion delegation. Default `true`. */
+  includePublicSpace?: boolean;
+  /**
+   * Additional permissions beyond the defaults. Use for cross-space access,
+   * DuckDB (opt-in), or `skipPrefix: true` entries.
+   */
+  permissions?: PermissionEntry[];
+  /** Pre-delegations to other DIDs at sign-in. */
+  delegations?: ManifestDelegation[];
+}
+
+/**
+ * A resolved permission entry with fully-expanded paths and action URNs.
+ * This is the shape the delegation flow compares against parsed recap
+ * capabilities, and the shape the session-key delegation path actually uses.
+ */
+export interface ResourceCapability {
+  /** Long-form service, e.g. "tinycloud.kv". */
+  service: string;
+  /** Space id — "default" stays as-is here; the caller resolves it to a full SpaceId at sign-in time. */
+  space: string;
+  /** Path with the manifest prefix applied (or skipped per `skipPrefix`). */
+  path: string;
+  /** Full-URN actions, e.g. ["tinycloud.kv/get", "tinycloud.kv/put"]. */
+  actions: string[];
+  /** Per-entry expiry override in milliseconds. */
+  expiryMs?: number;
+}
+
+/**
+ * A resolved delegation entry with fully-expanded permissions.
+ */
+export interface ResolvedDelegate {
+  /** DID of the delegate. */
+  did: string;
+  /** Informational display name. Optional. */
+  name?: string;
+  /** Expiry in milliseconds (per-delegation > manifest default > 30 days). */
+  expiryMs: number;
+  /** Fully resolved permissions. */
+  permissions: ResourceCapability[];
+}
+
+/**
+ * The output of {@link resolveManifest}: a fully-expanded capability set
+ * ready to drive the SIWE recap.
+ */
+export interface ResolvedCapabilities {
+  /** Bundle identifier copied from manifest.id. */
+  id: string;
+  /** All session-key resources with paths fully resolved (prefix applied). */
+  resources: ResourceCapability[];
+  /** Default expiry for the session, in milliseconds. */
+  expiryMs: number;
+  /** Whether to include the public-space companion. */
+  includePublicSpace: boolean;
+  /** Additional delegate targets with resolved paths. */
+  additionalDelegates: ResolvedDelegate[];
+}
+
+/**
+ * Thrown when the manifest fails validation (missing id/name, bad expiry,
+ * empty actions on a permission, etc).
+ */
+export class ManifestValidationError extends Error {
+  constructor(message: string) {
+    super(`Manifest validation failed: ${message}`);
+    this.name = "ManifestValidationError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Default expiry when neither the manifest, delegation, nor permission
+ * specifies one. Spec: 30 days.
+ */
+export const DEFAULT_EXPIRY = "30d";
+
+/**
+ * Default `defaults` value when the manifest omits it. Spec: standard tier.
+ */
+export const DEFAULT_DEFAULTS: ManifestDefaults = true;
+
+/**
+ * Known services and their short-form (recap URI) names. The TinyCloud
+ * node encodes the recap resource URI with the short service name, while
+ * action URNs and manifest entries use the long `tinycloud.<short>` form.
+ * This table is the canonical bridge between the two.
+ */
+export const SERVICE_SHORT_TO_LONG: Readonly<Record<string, string>> =
+  Object.freeze({
+    kv: "tinycloud.kv",
+    sql: "tinycloud.sql",
+    duckdb: "tinycloud.duckdb",
+    capabilities: "tinycloud.capabilities",
+    hooks: "tinycloud.hooks",
+  });
+
+/**
+ * Inverse of {@link SERVICE_SHORT_TO_LONG}.
+ */
+export const SERVICE_LONG_TO_SHORT: Readonly<Record<string, string>> =
+  Object.freeze(
+    Object.fromEntries(
+      Object.entries(SERVICE_SHORT_TO_LONG).map(([s, l]) => [l, s])
+    )
+  );
+
+/**
+ * Default permission entries for the `true` / standard tier.
+ *
+ * `tinycloud.capabilities:read` is ALWAYS present in any non-false default
+ * so delegation chains can be verified.
+ */
+const DEFAULT_STANDARD_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] =
+  [
+    {
+      service: "tinycloud.kv",
+      space: "default",
+      path: "/",
+      actions: ["get", "put", "del", "list", "metadata"],
+    },
+    {
+      service: "tinycloud.sql",
+      space: "default",
+      path: "/",
+      actions: ["read", "write"],
+    },
+    {
+      service: "tinycloud.capabilities",
+      space: "default",
+      path: "/",
+      actions: ["read"],
+    },
+  ];
+
+/**
+ * Default permission entries for the `"admin"` tier: standard + sql/ddl +
+ * capabilities/admin.
+ */
+const DEFAULT_ADMIN_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] = [
+  {
+    service: "tinycloud.kv",
+    space: "default",
+    path: "/",
+    actions: ["get", "put", "del", "list", "metadata"],
+  },
+  {
+    service: "tinycloud.sql",
+    space: "default",
+    path: "/",
+    actions: ["read", "write", "ddl"],
+  },
+  {
+    service: "tinycloud.capabilities",
+    space: "default",
+    path: "/",
+    actions: ["read", "admin"],
+  },
+];
+
+/**
+ * Default permission entries for the `"all"` tier: admin + DuckDB.
+ *
+ * DuckDB is opt-in and only appears in this tier or in explicit manifest
+ * `permissions` entries.
+ */
+const DEFAULT_ALL_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] = [
+  {
+    service: "tinycloud.kv",
+    space: "default",
+    path: "/",
+    actions: ["get", "put", "del", "list", "metadata"],
+  },
+  {
+    service: "tinycloud.sql",
+    space: "default",
+    path: "/",
+    actions: ["read", "write", "ddl"],
+  },
+  {
+    service: "tinycloud.duckdb",
+    space: "default",
+    path: "/",
+    actions: ["read", "write"],
+  },
+  {
+    service: "tinycloud.capabilities",
+    space: "default",
+    path: "/",
+    actions: ["read", "admin"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an ms-format duration string (e.g. "30d", "2h", "1y") into
+ * milliseconds.
+ *
+ * @throws {ManifestValidationError} on empty string, non-string input, or
+ * any input `ms()` cannot parse.
+ */
+export function parseExpiry(duration: string): number {
+  if (typeof duration !== "string" || duration.length === 0) {
+    throw new ManifestValidationError(
+      `expiry must be a non-empty duration string (got ${JSON.stringify(duration)})`
+    );
+  }
+  // `ms` returns `undefined` for unparseable input and can return a number
+  // or a string depending on the call signature; cast explicitly.
+  const parsed = (ms as unknown as (v: string) => number | undefined)(
+    duration
+  );
+  if (typeof parsed !== "number" || !Number.isFinite(parsed) || parsed <= 0) {
+    throw new ManifestValidationError(
+      `invalid expiry duration: ${JSON.stringify(duration)}`
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Expand a list of action short names (or already-expanded URNs) into full
+ * ability URNs of the form `<service>/<action>`.
+ *
+ * Examples:
+ *   `expandActionShortNames("tinycloud.kv", ["get", "put"])`
+ *     → `["tinycloud.kv/get", "tinycloud.kv/put"]`
+ *   `expandActionShortNames("tinycloud.kv", ["tinycloud.kv/get"])`
+ *     → `["tinycloud.kv/get"]` (passed through unchanged)
+ */
+export function expandActionShortNames(
+  service: string,
+  actions: readonly string[]
+): string[] {
+  return actions.map((a) => {
+    if (a.includes("/")) {
+      // Already a full URN — pass through.
+      return a;
+    }
+    return `${service}/${a}`;
+  });
+}
+
+/**
+ * Apply the manifest prefix to a permission path per the spec rules.
+ *
+ * - `skipPrefix: true` → path is returned as-is
+ * - `prefix === ""` → path is returned as-is
+ * - path starts with "/" → `prefix + path`  (e.g. "com.listen.app" + "/" → "com.listen.app/")
+ * - otherwise → `prefix + "/" + path`  (e.g. "com.listen.app" + "data.sqlite" → "com.listen.app/data.sqlite")
+ */
+export function applyPrefix(
+  prefix: string,
+  path: string,
+  skipPrefix: boolean
+): string {
+  if (skipPrefix) {
+    return path;
+  }
+  if (prefix === "") {
+    return path;
+  }
+  if (path.startsWith("/")) {
+    return `${prefix}${path}`;
+  }
+  return `${prefix}/${path}`;
+}
+
+/**
+ * Fetch and parse a manifest from a URL (browser) or file path (node).
+ * The runtime decides the fetch strategy via `globalThis.fetch`; this is
+ * platform-agnostic. Callers that want custom loading should JSON.parse a
+ * Manifest themselves and skip this helper.
+ *
+ * @throws if the fetch fails, the JSON is invalid, or the manifest fails
+ * validation.
+ */
+export async function loadManifest(url: string): Promise<Manifest> {
+  const fetchFn: typeof fetch | undefined = (globalThis as { fetch?: typeof fetch }).fetch;
+  if (typeof fetchFn !== "function") {
+    throw new ManifestValidationError(
+      "loadManifest requires a global fetch; pass the manifest object directly on runtimes without fetch"
+    );
+  }
+  const res = await fetchFn(url);
+  if (!res.ok) {
+    throw new ManifestValidationError(
+      `failed to fetch manifest from ${url}: HTTP ${res.status}`
+    );
+  }
+  const json = (await res.json()) as unknown;
+  return validateManifest(json);
+}
+
+/**
+ * Validate a manifest-shaped object and return it strongly-typed.
+ * Throws {@link ManifestValidationError} on any hard failure.
+ */
+export function validateManifest(input: unknown): Manifest {
+  if (input === null || typeof input !== "object") {
+    throw new ManifestValidationError("manifest must be an object");
+  }
+  const m = input as Manifest;
+  if (typeof m.id !== "string" || m.id.length === 0) {
+    throw new ManifestValidationError("manifest.id is required and must be a non-empty string");
+  }
+  if (typeof m.name !== "string" || m.name.length === 0) {
+    throw new ManifestValidationError("manifest.name is required and must be a non-empty string");
+  }
+  if (m.expiry !== undefined) {
+    // Will throw with a clear error if invalid.
+    parseExpiry(m.expiry);
+  }
+  if (m.permissions !== undefined) {
+    if (!Array.isArray(m.permissions)) {
+      throw new ManifestValidationError("manifest.permissions must be an array");
+    }
+    m.permissions.forEach((p, i) =>
+      validatePermissionEntry(p, `permissions[${i}]`)
+    );
+  }
+  if (m.delegations !== undefined) {
+    if (!Array.isArray(m.delegations)) {
+      throw new ManifestValidationError("manifest.delegations must be an array");
+    }
+    m.delegations.forEach((d, i) => {
+      if (typeof d?.to !== "string" || d.to.length === 0) {
+        throw new ManifestValidationError(
+          `delegations[${i}].to is required and must be a non-empty DID string`
+        );
+      }
+      if (d.expiry !== undefined) {
+        parseExpiry(d.expiry);
+      }
+      if (!Array.isArray(d.permissions)) {
+        throw new ManifestValidationError(
+          `delegations[${i}].permissions must be an array`
+        );
+      }
+      d.permissions.forEach((p, j) =>
+        validatePermissionEntry(p, `delegations[${i}].permissions[${j}]`)
+      );
+    });
+  }
+  return m;
+}
+
+function validatePermissionEntry(p: unknown, path: string): void {
+  if (p === null || typeof p !== "object") {
+    throw new ManifestValidationError(`${path} must be an object`);
+  }
+  const entry = p as PermissionEntry;
+  if (typeof entry.service !== "string" || entry.service.length === 0) {
+    throw new ManifestValidationError(`${path}.service is required`);
+  }
+  if (typeof entry.space !== "string" || entry.space.length === 0) {
+    throw new ManifestValidationError(`${path}.space is required`);
+  }
+  if (typeof entry.path !== "string") {
+    throw new ManifestValidationError(
+      `${path}.path is required (use "" or "/" for root)`
+    );
+  }
+  if (!Array.isArray(entry.actions) || entry.actions.length === 0) {
+    throw new ManifestValidationError(
+      `${path}.actions must be a non-empty array`
+    );
+  }
+  if (entry.expiry !== undefined) {
+    parseExpiry(entry.expiry);
+  }
+}
+
+/**
+ * Normalize a `defaults` value: lowercase + trim, then match against known
+ * tiers. Unknown string values silently fall back to `true` (standard).
+ * Boolean values pass through.
+ */
+export function normalizeDefaults(
+  value: Manifest["defaults"] | undefined
+): ManifestDefaults {
+  if (value === undefined) {
+    return DEFAULT_DEFAULTS;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    // Spec says unknown values silently fall back to `true`.
+    return true;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "admin" || normalized === "all") {
+    return normalized;
+  }
+  // Anything else, including "true"/"false"/"standard"/garbage, falls back
+  // to the standard tier per spec.
+  return true;
+}
+
+/**
+ * Return the default permission entries for the given tier. Entries are
+ * deep-cloned so callers can mutate them without affecting the constants.
+ */
+function defaultEntriesForTier(
+  tier: ManifestDefaults
+): PermissionEntry[] {
+  if (tier === false) {
+    return [];
+  }
+  const source =
+    tier === "admin"
+      ? DEFAULT_ADMIN_ENTRIES
+      : tier === "all"
+        ? DEFAULT_ALL_ENTRIES
+        : DEFAULT_STANDARD_ENTRIES;
+  return source.map((e) => ({
+    service: e.service,
+    space: e.space,
+    path: e.path,
+    actions: [...e.actions],
+  }));
+}
+
+/**
+ * Resolve a raw manifest into a {@link ResolvedCapabilities} object: expand
+ * shortform actions, apply the prefix, merge defaults, and compute effective
+ * expiries. Pure function — does no I/O.
+ *
+ * Resolution semantics (spec):
+ * - `prefix` defaults to `id`; set to `""` to disable prefix application entirely.
+ * - `defaults` defaults to `true` (standard tier); unknown string values fall back to `true`.
+ * - Per-entry expiry overrides per-delegation overrides manifest > `DEFAULT_EXPIRY`.
+ * - Default entries use `skipPrefix: false` so they inherit the manifest prefix.
+ * - Prefix inheritance applies identically to `permissions` and `delegations[*].permissions`.
+ */
+export function resolveManifest(
+  input: Manifest
+): ResolvedCapabilities {
+  const manifest = validateManifest(input);
+
+  const prefix = manifest.prefix !== undefined ? manifest.prefix : manifest.id;
+  const expiryMs = parseExpiry(manifest.expiry ?? DEFAULT_EXPIRY);
+  const includePublicSpace = manifest.includePublicSpace ?? true;
+  const tier = normalizeDefaults(manifest.defaults);
+
+  const defaultEntries = defaultEntriesForTier(tier);
+  const explicitEntries = manifest.permissions ?? [];
+
+  // Merge order: defaults first, then explicit entries, so explicit entries
+  // for the same (service, space, path) tuple override defaults.
+  const allEntries: PermissionEntry[] = [...defaultEntries, ...explicitEntries];
+
+  const resources: ResourceCapability[] = allEntries.map((entry) =>
+    resolveEntry(entry, prefix, expiryMs)
+  );
+
+  const additionalDelegates: ResolvedDelegate[] = (
+    manifest.delegations ?? []
+  ).map((d) => ({
+    did: d.to,
+    name: d.name,
+    expiryMs: parseExpiry(d.expiry ?? manifest.expiry ?? DEFAULT_EXPIRY),
+    permissions: d.permissions.map((entry) =>
+      resolveEntry(
+        entry,
+        prefix,
+        parseExpiry(d.expiry ?? manifest.expiry ?? DEFAULT_EXPIRY)
+      )
+    ),
+  }));
+
+  return {
+    id: manifest.id,
+    resources,
+    expiryMs,
+    includePublicSpace,
+    additionalDelegates,
+  };
+}
+
+/**
+ * Expand a single permission entry into a {@link ResourceCapability}:
+ * apply the prefix to the path and expand short actions into full URNs.
+ */
+function resolveEntry(
+  entry: PermissionEntry,
+  prefix: string,
+  _inheritedExpiryMs: number
+): ResourceCapability {
+  const resolvedPath = applyPrefix(
+    prefix,
+    entry.path,
+    entry.skipPrefix === true
+  );
+  const resolvedActions = expandActionShortNames(entry.service, entry.actions);
+  const entryExpiryMs =
+    entry.expiry !== undefined ? parseExpiry(entry.expiry) : undefined;
+  return {
+    service: entry.service,
+    space: entry.space,
+    path: resolvedPath,
+    actions: resolvedActions,
+    // Only populate `expiryMs` when the entry had its own expiry override.
+    // When absent, callers use the parent (delegation or manifest) expiry
+    // which is carried on ResolvedDelegate.expiryMs / ResolvedCapabilities.expiryMs.
+    ...(entryExpiryMs !== undefined ? { expiryMs: entryExpiryMs } : {}),
+  };
+}

--- a/packages/sdk-core/src/wasm.ts
+++ b/packages/sdk-core/src/wasm.ts
@@ -8,6 +8,7 @@
  */
 
 import type { InvokeAnyFunction, InvokeFunction } from "@tinycloud/sdk-services";
+import type { WasmRecapEntry } from "./capabilities";
 
 /**
  * Platform-agnostic WASM bindings interface.
@@ -31,6 +32,15 @@ export interface IWasmBindings {
   makeSpaceId: (address: string, chainId: number, prefix: string) => string;
   /** Create a delegation */
   createDelegation: (...args: any[]) => any;
+  /**
+   * Parse the recap resource of a signed SIWE message into structured
+   * permission entries. Used by the capability-chain delegation flow to
+   * decide whether a requested delegation is derivable from the current
+   * session without a fresh wallet prompt.
+   *
+   * Returns an empty array when the SIWE has no recap resource.
+   */
+  parseRecapFromSiwe: (siweString: string) => WasmRecapEntry[];
   /** Generate a host SIWE message for space activation */
   generateHostSIWEMessage: (params: any) => string;
   /** Convert a signed SIWE message to delegation headers */

--- a/packages/sdk-core/tsup.config.ts
+++ b/packages/sdk-core/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   // Externalize all dependencies — don't bundle them into the output
   external: [
     '@tinycloud/sdk-services',
+    'ms',
     'siwe',
     'zod',
     'zod-to-json-schema',

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -26,8 +26,8 @@ js-sys = "0.3.59"
 # tinycloud-sdk-rs = { path = "../../../tinycloud-node/tinycloud-sdk-rs" }
 # tinycloud-sdk-wasm = { path = "../../../tinycloud-node/tinycloud-sdk-wasm" }
 # For release, update rev after pushing tinycloud-node changes:
-tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "e0449685" }
-tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "e0449685" }
+tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "3e4b217790dbdb9b4353b9074ddc087336cc12af" }
+tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "3e4b217790dbdb9b4353b9074ddc087336cc12af" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.83"
 serde-wasm-bindgen = "0.6.5"

--- a/packages/sdk-rs/packages/node/src/index.ts
+++ b/packages/sdk-rs/packages/node/src/index.ts
@@ -30,6 +30,11 @@ export {
   siweToDelegationHeaders,
   // Delegation creation
   createDelegation,
+  // Recap parsing: extract `{ service, space, path, actions }` entries from a
+  // signed SIWE string. Used by the capability-chain delegation flow to decide
+  // whether a requested delegation is derivable from the current session
+  // without a fresh wallet prompt.
+  parseRecapFromSiwe,
   // Protocol version
   protocolVersion,
   // Vault crypto

--- a/packages/sdk-rs/packages/web/src/index.ts
+++ b/packages/sdk-rs/packages/web/src/index.ts
@@ -28,6 +28,11 @@ export namespace tinycloud {
   export import ensureEip55 = lib.ensureEip55;
   // Delegation creation
   export import createDelegation = lib.createDelegation;
+  // Recap parsing: extract `{ service, space, path, actions }` entries from a
+  // signed SIWE string. Used by the capability-chain delegation flow to decide
+  // whether a requested delegation is derivable from the current session
+  // without a fresh wallet prompt.
+  export import parseRecapFromSiwe = lib.parseRecapFromSiwe;
   // Protocol version
   export import protocolVersion = lib.protocolVersion;
   // Vault crypto

--- a/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
+++ b/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
@@ -27,6 +27,15 @@ export class BrowserWasmBindings implements IWasmBindings {
     session: any, delegateDID: string, spaceId: string,
     path: string, actions: string[], expirationSecs: number, notBeforeSecs?: number
   ) { return tinycloud.createDelegation(session, delegateDID, spaceId, path, actions, expirationSecs, notBeforeSecs); }
+  parseRecapFromSiwe(siweString: string) {
+    // The WASM binding returns a JS array of { service, space, path, actions }.
+    return tinycloud.parseRecapFromSiwe(siweString) as {
+      service: string;
+      space: string;
+      path: string;
+      actions: string[];
+    }[];
+  }
   generateHostSIWEMessage(params: any): string { return tinycloud.generateHostSIWEMessage(params); }
   siweToDelegationHeaders(params: any) { return tinycloud.siweToDelegationHeaders(params); }
   protocolVersion(): number { return tinycloud.protocolVersion(); }

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -188,4 +188,33 @@ export {
 } from '@tinycloud/node-sdk/core';
 
 // TinyCloudNode re-export (for advanced usage)
-export { TinyCloudNode, TinyCloudNodeConfig } from '@tinycloud/node-sdk/core';
+export {
+  TinyCloudNode,
+  TinyCloudNodeConfig,
+  type DelegateToOptions,
+  type DelegateToResult,
+} from '@tinycloud/node-sdk/core';
+
+// Capability-chain delegation types and errors (spec: .claude/specs/capability-chain.md)
+export {
+  // Manifest shapes — PermissionEntry is what callers pass to delegateTo.
+  type Manifest,
+  type ManifestDefaults,
+  type ManifestDelegation,
+  type PermissionEntry,
+  type ResolvedCapabilities,
+  type ResolvedDelegate,
+  type ResourceCapability,
+  // Errors raised by delegateTo / requestPermissions.
+  PermissionNotInManifestError,
+  SessionExpiredError,
+  ManifestValidationError,
+  // Resolution + subset helpers for apps that want to compose manifests
+  // at runtime.
+  resolveManifest,
+  validateManifest,
+  loadManifest,
+  isCapabilitySubset,
+  expandActionShortNames,
+  parseExpiry,
+} from '@tinycloud/sdk-core';

--- a/packages/web-sdk/src/modules/requestPermissionsCore.ts
+++ b/packages/web-sdk/src/modules/requestPermissionsCore.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure core of the `TinyCloudWeb.requestPermissions` escalation flow.
+ *
+ * Exposed as a standalone function so unit tests can exercise the
+ * control flow (validation → modal → compose → signOut → signIn) without
+ * instantiating the full `TinyCloudWeb` class (which wants a real WASM
+ * binding and browser wallet signer).
+ *
+ * Not re-exported from the package entry point — test surface only.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  ClientSession,
+  Manifest,
+  PermissionEntry,
+} from "@tinycloud/sdk-core";
+
+export interface RequestPermissionsCoreDeps {
+  /** Current stored manifest. Must be defined — caller validates first. */
+  manifest: Manifest;
+  /**
+   * Show the permission request modal. Resolves with `{ approved }`
+   * once the user interacts. In tests this is a stub; in production it
+   * is `ModalManager.showPermissionRequestModal`.
+   */
+  showModal: (opts: {
+    appName: string;
+    appIcon?: string;
+    additional: PermissionEntry[];
+  }) => Promise<{ approved: boolean }>;
+  /**
+   * Tear down the SDK-side session state. Wallet stays connected.
+   */
+  signOut: () => Promise<void>;
+  /**
+   * Run a fresh sign-in with the composed manifest already stored on
+   * the caller. Returns the new client session on success.
+   */
+  signIn: () => Promise<ClientSession>;
+  /**
+   * Write-through hook so the caller can update its stored manifest
+   * before the new sign-in runs. Called once, with the composed manifest,
+   * only on the approve path.
+   */
+  writeManifest: (next: Manifest) => void;
+}
+
+export interface RequestPermissionsCoreResult {
+  approved: boolean;
+  session?: ClientSession;
+}
+
+/**
+ * Validate the additional permissions array and throw with a clear
+ * message if empty. Exported so the caller (`TinyCloudWeb`) can share
+ * the same error text.
+ */
+export function validateAdditionalPermissions(
+  additional: PermissionEntry[],
+): void {
+  if (!Array.isArray(additional) || additional.length === 0) {
+    throw new Error(
+      "requestPermissions requires a non-empty additional permissions array",
+    );
+  }
+}
+
+/**
+ * Core escalation flow. See the TinyCloudWeb.requestPermissions JSDoc
+ * for the full spec-level description — this function is the plumbing.
+ */
+export async function requestPermissionsCore(
+  additional: PermissionEntry[],
+  deps: RequestPermissionsCoreDeps,
+): Promise<RequestPermissionsCoreResult> {
+  validateAdditionalPermissions(additional);
+
+  const modalResult = await deps.showModal({
+    appName: deps.manifest.name,
+    appIcon: deps.manifest.icon,
+    additional,
+  });
+
+  if (!modalResult.approved) {
+    return { approved: false };
+  }
+
+  // Union existing permissions with the newly-approved entries. We don't
+  // deduplicate — downstream `resolveManifest` merges entries
+  // deterministically and the server builds a single recap from the
+  // resolved list.
+  const composedManifest: Manifest = {
+    ...deps.manifest,
+    permissions: [...(deps.manifest.permissions ?? []), ...additional],
+  };
+  deps.writeManifest(composedManifest);
+
+  await deps.signOut();
+  const session = await deps.signIn();
+
+  return { approved: true, session };
+}

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -39,8 +39,14 @@ import {
   ServiceContext,
   ServiceSession,
   ISpaceCreationHandler,
+  type Manifest,
   type PermissionEntry,
 } from "@tinycloud/sdk-core";
+import { showPermissionRequestModal } from "../notifications/ModalManager";
+import {
+  requestPermissionsCore,
+  validateAdditionalPermissions,
+} from "./requestPermissionsCore";
 import type { providers } from "ethers";
 
 import { BrowserWalletSigner } from "../adapters/BrowserWalletSigner";
@@ -97,6 +103,27 @@ export interface Config extends ClientConfig {
 
   /** Shorthand for passing a Web3 provider */
   provider?: any;
+
+  /**
+   * App manifest used for sign-in and escalation flows.
+   *
+   * When provided, {@link TinyCloudWeb.requestPermissions} uses the
+   * manifest's `name` and `icon` to title the permission modal and
+   * composes escalation requests against the manifest's existing
+   * permission set. Phase 4 stores the manifest verbatim; the
+   * manifest-driven sign-in path itself lands in Phase 5.
+   */
+  manifest?: Manifest;
+}
+
+/**
+ * Result of {@link TinyCloudWeb.requestPermissions}. Populated with the
+ * fresh session on approve; empty on decline so callers can branch on
+ * `approved` without dereferencing a stale session.
+ */
+export interface RequestPermissionsResult {
+  approved: boolean;
+  session?: ClientSession;
 }
 
 // Share Link Utilities (static, no auth required)
@@ -175,8 +202,37 @@ export class TinyCloudWeb {
   /** User config */
   private config: Config;
 
+  /**
+   * App manifest stored from config (or updated via `setManifest`).
+   *
+   * `requestPermissions` reads this for the modal title/icon and for
+   * composing an expanded manifest on approve. Phase 4 treats this as a
+   * simple passthrough container — the manifest-driven sign-in flow lands
+   * in Phase 5, where `signIn` will consume this field directly.
+   */
+  private _manifest?: Manifest;
+
+  /**
+   * Test hook — override the modal shower and sign-in function used by
+   * {@link requestPermissions}. Not part of the public API. Tests set
+   * these via `(tcw as any)._testHooks = { ... }` so they can exercise
+   * the escalation control flow without a real DOM or wallet.
+   *
+   * @internal
+   */
+  private _testHooks?: {
+    showModal?: (opts: {
+      appName: string;
+      appIcon?: string;
+      additional: PermissionEntry[];
+    }) => Promise<{ approved: boolean }>;
+    signIn?: () => Promise<ClientSession>;
+    signOut?: () => Promise<void>;
+  };
+
   constructor(config: Config = {}) {
     this.config = config;
+    this._manifest = config.manifest;
 
     // Initialize browser notification handler
     this.notificationHandler = new BrowserNotificationHandler(config.notifications);
@@ -387,6 +443,73 @@ export class TinyCloudWeb {
     const node = await this.ensureNode();
     return node.delegateTo(did, permissions, options);
   };
+
+  /**
+   * Get the stored manifest (if any). Returns a shallow clone so callers
+   * can't accidentally mutate our internal state.
+   */
+  getManifest(): Manifest | undefined {
+    if (this._manifest === undefined) return undefined;
+    return { ...this._manifest };
+  }
+
+  /**
+   * Install or replace the stored manifest. Used by apps that compose
+   * their manifest at runtime (e.g. after fetching a backend's advertised
+   * permissions) and by the escalation flow inside
+   * {@link requestPermissions}.
+   */
+  setManifest(manifest: Manifest): void {
+    this._manifest = manifest;
+  }
+
+  /**
+   * Request additional permissions on top of the currently-signed
+   * session. Shows a confirmation modal; on approve, signs out the
+   * current session (without disconnecting the wallet) and runs a fresh
+   * `signIn` with the composed manifest. On decline, returns
+   * `{ approved: false }` with no state changes.
+   *
+   * Spec: `.claude/specs/capability-chain.md` §requestPermissions.
+   *
+   * Phase 4 note: the actual manifest-driven `signIn` is Phase 5. For
+   * now, the escalation composes an updated manifest, signs out, and
+   * calls `signIn()` — which still uses the current sign-in path. The
+   * updated `_manifest` field is available for the Phase 5 refactor to
+   * pick up directly.
+   */
+  async requestPermissions(
+    additional: PermissionEntry[],
+  ): Promise<RequestPermissionsResult> {
+    // Shared validation (also called by the core). Keeping the guard
+    // here short-circuits before any manifest lookup so the error text
+    // is unambiguous.
+    validateAdditionalPermissions(additional);
+
+    const manifest = this._manifest;
+    // Phase 4: we require a stored manifest for escalation so we can
+    // compose the expanded permission set. Apps that signed in without a
+    // manifest must set one via `setManifest` before escalating, or
+    // re-run signIn with an explicit manifest (Phase 5).
+    if (manifest === undefined) {
+      throw new Error(
+        "requestPermissions requires a stored manifest. Pass `manifest` in the TinyCloudWeb config or call setManifest() before requesting escalation.",
+      );
+    }
+
+    // Delegate to the pure core with injected dependencies. Test hooks
+    // override any or all of them; production defaults wire to the real
+    // modal manager and the class's own signOut/signIn methods.
+    return requestPermissionsCore(additional, {
+      manifest,
+      showModal: this._testHooks?.showModal ?? showPermissionRequestModal,
+      signOut: this._testHooks?.signOut ?? (() => this.signOut()),
+      signIn: this._testHooks?.signIn ?? (() => this.signIn()),
+      writeManifest: (next) => {
+        this._manifest = next;
+      },
+    });
+  }
 
   async useDelegation(delegation: PortableDelegation): Promise<DelegatedAccess> {
     const node = await this.ensureNode();

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -10,7 +10,12 @@
  * @packageDocumentation
  */
 
-import { TinyCloudNode, TinyCloudNodeConfig } from "@tinycloud/node-sdk/core";
+import {
+  TinyCloudNode,
+  TinyCloudNodeConfig,
+  type DelegateToOptions,
+  type DelegateToResult,
+} from "@tinycloud/node-sdk/core";
 import {
   IKVService,
   ISQLService,
@@ -34,6 +39,7 @@ import {
   ServiceContext,
   ServiceSession,
   ISpaceCreationHandler,
+  type PermissionEntry,
 } from "@tinycloud/sdk-core";
 import type { providers } from "ethers";
 
@@ -359,6 +365,28 @@ export class TinyCloudWeb {
     const node = await this.ensureNode();
     return node.createDelegation(params);
   }
+
+  /**
+   * Issue a delegation using the capability-chain flow (spec:
+   * `.claude/specs/capability-chain.md`). When the requested permissions
+   * are a subset of the current session's recap, no wallet prompt is
+   * shown — the delegation is signed by the session key via WASM. When
+   * they are not, this throws `PermissionNotInManifestError` so callers
+   * can trigger an escalation flow via {@link requestPermissions}.
+   *
+   * Pass `{ forceWalletSign: true }` to bypass the derivability check and
+   * always use the wallet-signed SIWE path.
+   *
+   * Current limitation: exactly one {@link PermissionEntry} per call.
+   */
+  delegateTo = async (
+    did: string,
+    permissions: PermissionEntry[],
+    options?: DelegateToOptions,
+  ): Promise<DelegateToResult> => {
+    const node = await this.ensureNode();
+    return node.delegateTo(did, permissions, options);
+  };
 
   async useDelegation(delegation: PortableDelegation): Promise<DelegatedAccess> {
     const node = await this.ensureNode();

--- a/packages/web-sdk/src/notifications/ModalManager.ts
+++ b/packages/web-sdk/src/notifications/ModalManager.ts
@@ -1,9 +1,18 @@
 import { TinyCloudSpaceModal, type SpaceCreationModalOptions, type SpaceCreationResult } from './SpaceCreationModal';
 import { TinyCloudNodeSelectionModal, type NodeSelectionModalOptions, type NodeSelectionResult } from './NodeSelectionModal';
+import {
+  TinyCloudPermissionRequestModal,
+  type PermissionRequestModalOptions,
+  type PermissionRequestResult,
+} from './PermissionRequestModal';
 
 export class ModalManager {
   private static instance: ModalManager;
-  private activeModal: TinyCloudSpaceModal | TinyCloudNodeSelectionModal | null = null;
+  private activeModal:
+    | TinyCloudSpaceModal
+    | TinyCloudNodeSelectionModal
+    | TinyCloudPermissionRequestModal
+    | null = null;
 
   private constructor() { }
 
@@ -60,6 +69,27 @@ export class ModalManager {
     });
   }
 
+  public showPermissionRequestModal(
+    options: PermissionRequestModalOptions,
+  ): Promise<PermissionRequestResult> {
+    this.closeActiveModal();
+
+    const modal = new TinyCloudPermissionRequestModal({
+      ...options,
+      onDismiss: () => {
+        this.activeModal = null;
+        options.onDismiss?.();
+      },
+    });
+
+    document.body.appendChild(modal);
+    this.activeModal = modal;
+
+    return modal.getCompletionPromise().finally(() => {
+      this.activeModal = null;
+    });
+  }
+
   public closeActiveModal(): void {
     if (this.activeModal) {
       this.activeModal.remove();
@@ -79,4 +109,10 @@ export const showSpaceCreationModal = (options: SpaceCreationModalOptions): Prom
 
 export const showNodeSelectionModal = (options: NodeSelectionModalOptions): Promise<NodeSelectionResult> => {
   return ModalManager.getInstance().showNodeSelectionModal(options);
+};
+
+export const showPermissionRequestModal = (
+  options: PermissionRequestModalOptions,
+): Promise<PermissionRequestResult> => {
+  return ModalManager.getInstance().showPermissionRequestModal(options);
 };

--- a/packages/web-sdk/src/notifications/PermissionRequestModal.ts
+++ b/packages/web-sdk/src/notifications/PermissionRequestModal.ts
@@ -1,0 +1,354 @@
+/**
+ * PermissionRequestModal
+ *
+ * Web Component that shows the user a list of additional capabilities an
+ * app wants to request on top of the currently-signed session. Used by
+ * `TinyCloudWeb.requestPermissions` as the confirmation step before we
+ * tear down the current session and run a fresh signIn with an expanded
+ * manifest.
+ *
+ * Matches the `SpaceCreationModal` pattern: a Web Component with a shadow
+ * DOM, returning a completion promise via `getCompletionPromise()`. The
+ * DOM lifecycle (append / remove) is managed by `ModalManager`.
+ *
+ * Canonical spec: `.claude/specs/capability-chain.md`.
+ */
+
+import type { PermissionEntry } from "@tinycloud/sdk-core";
+
+export interface PermissionRequestModalOptions {
+  /** Display name of the app requesting permissions (from the manifest). */
+  appName: string;
+  /** Optional app icon URL (from the manifest). */
+  appIcon?: string;
+  /** The additional permissions the app wants on top of its current session. */
+  additional: PermissionEntry[];
+  /** Called when the user clicks Decline or dismisses the modal. */
+  onDismiss?: () => void;
+}
+
+export interface PermissionRequestResult {
+  /** True when the user clicked Approve, false when they declined or dismissed. */
+  approved: boolean;
+}
+
+export class TinyCloudPermissionRequestModal extends HTMLElement {
+  private options: PermissionRequestModalOptions;
+  private isVisible: boolean = false;
+  private resolveResult: ((result: PermissionRequestResult) => void) | null =
+    null;
+  private completionPromise: Promise<PermissionRequestResult>;
+
+  constructor(options: PermissionRequestModalOptions) {
+    super();
+    this.options = options;
+    this.attachShadow({ mode: "open" });
+    this.render();
+
+    this.completionPromise = new Promise<PermissionRequestResult>((resolve) => {
+      this.resolveResult = resolve;
+    });
+  }
+
+  public getCompletionPromise(): Promise<PermissionRequestResult> {
+    return this.completionPromise;
+  }
+
+  connectedCallback() {
+    this.show();
+    this.setupEventListeners();
+  }
+
+  disconnectedCallback() {
+    document.body.style.overflow = "";
+  }
+
+  private render(): void {
+    const entriesHtml = this.options.additional
+      .map((entry) => this.renderEntry(entry))
+      .join("");
+
+    // We deliberately HTML-escape every dynamic string below. appName and
+    // path come straight from user-controlled manifest input; dropping
+    // them into innerHTML without escaping would be an XSS vector.
+    const appName = escapeHtml(this.options.appName);
+    const iconMarkup = this.options.appIcon
+      ? `<img class="app-icon" src="${escapeAttr(this.options.appIcon)}" alt="" />`
+      : `<div class="app-icon app-icon--placeholder">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+          </svg>
+        </div>`;
+
+    this.shadowRoot!.innerHTML = `
+      <style>${this.getModalStyles()}</style>
+      <div class="modal-backdrop" data-state="hidden">
+        <div class="modal-container">
+          <div class="modal-content">
+            <div class="modal-header">
+              ${iconMarkup}
+              <h2 class="modal-title">${appName} is requesting additional permissions</h2>
+              <button class="modal-close" aria-label="Close">
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M1 1L13 13M13 1L1 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                </svg>
+              </button>
+            </div>
+
+            <div class="modal-body">
+              <p class="modal-description">
+                Approving will sign you out of your current session and start a new one with the expanded permissions.
+              </p>
+              <ul class="permission-list">${entriesHtml}</ul>
+            </div>
+
+            <div class="modal-actions">
+              <button class="modal-button modal-button--secondary" data-action="decline">
+                Decline
+              </button>
+              <button class="modal-button modal-button--primary" data-action="approve">
+                Approve
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderEntry(entry: PermissionEntry): string {
+    const service = escapeHtml(entry.service);
+    const space = escapeHtml(entry.space);
+    const path = escapeHtml(entry.path === "" ? "/" : entry.path);
+    const actions = entry.actions
+      .map((a) => `<code class="action">${escapeHtml(a)}</code>`)
+      .join(" ");
+    return `
+      <li class="permission-entry">
+        <div class="entry-head">
+          <span class="entry-service">${service}</span>
+          <span class="entry-space">${space}</span>
+        </div>
+        <div class="entry-path">${path}</div>
+        <div class="entry-actions">${actions}</div>
+      </li>
+    `;
+  }
+
+  private getModalStyles(): string {
+    return `
+      :host {
+        --modal-bg: hsl(0 0% 3.9%);
+        --modal-border: hsl(0 0% 14.9%);
+        --modal-foreground: hsl(0 0% 98%);
+        --modal-muted: hsl(0 0% 63.9%);
+        --modal-accent: hsl(217 91% 60%);
+        --modal-accent-hover: hsl(217 91% 65%);
+        --modal-secondary: hsl(0 0% 10%);
+        --modal-secondary-hover: hsl(0 0% 15%);
+        --modal-overlay: rgba(0, 0, 0, 0.5);
+      }
+      .modal-backdrop {
+        position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+        background: var(--modal-overlay);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        z-index: 2000000;
+        display: flex; align-items: center; justify-content: center;
+        padding: 20px; opacity: 0;
+        transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+        pointer-events: none;
+      }
+      .modal-backdrop[data-state="visible"] { opacity: 1; pointer-events: auto; }
+      .modal-container {
+        transform: scale(0.95) translateY(10px);
+        transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      .modal-backdrop[data-state="visible"] .modal-container { transform: scale(1) translateY(0); }
+      .modal-content {
+        background: var(--modal-bg);
+        border: 1px solid var(--modal-border);
+        border-radius: 16px;
+        box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(255, 255, 255, 0.05);
+        max-width: 520px; width: 100%;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        color: var(--modal-foreground);
+      }
+      .modal-header {
+        padding: 24px 24px 0 24px;
+        display: flex; align-items: flex-start; gap: 16px; position: relative;
+      }
+      .app-icon {
+        flex-shrink: 0; width: 48px; height: 48px;
+        border-radius: 12px; object-fit: cover;
+        background: var(--modal-secondary);
+      }
+      .app-icon--placeholder {
+        display: flex; align-items: center; justify-content: center;
+        background: var(--modal-accent); color: white;
+      }
+      .modal-title {
+        flex: 1; font-size: 18px; font-weight: 600; line-height: 1.3;
+        margin: 0; margin-top: 4px;
+      }
+      .modal-close {
+        position: absolute; top: 0; right: 0;
+        background: transparent; border: none;
+        color: var(--modal-muted); cursor: pointer;
+        padding: 8px; border-radius: 6px; opacity: 0.7;
+        transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+        display: flex; align-items: center; justify-content: center;
+      }
+      .modal-close:hover { opacity: 1; background: var(--modal-secondary); color: var(--modal-foreground); }
+      .modal-body { padding: 20px 24px; }
+      .modal-description {
+        font-size: 14px; line-height: 1.5; margin: 0 0 16px 0; color: var(--modal-muted);
+      }
+      .permission-list {
+        list-style: none; padding: 0; margin: 0;
+        display: flex; flex-direction: column; gap: 10px;
+        max-height: 320px; overflow-y: auto;
+      }
+      .permission-entry {
+        background: var(--modal-secondary);
+        border: 1px solid var(--modal-border);
+        border-radius: 10px; padding: 12px 14px;
+      }
+      .entry-head {
+        display: flex; justify-content: space-between; align-items: center;
+        font-size: 13px; margin-bottom: 6px;
+      }
+      .entry-service { font-weight: 600; color: var(--modal-foreground); }
+      .entry-space {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace;
+        font-size: 11px; color: var(--modal-muted);
+      }
+      .entry-path {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace;
+        font-size: 12px; color: var(--modal-muted); margin-bottom: 8px;
+        word-break: break-all;
+      }
+      .entry-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+      .action {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace;
+        font-size: 11px; padding: 2px 8px;
+        background: var(--modal-bg); border: 1px solid var(--modal-border);
+        border-radius: 6px; color: var(--modal-foreground);
+      }
+      .modal-actions {
+        padding: 0 24px 24px 24px;
+        display: flex; gap: 12px; justify-content: flex-end;
+      }
+      .modal-button {
+        padding: 12px 20px; border-radius: 8px;
+        font-size: 14px; font-weight: 500; cursor: pointer;
+        transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+        border: 1px solid transparent;
+        display: flex; align-items: center; gap: 8px;
+        min-width: 100px; justify-content: center;
+      }
+      .modal-button--secondary {
+        background: var(--modal-secondary);
+        border-color: var(--modal-border);
+        color: var(--modal-foreground);
+      }
+      .modal-button--secondary:hover {
+        background: var(--modal-secondary-hover);
+        border-color: hsl(0 0% 25%);
+        transform: translateY(-1px);
+      }
+      .modal-button--primary { background: var(--modal-accent); color: white; }
+      .modal-button--primary:hover { background: var(--modal-accent-hover); transform: translateY(-1px); }
+      .modal-button--primary:active { transform: translateY(0); }
+      @media (max-width: 640px) {
+        .modal-content { max-width: 100%; margin: 0 16px; border-radius: 12px; }
+        .modal-header { padding: 20px 20px 0 20px; }
+        .modal-body { padding: 16px 20px; }
+        .modal-actions { padding: 0 20px 20px 20px; flex-direction: column-reverse; }
+        .modal-button { width: 100%; }
+      }
+    `;
+  }
+
+  private setupEventListeners(): void {
+    const backdrop = this.shadowRoot!.querySelector(".modal-backdrop");
+    const closeButton = this.shadowRoot!.querySelector(".modal-close");
+    const declineButton = this.shadowRoot!.querySelector('[data-action="decline"]');
+    const approveButton = this.shadowRoot!.querySelector('[data-action="approve"]');
+
+    backdrop?.addEventListener("click", (e) => {
+      if (e.target === backdrop) {
+        this.dismiss();
+      }
+    });
+
+    closeButton?.addEventListener("click", () => this.dismiss());
+    declineButton?.addEventListener("click", () => this.dismiss());
+    approveButton?.addEventListener("click", () => this.handleApprove());
+
+    document.addEventListener("keydown", this.handleKeyDown);
+  }
+
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === "Escape" && this.isVisible) {
+      this.dismiss();
+    }
+  };
+
+  private handleApprove(): void {
+    this.resolveResult?.({ approved: true });
+    this.hide();
+  }
+
+  private show(): void {
+    this.isVisible = true;
+    document.body.style.overflow = "hidden";
+    requestAnimationFrame(() => {
+      const backdrop = this.shadowRoot!.querySelector(".modal-backdrop");
+      backdrop?.setAttribute("data-state", "visible");
+    });
+  }
+
+  private hide(): void {
+    const backdrop = this.shadowRoot!.querySelector(".modal-backdrop");
+    backdrop?.setAttribute("data-state", "hidden");
+    setTimeout(() => {
+      this.remove();
+      document.body.style.overflow = "";
+      document.removeEventListener("keydown", this.handleKeyDown);
+    }, 200);
+    this.isVisible = false;
+  }
+
+  private dismiss(): void {
+    this.resolveResult?.({ approved: false });
+    this.options.onDismiss?.();
+    this.hide();
+  }
+}
+
+// HTML escaping helpers. Kept local so the modal file has no cross-package
+// dependency — any future "html-entities" move can replace these in-place.
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s);
+}
+
+// Register exactly once even under HMR / repeated bundler runs.
+if (
+  typeof customElements !== "undefined" &&
+  !customElements.get("tinycloud-permission-request-modal")
+) {
+  customElements.define(
+    "tinycloud-permission-request-modal",
+    TinyCloudPermissionRequestModal,
+  );
+}

--- a/packages/web-sdk/tests/PermissionRequestModal.test.ts
+++ b/packages/web-sdk/tests/PermissionRequestModal.test.ts
@@ -1,0 +1,238 @@
+/**
+ * State-machine tests for TinyCloudPermissionRequestModal.
+ *
+ * The modal is a Web Component that depends on a handful of browser
+ * globals (HTMLElement, customElements, document, requestAnimationFrame).
+ * Rather than pulling in happy-dom/jsdom as a new dependency just for
+ * this, we install a minimal stub for each global the class touches and
+ * drive the state machine directly via its private methods.
+ *
+ * We exercise two scenarios:
+ *   1. Approve button → completion promise resolves with `{ approved: true }`
+ *   2. Decline/dismiss  → completion promise resolves with `{ approved: false }`
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Minimal DOM shim
+// ---------------------------------------------------------------------------
+
+class FakeElement {
+  private attrs = new Map<string, string>();
+  private listeners = new Map<string, Array<(e: any) => void>>();
+  public innerHTML = "";
+  private children: FakeElement[] = [];
+
+  setAttribute(name: string, value: string): void {
+    this.attrs.set(name, value);
+  }
+  getAttribute(name: string): string | null {
+    return this.attrs.get(name) ?? null;
+  }
+  removeAttribute(name: string): void {
+    this.attrs.delete(name);
+  }
+  addEventListener(name: string, cb: (e: any) => void): void {
+    const list = this.listeners.get(name);
+    if (list === undefined) {
+      this.listeners.set(name, [cb]);
+    } else {
+      list.push(cb);
+    }
+  }
+  removeEventListener(name: string, cb: (e: any) => void): void {
+    const list = this.listeners.get(name);
+    if (list !== undefined) {
+      const idx = list.indexOf(cb);
+      if (idx >= 0) list.splice(idx, 1);
+    }
+  }
+  dispatchEvent(event: { type: string; target?: any; key?: string }): void {
+    const list = this.listeners.get(event.type);
+    if (list === undefined) return;
+    for (const cb of list) cb(event);
+  }
+  querySelector(_sel: string): FakeElement | null {
+    // The modal only uses querySelector to wire event listeners on a few
+    // well-known nodes. We return a shared child so the test can fire
+    // events on it regardless of selector.
+    if (this.children.length === 0) {
+      this.children.push(new FakeElement());
+    }
+    return this.children[0];
+  }
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+  remove(): void {
+    // no-op for the shim
+  }
+}
+
+class FakeShadowRoot extends FakeElement {}
+
+class FakeHTMLElement extends FakeElement {
+  public shadowRoot: FakeShadowRoot | null = null;
+  attachShadow(_opts: { mode: "open" | "closed" }): FakeShadowRoot {
+    this.shadowRoot = new FakeShadowRoot();
+    return this.shadowRoot;
+  }
+}
+
+// Install the shim before the SUT module is imported so the
+// `class extends HTMLElement` binding resolves to the fake.
+const originalGlobals = {
+  HTMLElement: (globalThis as any).HTMLElement,
+  customElements: (globalThis as any).customElements,
+  document: (globalThis as any).document,
+  requestAnimationFrame: (globalThis as any).requestAnimationFrame,
+  setTimeout: (globalThis as any).setTimeout,
+};
+
+beforeAll(() => {
+  (globalThis as any).HTMLElement = FakeHTMLElement;
+  (globalThis as any).customElements = {
+    define: () => {},
+    get: () => undefined,
+  };
+  const body: any = new FakeElement();
+  body.style = {};
+  (globalThis as any).document = {
+    body,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  (globalThis as any).requestAnimationFrame = (cb: () => void) => {
+    // Run synchronously so the test doesn't race the modal's show() delay.
+    cb();
+    return 0;
+  };
+  // Run setTimeout synchronously so the modal's hide() animation delay
+  // cannot fire after afterAll has restored the globals, which would
+  // crash with "document is not defined" deep inside the test runner.
+  (globalThis as any).setTimeout = (cb: () => void) => {
+    cb();
+    return 0;
+  };
+});
+
+afterAll(() => {
+  (globalThis as any).HTMLElement = originalGlobals.HTMLElement;
+  (globalThis as any).customElements = originalGlobals.customElements;
+  (globalThis as any).document = originalGlobals.document;
+  (globalThis as any).requestAnimationFrame =
+    originalGlobals.requestAnimationFrame;
+  (globalThis as any).setTimeout = originalGlobals.setTimeout;
+});
+
+// Dynamic import so the shim is in place before module evaluation.
+async function loadModal(): Promise<any> {
+  const mod = await import(
+    "../src/notifications/PermissionRequestModal"
+  );
+  return mod.TinyCloudPermissionRequestModal;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TinyCloudPermissionRequestModal", () => {
+  const sampleOptions = {
+    appName: "Example App",
+    appIcon: "https://example.com/icon.png",
+    additional: [
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "items/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ],
+  };
+
+  test("constructor renders the shadow DOM", async () => {
+    const Modal = await loadModal();
+    const modal = new Modal(sampleOptions);
+    expect(modal.shadowRoot).not.toBeNull();
+    // The title should include the escaped app name. We assert the
+    // rendered HTML contains it rather than poking deeper into the
+    // shadow tree shim.
+    expect(modal.shadowRoot.innerHTML).toContain("Example App");
+    expect(modal.shadowRoot.innerHTML).toContain("tinycloud.kv");
+    expect(modal.shadowRoot.innerHTML).toContain("tinycloud.kv/get");
+  });
+
+  test("approve resolves with { approved: true }", async () => {
+    const Modal = await loadModal();
+    const modal = new Modal(sampleOptions);
+    // Simulate the connect lifecycle so setupEventListeners runs and the
+    // internal state machine is wired.
+    modal.connectedCallback();
+
+    // Drive the approve path directly — the shim's querySelector returns
+    // a shared fake child element which received the click listener, so
+    // we reach into the modal's private method for determinism.
+    (modal as any).handleApprove();
+
+    const result = await modal.getCompletionPromise();
+    expect(result).toEqual({ approved: true });
+  });
+
+  test("dismiss resolves with { approved: false }", async () => {
+    const Modal = await loadModal();
+    let dismissedFlag = false;
+    const modal = new Modal({
+      ...sampleOptions,
+      onDismiss: () => {
+        dismissedFlag = true;
+      },
+    });
+    modal.connectedCallback();
+
+    (modal as any).dismiss();
+
+    const result = await modal.getCompletionPromise();
+    expect(result).toEqual({ approved: false });
+    expect(dismissedFlag).toBe(true);
+  });
+
+  test("HTML-escapes the app name to prevent XSS", async () => {
+    const Modal = await loadModal();
+    const modal = new Modal({
+      ...sampleOptions,
+      appName: "<script>alert('pwn')</script>",
+    });
+    // The escaped title must appear; the raw <script> tag must not.
+    expect(modal.shadowRoot.innerHTML).not.toContain(
+      "<script>alert('pwn')</script>",
+    );
+    expect(modal.shadowRoot.innerHTML).toContain("&lt;script&gt;");
+  });
+
+  test("renders multiple permission entries", async () => {
+    const Modal = await loadModal();
+    const modal = new Modal({
+      ...sampleOptions,
+      additional: [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "items/",
+          actions: ["tinycloud.kv/get"],
+        },
+        {
+          service: "tinycloud.sql",
+          space: "default",
+          path: "/",
+          actions: ["tinycloud.sql/read"],
+        },
+      ],
+    });
+    expect(modal.shadowRoot.innerHTML).toContain("tinycloud.kv");
+    expect(modal.shadowRoot.innerHTML).toContain("tinycloud.sql");
+    expect(modal.shadowRoot.innerHTML).toContain("tinycloud.sql/read");
+  });
+});

--- a/packages/web-sdk/tests/requestPermissionsCore.test.ts
+++ b/packages/web-sdk/tests/requestPermissionsCore.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Control-flow tests for the `requestPermissionsCore` helper.
+ *
+ * The core is where the escalation state machine lives — this test
+ * file covers every branch without touching the real modal, the real
+ * wallet, or the real WASM.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  ClientSession,
+  Manifest,
+  PermissionEntry,
+} from "@tinycloud/sdk-core";
+
+import {
+  requestPermissionsCore,
+  validateAdditionalPermissions,
+} from "../src/modules/requestPermissionsCore";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseManifest: Manifest = {
+  id: "com.test.app",
+  name: "Test App",
+  icon: "https://example.com/icon.png",
+  permissions: [
+    {
+      service: "tinycloud.kv",
+      space: "default",
+      path: "items/",
+      actions: ["tinycloud.kv/get"],
+    },
+  ],
+};
+
+const additional: PermissionEntry[] = [
+  {
+    service: "tinycloud.kv",
+    space: "default",
+    path: "items/",
+    actions: ["tinycloud.kv/put"],
+  },
+];
+
+function fakeSession(): ClientSession {
+  return {
+    address: "0x0000000000000000000000000000000000000001",
+    walletAddress: "0x0000000000000000000000000000000000000001",
+    chainId: 1,
+    sessionKey: "default",
+    siwe: "fake-siwe",
+    signature: "0xfake",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("validateAdditionalPermissions", () => {
+  test("throws on empty array", () => {
+    expect(() => validateAdditionalPermissions([])).toThrow(/non-empty/);
+  });
+
+  test("throws on non-array", () => {
+    // We deliberately cast an invalid value to exercise the runtime guard.
+    expect(() =>
+      validateAdditionalPermissions(undefined as unknown as PermissionEntry[]),
+    ).toThrow(/non-empty/);
+  });
+
+  test("accepts a populated array", () => {
+    expect(() => validateAdditionalPermissions(additional)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decline path
+// ---------------------------------------------------------------------------
+
+describe("requestPermissionsCore: decline", () => {
+  test("returns { approved: false } and does not sign out / sign in", async () => {
+    const showModal = mock(() => Promise.resolve({ approved: false }));
+    const signOut = mock(() => Promise.resolve());
+    const signIn = mock(() => Promise.resolve(fakeSession()));
+    const writeManifest = mock(() => {});
+
+    const result = await requestPermissionsCore(additional, {
+      manifest: baseManifest,
+      showModal: showModal as any,
+      signOut,
+      signIn,
+      writeManifest,
+    });
+
+    expect(result).toEqual({ approved: false });
+    expect(showModal).toHaveBeenCalledTimes(1);
+    expect(signOut).not.toHaveBeenCalled();
+    expect(signIn).not.toHaveBeenCalled();
+    expect(writeManifest).not.toHaveBeenCalled();
+  });
+
+  test("passes the manifest name + icon + additional to the modal", async () => {
+    let seenOpts: any;
+    const showModal = mock((opts: any) => {
+      seenOpts = opts;
+      return Promise.resolve({ approved: false });
+    });
+
+    await requestPermissionsCore(additional, {
+      manifest: baseManifest,
+      showModal: showModal as any,
+      signOut: async () => {},
+      signIn: async () => fakeSession(),
+      writeManifest: () => {},
+    });
+
+    expect(seenOpts.appName).toBe("Test App");
+    expect(seenOpts.appIcon).toBe("https://example.com/icon.png");
+    expect(seenOpts.additional).toEqual(additional);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approve path
+// ---------------------------------------------------------------------------
+
+describe("requestPermissionsCore: approve", () => {
+  test("composes expanded manifest, signs out, signs in, returns session", async () => {
+    const order: string[] = [];
+    const newSession = fakeSession();
+    let writtenManifest: Manifest | undefined;
+
+    const result = await requestPermissionsCore(additional, {
+      manifest: baseManifest,
+      showModal: async () => {
+        order.push("modal");
+        return { approved: true };
+      },
+      signOut: async () => {
+        order.push("signOut");
+      },
+      signIn: async () => {
+        order.push("signIn");
+        return newSession;
+      },
+      writeManifest: (next) => {
+        order.push("writeManifest");
+        writtenManifest = next;
+      },
+    });
+
+    expect(result).toEqual({ approved: true, session: newSession });
+
+    // Order: modal → writeManifest → signOut → signIn. writeManifest
+    // must come before signOut so a Phase 5 signIn refactor that reads
+    // `_manifest` at the start of signIn sees the composed manifest.
+    expect(order).toEqual(["modal", "writeManifest", "signOut", "signIn"]);
+
+    // Composed manifest contains the original + additional entries.
+    expect(writtenManifest?.permissions).toEqual([
+      ...(baseManifest.permissions ?? []),
+      ...additional,
+    ]);
+    // Other manifest fields pass through unchanged.
+    expect(writtenManifest?.id).toBe(baseManifest.id);
+    expect(writtenManifest?.name).toBe(baseManifest.name);
+  });
+
+  test("handles a manifest with no pre-existing permissions array", async () => {
+    const manifestNoPerms: Manifest = {
+      id: "com.test.app",
+      name: "Test",
+    };
+    let written: Manifest | undefined;
+
+    await requestPermissionsCore(additional, {
+      manifest: manifestNoPerms,
+      showModal: async () => ({ approved: true }),
+      signOut: async () => {},
+      signIn: async () => fakeSession(),
+      writeManifest: (next) => {
+        written = next;
+      },
+    });
+
+    expect(written?.permissions).toEqual(additional);
+  });
+
+  test("propagates signIn errors without swallowing", async () => {
+    const err = new Error("signIn failed");
+    await expect(
+      requestPermissionsCore(additional, {
+        manifest: baseManifest,
+        showModal: async () => ({ approved: true }),
+        signOut: async () => {},
+        signIn: async () => {
+          throw err;
+        },
+        writeManifest: () => {},
+      }),
+    ).rejects.toBe(err);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty input guard (also checked by the core before anything else)
+// ---------------------------------------------------------------------------
+
+describe("requestPermissionsCore: validation", () => {
+  test("throws before calling the modal when additional is empty", async () => {
+    const showModal = mock(() => Promise.resolve({ approved: true }));
+    await expect(
+      requestPermissionsCore([], {
+        manifest: baseManifest,
+        showModal: showModal as any,
+        signOut: async () => {},
+        signIn: async () => fakeSession(),
+        writeManifest: () => {},
+      }),
+    ).rejects.toThrow(/non-empty/);
+    expect(showModal).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements manifest-driven capability-chain delegation so apps can sub-delegate to backends without additional wallet prompts after sign-in.

## Changes

- **sdk-rs**: rev bump to tinycloud-node commit `3e4b217` (`parseRecapFromSiwe` WASM export)
- **sdk-core**: new manifest + capabilities modules (`Manifest`, `PermissionEntry`, `ResolvedCapabilities`, `resolveManifest`, `isCapabilitySubset`, `parseRecapCapabilities`, default permission tiers, `ms`-format duration parsing, `PermissionNotInManifestError`, `SessionExpiredError`)
- **node-sdk**: `TinyCloudNode.delegateTo` with session-key UCAN fast path; legacy `createDelegation` routes through `delegateTo` with wallet-path fallback on `PermissionNotInManifestError`; 60s session expiry safety margin parsed from `session.siwe`
- **web-sdk**: `TinyCloudWeb.delegateTo` surface; `TinyCloudWeb.requestPermissions` escalation flow; `PermissionRequestModal` Web Component (matches `SpaceCreationModal` pattern); pure `requestPermissionsCore` helper for testability

## Test counts

- sdk-core: 530 pass / 0 fail (unchanged — Phase 2 tests already in)
- node-sdk: 23 pass / 0 fail (new: 15 helper + 8 delegateTo branch tests)
- web-sdk: 136 pass / 4 pre-existing fails (new: 5 modal state-machine + 9 requestPermissionsCore tests); pre-existing SIWE extension failures are unchanged from `main`

## Related

- Based on listen PR #1 context and the multi-prompt investigation
- Depends on TinyCloudLabs/tinycloud-node#47 (merged, commit `3e4b217`)
- Spec: see `listen` PR #1 `.claude/specs/`

## Test plan

- [x] Phase 2 sdk-core tests (530/0)
- [x] Phase 3 `delegateTo` derivability, expiry, forceWalletSign, legacy compat
- [x] Phase 4 modal state machine, escalation flow
- [x] `bun run build` clean across sdk-core, node-sdk, web-sdk
- [ ] Listen app end-to-end single-prompt sign-in (Phase 5, separate PR)