### PR TITLE
chore(release): bump beta past ghost 2.1.0-beta.0

### DIFF
--- a/.changeset/bump-past-ghost.md
+++ b/.changeset/bump-past-ghost.md
@@ -1,0 +1,14 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/web-sdk": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/sdk-services": minor
+"@tinycloud/node-sdk-wasm": patch
+"@tinycloud/web-sdk-wasm": patch
+---
+
+Bump past stale `2.1.0-beta.0` / `1.7.2-beta.0` ghost versions to publish PR #184's capability-chain delegation code.
+
+The earlier `2.1.0-beta.0` (TS SDKs) and `1.7.2-beta.0` (WASM) tarballs on npm predate PR #184 and are missing `resolveManifest`, `isCapabilitySubset`, manifest types, and the `parseRecapFromSiwe` re-export. This empty changeset forces `changeset version` to land on the next beta counter so the Beta Release workflow actually publishes the post-#184 code.
+
+All four TS packages in the linked group are named explicitly so `@tinycloud/sdk-services` advances too (naming only `@tinycloud/sdk-core` left it pinned at the ghost `2.1.0-beta.0`). Both WASM wrappers take a patch bump so the TS SDKs don't pin a stale `@tinycloud/*-sdk-wasm@1.7.2-beta.0`.


### PR DESCRIPTION
## Why

PR #184 (capability-chain delegation) shipped minor bumps to the TS SDK linked group and patch bumps to both WASM wrappers. The Beta Release workflow ran, but npm already had stale `2.1.0-beta.0` / `1.7.2-beta.0` tarballs from an earlier publish attempt that predated PR #184. `changeset publish` correctly refused to overwrite them ("already published on npm"), so PR #184's code never reached the registry.

The subsequent `chore: beta version packages` bot commit (`37aacc0`) on master rebaselined package.json from `2.0.4` to `2.1.0-beta.0` by consuming the PR #184 / #173 / #182 changesets — landing on the exact ghost number again. Without a new changeset, the next Release workflow run has nothing to do and master will stay pinned to a version that cannot be published.

## What

Single empty changeset (`.changeset/bump-past-ghost.md`) that:

- Minor-bumps the full TS linked group (`@tinycloud/sdk-core`, `@tinycloud/web-sdk`, `@tinycloud/node-sdk`, `@tinycloud/sdk-services`)
- Patch-bumps both WASM wrappers (`@tinycloud/node-sdk-wasm`, `@tinycloud/web-sdk-wasm`) so the TS SDKs don't pin stale `1.7.2-beta.0` wasm that's missing `parseRecapFromSiwe`

Verified locally with `bun changeset version` on a scratch branch:

| package | before | after |
| --- | --- | --- |
| `@tinycloud/sdk-core` | `2.1.0-beta.0` | `2.1.0-beta.1` |
| `@tinycloud/web-sdk` | `2.1.0-beta.0` | `2.1.0-beta.1` |
| `@tinycloud/node-sdk` | `2.1.0-beta.0` | `2.1.0-beta.1` |
| `@tinycloud/sdk-services` | `2.1.0-beta.0` | `2.1.0-beta.1` |
| `@tinycloud/node-sdk-wasm` | `1.7.2-beta.0` | `1.7.2-beta.1` |
| `@tinycloud/web-sdk-wasm` | `1.7.2-beta.0` | `1.7.2-beta.1` |

Note: naming only `@tinycloud/sdk-core` left `@tinycloud/sdk-services` pinned at the ghost `2.1.0-beta.0` despite the linked group. All four TS packages are named explicitly to guarantee the linked group moves in lockstep.

Scratch-branch diff was reset with `git checkout -- .` before committing — this PR touches only the new changeset file.

## Scope

- Does not modify `package.json` versions directly
- Does not modify the Release workflow
- Does not touch `.changeset/pre.json` manually
- Does not exit pre-mode

The actual version bump and publish happen in the automated Beta Release workflow on merge.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: Beta Release workflow run succeeds
- [ ] `npm view @tinycloud/sdk-core dist-tags` shows `beta: 2.1.0-beta.1` (or higher)
- [ ] Published `@tinycloud/sdk-core` tarball contains the manifest / capability-chain exports added in PR #184 (`resolveManifest`, `isCapabilitySubset`, etc.)