### PR TITLE
fix(node-sdk): remove Bearer prefix from UCAN delegation header

### DIFF
--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -1887,17 +1887,17 @@ export class TinyCloudNode {
     // (service, path) before signing. Consumers that need the full
     // multi-resource picture read `.resources`.
     const primary = result.resources[0];
-    const delegationHeader = { Authorization: `Bearer ${result.delegation}` };
+    // Use the raw JWT without a "Bearer " prefix. The host's HeaderEncode
+    // decoder passes the header value directly to Ucan::decode(), which
+    // expects a bare JWT string. The wallet-signed CACAO path also uses
+    // raw base64 without any prefix. Adding "Bearer " causes a parse
+    // failure that surfaces as a 401 from the host.
+    const delegationHeader = { Authorization: result.delegation };
 
-    // Activate the delegation with the host. This registers the UCAN in
-    // the host's delegation store so that downstream consumers (e.g. a
-    // backend calling `useDelegation`) can reference its CID as a parent
-    // in their own invoker SIWE. Without this step, the host rejects any
-    // downstream delegation with "Cannot find parent delegation" because
-    // the UCAN was only signed client-side and never stored.
-    //
-    // Mirrors the legacy `createDelegationWalletPath` at line 2092 which
-    // does the same for wallet-signed SIWE delegations.
+    // Activate the delegation with the host so downstream consumers (e.g.
+    // a backend calling useDelegation) can find it by CID when building
+    // their invoker SIWE. The host validates the UCAN's parent chain
+    // (session key → wallet SIWE) to confirm authority.
     const activateResult = await activateSessionWithHost(
       this.config.host!,
       delegationHeader,


### PR DESCRIPTION
Root cause of the 401 from node.tinycloud.xyz that blocked listen's manifest-driven sign-in since 2.1.0-beta.3. The host's HeaderEncode::decode passes the Authorization value directly to Ucan::decode which expects bare JWT — the Bearer prefix caused a parse failure. Also re-adds activateSessionWithHost since the chain validation now passes.