### PR TITLE
fix(ci): drop --tag beta from Beta Release publish

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -107,7 +107,7 @@ jobs:
           # loop 403'd on sdk-core@2.1.0-beta.0 in the 2026-04-10 release after
           # PR #182, aborting before the wasm packages (which actually needed
           # publishing) were attempted.
-          bunx changeset publish --tag beta
+          bunx changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

The Beta Release job in `.github/workflows/changesets.yml` runs `bunx changeset publish --tag beta`, but the repo is in changesets pre mode (tag: `beta`). Changesets explicitly disallows combining pre mode with `--tag <name>`:

```
Releasing under custom tag is not allowed in pre mode
To resolve this exit the pre mode by running `changeset pre exit`
```

In pre mode, changesets automatically tags published packages as `beta`, so the `--tag beta` flag is both redundant and forbidden.

This has been failing since at least run #173 — every merge to master produces a red Beta Release run and no new beta ships. This unblocks publishes after PR #184.

## Change

Minimal diff: drop `--tag beta` from the Beta Release publish step. The Stable Release publish step (which runs outside pre mode) is left untouched.

## Test plan

- [ ] Workflow file lints green in CI
- [ ] After merge, the Beta Release job runs to completion
- [ ] `npm view @tinycloud/web-sdk dist-tags` and `npm view @tinycloud/sdk-core dist-tags` show a new `beta` version including PR #184's changes