### PR TITLE
fix(sdk-core): normalize space URI in recap parse for derivability check

### DIFF
--- a/.changeset/fix-normalize-space-uri.md
+++ b/.changeset/fix-normalize-space-uri.md
@@ -1,0 +1,27 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-services": patch
+---
+
+fix(sdk-core): normalize space URI in recap parse for derivability check
+
+The Rust WASM `parseRecapFromSiwe` returns `space` as the full recap target
+URI (`tinycloud:pkh:eip155:{chainId}:{address}:{name}`), while manifest
+permissions and backend-advertised permissions use the short `{name}` form
+(e.g. `"default"`). `isCapabilitySubset` was doing strict string comparison
+on `space`, so mixing the two forms always failed — `delegateTo` would throw
+`PermissionNotInManifestError` even when the session recap covered every
+requested capability.
+
+This broke end-to-end manifest-driven sign-in in the listen app, where the
+session SIWE was signed correctly with the union of all manifest abilities
+but `delegateTo(backendDID, info.permissions)` still failed on the subset
+check because `"tinycloud:pkh:eip155:1:0xd559...:default"` and `"default"`
+didn't match as strings.
+
+Fix: add a `normalizeSpace` helper that extracts the trailing name segment
+from a `tinycloud:` URI. Apply it in `parseRecapCapabilities` (so the output
+is always in short-name form) and defensively in `isCapabilitySubset` on
+both sides (so callers passing either form work transparently).

--- a/packages/sdk-core/src/capabilities.test.ts
+++ b/packages/sdk-core/src/capabilities.test.ts
@@ -12,6 +12,7 @@ import {
   PermissionNotInManifestError,
   SessionExpiredError,
   isCapabilitySubset,
+  normalizeSpace,
   parseRecapCapabilities,
   type WasmRecapEntry,
 } from "./capabilities";
@@ -410,5 +411,147 @@ describe("SessionExpiredError", () => {
     expect(err.name).toBe("SessionExpiredError");
     expect(err.expiredAt).toEqual(when);
     expect(err.message).toBe("Session expired at 2024-01-01T00:00:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSpace
+// ---------------------------------------------------------------------------
+
+describe("normalizeSpace", () => {
+  it("passes short names through unchanged", () => {
+    expect(normalizeSpace("default")).toBe("default");
+    expect(normalizeSpace("work-space")).toBe("work-space");
+    expect(normalizeSpace("")).toBe("");
+  });
+
+  it("extracts the name from a full pkh URI", () => {
+    expect(
+      normalizeSpace(
+        "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:default"
+      )
+    ).toBe("default");
+    expect(
+      normalizeSpace(
+        "tinycloud:pkh:eip155:1:0xabc0000000000000000000000000000000000000:work-space"
+      )
+    ).toBe("work-space");
+  });
+
+  it("returns the original string on a trailing-colon URI (degrades to strict mismatch)", () => {
+    const malformed = "tinycloud:pkh:eip155:1:0xabc:";
+    expect(normalizeSpace(malformed)).toBe(malformed);
+  });
+
+  it("passes non-tinycloud URIs through unchanged", () => {
+    expect(normalizeSpace("did:key:z6Mk")).toBe("did:key:z6Mk");
+    expect(normalizeSpace("foo")).toBe("foo");
+  });
+});
+
+describe("isCapabilitySubset with mixed space forms", () => {
+  const fullUri =
+    "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:default";
+
+  it("matches short-form requested against full-URI granted (recap parse direction)", () => {
+    const granted: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: fullUri,
+        path: "",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(true);
+    expect(missing).toEqual([]);
+  });
+
+  it("matches full-URI requested against short-form granted (defensive symmetric)", () => {
+    const granted: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: fullUri,
+        path: "",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(true);
+    expect(missing).toEqual([]);
+  });
+
+  it("still rejects mismatched space names regardless of form", () => {
+    const granted: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: fullUri,
+        path: "",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "work-space",
+        path: "",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(false);
+    expect(missing).toHaveLength(1);
+  });
+});
+
+describe("parseRecapCapabilities normalizes space", () => {
+  it("converts a full pkh URI from the recap to the short name", () => {
+    const parseWasm = (_siwe: string): WasmRecapEntry[] => [
+      {
+        service: "kv",
+        space:
+          "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:default",
+        path: "",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+    const out = parseRecapCapabilities(parseWasm, "fake-siwe");
+    expect(out).toEqual([
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ]);
+  });
+
+  it("passes short-name spaces through (forward compatibility)", () => {
+    const parseWasm = (_siwe: string): WasmRecapEntry[] => [
+      {
+        service: "sql",
+        space: "default",
+        path: "",
+        actions: ["tinycloud.sql/read"],
+      },
+    ];
+    const out = parseRecapCapabilities(parseWasm, "fake-siwe");
+    expect(out[0].space).toBe("default");
   });
 });

--- a/packages/sdk-core/src/capabilities.ts
+++ b/packages/sdk-core/src/capabilities.ts
@@ -58,6 +58,41 @@ export class SessionExpiredError extends Error {
 }
 
 // ---------------------------------------------------------------------------
+// Space normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a space identifier to its short-name form.
+ *
+ * Recap resource URIs in a signed SIWE encode the space as a full URI of the
+ * form `tinycloud:pkh:eip155:{chainId}:{address}:{name}` (e.g.
+ * `tinycloud:pkh:eip155:1:0xd559...:default`). Manifest permissions and
+ * backend-advertised permissions use the short `{name}` form (e.g.
+ * `"default"`).
+ *
+ * Strict string comparison between these two forms would always fail, so we
+ * normalize both sides to the short name before comparing. The trailing
+ * segment after the last `:` in a `tinycloud:` URI is the space name.
+ *
+ * Short names (`"default"`, `"work-space"`) are returned unchanged.
+ * Any non-`tinycloud:` string is returned unchanged. A malformed URI with a
+ * trailing colon is returned unchanged (so the check degrades to a strict
+ * mismatch rather than collapsing to an empty string).
+ *
+ * @internal
+ */
+export function normalizeSpace(space: string): string {
+  if (!space.startsWith("tinycloud:")) {
+    return space;
+  }
+  const lastColon = space.lastIndexOf(":");
+  if (lastColon === -1 || lastColon === space.length - 1) {
+    return space;
+  }
+  return space.slice(lastColon + 1);
+}
+
+// ---------------------------------------------------------------------------
 // Subset check
 // ---------------------------------------------------------------------------
 
@@ -117,7 +152,10 @@ function canonicalizeEntryMatches(
   if (requested.service !== granted.service) {
     return false;
   }
-  if (requested.space !== granted.space) {
+  // Normalize both sides so callers passing short names (`"default"`) match
+  // recap-parsed full URIs (`"tinycloud:pkh:eip155:1:0xd559...:default"`) and
+  // vice versa. Idempotent for short names.
+  if (normalizeSpace(requested.space) !== normalizeSpace(granted.space)) {
     return false;
   }
   if (!pathContains(granted.path, requested.path)) {
@@ -235,7 +273,10 @@ export function parseRecapCapabilities(
         : `tinycloud.${entry.service}`);
     return {
       service: longService,
-      space: entry.space,
+      // The Rust layer emits the space as a full `tinycloud:pkh:...:name`
+      // URI (the recap target URI). Normalize to the short name so the
+      // returned entries match the shape manifests use.
+      space: normalizeSpace(entry.space),
       path: entry.path,
       actions: [...entry.actions],
     };


### PR DESCRIPTION
## Summary

Hotfix for sdk-core@2.1.0-beta.2. The recap-parsing layer returns \`space\` as a full pkh URI while manifest permissions use the short name, so \`isCapabilitySubset\` always failed on mixed forms → \`delegateTo\` threw \`PermissionNotInManifestError\` even when the session recap covered every requested capability.

## The bug

The Rust \`parseRecapFromSiwe\` returns \`ParsedRecapEntry.space\` as the full recap target URI:

\`\`\`
tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:default
\`\`\`

But manifest permissions and backend-advertised permissions use the short form \`"default"\`.

\`parseRecapCapabilities\` normalized the service (short → long) but passed \`space\` through unchanged. Strict string comparison in \`isCapabilitySubset\` → mismatch → "Missing N entries" for every backend delegation.

Verified end-to-end in listen PR #4: decoded the signed SIWE's recap, confirmed the \`att:\` map keys were all full pkh URIs, and that the app's manifest permissions flowed through \`signIn\` correctly — the only break was the comparison layer.

## The fix

- New \`normalizeSpace(space)\` helper: extracts the trailing name segment after the last \`:\` in a \`tinycloud:\` URI; passes short names and non-\`tinycloud:\` strings through unchanged; returns the original on a trailing-colon malformed URI.
- Apply in \`parseRecapCapabilities\` so its output is always in short-name form.
- Apply defensively in \`isCapabilitySubset\` on both sides so callers can pass either form transparently.

## Tests

+14 in capabilities.test.ts covering normalizeSpace edge cases, mixed-form subset checks, and parseRecapCapabilities normalization. All 541/541 sdk-core tests pass, build clean.

## Downstream

Unblocks listen PR #4 (feat/manifest-capability-chain). After the beta publishes, listen just needs a version bump to pick it up.