### PR TITLE
docs: clarify OpenKey example SIWE nonce usage

### DIFF
--- a/apps/openkey-example/README.md
+++ b/apps/openkey-example/README.md
@@ -12,8 +12,9 @@ User clicks "Connect with OpenKey"
   -> Returns { address, keyId, keyType }
   -> OpenKeyProvider created
   -> Wrapped in ethers Web3Provider
-  -> Passed to TinyCloudWeb
-  -> signIn() triggers SIWE signing via OpenKey iframe modal
+  -> TinyCloudWeb receives `provider` + `siweConfig`
+  -> TinyCloudWeb uses its normal SIWE nonce flow unless you override `siweConfig.nonce`
+  -> `signIn()` triggers SIWE signing via OpenKey iframe modal
   -> TinyCloud operations work as normal
 ```
 
@@ -156,10 +157,12 @@ src/
 
 ### `src/pages/Home.tsx`
 
-The main authentication flow uses the SDK's built-in `OpenKeyProvider`:
+The main authentication flow uses the SDK's built-in `OpenKeyProvider` and passes the TinyCloud auth config at the app layer:
 
 ```typescript
 import { OpenKey, OpenKeyProvider } from '@openkey/sdk';
+import { TinyCloudWeb } from '@tinycloud/web-sdk';
+import { providers } from 'ethers';
 
 const connectAndSignIn = async () => {
   // 1. Connect to OpenKey (iframe modal)
@@ -174,13 +177,32 @@ const connectAndSignIn = async () => {
 
   // 4. Create TinyCloudWeb with the provider
   const tcw = new TinyCloudWeb({
-    providers: { web3: { driver: web3Provider } },
+    provider: web3Provider,
+    siweConfig: {
+      statement: 'Sign in to the TinyCloud OpenKey example app.',
+      domain: window.location.hostname,
+    },
   });
 
   // 5. Sign in (SIWE signing routed through OpenKey)
   await tcw.signIn();
 };
 ```
+
+If you need to override the nonce in an example, use a fixed placeholder and document that production code must fetch a one-time nonce from your backend:
+
+```typescript
+const tcw = new TinyCloudWeb({
+  provider: web3Provider,
+  siweConfig: {
+    nonce: '1234', // Example only. In production, fetch a random one-time nonce from your server.
+    statement: 'Sign in to the TinyCloud OpenKey example app.',
+    domain: window.location.hostname,
+  },
+});
+```
+
+Do not add browser-side nonce generation helpers. For production authentication, the nonce should be issued by your backend, verified there, and invalidated after use.
 
 ## Building for Production
 

--- a/apps/openkey-example/src/pages/Home.tsx
+++ b/apps/openkey-example/src/pages/Home.tsx
@@ -115,10 +115,10 @@ function Home() {
       const ethersProvider = new providers.Web3Provider(eip1193Provider as any);
 
       const tcwConfig = getTinyCloudWebConfig({
-        providers: {
-          web3: {
-            driver: ethersProvider,
-          },
+        provider: ethersProvider,
+        siweConfig: {
+          statement: "Sign in to the TinyCloud OpenKey example app.",
+          domain: window.location.hostname,
         },
       });
 

--- a/apps/openkey-example/src/pages/Shared.tsx
+++ b/apps/openkey-example/src/pages/Shared.tsx
@@ -139,7 +139,11 @@ const Shared = () => {
       const ethersProvider = new providers.Web3Provider(eip1193Provider as any);
 
       const tcwInstance = new TinyCloudWeb({
-        providers: { web3: { driver: ethersProvider } },
+        provider: ethersProvider,
+        siweConfig: {
+          statement: 'Sign in to the TinyCloud OpenKey example app.',
+          domain: window.location.hostname,
+        },
       });
       await tcwInstance.signIn();
       setTcw(tcwInstance);


### PR DESCRIPTION
## Summary
- remove browser-side nonce generation guidance from the OpenKey example
- keep the example on `provider` plus normal `siweConfig` usage
- document that production nonce overrides must come from the server
- show a fixed placeholder nonce only as an example override

## Validation
- `git diff --check`

## Notes
- this is app/docs scope only; no package surface or changeset