### PR TITLE
feat: add per-call SIWE nonce override

### DIFF
--- a/.changeset/bright-bats-jump.md
+++ b/.changeset/bright-bats-jump.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Add an optional per-call `nonce` override to `signIn()` while preserving constructor-level `siweConfig.nonce` support.

--- a/documentation/docs/web-sdk/api/userauthorization.md
+++ b/documentation/docs/web-sdk/api/userauthorization.md
@@ -26,7 +26,7 @@ Creates a new instance of the UserAuthorization class.
 
 **Parameters:**
 - `config` - Configuration options for user authorization
-  - `siweConfig` - Configuration for Sign-In with Ethereum (SIWE)
+  - `siweConfig` - Configuration for Sign-In with Ethereum (SIWE), including a default `nonce`
   - `walletConnectProjectId` - Optional WalletConnect project ID
 
 ## Properties
@@ -66,17 +66,21 @@ console.log('Connected to wallet:', connected.address);
 ### signIn
 
 ```typescript
-async signIn(): Promise<TCWClientSession>
+async signIn(options?: { nonce?: string }): Promise<TCWClientSession>
 ```
 
 Signs the user in using Sign-In with Ethereum (SIWE).
 
 **Returns:** A Promise that resolves to a TCWClientSession object containing the session information.
 
+**Options:**
+- `nonce` - Per-call nonce override. When provided, it takes precedence over `siweConfig.nonce` for that sign-in only. This nonce should come from your server and be validated there as a one-time challenge.
+
 **Example:**
 ```typescript
 await auth.connect();
-const session = await auth.signIn();
+const nonce = await fetch('/api/siwe/nonce').then((response) => response.text());
+const session = await auth.signIn({ nonce });
 console.log('User signed in:', session.address);
 ```
 

--- a/documentation/docs/web-sdk/guides/authentication-guide.md
+++ b/documentation/docs/web-sdk/guides/authentication-guide.md
@@ -48,8 +48,10 @@ The `connect` method will detect available wallets (such as MetaMask) and prompt
 After connecting to a wallet, you can sign the user in:
 
 ```typescript
+const nonce = await fetch('/api/siwe/nonce').then((response) => response.text());
+
 // Sign in the user
-await tc.signIn();
+await tc.signIn({ nonce });
 
 // Check if signed in
 const isSignedIn = tc.isSignedIn();
@@ -61,6 +63,10 @@ The `signIn` method will:
 2. Prompt the user to sign the message with their wallet
 3. Verify the signature
 4. Create a session for the user
+
+If you pass `nonce` to `signIn()`, that value overrides `siweConfig.nonce` for that one call.
+
+The nonce must come from your server or relying party backend. It should be stored server-side, verified on sign-in, and invalidated after use. Do not generate the SIWE nonce in the browser for production authentication flows.
 
 ## Working with Sessions
 
@@ -106,6 +112,13 @@ const tc = new TinyCloudWeb({
     ],
   }
 });
+```
+
+When your backend issues the nonce before sign-in, pass it per call instead of hard-coding it in the constructor:
+
+```typescript
+const nonce = await fetch('/api/siwe/nonce').then((response) => response.text());
+await tc.signIn({ nonce });
 ```
 
 ## Error Handling

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -56,6 +56,7 @@ import {
   IWasmBindings,
   ISessionManager,
   ISpaceCreationHandler,
+  SignInOptions,
   // v2 services
   DelegationManager,
   SpaceService,
@@ -490,8 +491,10 @@ export class TinyCloudNode {
    * Sign in and create a new session.
    * This creates the user's space if it doesn't exist.
    * Requires wallet mode (privateKey in config).
+   *
+   * @param options - Optional per-call SIWE overrides for this sign-in only
    */
-  async signIn(): Promise<void> {
+  async signIn(options?: SignInOptions): Promise<void> {
     if (!this.signer || !this.tc) {
       throw new Error(
         "Cannot signIn() in session-only mode. Provide a privateKey in config to create your own space."
@@ -511,7 +514,7 @@ export class TinyCloudNode {
     this._hooks = undefined;
     this._serviceContext = undefined;
 
-    await this.tc.signIn();
+    await this.tc.signIn(options);
 
     // Initialize service context with session
     this.initializeServices();

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+  type IWasmBindings,
+  type ISessionManager,
+  type ISigner,
+} from "@tinycloud/sdk-core";
+import { NodeUserAuthorization } from "./NodeUserAuthorization";
+import { MemorySessionStorage } from "../storage/MemorySessionStorage";
+
+function createSessionManager(): ISessionManager {
+  const keys = new Map<string, string>();
+
+  const ensureKey = (id: string): string => {
+    if (!keys.has(id)) {
+      keys.set(id, JSON.stringify({ kty: "OKP", kid: id }));
+    }
+    return id;
+  };
+
+  return {
+    createSessionKey(id: string): string {
+      return ensureKey(id);
+    },
+    renameSessionKeyId(oldId: string, newId: string): void {
+      const value = keys.get(oldId);
+      if (value) {
+        keys.delete(oldId);
+        keys.set(newId, value.replace(`"kid":"${oldId}"`, `"kid":"${newId}"`));
+      } else {
+        ensureKey(newId);
+      }
+    },
+    getDID(keyId: string): string {
+      return `did:key:${keyId}`;
+    },
+    jwk(keyId: string): string | undefined {
+      const existing = keys.get(keyId);
+      if (existing) {
+        return existing;
+      }
+      ensureKey(keyId);
+      return keys.get(keyId);
+    },
+  };
+}
+
+function createWasmBindings(captured: Array<Record<string, unknown>>): IWasmBindings {
+  const sessionManager = createSessionManager();
+
+  return {
+    invoke: async () => undefined,
+    prepareSession: (params: Record<string, unknown>) => {
+      captured.push(params);
+      return {
+        siwe: [
+          `Nonce: ${String(params.nonce ?? "")}`,
+          `Issued At: ${String(params.issuedAt)}`,
+          `Expiration Time: ${String(params.expirationTime)}`,
+        ].join("\n"),
+        jwk: params.jwk,
+        spaceId: params.spaceId,
+        verificationMethod: "did:key:verification",
+      };
+    },
+    completeSessionSetup: () => ({
+      delegationHeader: { Authorization: "Bearer session" },
+      delegationCid: "bafy-session",
+    }),
+    ensureEip55: (address: string) => address,
+    makeSpaceId: (address: string, chainId: number, prefix: string) =>
+      `${prefix}:${chainId}:${address}`,
+    createDelegation: async () => {
+      throw new Error("not used");
+    },
+    generateHostSIWEMessage: () => "",
+    siweToDelegationHeaders: () => ({ Authorization: "Bearer host" }),
+    protocolVersion: () => 1,
+    vault_encrypt: () => new Uint8Array(),
+    vault_decrypt: () => new Uint8Array(),
+    vault_derive_key: () => new Uint8Array(),
+    vault_x25519_from_seed: () => ({ publicKey: new Uint8Array(), privateKey: new Uint8Array() }),
+    vault_x25519_dh: () => new Uint8Array(),
+    vault_random_bytes: () => new Uint8Array(),
+    vault_sha256: () => new Uint8Array(),
+    createSessionManager: () => sessionManager,
+  };
+}
+
+function createSigner(calls: string[]): ISigner {
+  return {
+    getAddress: async () => "0x1234567890abcdef1234567890abcdef12345678",
+    getChainId: async () => 1,
+    signMessage: async (message: string) => {
+      calls.push(message);
+      return "0xsigned";
+    },
+  };
+}
+
+afterEach(() => {
+  // Restore the native fetch if a test replaced it.
+  if ((globalThis as any).__originalFetch) {
+    globalThis.fetch = (globalThis as any).__originalFetch;
+    delete (globalThis as any).__originalFetch;
+  }
+});
+
+test("NodeUserAuthorization.signIn keeps constructor siweConfig.nonce when no per-call nonce is provided", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const signedMessages: string[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).__originalFetch = originalFetch;
+  globalThis.fetch = async (input: any, init?: any) => {
+    const url = String(input);
+    if (url.endsWith("/info")) {
+      return new Response(
+        JSON.stringify({ protocol: 1, version: "1.0.0", features: [] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url.endsWith("/delegate") && init?.method === "POST") {
+      return new Response(JSON.stringify({ activated: ["space"], skipped: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  const auth = new NodeUserAuthorization({
+    signer: createSigner(signedMessages),
+    wasmBindings: createWasmBindings(captured),
+    signStrategy: { type: "auto-sign" },
+    domain: "example.com",
+    tinycloudHosts: ["https://tinycloud.test"],
+    sessionStorage: new MemorySessionStorage(),
+    siweConfig: { nonce: "constructor-nonce" },
+  });
+
+  await auth.signIn();
+
+  expect(captured[0]?.nonce).toBe("constructor-nonce");
+  expect(signedMessages[0]).toContain("Nonce: constructor-nonce");
+});
+
+test("NodeUserAuthorization.signIn lets a per-call nonce override siweConfig.nonce", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const signedMessages: string[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).__originalFetch = originalFetch;
+  globalThis.fetch = async (input: any, init?: any) => {
+    const url = String(input);
+    if (url.endsWith("/info")) {
+      return new Response(
+        JSON.stringify({ protocol: 1, version: "1.0.0", features: [] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url.endsWith("/delegate") && init?.method === "POST") {
+      return new Response(JSON.stringify({ activated: ["space"], skipped: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  const auth = new NodeUserAuthorization({
+    signer: createSigner(signedMessages),
+    wasmBindings: createWasmBindings(captured),
+    signStrategy: { type: "auto-sign" },
+    domain: "example.com",
+    tinycloudHosts: ["https://tinycloud.test"],
+    sessionStorage: new MemorySessionStorage(),
+    siweConfig: { nonce: "constructor-nonce" },
+  });
+
+  await auth.signIn({ nonce: "call-nonce" });
+
+  expect(captured[0]?.nonce).toBe("call-nonce");
+  expect(captured[0]?.nonce).not.toBe("constructor-nonce");
+  expect(signedMessages[0]).toContain("Nonce: call-nonce");
+});

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -8,6 +8,7 @@ import {
   PersistedSessionData,
   TinyCloudSession,
   SiweConfig,
+  SignInOptions,
   fetchPeerId,
   submitHostDelegation,
   activateSessionWithHost,
@@ -297,17 +298,19 @@ export class NodeUserAuthorization implements IUserAuthorization {
    * - resources are appended to the default resources
    * - uri triggers a warning (overwriting delegation target)
    * - all other fields override directly
+   * - per-call nonce overrides siweConfig.nonce when provided
    */
-  private buildSiweOverrides(): Record<string, unknown> {
-    // Seed with top-level nonce; siweConfig fields layered on top take precedence.
+  private buildSiweOverrides(options?: SignInOptions): Record<string, unknown> {
     const base: Record<string, unknown> = { uri: this.uri };
     if (this.nonce !== undefined) {
       base.nonce = this.nonce;
     }
 
-    if (!this.siweConfig) return base;
+    if (!this.siweConfig && !options?.nonce) {
+      return base;
+    }
 
-    const { statement, resources, uri, ...rest } = this.siweConfig;
+    const { statement, resources, uri, ...rest } = this.siweConfig ?? {};
     const overrides: Record<string, unknown> = { ...base, ...rest };
 
     if (statement) {
@@ -326,6 +329,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
           "This may break delegation chain validation if the URI does not match the session key DID.",
       );
       overrides.uri = uri;
+    }
+
+    if (options?.nonce) {
+      overrides.nonce = options.nonce;
     }
 
     return overrides;
@@ -539,8 +546,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
    * 2. Call prepareSession() which generates the SIWE with ReCap capabilities
    * 3. Sign the SIWE string from prepareSession
    * 4. Call completeSessionSetup() with the prepared session + signature
+   *
+   * @param options - Optional per-call SIWE overrides for this sign-in only
    */
-  async signIn(): Promise<ClientSession> {
+  async signIn(options?: SignInOptions): Promise<ClientSession> {
     // Get signer address and chain ID
     this._address = await this.signer.getAddress();
     this._chainId = await this.signer.getChainId();
@@ -580,7 +589,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       expirationTime: expirationTime.toISOString(),
       spaceId,
       jwk,
-      ...this.buildSiweOverrides(),
+      ...this.buildSiweOverrides(options),
     });
 
     // Sign the SIWE message from prepareSession (NOT a separately generated SIWE)

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -24,6 +24,7 @@ export type {
   IUserAuthorization,
   ClientSession,
   Extension,
+  SignInOptions,
   PersistedSessionData,
   TinyCloudSession,
   INotificationHandler,

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -48,6 +48,7 @@ export type {
   IUserAuthorization,
   ClientSession,
   Extension,
+  SignInOptions,
   PersistedSessionData,
   TinyCloudSession,
   INotificationHandler,

--- a/packages/sdk-core/src/TinyCloud.signIn.test.ts
+++ b/packages/sdk-core/src/TinyCloud.signIn.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { TinyCloud } from "./TinyCloud";
+import type { ClientSession, IUserAuthorization, SignInOptions } from "./userAuthorization";
+
+test("TinyCloud.signIn forwards per-call nonce options to authorization", async () => {
+  const calls: Array<SignInOptions | undefined> = [];
+  const session: ClientSession = {
+    address: "0x1234567890abcdef1234567890abcdef12345678",
+    walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+    chainId: 1,
+    sessionKey: "session-1",
+    siwe: "siwe",
+    signature: "signature",
+  };
+
+  const auth: IUserAuthorization = {
+    session: undefined,
+    extend() {},
+    signIn: async (options?: SignInOptions) => {
+      calls.push(options);
+      return session;
+    },
+    signOut: async () => {},
+    address: () => undefined,
+    chainId: () => undefined,
+    signMessage: async () => "0xsignature",
+  };
+
+  const tc = new TinyCloud(auth);
+
+  await expect(tc.signIn({ nonce: "call-nonce" })).resolves.toEqual(session);
+  expect(calls).toEqual([{ nonce: "call-nonce" }]);
+});

--- a/packages/sdk-core/src/TinyCloud.ts
+++ b/packages/sdk-core/src/TinyCloud.ts
@@ -2,6 +2,7 @@ import {
   IUserAuthorization,
   ClientSession,
   Extension,
+  SignInOptions,
 } from "./userAuthorization";
 import {
   ServiceContext,
@@ -432,10 +433,11 @@ export class TinyCloud {
   /**
    * Sign in and create a new session.
    * Notifies services of the new session after successful sign-in.
+   * @param options - Optional per-call SIWE overrides for this sign-in only
    * @returns The new session
    */
-  public async signIn(): Promise<ClientSession> {
-    const session = await this.userAuthorization.signIn();
+  public async signIn(options?: SignInOptions): Promise<ClientSession> {
+    const session = await this.userAuthorization.signIn(options);
 
     // Notify services of the new session
     const serviceSession = this.toServiceSession(session);

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -58,6 +58,7 @@ export {
   PartialSiweMessage,
   UserAuthorizationConfig,
 } from "./userAuthorization";
+export type { SignInOptions } from "./userAuthorization";
 
 // Main TinyCloud class
 export { TinyCloud, TinyCloudConfig } from "./TinyCloud";

--- a/packages/sdk-core/src/userAuthorization.ts
+++ b/packages/sdk-core/src/userAuthorization.ts
@@ -36,6 +36,14 @@ export interface PartialSiweMessage extends Partial<SiweConfig> {
 }
 
 /**
+ * Options for a single sign-in call.
+ */
+export interface SignInOptions {
+  /** Nonce to use for this sign-in only. Overrides `siweConfig.nonce` when provided. */
+  nonce?: string;
+}
+
+/**
  * Platform-agnostic user authorization interface.
  *
  * This interface defines how users authenticate and manage sessions.
@@ -58,9 +66,10 @@ export interface IUserAuthorization {
   /**
    * Sign in and create a new session.
    * This will prompt for wallet signature (browser) or use configured strategy (node).
+   * Per-call options override constructor defaults for this sign-in only.
    * @returns The new session
    */
-  signIn(): Promise<ClientSession>;
+  signIn(options?: SignInOptions): Promise<ClientSession>;
 
   /**
    * Sign out and clear the current session.

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -58,6 +58,7 @@ export {
   PersistedSessionData,
   PartialSiweMessage,
 } from '@tinycloud/sdk-core';
+export type { SignInOptions } from '@tinycloud/sdk-core';
 
 // Re-export KV service types for direct usage
 export {

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -41,6 +41,7 @@ import {
   ISpaceCreationHandler,
   type Manifest,
   type PermissionEntry,
+  SignInOptions,
 } from "@tinycloud/sdk-core";
 import { showPermissionRequestModal } from "../notifications/ModalManager";
 import {
@@ -355,9 +356,9 @@ export class TinyCloudWeb {
   // Auth Methods (delegate to TinyCloudNode)
   // ===========================================================================
 
-  signIn = async (): Promise<ClientSession> => {
+  signIn = async (options?: SignInOptions): Promise<ClientSession> => {
     const node = await this.ensureNode();
-    await node.signIn();
+    await node.signIn(options);
     const session = node.session;
     if (!session) throw new Error("Sign-in completed but no session available");
     return {

--- a/packages/web-sdk/tests/web-sdk.test.ts
+++ b/packages/web-sdk/tests/web-sdk.test.ts
@@ -29,7 +29,7 @@ test('Instantiate TinyCloudWeb with providers.web3.driver and successfully sign 
     },
   };
   const tcw = new TinyCloudWeb(config);
-  await expect(tcw.signIn()).resolves.not.toThrowError();
+  await expect(tcw.signIn({ nonce: 'web-call-nonce' })).resolves.not.toThrowError();
   await expect(tcw.signOut()).resolves.not.toThrowError();
 });
 


### PR DESCRIPTION
## Summary
- add `signIn(options?: { nonce?: string })` across sdk-core, node-sdk, and web-sdk
- make per-call nonce override constructor `siweConfig.nonce`
- update auth docs to require server-issued nonces
- add focused tests and a changeset

## Validation
- `bun test packages/sdk-core/src/TinyCloud.signIn.test.ts`
- `bun test packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts`
- `bun run build` for `packages/sdk-services` and `packages/sdk-core`

## Notes
- full web-sdk and node-sdk type/build checks are still blocked in this checkout by missing generated WASM declarations and local test deps