### PR TITLE
fix: manifest-driven signIn + multi-entry delegateTo (closes 2.1.0-beta.1 gaps)

### DIFF
--- a/.changeset/manifest-signin-multi-delegate.md
+++ b/.changeset/manifest-signin-multi-delegate.md
@@ -1,0 +1,22 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+"@tinycloud/node-sdk-wasm": patch
+"@tinycloud/web-sdk-wasm": patch
+---
+
+Wire manifest-driven `signIn` and multi-resource `delegateTo` end-to-end (closes the two gaps in `2.1.0-beta.1`).
+
+`signIn` now reads `config.manifest` and resolves it (via `resolveManifest` + the new `manifestAbilitiesUnion`) into the WASM `abilities` map used by `prepareSession`. The resulting SIWE recap covers the union of the app's own permissions AND every manifest-declared delegation's permissions, so the session key acquires coverage for both runtime use and downstream sub-delegations in one wallet prompt. Apps that don't pass a manifest fall back to `defaultActions` (legacy behaviour, no change).
+
+`delegateTo(did, permissions)` no longer rejects multi-entry input. The SDK now folds every `(service, path, actions)` entry into a single multi-resource abilities map and calls the WASM `createDelegation` once — producing ONE signed UCAN whose `attenuation` carries every grant. The returned `PortableDelegation` has the new optional `resources?: DelegatedResource[]` field listing the full breakdown; the legacy flat `path` + `actions` fields mirror the first (sorted) resource for back-compat.
+
+Listen-style apps that needed to delegate KV + SQL on the same prefix to a backend can now do so in a single `tcw.delegateTo(backendDID, [...])` call with no wallet prompt.
+
+**Breaking changes** — pre-2.1.0-beta.2 callers will need to update:
+
+- `@tinycloud/sdk-core`: `CreateDelegationWasmParams` swaps `path: string; actions: string[]` for `abilities: Record<string, Record<string, string[]>>`. `CreateDelegationWasmResult` swaps the flat `path` + `actions` for `resources: DelegatedResource[]`. New exports: `DelegatedResource`, `AbilitiesMap`, `manifestAbilitiesUnion`, `resourceCapabilitiesToAbilitiesMap`.
+- `@tinycloud/node-sdk`: `TinyCloudNodeConfig` gains an optional `manifest?: Manifest` field. `TinyCloudNode` gains `setManifest(manifest)` and `manifest` getter passthroughs to the underlying auth handler. `delegateTo` no longer throws on multi-entry input — apps that relied on that behaviour for validation must add their own length check. `PortableDelegation` gains an optional `resources?: DelegatedResource[]` field.
+- `@tinycloud/web-sdk`: `TinyCloudWeb.setManifest()` now forwards the new manifest into the underlying `TinyCloudNode` so the next `signIn()` picks it up. `BrowserWasmBindings.createDelegation` signature aligned with the new WASM ABI.
+- `@tinycloud/node-sdk-wasm` / `@tinycloud/web-sdk-wasm`: the `createDelegation` WASM export takes `abilities: object` (multi-resource map) instead of `path: string, actions: string[]`. The Rust rev in `packages/sdk-rs/Cargo.toml` is bumped to the merge commit of the `feat/create-delegation-multi-resource` PR in `tinycloud-node`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "cacaos"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=6f6fc8602eb94089c933bdab88a19e5ea6c92fd8#6f6fc8602eb94089c933bdab88a19e5ea6c92fd8"
 dependencies = [
  "async-trait",
  "hex",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=6f6fc8602eb94089c933bdab88a19e5ea6c92fd8#6f6fc8602eb94089c933bdab88a19e5ea6c92fd8"
 dependencies = [
  "hex",
  "http 1.4.0",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "siwe-recap"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=6f6fc8602eb94089c933bdab88a19e5ea6c92fd8#6f6fc8602eb94089c933bdab88a19e5ea6c92fd8"
 dependencies = [
  "base64 0.22.1",
  "ipld-core",
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-auth"
 version = "1.2.1"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=6f6fc8602eb94089c933bdab88a19e5ea6c92fd8#6f6fc8602eb94089c933bdab88a19e5ea6c92fd8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-rs"
 version = "1.2.1"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=6f6fc8602eb94089c933bdab88a19e5ea6c92fd8#6f6fc8602eb94089c933bdab88a19e5ea6c92fd8"
 dependencies = [
  "async-trait",
  "hex",
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-wasm"
 version = "1.2.1"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=3e4b217790dbdb9b4353b9074ddc087336cc12af#3e4b217790dbdb9b4353b9074ddc087336cc12af"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=6f6fc8602eb94089c933bdab88a19e5ea6c92fd8#6f6fc8602eb94089c933bdab88a19e5ea6c92fd8"
 dependencies = [
  "aes-gcm",
  "chrono",

--- a/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
@@ -104,9 +104,15 @@ function makeFakeWasmBindings(
       delegation: "fake-serialized-delegation",
       cid: "bafyfake",
       delegateDid: "did:pkh:eip155:1:0xDEAD",
-      path: "items/",
-      actions: ["tinycloud.kv/get"],
       expiry: Math.floor(Date.now() / 1000) + 3600,
+      resources: [
+        {
+          service: "kv",
+          space: "space://test",
+          path: "items/",
+          actions: ["tinycloud.kv/get"],
+        },
+      ],
     })),
     parseRecapFromSiwe: mock(() => [] as any[]),
     generateHostSIWEMessage: mock(() => ""),
@@ -221,9 +227,15 @@ describe("TinyCloudNode.delegateTo", () => {
       delegation: "fake-ucan-delegation",
       cid: "bafyfakeucan",
       delegateDid: BOB_DID,
-      path: "items/",
-      actions: ["tinycloud.kv/get"],
       expiry: Math.floor((Date.now() + 3600_000) / 1000),
+      resources: [
+        {
+          service: "kv",
+          space: "space://test",
+          path: "items/",
+          actions: ["tinycloud.kv/get"],
+        },
+      ],
     }));
     const prepareSessionSpy = mock(() => ({}));
 
@@ -290,8 +302,152 @@ describe("TinyCloudNode.delegateTo", () => {
     expect(prepareSessionSpy).not.toHaveBeenCalled();
   });
 
-  test("multi-entry input throws a clear error", async () => {
-    const wasm = makeFakeWasmBindings();
+  test("multi-entry input → ONE UCAN with merged abilities map", async () => {
+    // Multi-entry delegation is now first-class: the SDK folds every
+    // (service, path, actions) tuple into a single abilities map and
+    // calls WASM createDelegation once. The resulting PortableDelegation
+    // is a single signed blob whose `.resources` array lists every
+    // grant. This is the core fix that lets listen-style apps
+    // pre-declare backend delegations across KV + SQL in one
+    // manifest and have them issue from the session key in a single
+    // wallet-prompt-free operation.
+    const grantedRaw = [
+      {
+        // KV actions granted on the app prefix
+        service: "kv",
+        space: "default",
+        path: "com.listen.app/",
+        actions: [
+          "tinycloud.kv/get",
+          "tinycloud.kv/put",
+          "tinycloud.kv/del",
+          "tinycloud.kv/list",
+          "tinycloud.kv/metadata",
+        ],
+      },
+      {
+        // SQL actions granted on the app's database file
+        service: "sql",
+        space: "default",
+        path: "com.listen.app/data.sqlite",
+        actions: ["tinycloud.sql/read", "tinycloud.sql/write"],
+      },
+    ];
+
+    const parseSpy = mock(() => grantedRaw);
+    const createDelegationSpy = mock(() => ({
+      delegation: "fake-multi-resource-ucan",
+      cid: "bafymulti",
+      delegateDid: BOB_DID,
+      expiry: Math.floor((Date.now() + 3600_000) / 1000),
+      // Rust emits sorted by (service, path); for these entries kv < sql.
+      resources: [
+        {
+          service: "kv",
+          space: "space://test",
+          path: "com.listen.app/",
+          actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+        },
+        {
+          service: "sql",
+          space: "space://test",
+          path: "com.listen.app/data.sqlite",
+          actions: ["tinycloud.sql/read"],
+        },
+      ],
+    }));
+    const prepareSessionSpy = mock(() => ({}));
+
+    const wasm = makeFakeWasmBindings({
+      parseRecapFromSiwe: parseSpy as any,
+      createDelegation: createDelegationSpy as any,
+      prepareSession: prepareSessionSpy as any,
+    });
+
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+
+    const entries: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "com.listen.app/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+      {
+        service: "tinycloud.sql",
+        space: "default",
+        path: "com.listen.app/data.sqlite",
+        actions: ["tinycloud.sql/read"],
+      },
+    ];
+
+    const result = await node.delegateTo(BOB_DID, entries);
+
+    expect(result.prompted).toBe(false);
+    expect(result.delegation.delegateDID).toBe(BOB_DID);
+    // Flat path/actions mirror the first (sorted) resource
+    expect(result.delegation.path).toBe("com.listen.app/");
+    expect(result.delegation.actions).toEqual([
+      "tinycloud.kv/get",
+      "tinycloud.kv/put",
+    ]);
+    // The full multi-resource breakdown is available for consumers
+    // that need it.
+    expect(result.delegation.resources).toEqual([
+      {
+        service: "kv",
+        space: "space://test",
+        path: "com.listen.app/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+      {
+        service: "sql",
+        space: "space://test",
+        path: "com.listen.app/data.sqlite",
+        actions: ["tinycloud.sql/read"],
+      },
+    ]);
+    // Exactly ONE underlying WASM call for the entire multi-entry
+    // request — not N.
+    expect(createDelegationSpy).toHaveBeenCalledTimes(1);
+    expect(prepareSessionSpy).not.toHaveBeenCalled();
+
+    // Sanity: the abilities map we passed to WASM has both services
+    // grouped correctly. createDelegation is mocked so we can inspect
+    // call.mock.calls for the actual shape.
+    const call = (createDelegationSpy as any).mock.calls[0];
+    // call = [session, delegateDID, spaceId, abilities, expirationSecs, notBeforeSecs]
+    const abilitiesSent = call[3];
+    expect(abilitiesSent).toEqual({
+      kv: {
+        "com.listen.app/": ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+      sql: {
+        "com.listen.app/data.sqlite": ["tinycloud.sql/read"],
+      },
+    });
+  });
+
+  test("multi-entry with one missing cap → PermissionNotInManifestError surfaces ALL missing", async () => {
+    // One entry is a subset; the other is NOT. delegateTo must reject
+    // the whole call, not partially issue — partial issuance would
+    // produce a delegation the caller didn't ask for.
+    const parseSpy = mock(() => [
+      {
+        service: "kv",
+        space: "default",
+        path: "/",
+        actions: ["tinycloud.kv/get"],
+      },
+    ]);
+    const createDelegationSpy = mock(() => ({}));
+
+    const wasm = makeFakeWasmBindings({
+      parseRecapFromSiwe: parseSpy as any,
+      createDelegation: createDelegationSpy as any,
+    });
+
     const node = new TinyCloudNode({ wasmBindings: wasm });
     installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
 
@@ -300,19 +456,20 @@ describe("TinyCloudNode.delegateTo", () => {
         service: "tinycloud.kv",
         space: "default",
         path: "items/",
-        actions: ["tinycloud.kv/get"],
+        actions: ["tinycloud.kv/get"], // covered
       },
       {
         service: "tinycloud.sql",
         space: "default",
         path: "/",
-        actions: ["tinycloud.sql/read"],
+        actions: ["tinycloud.sql/read"], // NOT covered
       },
     ];
 
-    await expect(node.delegateTo(BOB_DID, entries)).rejects.toThrow(
-      /one permission entry per call/,
+    await expect(node.delegateTo(BOB_DID, entries)).rejects.toBeInstanceOf(
+      PermissionNotInManifestError,
     );
+    expect(createDelegationSpy).not.toHaveBeenCalled();
   });
 
   test("empty permissions array throws", async () => {
@@ -345,9 +502,15 @@ describe("TinyCloudNode.delegateTo", () => {
       delegation: "fake",
       cid: "bafy",
       delegateDid: BOB_DID,
-      path: "items/",
-      actions: ["tinycloud.kv/get"],
       expiry: Math.floor(Date.now() / 1000) + 3600,
+      resources: [
+        {
+          service: "kv",
+          space: "space://test",
+          path: "items/",
+          actions: ["tinycloud.kv/get"],
+        },
+      ],
     }));
 
     const wasm = makeFakeWasmBindings({
@@ -402,9 +565,15 @@ describe("TinyCloudNode.delegateTo", () => {
       delegation: "fake-legacy-routed",
       cid: "bafylegacy",
       delegateDid: BOB_DID,
-      path: "items/",
-      actions: ["tinycloud.kv/get"],
       expiry: Math.floor(Date.now() / 1000) + 3600,
+      resources: [
+        {
+          service: "kv",
+          space: "space://test",
+          path: "items/",
+          actions: ["tinycloud.kv/get"],
+        },
+      ],
     }));
 
     const wasm = makeFakeWasmBindings({

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Unit tests for manifest-driven `signIn`.
+ *
+ * The headline behavior we're verifying: when a manifest is passed in
+ * the TinyCloudNode config, `signIn()` resolves it via
+ * `resolveManifest` + `manifestAbilitiesUnion` and uses the resulting
+ * abilities map as the SIWE recap — instead of the legacy
+ * `defaultActions` table.
+ *
+ * Coverage:
+ * - Manifest with own permissions only → recap reflects those entries
+ * - Manifest with `delegations[]` → recap covers BOTH the app's caps
+ *   AND every delegation target's permissions (the union)
+ * - No manifest installed → falls back to `defaultActions` (legacy)
+ * - Manifest installed via `setManifest()` post-construction takes
+ *   effect on the next signIn
+ *
+ * The WASM `prepareSession` call is mocked so we can inspect the
+ * `abilities` argument directly without standing up a real session.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  type IWasmBindings,
+  type ISessionManager,
+  type Manifest,
+} from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+// ---------------------------------------------------------------------------
+// Test fixtures (subset of delegateTo.test.ts; intentionally duplicated to
+// keep this file self-contained and easy to read in isolation)
+// ---------------------------------------------------------------------------
+
+function makeFakeSessionManager(): ISessionManager {
+  // Pre-seed with "default" since that's the key name the
+  // TinyCloudNode constructor uses on the WASM side; the real
+  // WASM session manager creates it eagerly. Without this, signIn's
+  // `renameSessionKeyId("default", keyId)` is a no-op and the
+  // subsequent `jwk(keyId)` returns undefined → "Failed to create
+  // session key" error.
+  const keys = new Set<string>(["default"]);
+  return {
+    createSessionKey(id: string): string {
+      keys.add(id);
+      return id;
+    },
+    renameSessionKeyId(oldId: string, newId: string): void {
+      if (keys.has(oldId)) {
+        keys.delete(oldId);
+        keys.add(newId);
+      }
+    },
+    getDID(keyId: string): string {
+      return `did:key:z6MkTest-${keyId}`;
+    },
+    jwk(keyId: string): string | undefined {
+      if (!keys.has(keyId)) return undefined;
+      return JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" });
+    },
+  };
+}
+
+function makeFakeWasmBindings(
+  overrides: Partial<IWasmBindings> = {},
+): IWasmBindings {
+  const base: IWasmBindings = {
+    invoke: mock(() => Promise.resolve({} as any)) as any,
+    invokeAny: mock(() => Promise.resolve({} as any)) as any,
+    prepareSession: mock(() => ({
+      siwe: "fake-siwe",
+      jwk: { kty: "OKP" },
+      spaceId: "space://test",
+      verificationMethod: "did:key:z6MkTestSession",
+    })),
+    completeSessionSetup: mock(() => ({
+      delegationHeader: { Authorization: "Bearer fake" },
+      delegationCid: "bafyfake",
+      jwk: { kty: "OKP" },
+      spaceId: "space://test",
+      verificationMethod: "did:key:z6MkTestSession",
+    })),
+    ensureEip55: (a: string) => a,
+    makeSpaceId: (a: string, c: number, p: string) => `tinycloud:pkh:eip155:${c}:${a}:${p}`,
+    createDelegation: mock(() => ({})),
+    parseRecapFromSiwe: mock(() => [] as any[]),
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(),
+      privateKey: new Uint8Array(),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array()),
+    vault_sha256: mock(() => new Uint8Array()),
+    createSessionManager: makeFakeSessionManager,
+  };
+  return { ...base, ...overrides };
+}
+
+/**
+ * Build a TinyCloudNode wired to a fake signer + the supplied wasm.
+ *
+ * The signer is the minimal duck-typed shape NodeUserAuthorization.signIn
+ * needs: getAddress, getChainId, signMessage. We don't reach the network
+ * calls (checkNodeInfo, ensureSpaceExists) because we override those via
+ * monkey-patching the auth instance after construction.
+ */
+function makeNodeWithSigner(
+  wasm: IWasmBindings,
+  config: Partial<ConstructorParameters<typeof TinyCloudNode>[0]> = {},
+): TinyCloudNode {
+  const fakeSigner = {
+    signMessage: async () => "0x" + "ff".repeat(65),
+    getAddress: async () => "0x0000000000000000000000000000000000000001",
+    getChainId: async () => 1,
+  };
+  return new TinyCloudNode({
+    wasmBindings: wasm,
+    signer: fakeSigner as any,
+    ...config,
+  });
+}
+
+/**
+ * Stub out the post-prepareSession network calls so signIn can complete
+ * without contacting a real server. We monkey-patch the inner auth
+ * handler's methods directly because they're not part of any public
+ * interface — this is a unit test, not an integration test.
+ */
+function stubAuthNetworkCalls(node: TinyCloudNode): void {
+  const auth = (node as any).auth;
+  if (!auth) throw new Error("expected auth handler to be present");
+  // checkNodeInfo is imported at module level inside NodeUserAuthorization;
+  // we can't easily replace it. Instead we replace the methods that wrap
+  // it: ensureSpaceExists is the post-signIn hook, and the import call
+  // happens via `checkNodeInfo(this.tinycloudHosts[0], ...)` which we
+  // intercept by overriding the `tinycloudHosts` array via reflection.
+  // Simpler: replace `signIn` with a thin wrapper that catches the
+  // post-prepareSession network errors. But the cleanest approach is
+  // to mock the global fetch the WASM/server layer uses.
+  //
+  // Replace ensureSpaceExists with a no-op so we don't hit
+  // activateSessionWithHost. checkNodeInfo is already mockable via the
+  // global fetch which Bun's test runner doesn't intercept by default.
+  // We'll instead just stub the entire auth.ensureSpaceExists.
+  auth.ensureSpaceExists = async () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TinyCloudNode.signIn — manifest-driven recap", () => {
+  test("no manifest → uses defaultActions (legacy fallback)", async () => {
+    const prepareSessionSpy = mock((cfg: any) => ({
+      siwe: "fake-siwe",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: "did:key:z6MkTestSession",
+    }));
+    const wasm = makeFakeWasmBindings({
+      prepareSession: prepareSessionSpy as any,
+    });
+
+    const node = makeNodeWithSigner(wasm);
+    stubAuthNetworkCalls(node);
+
+    // Replace checkNodeInfo via the global fetch — the simplest path
+    // is to override the prototype method on the auth handler.
+    const auth = (node as any).auth;
+    const originalSignIn = auth.signIn.bind(auth);
+    auth.signIn = async () => {
+      // Reach into the auth's `wasm.prepareSession` path by simulating
+      // just the part we need to assert: call signIn but stub out the
+      // network bits via a try/catch that swallows the post-prepareSession
+      // errors. We rebuild the assertions on the prepareSession spy.
+      try {
+        return await originalSignIn();
+      } catch {
+        // checkNodeInfo network failure is expected in unit-test mode;
+        // we already captured what we care about via prepareSessionSpy.
+        return undefined as any;
+      }
+    };
+
+    await auth.signIn();
+
+    expect(prepareSessionSpy).toHaveBeenCalled();
+    const cfg = (prepareSessionSpy as any).mock.calls[0][0];
+    // defaultActions table: kv/sql/duckdb/capabilities/hooks under "" path
+    expect(cfg.abilities).toBeDefined();
+    expect(Object.keys(cfg.abilities).sort()).toEqual([
+      "capabilities",
+      "duckdb",
+      "hooks",
+      "kv",
+      "sql",
+    ]);
+    // Empty path means "no path segment" — same convention as the
+    // legacy default table.
+    expect(cfg.abilities.kv).toHaveProperty("");
+    expect(cfg.abilities.kv[""]).toContain("tinycloud.kv/get");
+  });
+
+  test("manifest with app permissions → recap reflects manifest", async () => {
+    const prepareSessionSpy = mock((cfg: any) => ({
+      siwe: "fake-siwe",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: "did:key:z6MkTestSession",
+    }));
+    const wasm = makeFakeWasmBindings({
+      prepareSession: prepareSessionSpy as any,
+    });
+
+    const manifest: Manifest = {
+      id: "com.listen.app",
+      name: "Listen",
+      // Standard tier defaults: kv/sql/capabilities under the
+      // manifest prefix. No DuckDB. No hooks.
+      defaults: true,
+    };
+
+    const node = makeNodeWithSigner(wasm, { manifest });
+    stubAuthNetworkCalls(node);
+
+    const auth = (node as any).auth;
+    try {
+      await auth.signIn();
+    } catch {
+      /* checkNodeInfo network call expected to fail in unit-test mode */
+    }
+
+    expect(prepareSessionSpy).toHaveBeenCalled();
+    const cfg = (prepareSessionSpy as any).mock.calls[0][0];
+
+    // Manifest standard tier produces kv + sql + capabilities entries,
+    // each scoped to the manifest prefix path "com.listen.app/".
+    // No DuckDB (only "all" tier includes it). No hooks (not in defaults).
+    expect(Object.keys(cfg.abilities).sort()).toEqual([
+      "capabilities",
+      "kv",
+      "sql",
+    ]);
+    expect(cfg.abilities.kv).toEqual({
+      "com.listen.app/": [
+        "tinycloud.kv/get",
+        "tinycloud.kv/put",
+        "tinycloud.kv/del",
+        "tinycloud.kv/list",
+        "tinycloud.kv/metadata",
+      ],
+    });
+    expect(cfg.abilities.sql).toEqual({
+      "com.listen.app/": ["tinycloud.sql/read", "tinycloud.sql/write"],
+    });
+    expect(cfg.abilities.capabilities).toEqual({
+      "com.listen.app/": ["tinycloud.capabilities/read"],
+    });
+  });
+
+  test("manifest with delegations → recap unions app caps + delegation caps", async () => {
+    // This is the headline test for the listen use case: an app
+    // declares its own permissions AND a backend delegation target,
+    // and the resulting SIWE recap covers both so the session key
+    // can later issue the backend delegation without a wallet
+    // prompt.
+    const prepareSessionSpy = mock((cfg: any) => ({
+      siwe: "fake-siwe",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: "did:key:z6MkTestSession",
+    }));
+    const wasm = makeFakeWasmBindings({
+      prepareSession: prepareSessionSpy as any,
+    });
+
+    const manifest: Manifest = {
+      id: "com.listen.app",
+      name: "Listen",
+      // App-side: only KV (turn off the broader defaults table).
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "/",
+          actions: ["get", "put"],
+        },
+      ],
+      // Backend delegation: SQL access on a specific db file.
+      delegations: [
+        {
+          to: "did:pkh:eip155:1:0xBACKEND00000000000000000000000000000000",
+          name: "Listen Backend",
+          permissions: [
+            {
+              service: "tinycloud.sql",
+              space: "default",
+              path: "data.sqlite",
+              actions: ["read", "write"],
+            },
+          ],
+        },
+      ],
+    };
+
+    const node = makeNodeWithSigner(wasm, { manifest });
+    stubAuthNetworkCalls(node);
+
+    const auth = (node as any).auth;
+    try {
+      await auth.signIn();
+    } catch {
+      /* network failure expected */
+    }
+
+    expect(prepareSessionSpy).toHaveBeenCalled();
+    const cfg = (prepareSessionSpy as any).mock.calls[0][0];
+
+    // The recap union must contain BOTH services. KV from the app's
+    // own permissions; SQL from the delegation's permissions.
+    expect(Object.keys(cfg.abilities).sort()).toEqual(["kv", "sql"]);
+
+    // KV path inherits the manifest prefix.
+    expect(cfg.abilities.kv).toEqual({
+      "com.listen.app/": ["tinycloud.kv/get", "tinycloud.kv/put"],
+    });
+
+    // SQL path also inherits the manifest prefix —
+    // "data.sqlite" → "com.listen.app/data.sqlite". This is the
+    // test that proves the delegation's permissions go through the
+    // same prefix-application logic as the app's own.
+    expect(cfg.abilities.sql).toEqual({
+      "com.listen.app/data.sqlite": ["tinycloud.sql/read", "tinycloud.sql/write"],
+    });
+  });
+
+  test("setManifest() post-construction takes effect on next signIn", async () => {
+    const prepareSessionSpy = mock((cfg: any) => ({
+      siwe: "fake-siwe",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: "did:key:z6MkTestSession",
+    }));
+    const wasm = makeFakeWasmBindings({
+      prepareSession: prepareSessionSpy as any,
+    });
+
+    // Construct without a manifest, then install one and confirm the
+    // installed manifest drives the next signIn's recap.
+    const node = makeNodeWithSigner(wasm);
+    stubAuthNetworkCalls(node);
+
+    node.setManifest({
+      id: "com.demo.app",
+      name: "Demo",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.kv",
+          space: "default",
+          path: "config",
+          actions: ["get"],
+        },
+      ],
+    });
+
+    const auth = (node as any).auth;
+    try {
+      await auth.signIn();
+    } catch {
+      /* network failure expected */
+    }
+
+    expect(prepareSessionSpy).toHaveBeenCalled();
+    const cfg = (prepareSessionSpy as any).mock.calls[0][0];
+    expect(cfg.abilities).toEqual({
+      kv: {
+        "com.demo.app/config": ["tinycloud.kv/get"],
+      },
+    });
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -82,6 +82,11 @@ import {
   expandActionShortNames,
   isCapabilitySubset,
   parseRecapCapabilities,
+  // Manifest-driven sign-in
+  type Manifest,
+  type AbilitiesMap,
+  resourceCapabilitiesToAbilitiesMap,
+  SERVICE_LONG_TO_SHORT,
 } from "@tinycloud/sdk-core";
 import { NodeUserAuthorization } from "./authorization/NodeUserAuthorization";
 import { FileSessionStorage } from "./storage/FileSessionStorage";
@@ -138,6 +143,22 @@ export interface TinyCloudNodeConfig {
   nonce?: string;
   /** Optional SIWE configuration overrides (e.g., nonce for server-provided nonces) */
   siweConfig?: SiweConfig;
+  /**
+   * App manifest driving the SIWE recap at sign-in.
+   *
+   * When set, `signIn()` resolves the manifest, unions the app's own
+   * permissions with every manifest-declared delegation's permissions,
+   * and uses that union as the session's granted capabilities — NOT
+   * the legacy `defaultActions` table. This is what makes
+   * `delegateTo(manifestDeclaredDid, permissions)` work without a
+   * wallet prompt: the session key's recap already covers the
+   * delegation target's needs at sign-in time.
+   *
+   * When omitted, `signIn()` falls back to `defaultActions` for
+   * backwards compatibility with callers that pre-date the manifest
+   * flow.
+   */
+  manifest?: Manifest;
 }
 
 /**
@@ -372,11 +393,39 @@ export class TinyCloudNode {
       spaceCreationHandler: config.spaceCreationHandler,
       nonce: config.nonce,
       siweConfig: config.siweConfig,
+      manifest: config.manifest,
     });
 
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.wasmBindings.invokeAny,
     });
+  }
+
+  /**
+   * Install or replace the manifest that drives the SIWE recap at
+   * sign-in. Takes effect on the next `signIn()` call — the current
+   * session (if any) is not touched. Wire this up from a higher
+   * layer (e.g. TinyCloudWeb.setManifest) so the manifest is kept
+   * in sync across the stack.
+   */
+  setManifest(manifest: Manifest | undefined): void {
+    if (!this.auth) {
+      // Session-only mode has no auth handler, so there's nothing to
+      // update. The caller almost certainly wanted wallet mode — fail
+      // loudly rather than silently dropping the manifest.
+      throw new Error(
+        "setManifest requires wallet mode. Provide a signer or privateKey in the TinyCloudNode config.",
+      );
+    }
+    this.auth.setManifest(manifest);
+  }
+
+  /**
+   * Return the manifest currently installed on the auth handler,
+   * or `undefined` if none is set.
+   */
+  get manifest(): Manifest | undefined {
+    return this.auth?.manifest;
   }
 
   /**
@@ -984,7 +1033,19 @@ export class TinyCloudNode {
 
   /**
    * Wrapper for the WASM createDelegation function.
-   * Adapts the WASM interface to what SharingService expects.
+   *
+   * The WASM call now takes a multi-resource `abilities` map
+   * (matching `prepareSession`'s shape) and emits ONE UCAN that
+   * covers every `(service, path, actions)` entry. We mirror the raw
+   * result back through `CreateDelegationWasmResult`, converting the
+   * seconds-since-epoch `expiry` to a Date and normalizing the
+   * `delegateDid` → `delegateDID` case.
+   *
+   * Both SharingService (single-entry) and
+   * {@link TinyCloudNode.delegateTo} (multi-entry) drive this through
+   * the same code path so there's exactly one place that touches the
+   * WASM boundary.
+   *
    * @internal
    */
   private createDelegationWrapper(params: CreateDelegationWasmParams): CreateDelegationWasmResult {
@@ -1001,8 +1062,7 @@ export class TinyCloudNode {
       wasmSession,
       params.delegateDID,
       params.spaceId,
-      params.path,
-      params.actions,
+      params.abilities,
       params.expirationSecs,
       params.notBeforeSecs
     );
@@ -1010,10 +1070,12 @@ export class TinyCloudNode {
     return {
       delegation: result.delegation,
       cid: result.cid,
-      delegateDID: result.delegateDid,
-      path: result.path,
-      actions: result.actions,
+      // Rust serde `rename_all = "camelCase"` emits `delegateDid`
+      // (lowercase d); the TypeScript interface uses `delegateDID`
+      // (historical, matches Delegation.delegateDID). Normalize here.
+      delegateDID: result.delegateDid ?? result.delegateDID,
       expiry: new Date(result.expiry * 1000),
+      resources: result.resources,
     };
   }
 
@@ -1574,24 +1636,38 @@ export class TinyCloudNode {
   /**
    * Issue a delegation using the capability-chain flow.
    *
-   * When the requested permissions are a subset of the current session's
-   * recap, the delegation is signed by the session key via WASM — no wallet
-   * prompt. When they are not, a {@link PermissionNotInManifestError} is
-   * raised so the caller can trigger an escalation flow (e.g.
-   * `TinyCloudWeb.requestPermissions`). Passing `forceWalletSign: true`
-   * bypasses the derivability check and always uses the wallet-signed SIWE
-   * path — used by the legacy `createDelegation` fallback and by callers
-   * that want explicit wallet confirmation.
+   * When every requested permission is a subset of the current
+   * session's recap, the delegation is signed by the session key via
+   * WASM — no wallet prompt. When at least one is NOT derivable, a
+   * {@link PermissionNotInManifestError} is raised (carrying the
+   * missing entries) so the caller can trigger an escalation flow
+   * (e.g. `TinyCloudWeb.requestPermissions`). Passing
+   * `forceWalletSign: true` bypasses the derivability check and
+   * always uses the wallet-signed SIWE path — used by the legacy
+   * `createDelegation` fallback and by callers that want explicit
+   * wallet confirmation.
    *
-   * Current limitation: exactly one {@link PermissionEntry} per call. For
-   * multi-resource delegation, call `delegateTo` multiple times. This keeps
-   * each delegation a single `(spaceId, path)` grant, which matches the
-   * underlying `PortableDelegation` shape.
+   * Multi-entry delegations are now emitted as **one** signed UCAN:
+   * the underlying WASM `createDelegation` takes a full
+   * `HashMap<Service, HashMap<Path, Vec<Ability>>>` abilities map
+   * and produces a single attenuation carrying every
+   * `(service, path, actions)` entry. The returned
+   * {@link DelegateToResult.delegation} is that single blob, and
+   * apps can POST it to their backend exactly like a single-entry
+   * delegation (the server verifies all granted resources from one
+   * UCAN).
    *
-   * @throws {@link SessionExpiredError} when there is no session or the
-   *   current session has expired (or will within the 60s safety margin).
-   * @throws {@link PermissionNotInManifestError} when the requested entries
-   *   are not a subset of the granted session capabilities and
+   * For single-entry requests the `PortableDelegation.path` and
+   * `.actions` fields mirror the one granted entry. For
+   * multi-entry requests they mirror the **first** entry (stable
+   * lexicographic order from the Rust side); consumers that need
+   * the full picture read `PortableDelegation.resources`.
+   *
+   * @throws {@link SessionExpiredError} when there is no session or
+   *   the current session has expired (or will within the 60s
+   *   safety margin).
+   * @throws {@link PermissionNotInManifestError} when any requested
+   *   entry is not a subset of the granted session capabilities and
    *   `forceWalletSign` is not set.
    */
   async delegateTo(
@@ -1614,74 +1690,89 @@ export class TinyCloudNode {
       }
     }
 
-    // 2. Require exactly one permission entry per call. The legacy
-    //    createDelegation API bundles actions across services for a single
-    //    (space, path), so we enforce the same cardinality here and let
-    //    callers loop for multi-entry scenarios.
+    // 2. Input validation. Empty arrays and non-arrays both fail here so
+    //    downstream code can safely assume at least one entry.
     if (!Array.isArray(permissions) || permissions.length === 0) {
       throw new Error(
         "delegateTo requires a non-empty permissions array",
       );
     }
-    if (permissions.length > 1) {
-      throw new Error(
-        "delegateTo currently supports one permission entry per call. " +
-          "Call delegateTo multiple times for multi-resource delegation.",
-      );
-    }
-    const entry = permissions[0];
 
-    // 3. Defensively expand any short-form action names into full URNs so
-    //    the subset check and downstream WASM call both see canonical form.
-    const expandedEntry: PermissionEntry = {
+    // 3. Defensively expand any short-form action names into full URNs
+    //    for every entry so the subset check and downstream WASM call
+    //    both see canonical form. This also deep-copies the entries so
+    //    we don't mutate caller-owned data.
+    const expandedEntries: PermissionEntry[] = permissions.map((entry) => ({
       ...entry,
       actions: expandActionShortNames(entry.service, entry.actions),
-    };
+    }));
 
     // 4. Compute expiration. `options.expiry` overrides the default 1h.
-    //    ms-format ("7d") or raw millisecond count both accepted.
+    //    ms-format ("7d") or raw millisecond count both accepted. Cap
+    //    at the session's own expiry so we never emit a UCAN whose
+    //    validity exceeds the parent chain.
     const now = new Date();
     const expiryMs = resolveExpiryMs(options?.expiry);
     const expirationTime = new Date(now.getTime() + expiryMs);
-    // Cap expiry at the session's own expiry so we never emit a UCAN whose
-    // validity exceeds the parent chain.
     let effectiveExpiration = expirationTime;
     if (sessionExpiry !== undefined && sessionExpiry < expirationTime) {
       effectiveExpiration = sessionExpiry;
     }
 
-    // 5. forceWalletSign short-circuit → always legacy path.
+    // 5. forceWalletSign short-circuit → always legacy path. The
+    //    legacy wallet path currently handles one `(space, path)` at
+    //    a time, so we only support single-entry when forced. Callers
+    //    that need multi-entry wallet-signed delegations should issue
+    //    them via the legacy `createDelegation` which loops internally
+    //    (or just not pass `forceWalletSign: true`).
     if (options?.forceWalletSign) {
+      if (expandedEntries.length > 1) {
+        throw new Error(
+          "delegateTo with forceWalletSign=true supports at most one " +
+            "PermissionEntry. Multi-entry requests must go through the " +
+            "session-key UCAN path (drop forceWalletSign) or the legacy " +
+            "createDelegation method.",
+        );
+      }
       const delegation = await this.createDelegationLegacyWalletPath(
         did,
-        expandedEntry,
+        expandedEntries[0],
         effectiveExpiration,
       );
       return { delegation, prompted: true };
     }
 
-    // 6. Derivability check. `parseRecapCapabilities` is a thin wrapper
-    //    around the injected WASM binding; the binding is required because
-    //    `IWasmBindings` declares `parseRecapFromSiwe` as mandatory. If the
-    //    runtime binding hasn't been updated, this call will surface a
-    //    clear TypeError rather than silently falling through.
+    // 6. Derivability check across ALL entries. If any entry is not a
+    //    subset of the granted session capabilities, the whole call
+    //    fails with a typed error carrying the missing entries — we do
+    //    NOT partially issue and drop the failing ones, because that
+    //    would produce a delegation the caller didn't ask for.
+    //
+    //    `parseRecapCapabilities` is a thin wrapper around the
+    //    injected WASM binding; the binding is required because
+    //    `IWasmBindings` declares `parseRecapFromSiwe` as mandatory.
+    //    If the runtime binding hasn't been updated, this call will
+    //    surface a clear TypeError rather than silently falling
+    //    through.
     const granted = parseRecapCapabilities(
       (siwe: string) => this.wasmBindings.parseRecapFromSiwe(siwe),
       session.siwe,
     );
-    const requested: PermissionEntry[] = [expandedEntry];
-    const { subset, missing } = isCapabilitySubset(requested, granted);
+    const { subset, missing } = isCapabilitySubset(expandedEntries, granted);
 
     if (!subset) {
       throw new PermissionNotInManifestError(missing, granted);
     }
 
-    // 7. Subset path — sign the sub-delegation with the session key via WASM.
-    //    No wallet prompt. `createDelegationWrapper` is the same path used
-    //    by SharingService today.
+    // 7. Subset path — sign ONE sub-delegation with the session key
+    //    via WASM that carries every requested entry. No wallet
+    //    prompt. `createDelegationViaWasmPath` builds the
+    //    multi-resource abilities map and returns a single
+    //    PortableDelegation whose `.resources` field lists every
+    //    granted entry.
     const delegation = await this.createDelegationViaWasmPath(
       did,
-      expandedEntry,
+      expandedEntries,
       effectiveExpiration,
       session,
     );
@@ -1691,23 +1782,78 @@ export class TinyCloudNode {
   /**
    * Issue a delegation via the session-key UCAN WASM path.
    *
-   * The caller has already verified the request is derivable from the
-   * current session; we just need to shape the inputs for
-   * {@link createDelegationWrapper}.
+   * The caller has already verified every entry is derivable from
+   * the current session; we build one multi-resource abilities map
+   * and emit one signed UCAN covering them all.
+   *
+   * All entries must share the same target space (the UCAN is
+   * scoped to a single space). If they don't, this throws — mixing
+   * spaces in a single delegation is not supported by the underlying
+   * Rust create_delegation call and the resulting UCAN would be
+   * under-specified.
    *
    * @internal
    */
   private async createDelegationViaWasmPath(
     did: string,
-    entry: PermissionEntry,
+    entries: PermissionEntry[],
     expirationTime: Date,
     session: TinyCloudSession,
   ): Promise<PortableDelegation> {
-    // Translate the manifest `space` field into the server-side spaceId.
-    // "default" resolves to the session's primary space; any other value
-    // is trusted as a raw space URI (this matches how the rest of the
-    // node-sdk treats `spaceIdOverride`).
-    const spaceId = entry.space === "default" ? session.spaceId : entry.space;
+    if (entries.length === 0) {
+      throw new Error(
+        "createDelegationViaWasmPath requires a non-empty entries array",
+      );
+    }
+
+    // Translate the manifest `space` field into the server-side
+    // spaceId. "default" resolves to the session's primary space;
+    // any other value is trusted as a raw space URI (matches how
+    // the rest of the node-sdk treats `spaceIdOverride`).
+    const resolvedSpaces = new Set<string>();
+    for (const entry of entries) {
+      const spaceId =
+        entry.space === "default" ? session.spaceId : entry.space;
+      resolvedSpaces.add(spaceId);
+    }
+    if (resolvedSpaces.size !== 1) {
+      throw new Error(
+        `delegateTo: all permission entries must target the same space, got ${resolvedSpaces.size}: ${JSON.stringify([...resolvedSpaces])}`,
+      );
+    }
+    const spaceId = [...resolvedSpaces][0];
+
+    // Convert entries to the WASM abilities shape. Each entry's
+    // `service` is the long form (e.g. "tinycloud.kv") which we
+    // translate to the short form keyed by the abilities map.
+    // Multiple entries on the same (service, path) merge and dedupe
+    // their action lists — unusual in practice (the subset check
+    // should have pruned dupes already) but cheap and safe.
+    const abilities: AbilitiesMap = {};
+    for (const entry of entries) {
+      const shortService = SERVICE_LONG_TO_SHORT[entry.service];
+      if (shortService === undefined) {
+        throw new Error(
+          `delegateTo: unknown service '${entry.service}' — no short-form mapping`,
+        );
+      }
+      if (abilities[shortService] === undefined) {
+        abilities[shortService] = {};
+      }
+      const pathsMap = abilities[shortService];
+      const existing = pathsMap[entry.path];
+      if (existing === undefined) {
+        pathsMap[entry.path] = [...entry.actions];
+      } else {
+        const seen = new Set(existing);
+        for (const action of entry.actions) {
+          if (!seen.has(action)) {
+            existing.push(action);
+            seen.add(action);
+          }
+        }
+      }
+    }
 
     // Build ServiceSession from TinyCloudSession. This mirrors how
     // SharingService hands sessions to createDelegationWrapper.
@@ -1724,21 +1870,27 @@ export class TinyCloudNode {
       session: serviceSession,
       delegateDID: did,
       spaceId,
-      path: entry.path,
-      actions: entry.actions,
+      abilities,
       expirationSecs,
     });
 
-    // Translate the WASM result into a PortableDelegation. We don't have a
-    // structured delegation header from the WASM path, so we synthesize one
-    // from the serialized delegation (the recipient decodes it via
-    // `deserializeDelegation`).
+    // Translate the WASM result into a PortableDelegation. We don't
+    // have a structured delegation header from the WASM path, so we
+    // synthesize one from the serialized delegation (the recipient
+    // decodes it via `deserializeDelegation`).
+    //
+    // The flat `.path` and `.actions` fields mirror the first
+    // resource — stable because the Rust side sorts by
+    // (service, path) before signing. Consumers that need the full
+    // multi-resource picture read `.resources`.
+    const primary = result.resources[0];
     return {
       cid: result.cid,
       delegationHeader: { Authorization: `Bearer ${result.delegation}` },
       spaceId,
-      path: entry.path,
-      actions: entry.actions,
+      path: primary.path,
+      actions: primary.actions,
+      resources: result.resources,
       disableSubDelegation: false,
       expiry: result.expiry,
       delegateDID: did,
@@ -1825,38 +1977,38 @@ export class TinyCloudNode {
       resolvedDelegateDID = `did:pkh:eip155:1:${address}`;
     }
 
-    // Legacy params lump multiple services' actions under one path. The
-    // fast-path `delegateTo` emits one `PortableDelegation` per entry, so
-    // we only take the fast path when the legacy request contains actions
-    // for exactly one service. Multi-service legacy calls always go through
-    // the wallet path to preserve today's single-PortableDelegation return
-    // shape (with its `publicDelegation` companion for KV).
+    // Legacy params lump multiple services' actions under one path. We
+    // now emit ONE multi-resource UCAN for any number of entries via
+    // the fast path, so there's no longer a "single-entry only" gate
+    // here — the fast path handles N entries and returns a single
+    // PortableDelegation whose `.resources` describes the full set.
+    //
+    // Fall back to the wallet path when the capabilities aren't
+    // derivable from the current session (PermissionNotInManifestError)
+    // so legacy callers requesting scope outside their session continue
+    // to see a wallet prompt, matching today's behaviour.
     const entries = legacyParamsToPermissionEntries(
       params.actions,
       params.path,
       params.spaceIdOverride,
     );
-    if (entries.length === 1) {
-      try {
-        const result = await this.delegateTo(
-          resolvedDelegateDID,
-          [entries[0]],
-          params.expiryMs !== undefined
-            ? { expiry: params.expiryMs }
-            : undefined,
-        );
-        return result.delegation;
-      } catch (err) {
-        if (err instanceof PermissionNotInManifestError) {
-          // Expected — fall through to the wallet path below. Legacy
-          // callers that request scope outside their current session
-          // continue to see a wallet prompt, matching today's behaviour.
-        } else {
-          // SessionExpiredError and any other error class must propagate.
-          // An expired session can't be rescued by re-signing the SIWE
-          // here — the caller needs to run signIn() again.
-          throw err;
-        }
+    try {
+      const result = await this.delegateTo(
+        resolvedDelegateDID,
+        entries,
+        params.expiryMs !== undefined ? { expiry: params.expiryMs } : undefined,
+      );
+      return result.delegation;
+    } catch (err) {
+      if (err instanceof PermissionNotInManifestError) {
+        // Expected — fall through to the wallet path below. Legacy
+        // callers that request scope outside their current session
+        // continue to see a wallet prompt, matching today's behaviour.
+      } else {
+        // SessionExpiredError and any other error class must propagate.
+        // An expired session can't be rescued by re-signing the SIWE
+        // here — the caller needs to run signIn() again.
+        throw err;
       }
     }
 

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -16,6 +16,10 @@ import {
   AutoApproveSpaceCreationHandler,
   IWasmBindings,
   ISessionManager,
+  Manifest,
+  AbilitiesMap,
+  manifestAbilitiesUnion,
+  resolveManifest,
 } from "@tinycloud/sdk-core";
 import {
   SignStrategy,
@@ -64,6 +68,25 @@ export interface NodeUserAuthorizationConfig {
   nonce?: string;
   /** Optional SIWE configuration overrides (e.g., nonce for server-provided nonces) */
   siweConfig?: SiweConfig;
+  /**
+   * App manifest used to drive the SIWE recap at sign-in.
+   *
+   * When set, `signIn` resolves the manifest (via
+   * {@link resolveManifest}), unions the app's own permissions with
+   * every `delegations[*].permissions` list, converts to the WASM
+   * abilities shape, and uses that map as the session's granted
+   * capabilities — *instead* of `defaultActions`.
+   *
+   * This is what makes manifest-declared pre-delegations usable: the
+   * session key's recap covers both the app's runtime needs and the
+   * downstream delegation targets, so `delegateTo` can issue the
+   * sub-delegation via the session-key UCAN path without a wallet
+   * prompt.
+   *
+   * When omitted, `signIn` falls back to `defaultActions` for
+   * backwards compatibility.
+   */
+  manifest?: Manifest;
 }
 
 /**
@@ -115,6 +138,12 @@ export class NodeUserAuthorization implements IUserAuthorization {
   private readonly nonce?: string;
   private readonly siweConfig?: SiweConfig;
   private readonly wasm: IWasmBindings;
+  /**
+   * Stored manifest, if one was provided at construction time. Used by
+   * {@link signIn} to derive the session's granted capabilities instead
+   * of falling back to {@link defaultActions}.
+   */
+  private _manifest?: Manifest;
 
   private sessionManager: ISessionManager;
   private extensions: Extension[] = [];
@@ -184,9 +213,28 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this.enablePublicSpace = config.enablePublicSpace ?? true;
     this.nonce = config.nonce;
     this.siweConfig = config.siweConfig;
+    this._manifest = config.manifest;
 
     // Initialize session manager via WASM bindings
     this.sessionManager = this.wasm.createSessionManager();
+  }
+
+  /**
+   * Return the manifest currently driving sign-in behavior, or
+   * `undefined` if none is set. Used by TinyCloudWeb/TinyCloudNode
+   * internals to surface the manifest for requestPermissions flows
+   * without forcing the caller to track it separately.
+   */
+  get manifest(): Manifest | undefined {
+    return this._manifest;
+  }
+
+  /**
+   * Install or replace the stored manifest. Takes effect on the next
+   * `signIn()` call — the current session (if any) is not touched.
+   */
+  setManifest(manifest: Manifest | undefined): void {
+    this._manifest = manifest;
   }
 
   /**
@@ -206,6 +254,40 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
   get nodeFeatures(): string[] {
     return this._nodeFeatures;
+  }
+
+  /**
+   * Compute the `abilities` map the WASM `prepareSession` call should
+   * see at sign-in time.
+   *
+   * When a manifest is installed, we resolve it and union together:
+   * - the app's own `resources` (what it needs at runtime)
+   * - every `additionalDelegates[*].permissions` list (what it will
+   *   re-delegate to other DIDs post sign-in)
+   *
+   * into the short-service / path / full-URN-actions shape the WASM
+   * layer expects. This is the key invariant that lets
+   * {@link TinyCloudNode.delegateTo} issue manifest-declared
+   * delegations via the session key (no wallet prompt): the session's
+   * own recap already covers every action those delegations need.
+   *
+   * When no manifest is installed, we fall back to the
+   * {@link defaultActions} table so existing callers see no change.
+   *
+   * This is a pure function of `this._manifest` + `this.defaultActions`
+   * — the manifest resolution performs no I/O and throws a
+   * {@link ManifestValidationError} on structural problems (missing
+   * id/name, unparseable expiry, etc), which will surface at sign-in
+   * rather than being silently swallowed.
+   *
+   * @internal
+   */
+  private resolveSignInAbilities(): AbilitiesMap {
+    if (this._manifest === undefined) {
+      return this.defaultActions;
+    }
+    const resolved = resolveManifest(this._manifest);
+    return manifestAbilitiesUnion(resolved);
   }
 
   /**
@@ -483,9 +565,14 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const now = new Date();
     const expirationTime = new Date(now.getTime() + this.sessionExpirationMs);
 
-    // Prepare session - this creates the SIWE message with ReCap capabilities
+    // Prepare session - this creates the SIWE message with ReCap capabilities.
+    //
+    // When a manifest is installed, `resolveSignInAbilities()` returns
+    // the union of app permissions + every manifest-declared
+    // delegation's permissions in the shape `prepareSession` accepts.
+    // Otherwise it returns `defaultActions` unchanged (legacy path).
     const prepared = this.wasm.prepareSession({
-      abilities: this.defaultActions,
+      abilities: this.resolveSignInAbilities(),
       address,
       chainId,
       domain: this.domain,
@@ -680,9 +767,14 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const now = new Date();
     const expirationTime = new Date(now.getTime() + this.sessionExpirationMs);
 
-    // Prepare session - this creates the SIWE message with ReCap capabilities
+    // Prepare session - this creates the SIWE message with ReCap capabilities.
+    //
+    // When a manifest is installed, `resolveSignInAbilities()` returns
+    // the union of app permissions + every manifest-declared
+    // delegation's permissions in the shape `prepareSession` accepts.
+    // Otherwise it returns `defaultActions` unchanged (legacy path).
     const prepared = this.wasm.prepareSession({
-      abilities: this.defaultActions,
+      abilities: this.resolveSignInAbilities(),
       address,
       chainId,
       domain: this.domain,

--- a/packages/node-sdk/src/delegation.ts
+++ b/packages/node-sdk/src/delegation.ts
@@ -1,4 +1,4 @@
-import { Delegation } from "@tinycloud/sdk-core";
+import { Delegation, DelegatedResource } from "@tinycloud/sdk-core";
 
 /**
  * A portable delegation that can be transported between users.
@@ -10,6 +10,12 @@ import { Delegation } from "@tinycloud/sdk-core";
  * - `ownerAddress`: Space owner's address for session creation
  * - `chainId`: Chain ID for session creation
  * - `host`: Optional server URL
+ * - `resources`: Multi-resource grant breakdown (present when the
+ *   delegation was issued via the multi-resource WASM path, i.e. one
+ *   UCAN covering multiple `(service, path, actions)` entries). The
+ *   flat `path` + `actions` fields mirror the first entry for
+ *   single-resource callers; consumers that need the full picture
+ *   read `resources`.
  */
 export interface PortableDelegation extends Omit<Delegation, "isRevoked"> {
   /** The authorization header for this delegation (structured format) */
@@ -29,6 +35,15 @@ export interface PortableDelegation extends Omit<Delegation, "isRevoked"> {
 
   /** Companion delegation for the user's public space (auto-created when includePublicSpace is true) */
   publicDelegation?: PortableDelegation;
+
+  /**
+   * Full multi-resource grant breakdown. Present when the delegation
+   * was issued via the multi-resource WASM path; each entry describes
+   * one `(service, space, path, actions)` grant carried by the single
+   * underlying UCAN. When absent, only the flat `path` + `actions`
+   * fields are authoritative (legacy single-resource shape).
+   */
+  resources?: DelegatedResource[];
 }
 
 /**

--- a/packages/sdk-core/src/delegations/SharingService.ts
+++ b/packages/sdk-core/src/delegations/SharingService.ts
@@ -39,6 +39,44 @@ import { DelegationErrorCodes } from "./types";
 import type { DelegationManager } from "./DelegationManager";
 import type { ICapabilityKeyRegistry } from "../authorization/CapabilityKeyRegistry";
 import { validateEncodedShareData } from "./SharingService.schema.js";
+import { SERVICE_LONG_TO_SHORT } from "../manifest";
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Infer the short-form service name (`"kv"`, `"sql"`, etc) that all of the
+ * given full-URN action strings belong to.
+ *
+ * SharingService issues single-service delegations (KV-only, SQL-only, …) —
+ * the multi-resource WASM `createDelegation` call requires the service
+ * segment explicitly because it's keyed separately from the action list.
+ * This helper extracts the namespace half (`"tinycloud.kv"`) from each URN,
+ * maps it to the short form via {@link SERVICE_LONG_TO_SHORT}, and returns
+ * `undefined` if the actions are not all from the same known service.
+ *
+ * Returning `undefined` is intentional: the caller must surface a clear
+ * error rather than guessing.
+ */
+function inferShortServiceFromActionUrns(
+  actions: readonly string[]
+): string | undefined {
+  let short: string | undefined;
+  for (const action of actions) {
+    const slash = action.indexOf("/");
+    if (slash === -1) return undefined;
+    const longService = action.slice(0, slash);
+    const candidate = SERVICE_LONG_TO_SHORT[longService];
+    if (candidate === undefined) return undefined;
+    if (short === undefined) {
+      short = candidate;
+    } else if (short !== candidate) {
+      return undefined;
+    }
+  }
+  return short;
+}
 
 // =============================================================================
 // Constants
@@ -752,14 +790,49 @@ export class SharingService implements ISharingService {
     }
 
     if (this.createDelegationWasmFn) {
-      // Client-side delegation creation via WASM
+      // Client-side delegation creation via WASM.
+      //
+      // SharingService always issues single-resource delegations (one
+      // path, one action list). The multi-resource WASM API takes an
+      // `abilities` map shaped `Record<shortService, Record<path,
+      // actions[]>>`, so we infer the short service from the first
+      // action URN (every action in a share call shares the same
+      // service namespace by construction — KV-only, SQL-only, etc).
+      //
+      // The result comes back with a `resources` array; for a
+      // single-entry call it always has exactly one entry, and we
+      // mirror that entry's `path` + `actions` back into the flat
+      // Delegation shape that the rest of SharingService works with.
       try {
+        if (actions.length === 0) {
+          return {
+            ok: false,
+            error: createError(
+              DelegationErrorCodes.VALIDATION_ERROR,
+              "createDelegation requires at least one action"
+            ),
+          };
+        }
+        const shortService = inferShortServiceFromActionUrns(actions);
+        if (shortService === undefined) {
+          return {
+            ok: false,
+            error: createError(
+              DelegationErrorCodes.VALIDATION_ERROR,
+              `createDelegation: cannot infer service from actions ${JSON.stringify(actions)} — expected full URNs like "tinycloud.kv/get"`
+            ),
+          };
+        }
+
         const wasmResult = this.createDelegationWasmFn({
           session: this.session,
           delegateDID,
           spaceId: this.session.spaceId,
-          path,
-          actions,
+          abilities: {
+            [shortService]: {
+              [path]: [...actions],
+            },
+          },
           expirationSecs: Math.floor(expiry.getTime() / 1000),
         });
 
@@ -782,12 +855,27 @@ export class SharingService implements ISharingService {
           };
         }
 
+        // Single-entry call → resources[0] is authoritative for the
+        // flat Delegation shape. We assert length here because a
+        // zero-length result would mean the Rust side dropped our
+        // single input — that's a protocol bug, not a runtime
+        // condition to silently coerce.
+        if (wasmResult.resources.length === 0) {
+          return {
+            ok: false,
+            error: createError(
+              DelegationErrorCodes.CREATION_FAILED,
+              "createDelegation WASM returned empty resources array for a single-entry request"
+            ),
+          };
+        }
+        const primary = wasmResult.resources[0];
         return {
           cid: wasmResult.cid,
           delegateDID: wasmResult.delegateDID,
           spaceId: this.session.spaceId,
-          path: wasmResult.path,
-          actions: wasmResult.actions,
+          path: primary.path,
+          actions: primary.actions,
           expiry: wasmResult.expiry,
           isRevoked: false,
           authHeader: wasmResult.delegation,

--- a/packages/sdk-core/src/delegations/index.ts
+++ b/packages/sdk-core/src/delegations/index.ts
@@ -70,6 +70,7 @@ export {
   // WASM delegation types
   CreateDelegationWasmParams,
   CreateDelegationWasmResult,
+  DelegatedResource,
 } from "./types";
 
 // Classes

--- a/packages/sdk-core/src/delegations/types.schema.test.ts
+++ b/packages/sdk-core/src/delegations/types.schema.test.ts
@@ -612,26 +612,40 @@ describe("DelegationApiResponseSchema", () => {
 // =============================================================================
 
 describe("CreateDelegationWasmParamsSchema", () => {
-  it("should validate params with mock session", () => {
+  // Params schema was migrated to the multi-resource shape alongside
+  // the Rust create_delegation WASM change: `path` + `actions` →
+  // `abilities: Record<short service, Record<path, actionURNs[]>>`.
+  // These tests cover the single-entry and multi-entry cases that
+  // flow through the same validator.
+  it("should validate single-entry abilities params", () => {
     const params = {
       session: { did: "did:key:z6MkTest", spaceId: "space-123" },
       delegateDID: "did:key:z6MkTarget",
       spaceId: "space-123",
-      path: "/kv/test",
-      actions: ["tinycloud.kv/get"],
+      abilities: {
+        kv: {
+          "/kv/test": ["tinycloud.kv/get"],
+        },
+      },
       expirationSecs: 1735689600,
     };
     const result = CreateDelegationWasmParamsSchema.safeParse(params);
     expect(result.success).toBe(true);
   });
 
-  it("should validate params with notBeforeSecs", () => {
+  it("should validate multi-service multi-path abilities params", () => {
     const params = {
       session: { did: "did:key:z6MkTest", spaceId: "space-123" },
       delegateDID: "did:key:z6MkTarget",
       spaceId: "space-123",
-      path: "/kv/test",
-      actions: ["tinycloud.kv/get"],
+      abilities: {
+        kv: {
+          "com.listen.app/": ["tinycloud.kv/get", "tinycloud.kv/put"],
+        },
+        sql: {
+          "com.listen.app/data.sqlite": ["tinycloud.sql/read"],
+        },
+      },
       expirationSecs: 1735689600,
       notBeforeSecs: 1704067200,
     };
@@ -641,14 +655,49 @@ describe("CreateDelegationWasmParamsSchema", () => {
 });
 
 describe("CreateDelegationWasmResultSchema", () => {
-  it("should validate a result", () => {
+  // Result schema now carries a `resources` array instead of flat
+  // path/actions fields. For single-entry calls `resources` has
+  // exactly one entry; for multi-entry it has one per
+  // (service, path) tuple in (service, path) lexicographic order.
+  it("should validate a single-resource result", () => {
     const result = {
       delegation: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9...",
       cid: "bafyrei1234567890",
       delegateDID: "did:key:z6MkTarget",
-      path: "/kv/test",
-      actions: ["tinycloud.kv/get"],
       expiry: new Date("2025-12-31"),
+      resources: [
+        {
+          service: "kv",
+          space: "tinycloud:pkh:eip155:1:0xabc:default",
+          path: "/kv/test",
+          actions: ["tinycloud.kv/get"],
+        },
+      ],
+    };
+    const parseResult = CreateDelegationWasmResultSchema.safeParse(result);
+    expect(parseResult.success).toBe(true);
+  });
+
+  it("should validate a multi-resource result", () => {
+    const result = {
+      delegation: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9...",
+      cid: "bafyrei1234567890",
+      delegateDID: "did:key:z6MkTarget",
+      expiry: new Date("2025-12-31"),
+      resources: [
+        {
+          service: "kv",
+          space: "tinycloud:pkh:eip155:1:0xabc:default",
+          path: "com.listen.app/",
+          actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+        },
+        {
+          service: "sql",
+          space: "tinycloud:pkh:eip155:1:0xabc:default",
+          path: "com.listen.app/data.sqlite",
+          actions: ["tinycloud.sql/read"],
+        },
+      ],
     };
     const parseResult = CreateDelegationWasmResultSchema.safeParse(result);
     expect(parseResult.success).toBe(true);

--- a/packages/sdk-core/src/delegations/types.schema.ts
+++ b/packages/sdk-core/src/delegations/types.schema.ts
@@ -522,7 +522,42 @@ export type DelegationApiResponse = z.infer<typeof DelegationApiResponseSchema>;
 // =============================================================================
 
 /**
+ * A single (service, space, path, actions) entry inside a
+ * createDelegation WASM result.
+ *
+ * Mirrors the Rust `DelegatedResource` struct in
+ * `tinycloud-sdk-wasm/src/session.rs`. Field names match the manifest
+ * {@link PermissionEntry} shape so callers can reconstruct what they sent
+ * without having to re-parse the UCAN.
+ *
+ * `service` is the short form (e.g. `"kv"`, `"sql"`) as returned by the
+ * Rust layer. The SDK layer translates to the long form
+ * (`"tinycloud.kv"`) when comparing against manifests.
+ */
+export const DelegatedResourceSchema = z.object({
+  /** Short-form service name, e.g. "kv", "sql", "duckdb", "capabilities", "hooks". */
+  service: z.string(),
+  /** Full space id string, e.g. "tinycloud:pkh:eip155:1:0x....:default". */
+  space: z.string(),
+  /** Resource path; empty string when the resource URI had no path segment. */
+  path: z.string(),
+  /** Full-URN ability strings, e.g. ["tinycloud.kv/get", "tinycloud.kv/put"]. */
+  actions: z.array(z.string()),
+});
+
+export type DelegatedResource = z.infer<typeof DelegatedResourceSchema>;
+
+/**
  * Input parameters for the createDelegation WASM function.
+ *
+ * A single call may encode multiple `(service, path, actions)` entries
+ * via the `abilities` map — the underlying UCAN will contain one
+ * attenuation entry per `(service, path)` pair, all signed by the same
+ * session key in one blob.
+ *
+ * The `abilities` shape is identical to what `prepareSession` accepts
+ * (`Record<shortService, Record<path, actionURNs[]>>`), so manifest
+ * resolution can feed both sides from one data structure.
  */
 export const CreateDelegationWasmParamsSchema = z.object({
   /** The session containing delegation credentials */
@@ -534,10 +569,23 @@ export const CreateDelegationWasmParamsSchema = z.object({
   delegateDID: z.string(),
   /** Space ID this delegation applies to */
   spaceId: z.string(),
-  /** Resource path this delegation grants access to */
-  path: z.string(),
-  /** Actions to authorize */
-  actions: z.array(z.string()),
+  /**
+   * Multi-resource abilities map: short-service → path → full-URN actions.
+   * Matches the shape accepted by `prepareSession`.
+   *
+   * Example:
+   * ```
+   * {
+   *   kv: {
+   *     "com.listen.app/": ["tinycloud.kv/get", "tinycloud.kv/put"]
+   *   },
+   *   sql: {
+   *     "com.listen.app/data.sqlite": ["tinycloud.sql/read"]
+   *   }
+   * }
+   * ```
+   */
+  abilities: z.record(z.string(), z.record(z.string(), z.array(z.string()))),
   /** Expiration time in seconds since Unix epoch */
   expirationSecs: z.number(),
   /** Optional not-before time in seconds since Unix epoch */
@@ -548,6 +596,11 @@ export type CreateDelegationWasmParams = z.infer<typeof CreateDelegationWasmPara
 
 /**
  * Result from the createDelegation WASM function.
+ *
+ * A single UCAN may cover multiple resources. The `resources` array
+ * describes every `(service, space, path, actions)` entry granted, in
+ * deterministic (service, path) lexicographic order (the Rust side sorts
+ * the HashMap entries before signing).
  */
 export const CreateDelegationWasmResultSchema = z.object({
   /** Base64url-encoded UCAN delegation */
@@ -556,12 +609,13 @@ export const CreateDelegationWasmResultSchema = z.object({
   cid: z.string(),
   /** DID of the delegate */
   delegateDID: z.string(),
-  /** Resource path the delegation grants access to */
-  path: z.string(),
-  /** Actions the delegation authorizes */
-  actions: z.array(z.string()),
   /** Expiration time */
   expiry: z.coerce.date(),
+  /**
+   * All (service, space, path, actions) entries granted by this delegation.
+   * Always non-empty on success.
+   */
+  resources: z.array(DelegatedResourceSchema),
 });
 
 export type CreateDelegationWasmResult = z.infer<typeof CreateDelegationWasmResultSchema>;

--- a/packages/sdk-core/src/delegations/types.ts
+++ b/packages/sdk-core/src/delegations/types.ts
@@ -90,6 +90,8 @@ export {
   type CreateDelegationWasmParams,
   CreateDelegationWasmResultSchema,
   type CreateDelegationWasmResult,
+  DelegatedResourceSchema,
+  type DelegatedResource,
 
   // Validation helpers
   validateDelegation,

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -190,6 +190,7 @@ export {
   CreateDelegationParams,
   CreateDelegationWasmParams,
   CreateDelegationWasmResult,
+  DelegatedResource,
   DelegationChain,
   DelegationApiResponse,
   // Configuration types
@@ -304,13 +305,17 @@ export {
   DEFAULT_EXPIRY,
   SERVICE_LONG_TO_SHORT,
   SERVICE_SHORT_TO_LONG,
+  // Types
+  type AbilitiesMap,
   // Functions
   applyPrefix,
   expandActionShortNames,
   loadManifest,
+  manifestAbilitiesUnion,
   normalizeDefaults,
   parseExpiry,
   resolveManifest,
+  resourceCapabilitiesToAbilitiesMap,
   validateManifest,
 } from "./manifest";
 

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -630,3 +630,108 @@ function resolveEntry(
     ...(entryExpiryMs !== undefined ? { expiryMs: entryExpiryMs } : {}),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Abilities map construction (bridge to WASM prepareSession / createDelegation)
+// ---------------------------------------------------------------------------
+
+/**
+ * The shape `prepareSession` and the multi-resource `createDelegation` WASM
+ * export both accept:
+ *
+ * ```
+ * { [shortService]: { [path]: [fullUrnAction, ...] } }
+ * ```
+ *
+ * - `shortService` is the recap-level service segment (`"kv"`, `"sql"`,
+ *   `"duckdb"`, `"capabilities"`, `"hooks"`) — not the manifest long form.
+ * - `path` is the fully-resolved path (prefix already applied). An empty
+ *   string means "no path segment" on the resource URI.
+ * - Action strings are full URNs like `"tinycloud.kv/get"`.
+ *
+ * This is a single source of truth for both the session's own recap (at
+ * sign-in) and the delegations it can derive (post sign-in). We re-use it
+ * for both so one manifest drives both sides.
+ */
+export type AbilitiesMap = Record<string, Record<string, string[]>>;
+
+/**
+ * Convert a list of {@link ResourceCapability} entries (manifest
+ * long-form service, full-URN actions) into the {@link AbilitiesMap}
+ * shape the WASM layer expects.
+ *
+ * When multiple entries target the same `(service, path)` pair, their
+ * action lists are merged and deduped. Entries whose service has no
+ * short-form mapping in {@link SERVICE_LONG_TO_SHORT} are rejected with
+ * a {@link ManifestValidationError} — the SDK does not silently drop
+ * unknown services because the recap encoding would lose them.
+ *
+ * Paths are kept verbatim: this function does NOT collapse
+ * `"com.listen.app/"` and `"com.listen.app"` or reinterpret empty /
+ * slash strings. Callers that care about path canonicalization should
+ * normalize before calling.
+ */
+export function resourceCapabilitiesToAbilitiesMap(
+  resources: readonly ResourceCapability[]
+): AbilitiesMap {
+  const out: AbilitiesMap = {};
+  for (const r of resources) {
+    const shortService = SERVICE_LONG_TO_SHORT[r.service];
+    if (shortService === undefined) {
+      throw new ManifestValidationError(
+        `unknown service '${r.service}' — no short-form mapping. Known services: ${Object.keys(SERVICE_LONG_TO_SHORT).join(", ")}`
+      );
+    }
+    if (out[shortService] === undefined) {
+      out[shortService] = {};
+    }
+    const pathsMap = out[shortService];
+    const existing = pathsMap[r.path];
+    if (existing === undefined) {
+      // Copy so downstream mutation can't leak back into the input.
+      pathsMap[r.path] = [...r.actions];
+    } else {
+      // Merge + dedupe while preserving first-seen order.
+      const seen = new Set(existing);
+      for (const action of r.actions) {
+        if (!seen.has(action)) {
+          existing.push(action);
+          seen.add(action);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the {@link AbilitiesMap} that a session should be signed with,
+ * given a {@link ResolvedCapabilities} (i.e. the output of
+ * {@link resolveManifest}).
+ *
+ * The resulting map is the **union** of:
+ * 1. the app's own resources (`resolved.resources`), and
+ * 2. every permission declared in every `additionalDelegates[*]` entry.
+ *
+ * The union is what makes the manifest's delegations ergonomic: at
+ * sign-in, the session key acquires recap coverage for both the app's
+ * runtime needs and every downstream delegation target. Post sign-in,
+ * `delegateTo(backendDID, backendPermissions)` can then issue the
+ * sub-delegation via the session key (no wallet prompt) because the
+ * caps are already part of the granted set.
+ *
+ * Duplicate `(service, path, action)` triples across resources and
+ * delegations are merged and deduped — the session SIWE doesn't need
+ * them repeated.
+ */
+export function manifestAbilitiesUnion(
+  resolved: ResolvedCapabilities
+): AbilitiesMap {
+  const all: ResourceCapability[] = [...resolved.resources];
+  for (const delegate of resolved.additionalDelegates) {
+    for (const perm of delegate.permissions) {
+      all.push(perm);
+    }
+  }
+  return resourceCapabilitiesToAbilitiesMap(all);
+}

--- a/packages/sdk-core/src/wasm-validation.test.ts
+++ b/packages/sdk-core/src/wasm-validation.test.ts
@@ -93,14 +93,27 @@ describe("WASM Validation Utilities", () => {
   });
 
   describe("validateCreateDelegationWasmOutput", () => {
+    // The raw result shape now carries a `resources` array instead
+    // of flat path/actions fields. These tests cover both single-
+    // and multi-resource results as well as the three expiry
+    // encodings the Rust WASM layer may emit (number seconds, ISO
+    // string, or Date after serde conversion).
+    const singleResource = [
+      {
+        service: "kv",
+        space: "tinycloud:pkh:eip155:1:0xabc:default",
+        path: "/shared/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+
     it("should validate a correct createDelegation result", () => {
       process.env.NODE_ENV = "development";
       const validResult = {
         delegation: "eyJhbGciOiJFUzI1NksifQ...",
         cid: "bafyreih...",
         delegateDID: "did:key:z6Mk...",
-        path: "/shared/",
-        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+        resources: singleResource,
         expiry: 1704067200,
       };
 
@@ -117,8 +130,7 @@ describe("WASM Validation Utilities", () => {
         delegation: "eyJhbGciOiJFUzI1NksifQ...",
         cid: "bafyreih...",
         delegateDID: "did:key:z6Mk...",
-        path: "/shared/",
-        actions: ["tinycloud.kv/get"],
+        resources: singleResource,
         expiry: new Date("2024-01-01T00:00:00Z"),
       };
 
@@ -134,8 +146,7 @@ describe("WASM Validation Utilities", () => {
         delegation: "eyJhbGciOiJFUzI1NksifQ...",
         cid: "bafyreih...",
         delegateDID: "did:key:z6Mk...",
-        path: "/shared/",
-        actions: ["tinycloud.kv/get"],
+        resources: singleResource,
         expiry: "2024-01-01T00:00:00Z",
       };
 
@@ -145,11 +156,41 @@ describe("WASM Validation Utilities", () => {
       expect(result.issues).toBeUndefined();
     });
 
+    it("should validate a multi-resource result", () => {
+      process.env.NODE_ENV = "development";
+      const validResult = {
+        delegation: "eyJhbGciOiJFUzI1NksifQ...",
+        cid: "bafyreih...",
+        delegateDID: "did:key:z6Mk...",
+        expiry: 1704067200,
+        resources: [
+          {
+            service: "kv",
+            space: "tinycloud:pkh:eip155:1:0xabc:default",
+            path: "com.listen.app/",
+            actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+          },
+          {
+            service: "sql",
+            space: "tinycloud:pkh:eip155:1:0xabc:default",
+            path: "com.listen.app/data.sqlite",
+            actions: ["tinycloud.sql/read"],
+          },
+        ],
+      };
+
+      const result = validateCreateDelegationWasmOutput(validResult);
+
+      expect(result.validated).toBe(true);
+      expect(result.issues).toBeUndefined();
+      expect(result.data.resources.length).toBe(2);
+    });
+
     it("should report issues for missing required fields", () => {
       process.env.NODE_ENV = "development";
       const invalidResult = {
         delegation: "eyJhbGciOiJFUzI1NksifQ...",
-        // missing cid, delegateDID, etc.
+        // missing cid, delegateDID, resources, etc.
       };
 
       // Suppress console.warn for this test

--- a/packages/sdk-core/src/wasm-validation.ts
+++ b/packages/sdk-core/src/wasm-validation.ts
@@ -109,9 +109,14 @@ export function validateWasmOutput<T>(
 /**
  * Schema for validating createDelegation WASM output.
  *
- * This is a relaxed version of CreateDelegationWasmResultSchema that
- * accepts the raw WASM output format (expiry as number/string) before
- * transformation to Date.
+ * This is a relaxed version of {@link CreateDelegationWasmResultSchema}
+ * that accepts the raw WASM output format: `expiry` may come back as a
+ * number (seconds since epoch, the Rust-native form) or a string before
+ * transformation to Date, and `delegateDID` may be emitted under the
+ * camelCase field name the WASM produces (`delegateDid`).
+ *
+ * The multi-resource `resources` array matches the strict schema: the
+ * Rust layer always emits it sorted by `(service, path)`.
  */
 export const CreateDelegationWasmRawResultSchema = z.object({
   /** Base64url-encoded UCAN delegation */
@@ -120,12 +125,21 @@ export const CreateDelegationWasmRawResultSchema = z.object({
   cid: z.string(),
   /** DID of the delegate */
   delegateDID: z.string(),
-  /** Resource path the delegation grants access to */
-  path: z.string(),
-  /** Actions the delegation authorizes */
-  actions: z.array(z.string()),
   /** Expiration time (may be number, string, or Date from WASM) */
   expiry: z.union([z.number(), z.string(), z.date()]),
+  /**
+   * Resources granted by this delegation. Each entry carries its own
+   * `(service, space, path, actions)` tuple. Always non-empty on
+   * success.
+   */
+  resources: z.array(
+    z.object({
+      service: z.string(),
+      space: z.string(),
+      path: z.string(),
+      actions: z.array(z.string()),
+    })
+  ),
 });
 
 export type CreateDelegationWasmRawResult = z.infer<

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -26,8 +26,8 @@ js-sys = "0.3.59"
 # tinycloud-sdk-rs = { path = "../../../tinycloud-node/tinycloud-sdk-rs" }
 # tinycloud-sdk-wasm = { path = "../../../tinycloud-node/tinycloud-sdk-wasm" }
 # For release, update rev after pushing tinycloud-node changes:
-tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "3e4b217790dbdb9b4353b9074ddc087336cc12af" }
-tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "3e4b217790dbdb9b4353b9074ddc087336cc12af" }
+tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "6f6fc8602eb94089c933bdab88a19e5ea6c92fd8" }
+tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "6f6fc8602eb94089c933bdab88a19e5ea6c92fd8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.83"
 serde-wasm-bindgen = "0.6.5"

--- a/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
+++ b/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
@@ -23,10 +23,34 @@ export class BrowserWasmBindings implements IWasmBindings {
   makeSpaceId(address: string, chainId: number, prefix: string): string {
     return tinycloud.makeSpaceId(address, chainId, prefix);
   }
+  /**
+   * Create a multi-resource delegation UCAN.
+   *
+   * The WASM signature changed from
+   *   (session, delegateDID, spaceId, path, actions, expirationSecs, notBeforeSecs)
+   * to
+   *   (session, delegateDID, spaceId, abilities, expirationSecs, notBeforeSecs)
+   * where `abilities` is the same `Record<short service, Record<path,
+   * actions[]>>` shape `prepareSession` accepts. One UCAN now covers
+   * every (service, path, actions) entry in the abilities map.
+   */
   createDelegation(
-    session: any, delegateDID: string, spaceId: string,
-    path: string, actions: string[], expirationSecs: number, notBeforeSecs?: number
-  ) { return tinycloud.createDelegation(session, delegateDID, spaceId, path, actions, expirationSecs, notBeforeSecs); }
+    session: any,
+    delegateDID: string,
+    spaceId: string,
+    abilities: Record<string, Record<string, string[]>>,
+    expirationSecs: number,
+    notBeforeSecs?: number
+  ) {
+    return tinycloud.createDelegation(
+      session,
+      delegateDID,
+      spaceId,
+      abilities,
+      expirationSecs,
+      notBeforeSecs
+    );
+  }
   parseRecapFromSiwe(siweString: string) {
     // The WASM binding returns a JS array of { service, space, path, actions }.
     return tinycloud.parseRecapFromSiwe(siweString) as {

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -105,13 +105,19 @@ export interface Config extends ClientConfig {
   provider?: any;
 
   /**
-   * App manifest used for sign-in and escalation flows.
+   * App manifest used for sign-in and escalation flows. When set,
+   * the SIWE recap issued at sign-in covers the union of the app's
+   * own permissions and every manifest-declared delegation's
+   * permissions — which is what enables
+   * `tcw.delegateTo(manifestDeclaredDid, permissions)` to run via
+   * the session-key UCAN path (no wallet prompt).
    *
    * When provided, {@link TinyCloudWeb.requestPermissions} uses the
    * manifest's `name` and `icon` to title the permission modal and
    * composes escalation requests against the manifest's existing
-   * permission set. Phase 4 stores the manifest verbatim; the
-   * manifest-driven sign-in path itself lands in Phase 5.
+   * permission set. The manifest is forwarded into the underlying
+   * {@link TinyCloudNode} so `signIn()` drives its SIWE recap from
+   * it directly.
    */
   manifest?: Manifest;
 }
@@ -206,9 +212,11 @@ export class TinyCloudWeb {
    * App manifest stored from config (or updated via `setManifest`).
    *
    * `requestPermissions` reads this for the modal title/icon and for
-   * composing an expanded manifest on approve. Phase 4 treats this as a
-   * simple passthrough container — the manifest-driven sign-in flow lands
-   * in Phase 5, where `signIn` will consume this field directly.
+   * composing an expanded manifest on approve. `_init` forwards this
+   * value into the underlying {@link TinyCloudNode} so `signIn()`
+   * drives its SIWE recap from the manifest. `setManifest` mirrors
+   * any post-construction updates onto the node so the next sign-in
+   * picks them up.
    */
   private _manifest?: Manifest;
 
@@ -268,6 +276,12 @@ export class TinyCloudWeb {
       wasmBindings: this.wasmBindings,
       nonce: this.config.nonce,
       siweConfig: this.config.siweConfig,
+      // Forward the manifest into the node-sdk layer. This is what
+      // finally wires up the manifest-driven sign-in flow end-to-end:
+      // TinyCloudWeb.Config.manifest → TinyCloudNode → NodeUserAuthorization,
+      // where `resolveManifest` + `manifestAbilitiesUnion` produce the
+      // actual `abilities` map passed to `prepareSession`.
+      manifest: this._manifest,
     };
 
     // Wire up signer if available
@@ -458,9 +472,20 @@ export class TinyCloudWeb {
    * their manifest at runtime (e.g. after fetching a backend's advertised
    * permissions) and by the escalation flow inside
    * {@link requestPermissions}.
+   *
+   * The manifest is forwarded to the underlying TinyCloudNode so the
+   * next `signIn()` picks it up. If the node has not been constructed
+   * yet (pre-init), the manifest is stored locally and forwarded
+   * later inside `_init`.
    */
   setManifest(manifest: Manifest): void {
     this._manifest = manifest;
+    // Forward eagerly if the node is already up. Pre-init, the
+    // manifest rides into the constructor via `nodeConfig.manifest`
+    // inside `_init`, which reads `this._manifest` at that time.
+    if (this._node) {
+      this._node.setManifest(manifest);
+    }
   }
 
   /**
@@ -472,11 +497,11 @@ export class TinyCloudWeb {
    *
    * Spec: `.claude/specs/capability-chain.md` §requestPermissions.
    *
-   * Phase 4 note: the actual manifest-driven `signIn` is Phase 5. For
-   * now, the escalation composes an updated manifest, signs out, and
-   * calls `signIn()` — which still uses the current sign-in path. The
-   * updated `_manifest` field is available for the Phase 5 refactor to
-   * pick up directly.
+   * On approve, this composes the expanded manifest, signs out the
+   * current session, and calls `signIn()` — which now drives its
+   * SIWE recap from `this._manifest` directly, so the fresh session
+   * is signed with the expanded capability set in a single wallet
+   * prompt.
    */
   async requestPermissions(
     additional: PermissionEntry[],
@@ -487,10 +512,10 @@ export class TinyCloudWeb {
     validateAdditionalPermissions(additional);
 
     const manifest = this._manifest;
-    // Phase 4: we require a stored manifest for escalation so we can
-    // compose the expanded permission set. Apps that signed in without a
-    // manifest must set one via `setManifest` before escalating, or
-    // re-run signIn with an explicit manifest (Phase 5).
+    // Escalation requires a stored manifest because we need to
+    // compose the expanded permission set from the current app's
+    // declared permissions. Apps that signed in without a manifest
+    // must set one via `setManifest` before escalating.
     if (manifest === undefined) {
       throw new Error(
         "requestPermissions requires a stored manifest. Pass `manifest` in the TinyCloudWeb config or call setManifest() before requesting escalation.",
@@ -500,6 +525,12 @@ export class TinyCloudWeb {
     // Delegate to the pure core with injected dependencies. Test hooks
     // override any or all of them; production defaults wire to the real
     // modal manager and the class's own signOut/signIn methods.
+    //
+    // `writeManifest` mirrors the updated manifest onto BOTH `_manifest`
+    // and the underlying node so the subsequent `signIn()` call picks
+    // it up automatically. Updating only `_manifest` would leave the
+    // node still configured with the pre-escalation manifest, and the
+    // new sign-in would grant the old capability set.
     return requestPermissionsCore(additional, {
       manifest,
       showModal: this._testHooks?.showModal ?? showPermissionRequestModal,
@@ -507,6 +538,7 @@ export class TinyCloudWeb {
       signIn: this._testHooks?.signIn ?? (() => this.signIn()),
       writeManifest: (next) => {
         this._manifest = next;
+        this._node?.setManifest(next);
       },
     });
   }


### PR DESCRIPTION
## Summary

Fixes the two SDK gaps that shipped in `@tinycloud/*@2.1.0-beta.1` and that block manifest-driven single-prompt sign-in flows for apps like listen.

## What was broken

### Gap 1 — `signIn` ignored `config.manifest`

`TinyCloudWeb.Config.manifest` was stored on the instance for `requestPermissions` to read, but `TinyCloudWeb.signIn() / TinyCloudNode.signIn() / NodeUserAuthorization.signIn()` never actually consumed it. The session SIWE recap was always built from the SDK's hardcoded `defaultActions` table — manifest-declared permissions and pre-delegations never reached the session key. The JSDoc on `Config.manifest` admitted this:

> Phase 4 stores the manifest verbatim; the manifest-driven sign-in path itself lands in Phase 5.

This PR is that Phase 5.

### Gap 2 — `delegateTo` hard-failed on multi-entry input

```ts
if (permissions.length > 1) {
  throw new Error(
    "delegateTo currently supports one permission entry per call. " +
      "Call delegateTo multiple times for multi-resource delegation.",
  );
}
```

Listen needed to delegate `tinycloud.kv` AND `tinycloud.sql` to a backend in one operation. This threw, forcing apps to either issue N separate UCANs (N CIDs, N POSTs) or fall back to the legacy wallet-signed path (N wallet prompts). Both broke the single-prompt invariant.

## What's fixed

### Gap 1 — `signIn` consumes `manifest`

- `NodeUserAuthorizationConfig` and `TinyCloudNodeConfig` gain an optional `manifest?: Manifest` field
- `NodeUserAuthorization` stores the manifest and exposes `manifest` getter + `setManifest()`
- New private `resolveSignInAbilities()` returns either the manifest's resolved abilities map (via the new sdk-core helpers `resolveManifest` + `manifestAbilitiesUnion`) or `defaultActions` as a legacy fallback
- Both `signIn()` and `prepareSessionForSigning()` now drive `prepareSession.abilities` from this helper
- `TinyCloudNode` exposes `setManifest()` and `manifest` getter passthroughs
- `TinyCloudWeb._init()` forwards `_manifest` into `nodeConfig.manifest`; `setManifest()` and `requestPermissions`'s `writeManifest` callback also mirror to the node

The resulting SIWE recap now covers the **union** of:
1. the app's own resources (from `manifest.permissions` + the defaults tier)
2. every `manifest.delegations[*].permissions` list

so the session key acquires capability coverage for both runtime calls AND every downstream sub-delegation target — in **one** wallet prompt.

### Gap 2 — `delegateTo` handles multi-entry as a single UCAN

This required a Rust-side change first: the Rust `Session::create_delegation` was hardcoded to `service = "kv"` and took a single `(path, actions)` pair, so even N wrapper calls would have produced wrong delegations for `sql`/`duckdb`/etc.

**Rust PR** (TinyCloudLabs/tinycloud-node#48, already merged at `6f6fc86`): extends `create_delegation` to take the same multi-resource abilities map shape as `prepareSession`:

```rust
pub fn create_delegation(
    &self,
    delegate_did: &str,
    space_id: &SpaceId,
    abilities: HashMap<Service, HashMap<Path, Vec<Ability>>>,
    expiration_secs: f64,
    not_before_secs: Option<f64>,
) -> Result<DelegationResult, DelegationError>
```

A single call now produces ONE signed UCAN whose `attenuation` carries every `(service, path, actions)` entry. New `DelegationResult.resources` field describes the full breakdown, sorted lexicographically by `(service, path)`. 11/11 Rust unit tests cover the round-trip.

**JS-side fix**:

- `delegateTo` lifts the multi-entry restriction. Derivability is checked against the union of all entries (no partial issuance — if any entry isn't a subset, the whole call throws `PermissionNotInManifestError` with the missing entries)
- `createDelegationViaWasmPath` accepts `PermissionEntry[]`, builds one abilities map, calls WASM `createDelegation` ONCE
- Returns the existing `{ delegation, prompted }` shape — the `delegation` is ONE `PortableDelegation` whose new optional `resources?: DelegatedResource[]` field carries the multi-resource breakdown. Flat `path` + `actions` mirror the first sorted resource for back-compat
- Legacy `createDelegation` no longer gates on `entries.length === 1`; multi-entry legacy calls also route through `delegateTo` first, falling back to wallet path on `PermissionNotInManifestError`
- `BrowserWasmBindings.createDelegation` signature aligned with the new WASM ABI (6 args, abilities map instead of flat path/actions)

## Type changes (sdk-core)

- `CreateDelegationWasmParams.abilities: Record<string, Record<string, string[]>>` replaces flat `path: string; actions: string[]`
- `CreateDelegationWasmResult.resources: DelegatedResource[]` replaces flat `path` / `actions`
- New types: `DelegatedResource`, `AbilitiesMap`
- New helpers in `manifest.ts`: `resourceCapabilitiesToAbilitiesMap`, `manifestAbilitiesUnion`
- `SharingService` updated to consume the new types (single-entry call infers short service from action URN namespace)

## Tests

- `@tinycloud/sdk-core`: **532/532** tests pass. New schema tests cover single- and multi-resource result shapes.
- `@tinycloud/node-sdk`: **28/28** tests pass.
  - New `TinyCloudNode.signInManifest.test.ts` (4 tests) covers the manifest-driven signIn path:
    - no manifest → defaultActions fallback
    - manifest with own permissions → recap reflects manifest tier
    - manifest with `delegations[]` → recap unions app caps + delegate caps (the headline listen test)
    - `setManifest()` post-construction takes effect on next signIn
  - `TinyCloudNode.delegateTo.test.ts` updated:
    - Removed the "multi-entry throws" test
    - Added "multi-entry → ONE UCAN with merged abilities map" verifying the abilities map sent to WASM has both services correctly grouped, exactly one WASM call, no wallet prompt
    - Added "multi-entry with one missing cap → PermissionNotInManifestError surfaces ALL missing"
    - Existing tests updated to return the new `resources[]` WASM shape
- Full monorepo `bun run build` is clean (10/10 tasks).

## Breaking changes

This is a beta-to-beta change so the surface breakage is acceptable, but consumers updating from `2.1.0-beta.1` need to know:

- `CreateDelegationWasmParams` and `CreateDelegationWasmResult` shape changed (breaking schema change in sdk-core)
- `BrowserWasmBindings.createDelegation` signature changed (6 args)
- `delegateTo` no longer throws on multi-entry input — apps that relied on this for validation must add their own length check
- `PortableDelegation` gains an optional `resources?: DelegatedResource[]` field
- The Rust rev in `packages/sdk-rs/Cargo.toml` is bumped to `6f6fc8602eb94089c933bdab88a19e5ea6c92fd8`

The full breaking-change list and migration notes live in the changeset (`.changeset/manifest-signin-multi-delegate.md`).

## Test plan

- [x] `bun run build` — clean
- [x] sdk-core unit tests — 532/532 pass
- [x] node-sdk unit tests — 28/28 pass
- [x] manifest-driven signIn produces a recap union of app + delegation caps (new test)
- [x] multi-entry `delegateTo` produces one UCAN (new test)
- [ ] CI green
- [ ] Beta Release workflow publishes `2.1.0-beta.2` (or whatever comes next in pre-mode)
- [ ] Listen Phase 5 retry succeeds against the new beta with exactly 1 wallet prompt on repeat sign-in

## Related

- TinyCloudLabs/tinycloud-node#48 — multi-resource Rust `create_delegation` (merged)
- Spec: `.claude/specs/manifest.md`, `.claude/specs/capability-chain.md` (in the listen worktree)