### PR TITLE
feat(node-sdk): expose DelegatedAccess.restorable for session persistence

### DIFF
--- a/.changeset/delegated-access-restorable.md
+++ b/.changeset/delegated-access-restorable.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/node-sdk": patch
+---
+
+Expose `DelegatedAccess.restorable` — a read-only projection of the activated session handles (`delegationHeader`, `delegationCid`, `spaceId`, `jwk`, `verificationMethod`, `address`, `chainId`) in the exact shape `TinyCloudNode.restoreSession(...)` consumes. Enables persisting a `useDelegation` activation across processes or restarts (e.g. agent runtimes that want vanilla `@tinycloud/cli` to operate against a delegated space). Note: in wallet mode the header/cid are minted against the activator's server-side session and expire with it (~1h), so callers must periodically re-run `useDelegation` + `restoreSession`.

--- a/packages/node-sdk/src/DelegatedAccess.test.ts
+++ b/packages/node-sdk/src/DelegatedAccess.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TinyCloudSession } from "@tinycloud/sdk-core";
+import { DelegatedAccess, type RestorableSession } from "./DelegatedAccess";
+import type { PortableDelegation } from "./delegation";
+
+function makeSession(): TinyCloudSession {
+  return {
+    address: "0x1204f2e9f634B5A8c09CA1579d351B99B27faE50",
+    chainId: 1,
+    sessionKey: "cli",
+    spaceId: "space:test",
+    delegationCid: "bafyreitest-activation-cid",
+    delegationHeader: { Authorization: "ucan:session-bound-header" },
+    verificationMethod: "did:key:z6Mkk9-session#z6Mkk9",
+    jwk: { kty: "OKP", crv: "Ed25519", x: "test-pub" },
+    siwe: "",
+    signature: "",
+  };
+}
+
+function makeDelegation(): PortableDelegation {
+  return {
+    cid: "bafyreitest-delegation-cid",
+    spaceId: "space:test",
+    chainId: 1,
+    path: "",
+    actions: ["tinycloud.kv/get"],
+    expiry: new Date(Date.now() + 24 * 3600 * 1000),
+    ownerAddress: "0xAAAaAaaAaaAaaAaAAaAaAaaAaAAaAAaAAaAaaAaa",
+    notBefore: new Date(),
+    delegateDID: "did:pkh:eip155:1:0xAGENT",
+  } as unknown as PortableDelegation;
+}
+
+describe("DelegatedAccess.restorable", () => {
+  const invoke = (() => {
+    throw new Error("invoke should not be called in this test");
+  }) as any;
+
+  test("projects session handles in the shape restoreSession consumes", () => {
+    const session = makeSession();
+    const access = new DelegatedAccess(session, makeDelegation(), "https://node.test", invoke);
+
+    const restorable: RestorableSession = access.restorable;
+
+    expect(restorable).toEqual({
+      delegationHeader: { Authorization: "ucan:session-bound-header" },
+      delegationCid: "bafyreitest-activation-cid",
+      spaceId: "space:test",
+      jwk: { kty: "OKP", crv: "Ed25519", x: "test-pub" },
+      verificationMethod: "did:key:z6Mkk9-session#z6Mkk9",
+      address: "0x1204f2e9f634B5A8c09CA1579d351B99B27faE50",
+      chainId: 1,
+    });
+  });
+
+  test("delegationCid is the session's activation cid, not the portable delegation's cid", () => {
+    // In wallet mode, useDelegation mints a new delegationCid bound to the
+    // activator's session key. Restoring must use that, not the portable
+    // delegation's own cid, or the server rejects the session.
+    const session = makeSession();
+    const delegation = makeDelegation();
+    const access = new DelegatedAccess(session, delegation, "https://node.test", invoke);
+
+    expect(access.restorable.delegationCid).toBe(session.delegationCid);
+    expect(access.restorable.delegationCid).not.toBe(delegation.cid);
+  });
+
+  test("returns a fresh object each read (caller can mutate without side effects)", () => {
+    const session = makeSession();
+    const access = new DelegatedAccess(session, makeDelegation(), "https://node.test", invoke);
+
+    const first = access.restorable;
+    const second = access.restorable;
+
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+  });
+});

--- a/packages/node-sdk/src/DelegatedAccess.ts
+++ b/packages/node-sdk/src/DelegatedAccess.ts
@@ -15,6 +15,28 @@ import type { InvokeFunction } from "@tinycloud/sdk-services";
 import { PortableDelegation } from "./delegation";
 
 /**
+ * The handles needed to rehydrate this delegation activation in a fresh
+ * `TinyCloudNode` via `TinyCloudNode.restoreSession(...)` in another process
+ * or after a restart.
+ *
+ * In wallet mode, `delegationHeader` and `delegationCid` are bound to the
+ * session key that ran `useDelegation`. They are NOT intrinsic to the
+ * portable delegation — they expire with the server-side session (typically
+ * ~1h). To keep a restored node alive longer, re-run `useDelegation` with
+ * the original portable delegation and call `restoreSession` again with the
+ * fresh `RestorableSession`.
+ */
+export interface RestorableSession {
+  delegationHeader: { Authorization: string };
+  delegationCid: string;
+  spaceId: string;
+  jwk: object;
+  verificationMethod: string;
+  address: string;
+  chainId: number;
+}
+
+/**
  * Provides access to a space via a received delegation.
  *
  * This is returned by TinyCloudNode.useDelegation() and provides
@@ -127,5 +149,24 @@ export class DelegatedAccess {
    */
   get hooks(): IHooksService {
     return this._hooks;
+  }
+
+  /**
+   * Export the handles needed to rehydrate this activated delegation via
+   * `TinyCloudNode.restoreSession(...)` in another process or after a
+   * restart.
+   *
+   * See `RestorableSession` for lifetime caveats.
+   */
+  get restorable(): RestorableSession {
+    return {
+      delegationHeader: this.session.delegationHeader,
+      delegationCid: this.session.delegationCid,
+      spaceId: this.session.spaceId,
+      jwk: this.session.jwk,
+      verificationMethod: this.session.verificationMethod,
+      address: this.session.address,
+      chainId: this.session.chainId,
+    };
   }
 }

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -127,6 +127,7 @@ export { NodeWasmBindings } from "./NodeWasmBindings";
 
 // Delegation
 export { DelegatedAccess } from "./DelegatedAccess";
+export type { RestorableSession } from "./DelegatedAccess";
 export {
   PortableDelegation,
   serializeDelegation,


### PR DESCRIPTION
## Summary

Adds `DelegatedAccess.restorable: RestorableSession` — a read-only projection of the activated session's handles in the exact shape `TinyCloudNode.restoreSession(...)` consumes. Enables rehydrating a `DelegatedAccess` activation in another process or after a restart.

```ts
const access = await nodeA.useDelegation(portable);
const handles = access.restorable; // persist to disk, send to a sidecar
// …later, in a fresh process…
await nodeB.restoreSession(handles);
// nodeB.kv / nodeB.sql now route through the delegated access
```

## Why

Agent runtimes (e.g. OpenCode-in-Docker) that want to run the official `@tinycloud/cli` against a delegated space. Today the activation state is locked inside `DelegatedAccess`'s private `session` field, forcing each consumer to write a custom CLI that re-activates per invocation. With this getter, a small sidecar can activate once at grant time, persist the handles to a `tc` profile, and let vanilla `tc` operate as if logged in — the canonical OAuth2 auth-sidecar pattern.

## Correctness note (documented in JSDoc)

In wallet mode, `useDelegation` mints a **new** `delegationHeader`/`delegationCid` bound to the activator's session key — they are **not** intrinsic to the `PortableDelegation` and they expire with the server-side session (~1h). Callers using this for persistence must re-run `useDelegation` + `restoreSession` periodically.

## Changes

- `packages/node-sdk/src/DelegatedAccess.ts` — new `RestorableSession` interface, new `get restorable()` getter
- `packages/node-sdk/src/index.ts` — re-export `RestorableSession` type
- `packages/node-sdk/src/DelegatedAccess.test.ts` — new, 3 tests

Additive only, fully backwards-compatible.

## Test plan

- [x] `bun test src/DelegatedAccess.test.ts` → 3/3 pass (shape projection, session-vs-delegation CID distinction, snapshot-per-read)
- [x] `bun test src/` → 33/33 pass (30 existing + 3 new)
- [x] `bun run build` succeeds for `@tinycloud/node-sdk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)