### PR TITLE
chore(release): publish UCAN header fix

### DIFF
--- a/.changeset/publish-ucan-header-fix.md
+++ b/.changeset/publish-ucan-header-fix.md
@@ -1,0 +1,12 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Publish the UCAN delegation header fix from PR #192.
+
+`createDelegationViaWasmPath` now activates session-key UCAN delegations with
+the raw serialized JWT in the `Authorization` header instead of prefixing it
+with `Bearer `. The TinyCloud host decodes this header directly as a UCAN JWT;
+the prefixed value causes host activation to fail with 401 during
+manifest-driven `delegateTo` flows such as TinyBoilerplate/OpenKey sign-in.


### PR DESCRIPTION
## Summary
- add a changeset to publish the PR #192 UCAN Authorization header fix
- bumps @tinycloud/node-sdk and @tinycloud/web-sdk so TinyBoilerplate can consume a beta without the stale `Bearer ` prefix

## Verification
- `bunx @changesets/cli status --since master`
- verified locally in TinyBoilerplate by patching the installed beta bundle: OpenKey passkey sign-in completed, both TinyCloud host `/delegate` calls returned 200, and backend delegation registration returned 200