### PR TITLE
fix(node-sdk): activate WASM-path delegations with host before returning

### DIFF
--- a/.changeset/fix-normalize-space-uri.md
+++ b/.changeset/fix-normalize-space-uri.md
@@ -1,0 +1,27 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-services": patch
+---
+
+fix(sdk-core): normalize space URI in recap parse for derivability check
+
+The Rust WASM `parseRecapFromSiwe` returns `space` as the full recap target
+URI (`tinycloud:pkh:eip155:{chainId}:{address}:{name}`), while manifest
+permissions and backend-advertised permissions use the short `{name}` form
+(e.g. `"default"`). `isCapabilitySubset` was doing strict string comparison
+on `space`, so mixing the two forms always failed — `delegateTo` would throw
+`PermissionNotInManifestError` even when the session recap covered every
+requested capability.
+
+This broke end-to-end manifest-driven sign-in in the listen app, where the
+session SIWE was signed correctly with the union of all manifest abilities
+but `delegateTo(backendDID, info.permissions)` still failed on the subset
+check because `"tinycloud:pkh:eip155:1:0xd559...:default"` and `"default"`
+didn't match as strings.
+
+Fix: add a `normalizeSpace` helper that extracts the trailing name segment
+from a `tinycloud:` URI. Apply it in `parseRecapCapabilities` (so the output
+is always in short-name form) and defensively in `isCapabilitySubset` on
+both sides (so callers passing either form work transparently).

--- a/.changeset/fix-wasm-delegation-host-activation.md
+++ b/.changeset/fix-wasm-delegation-host-activation.md
@@ -1,0 +1,26 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-services": patch
+---
+
+fix(node-sdk): activate WASM-path delegations with the host so downstream consumers can reference the parent CID
+
+`createDelegationViaWasmPath` (the session-key UCAN fast path used by
+`tcw.delegateTo` when the requested capabilities are derivable from the
+current session) was building the UCAN client-side and returning it
+directly without posting it to the host. This meant the host's delegation
+store never saw the UCAN.
+
+When a downstream consumer (e.g. a backend calling `node.useDelegation`)
+tried to reference the UCAN's CID as the parent of its own invoker SIWE,
+the host's chain-validation step failed with "Cannot find parent
+delegation" — the host looks up parents by CID in its local database,
+and the client-side-only UCAN was never stored.
+
+Fix: after computing the UCAN in `createDelegationViaWasmPath`, call
+`activateSessionWithHost` to POST the delegation header to `/delegate`
+before returning the `PortableDelegation`. This mirrors the legacy
+`createDelegationWalletPath` which has done the same for wallet-signed
+SIWE delegations since day one.

--- a/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
@@ -8,7 +8,7 @@
  * expiry-check branches in isolation.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   PermissionNotInManifestError,
@@ -173,6 +173,23 @@ describe("TinyCloudNode.delegateTo", () => {
   const BOB_DID = "did:pkh:eip155:1:0x00000000000000000000000000000000000000BB";
 
   const futureExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  // Stub global fetch so the derivable fast path's `activateSessionWithHost`
+  // call resolves locally without hitting node.tinycloud.xyz. Each test that
+  // exercises the WASM delegation path expects a successful activation; the
+  // SessionExpired / derivability / validation tests never reach fetch.
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ activated: [], skipped: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
 
   test("no session → SessionExpiredError with epoch", async () => {
     const wasm = makeFakeWasmBindings();

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -1884,9 +1884,30 @@ export class TinyCloudNode {
     // (service, path) before signing. Consumers that need the full
     // multi-resource picture read `.resources`.
     const primary = result.resources[0];
+    const delegationHeader = { Authorization: `Bearer ${result.delegation}` };
+
+    // Activate the delegation with the host. This registers the UCAN in
+    // the host's delegation store so that downstream consumers (e.g. a
+    // backend calling `useDelegation`) can reference its CID as a parent
+    // in their own invoker SIWE. Without this step, the host rejects any
+    // downstream delegation with "Cannot find parent delegation" because
+    // the UCAN was only signed client-side and never stored.
+    //
+    // Mirrors the legacy `createDelegationWalletPath` at line 2092 which
+    // does the same for wallet-signed SIWE delegations.
+    const activateResult = await activateSessionWithHost(
+      this.config.host!,
+      delegationHeader,
+    );
+    if (!activateResult.success) {
+      throw new Error(
+        `Failed to activate delegation with host: ${activateResult.error}`,
+      );
+    }
+
     return {
       cid: result.cid,
-      delegationHeader: { Authorization: `Bearer ${result.delegation}` },
+      delegationHeader,
       spaceId,
       path: primary.path,
       actions: primary.actions,

--- a/packages/sdk-core/src/capabilities.test.ts
+++ b/packages/sdk-core/src/capabilities.test.ts
@@ -12,6 +12,7 @@ import {
   PermissionNotInManifestError,
   SessionExpiredError,
   isCapabilitySubset,
+  normalizeSpace,
   parseRecapCapabilities,
   type WasmRecapEntry,
 } from "./capabilities";
@@ -410,5 +411,147 @@ describe("SessionExpiredError", () => {
     expect(err.name).toBe("SessionExpiredError");
     expect(err.expiredAt).toEqual(when);
     expect(err.message).toBe("Session expired at 2024-01-01T00:00:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSpace
+// ---------------------------------------------------------------------------
+
+describe("normalizeSpace", () => {
+  it("passes short names through unchanged", () => {
+    expect(normalizeSpace("default")).toBe("default");
+    expect(normalizeSpace("work-space")).toBe("work-space");
+    expect(normalizeSpace("")).toBe("");
+  });
+
+  it("extracts the name from a full pkh URI", () => {
+    expect(
+      normalizeSpace(
+        "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:default"
+      )
+    ).toBe("default");
+    expect(
+      normalizeSpace(
+        "tinycloud:pkh:eip155:1:0xabc0000000000000000000000000000000000000:work-space"
+      )
+    ).toBe("work-space");
+  });
+
+  it("returns the original string on a trailing-colon URI (degrades to strict mismatch)", () => {
+    const malformed = "tinycloud:pkh:eip155:1:0xabc:";
+    expect(normalizeSpace(malformed)).toBe(malformed);
+  });
+
+  it("passes non-tinycloud URIs through unchanged", () => {
+    expect(normalizeSpace("did:key:z6Mk")).toBe("did:key:z6Mk");
+    expect(normalizeSpace("foo")).toBe("foo");
+  });
+});
+
+describe("isCapabilitySubset with mixed space forms", () => {
+  const fullUri =
+    "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:default";
+
+  it("matches short-form requested against full-URI granted (recap parse direction)", () => {
+    const granted: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: fullUri,
+        path: "",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(true);
+    expect(missing).toEqual([]);
+  });
+
+  it("matches full-URI requested against short-form granted (defensive symmetric)", () => {
+    const granted: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: fullUri,
+        path: "",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(true);
+    expect(missing).toEqual([]);
+  });
+
+  it("still rejects mismatched space names regardless of form", () => {
+    const granted: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: fullUri,
+        path: "",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "work-space",
+        path: "",
+        actions: ["tinycloud.kv/get"],
+      },
+    ];
+    const { subset, missing } = isCapabilitySubset(requested, granted);
+    expect(subset).toBe(false);
+    expect(missing).toHaveLength(1);
+  });
+});
+
+describe("parseRecapCapabilities normalizes space", () => {
+  it("converts a full pkh URI from the recap to the short name", () => {
+    const parseWasm = (_siwe: string): WasmRecapEntry[] => [
+      {
+        service: "kv",
+        space:
+          "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:default",
+        path: "",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+    const out = parseRecapCapabilities(parseWasm, "fake-siwe");
+    expect(out).toEqual([
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ]);
+  });
+
+  it("passes short-name spaces through (forward compatibility)", () => {
+    const parseWasm = (_siwe: string): WasmRecapEntry[] => [
+      {
+        service: "sql",
+        space: "default",
+        path: "",
+        actions: ["tinycloud.sql/read"],
+      },
+    ];
+    const out = parseRecapCapabilities(parseWasm, "fake-siwe");
+    expect(out[0].space).toBe("default");
   });
 });

--- a/packages/sdk-core/src/capabilities.ts
+++ b/packages/sdk-core/src/capabilities.ts
@@ -58,6 +58,41 @@ export class SessionExpiredError extends Error {
 }
 
 // ---------------------------------------------------------------------------
+// Space normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a space identifier to its short-name form.
+ *
+ * Recap resource URIs in a signed SIWE encode the space as a full URI of the
+ * form `tinycloud:pkh:eip155:{chainId}:{address}:{name}` (e.g.
+ * `tinycloud:pkh:eip155:1:0xd559...:default`). Manifest permissions and
+ * backend-advertised permissions use the short `{name}` form (e.g.
+ * `"default"`).
+ *
+ * Strict string comparison between these two forms would always fail, so we
+ * normalize both sides to the short name before comparing. The trailing
+ * segment after the last `:` in a `tinycloud:` URI is the space name.
+ *
+ * Short names (`"default"`, `"work-space"`) are returned unchanged.
+ * Any non-`tinycloud:` string is returned unchanged. A malformed URI with a
+ * trailing colon is returned unchanged (so the check degrades to a strict
+ * mismatch rather than collapsing to an empty string).
+ *
+ * @internal
+ */
+export function normalizeSpace(space: string): string {
+  if (!space.startsWith("tinycloud:")) {
+    return space;
+  }
+  const lastColon = space.lastIndexOf(":");
+  if (lastColon === -1 || lastColon === space.length - 1) {
+    return space;
+  }
+  return space.slice(lastColon + 1);
+}
+
+// ---------------------------------------------------------------------------
 // Subset check
 // ---------------------------------------------------------------------------
 
@@ -117,7 +152,10 @@ function canonicalizeEntryMatches(
   if (requested.service !== granted.service) {
     return false;
   }
-  if (requested.space !== granted.space) {
+  // Normalize both sides so callers passing short names (`"default"`) match
+  // recap-parsed full URIs (`"tinycloud:pkh:eip155:1:0xd559...:default"`) and
+  // vice versa. Idempotent for short names.
+  if (normalizeSpace(requested.space) !== normalizeSpace(granted.space)) {
     return false;
   }
   if (!pathContains(granted.path, requested.path)) {
@@ -235,7 +273,10 @@ export function parseRecapCapabilities(
         : `tinycloud.${entry.service}`);
     return {
       service: longService,
-      space: entry.space,
+      // The Rust layer emits the space as a full `tinycloud:pkh:...:name`
+      // URI (the recap target URI). Normalize to the short name so the
+      // returned entries match the shape manifests use.
+      space: normalizeSpace(entry.space),
       path: entry.path,
       actions: [...entry.actions],
     };


### PR DESCRIPTION
## Summary

End-to-end listen testing with \`@tinycloud/web-sdk@2.1.0-beta.3\` surfaced a second gap in the manifest-driven delegation flow: \`createDelegationViaWasmPath\` was returning the UCAN client-side without ever posting it to the host, so downstream consumers couldn't reference its CID as a parent.

## The bug

The legacy \`createDelegationWalletPath\` has always posted wallet-signed SIWE delegations to \`/delegate\` before returning (line 2092). The new \`createDelegationViaWasmPath\` — the session-key UCAN fast path used by \`tcw.delegateTo\` when caps are derivable — skipped this step.

Flow that surfaced the issue:

1. User signs in with manifest → session key gets a recap covering backend caps (single prompt, works)
2. App calls \`tcw.delegateTo(backendDID, backendPermissions)\` → derivable → session-key UCAN path → \`prompted: false\` ✓
3. App POSTs the UCAN to the listen backend
4. Backend calls \`node.useDelegation(ucan)\` → builds invoker SIWE with \`parents: [ucan.cid]\` → POSTs to host
5. Host's chain validator: \"Cannot find parent delegation\"

The UCAN's CID was only ever computed client-side. The host never saw it because step 2 skipped the activation POST.

## The fix

After \`createDelegationWrapper\` computes the UCAN in \`createDelegationViaWasmPath\`, call \`activateSessionWithHost\` to POST \`{ Authorization: Bearer <jwt> }\` to \`/delegate\`. The host stores the UCAN in its delegation DB, assigns it the same CID the client computed (deterministic Blake3-256 hash), and downstream \`useDelegation\` calls can now find it via the chain lookup.

This matches exactly what the legacy wallet path has done since day one.

## Test changes

\`TinyCloudNode.delegateTo.test.ts\` now stubs \`globalThis.fetch\` with a \`beforeEach\`/\`afterEach\` pair so the derivable fast path's new activation step resolves locally instead of hitting \`node.tinycloud.xyz\`.

- 9/9 \`delegateTo.test.ts\`
- 28/28 full node-sdk
- 541/541 sdk-core

## Downstream

Unblocks listen PR #4 (\`feat/manifest-capability-chain\`). After the beta publishes, listen just needs a version bump to \`2.1.0-beta.4\` to pick up the fix.