### PR TITLE
Add SDK location registry resolver

### DIFF
--- a/.changeset/location-registry-resolver.md
+++ b/.changeset/location-registry-resolver.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/sdk-core": minor
+---
+
+Add TinyCloud location registry helpers for signed DID location records, multiaddr URL conversion, and priority-based cloud location resolution across explicit, blockchain, centralized registry, and fallback sources.

--- a/bun.lock
+++ b/bun.lock
@@ -202,9 +202,15 @@
       "name": "@tinycloud/sdk-core",
       "version": "2.2.0-beta.1",
       "dependencies": {
-        "@tinycloud/sdk-services": "2.1.0-beta.4",
+        "@multiformats/multiaddr": "^13.0.1",
+        "@multiformats/multiaddr-to-uri": "^12.0.0",
+        "@multiformats/uri-to-multiaddr": "^10.0.0",
+        "@noble/curves": "^1.9.7",
+        "@tinycloud/sdk-services": "2.1.0",
         "ms": "^2.1.3",
+        "multiformats": "^13.4.1",
         "siwe": "^3.0.0",
+        "viem": "^2.21.53",
         "zod": "^3.22.0",
         "zod-to-json-schema": "^3.22.0",
       },
@@ -1204,13 +1210,15 @@
 
     "@multiformats/multiaddr-to-uri": ["@multiformats/multiaddr-to-uri@12.0.0", "", { "dependencies": { "@multiformats/multiaddr": "^13.0.0" } }, "sha512-3uIEBCiy8tfzxYYBl81x1tISiNBQ7mHU4pGjippbJRoQYHzy/ZdZM/7JvTldr8pc/dzpkaNJxnsuxxlhsPOJsA=="],
 
+    "@multiformats/uri-to-multiaddr": ["@multiformats/uri-to-multiaddr@10.0.0", "", { "dependencies": { "@multiformats/multiaddr": "^13.0.0", "is-ip": "^5.0.0" } }, "sha512-QsmwLmY6iB1wDU1e1wyctqF0eP/2KD1QPLQ+APISuqETbCTSpaq159S/K/ssmWlBpSEkhH0SUfBUgGi014Ttfw=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@nicolo-ribaudo/eslint-scope-5-internals": ["@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1", "", { "dependencies": { "eslint-scope": "5.1.1" } }, "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg=="],
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
+    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 
@@ -2376,6 +2384,8 @@
 
     "clone-deep": ["clone-deep@4.0.1", "", { "dependencies": { "is-plain-object": "^2.0.4", "kind-of": "^6.0.2", "shallow-clone": "^3.0.0" } }, "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ=="],
 
+    "clone-regexp": ["clone-regexp@3.0.0", "", { "dependencies": { "is-regexp": "^3.0.0" } }, "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw=="],
+
     "clone-stats": ["clone-stats@1.0.0", "", {}, "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag=="],
 
     "cloneable-readable": ["cloneable-readable@1.1.3", "", { "dependencies": { "inherits": "^2.0.1", "process-nextick-args": "^2.0.0", "readable-stream": "^2.3.5" } }, "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ=="],
@@ -2445,6 +2455,8 @@
     "content-disposition": ["content-disposition@0.5.2", "", {}, "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-hrtime": ["convert-hrtime@5.0.0", "", {}, "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -2996,6 +3008,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "function-timeout": ["function-timeout@0.1.1", "", {}, "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg=="],
+
     "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
@@ -3224,6 +3238,8 @@
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
+    "ip-regex": ["ip-regex@5.0.0", "", {}, "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="],
+
     "ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
@@ -3285,6 +3301,8 @@
     "is-installed-globally": ["is-installed-globally@0.4.0", "", { "dependencies": { "global-dirs": "^3.0.0", "is-path-inside": "^3.0.2" } }, "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ=="],
 
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
+    "is-ip": ["is-ip@5.0.1", "", { "dependencies": { "ip-regex": "^5.0.0", "super-regex": "^0.2.0" } }, "sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw=="],
 
     "is-lambda": ["is-lambda@1.0.1", "", {}, "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="],
 
@@ -4766,6 +4784,8 @@
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
+    "super-regex": ["super-regex@0.2.0", "", { "dependencies": { "clone-regexp": "^3.0.0", "function-timeout": "^0.1.0", "time-span": "^5.1.0" } }, "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw=="],
+
     "superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -4823,6 +4843,8 @@
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
     "thunky": ["thunky@1.1.0", "", {}, "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="],
+
+    "time-span": ["time-span@5.1.0", "", { "dependencies": { "convert-hrtime": "^5.0.0" } }, "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -5480,6 +5502,8 @@
 
     "@nicolo-ribaudo/eslint-scope-5-internals/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 
+    "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@npmcli/arborist/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "@npmcli/git/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
@@ -5567,8 +5591,6 @@
     "@solana/transaction-messages/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
     "@solana/transactions/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
-
-    "@solana/web3.js/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@solana/web3.js/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5760,6 +5782,8 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
+    "clone-regexp/is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
+
     "cloneable-readable/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "coa/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
@@ -5819,8 +5843,6 @@
     "domexception/webidl-conversions": ["webidl-conversions@5.0.0", "", {}, "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="],
 
     "dot-prop/is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
-
-    "eciesjs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -7139,6 +7161,8 @@
     "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "@tinycloud/node-sdk-tests/ethers/@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
 
     "@tinycloud/node-sdk-tests/ethers/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -24,9 +24,15 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@multiformats/multiaddr": "^13.0.1",
+    "@multiformats/multiaddr-to-uri": "^12.0.0",
+    "@multiformats/uri-to-multiaddr": "^10.0.0",
+    "@noble/curves": "^1.9.7",
     "@tinycloud/sdk-services": "2.1.0",
+    "multiformats": "^13.4.1",
     "ms": "^2.1.3",
     "siwe": "^3.0.0",
+    "viem": "^2.21.53",
     "zod": "^3.22.0",
     "zod-to-json-schema": "^3.22.0"
   },

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -329,6 +329,31 @@ export {
   validateManifest,
 } from "./manifest";
 
+// TinyCloud location registry helpers
+export {
+  CloudLocationResolutionError,
+  LocationRecordValidationError,
+  canonicalLocationPayload,
+  fetchLocationRecord,
+  httpUrlToMultiaddr,
+  locationPayloadForRecord,
+  multiaddrToHttpUrl,
+  resolveCloudLocation,
+  signLocationRecord,
+  validateLocationRecord,
+  validateLocationRecordPayload,
+  verifyLocationRecord,
+  type LocationCandidate,
+  type LocationCandidateInput,
+  type LocationRecord,
+  type LocationRecordPayload,
+  type LocationRecordSigner,
+  type LocationResolutionAttempt,
+  type LocationSource,
+  type ResolveCloudLocationOptions,
+  type ResolvedCloudLocation,
+} from "./location";
+
 // Capability subset checking and recap parsing
 export {
   // Errors

--- a/packages/sdk-core/src/location.test.ts
+++ b/packages/sdk-core/src/location.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { ed25519 } from "@noble/curves/ed25519";
+import { bases } from "multiformats/basics";
+import { privateKeyToAccount } from "viem/accounts";
+import {
+  canonicalLocationPayload,
+  httpUrlToMultiaddr,
+  locationPayloadForRecord,
+  multiaddrToHttpUrl,
+  resolveCloudLocation,
+  signLocationRecord,
+  validateLocationRecord,
+  verifyLocationRecord,
+  type LocationRecordPayload,
+} from "./location";
+
+describe("location records", () => {
+  it("signs and verifies did:pkh records", async () => {
+    const account = privateKeyToAccount(
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
+    const payload: LocationRecordPayload = {
+      version: 1,
+      subject: `did:pkh:eip155:1:${account.address}`,
+      multiaddrs: ["/dns4/node.tinycloud.xyz/tcp/443/https"],
+      updated_at: "2026-04-28T16:00:00.000Z",
+      sequence: 1,
+    };
+
+    const record = await signLocationRecord(payload, {
+      type: "did:pkh",
+      signMessage: (message) => account.signMessage({ message }),
+    });
+
+    expect(validateLocationRecord(record)).toEqual(record);
+    expect(await verifyLocationRecord(record)).toBe(true);
+    expect(canonicalLocationPayload(locationPayloadForRecord(record))).not.toContain(
+      "signature",
+    );
+  });
+
+  it("signs and verifies did:key records", async () => {
+    const privateKey = new Uint8Array(32).fill(9);
+    const publicKey = ed25519.getPublicKey(privateKey);
+    const subject = `did:key:${bases.base58btc.encode(
+      Uint8Array.of(0xed, 0x01, ...publicKey),
+    )}`;
+    const payload: LocationRecordPayload = {
+      version: 1,
+      subject,
+      multiaddrs: ["/dns4/node.tinycloud.xyz/tcp/443/https"],
+      updated_at: "2026-04-28T16:00:00.000Z",
+      sequence: 1,
+    };
+
+    const record = await signLocationRecord(payload, {
+      type: "did:key",
+      signBytes: async (bytes) => ed25519.sign(bytes, privateKey),
+    });
+
+    expect(await verifyLocationRecord(record)).toBe(true);
+  });
+
+  it("converts http URLs and multiaddrs", () => {
+    const ma = httpUrlToMultiaddr("https://node.tinycloud.xyz/");
+    expect(ma).toBe("/dns/node.tinycloud.xyz/tcp/443/tls/http");
+    expect(multiaddrToHttpUrl(ma)).toBe("https://node.tinycloud.xyz");
+  });
+});
+
+describe("resolveCloudLocation", () => {
+  it("queries sources concurrently but ranks explicit first", async () => {
+    const subject = "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
+    const resolved = await resolveCloudLocation(subject, {
+      explicitMultiaddrs: ["/dns4/explicit.tinycloud.xyz/tcp/443/https"],
+      blockchain: async (requestedSubject) => {
+        expect(requestedSubject).toBe(subject);
+        return ["/dns4/chain.tinycloud.xyz/tcp/443/https"];
+      },
+      fallbackMultiaddrs: ["/dns4/fallback.tinycloud.xyz/tcp/443/https"],
+    });
+
+    expect(resolved.source).toBe("explicit");
+    expect(resolved.multiaddrs).toEqual([
+      "/dns4/explicit.tinycloud.xyz/tcp/443/https",
+    ]);
+    expect(resolved.attempts.map((attempt) => attempt.source)).toEqual([
+      "explicit",
+      "blockchain",
+      "centralized",
+      "fallback",
+    ]);
+  });
+
+  it("falls through when a higher-priority source fails", async () => {
+    const subject = "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
+    const resolved = await resolveCloudLocation(subject, {
+      blockchain: async () => {
+        throw new Error("chain unavailable");
+      },
+      fallbackMultiaddrs: ["/dns4/fallback.tinycloud.xyz/tcp/443/https"],
+    });
+
+    expect(resolved.source).toBe("fallback");
+    expect(resolved.attempts[1].error?.message).toBe("chain unavailable");
+  });
+});

--- a/packages/sdk-core/src/location.ts
+++ b/packages/sdk-core/src/location.ts
@@ -1,0 +1,512 @@
+/**
+ * TinyCloud location registry helpers.
+ *
+ * The registry maps a DID to one or more multiaddrs. Registry records are
+ * signed by the DID subject; centralized storage is only a discovery cache.
+ */
+
+import { multiaddr } from "@multiformats/multiaddr";
+import { multiaddrToUri } from "@multiformats/multiaddr-to-uri";
+import { uriToMultiaddr } from "@multiformats/uri-to-multiaddr";
+import { ed25519 } from "@noble/curves/ed25519";
+import { bases } from "multiformats/basics";
+import { verifyMessage } from "viem";
+
+export interface LocationRecordPayload {
+  version: 1;
+  subject: string;
+  multiaddrs: string[];
+  updated_at: string;
+  sequence: number;
+}
+
+export interface LocationRecord extends LocationRecordPayload {
+  signature: string;
+}
+
+export type LocationSource = "explicit" | "blockchain" | "centralized" | "fallback";
+
+export interface LocationCandidate {
+  source: LocationSource;
+  multiaddrs: string[];
+  record?: LocationRecord;
+}
+
+export interface LocationResolutionAttempt {
+  source: LocationSource;
+  candidate?: LocationCandidate;
+  error?: Error;
+}
+
+export interface ResolvedCloudLocation {
+  subject: string;
+  source: LocationSource;
+  multiaddrs: string[];
+  record?: LocationRecord;
+  attempts: LocationResolutionAttempt[];
+  resolvedAt: string;
+}
+
+export interface ResolveCloudLocationOptions {
+  /** Highest-priority location supplied directly by the caller. */
+  explicitMultiaddrs?: string[];
+  /** Optional blockchain resolver adapter. */
+  blockchain?: (
+    subject: string,
+  ) => Promise<LocationCandidateInput | null | undefined>;
+  /** Centralized location registry base URL, e.g. https://registry.tinycloud.xyz. */
+  centralizedRegistryUrl?: string;
+  /** Lowest-priority fallback location. */
+  fallbackMultiaddrs?: string[];
+  /** Custom fetch implementation. Defaults to globalThis.fetch. */
+  fetch?: typeof fetch;
+  /** Verify centralized/blockchain record signatures. Default true. */
+  verifyRecords?: boolean;
+}
+
+export type LocationCandidateInput =
+  | string[]
+  | LocationRecord
+  | {
+      multiaddrs: string[];
+      record?: LocationRecord;
+    };
+
+export type LocationRecordSigner =
+  | {
+      type: "did:pkh";
+      signMessage(message: string): Promise<string>;
+    }
+  | {
+      type: "did:key";
+      signBytes(bytes: Uint8Array): Promise<Uint8Array>;
+    };
+
+export class LocationRecordValidationError extends Error {
+  constructor(message: string) {
+    super(`Location record validation failed: ${message}`);
+    this.name = "LocationRecordValidationError";
+  }
+}
+
+export class CloudLocationResolutionError extends Error {
+  public readonly attempts: LocationResolutionAttempt[];
+
+  constructor(subject: string, attempts: LocationResolutionAttempt[]) {
+    super(`Unable to resolve TinyCloud location for ${subject}`);
+    this.name = "CloudLocationResolutionError";
+    this.attempts = attempts;
+  }
+}
+
+export function locationPayloadForRecord(
+  record: LocationRecord,
+): LocationRecordPayload {
+  return {
+    version: record.version,
+    subject: record.subject,
+    multiaddrs: [...record.multiaddrs],
+    updated_at: record.updated_at,
+    sequence: record.sequence,
+  };
+}
+
+export function canonicalLocationPayload(
+  payload: LocationRecordPayload,
+): string {
+  return JSON.stringify({
+    version: payload.version,
+    subject: payload.subject,
+    multiaddrs: payload.multiaddrs,
+    updated_at: payload.updated_at,
+    sequence: payload.sequence,
+  });
+}
+
+export async function signLocationRecord(
+  payload: LocationRecordPayload,
+  signer: LocationRecordSigner,
+): Promise<LocationRecord> {
+  validateLocationRecordPayload(payload);
+  const message = canonicalLocationPayload(payload);
+  const signature =
+    signer.type === "did:pkh"
+      ? await signer.signMessage(message)
+      : base64UrlEncode(await signer.signBytes(new TextEncoder().encode(message)));
+  return { ...payload, signature };
+}
+
+export function validateLocationRecordPayload(
+  input: unknown,
+): LocationRecordPayload {
+  if (input === null || typeof input !== "object") {
+    throw new LocationRecordValidationError("payload must be an object");
+  }
+
+  const payload = input as Partial<LocationRecordPayload>;
+  if (payload.version !== 1) {
+    throw new LocationRecordValidationError("version must be 1");
+  }
+  validateSubject(payload.subject);
+  validateMultiaddrs(payload.multiaddrs);
+  if (
+    typeof payload.updated_at !== "string" ||
+    Number.isNaN(Date.parse(payload.updated_at))
+  ) {
+    throw new LocationRecordValidationError("updated_at must be an ISO timestamp");
+  }
+  if (
+    typeof payload.sequence !== "number" ||
+    !Number.isSafeInteger(payload.sequence) ||
+    payload.sequence < 0
+  ) {
+    throw new LocationRecordValidationError(
+      "sequence must be a non-negative safe integer",
+    );
+  }
+
+  return {
+    version: 1,
+    subject: payload.subject,
+    multiaddrs: [...payload.multiaddrs],
+    updated_at: payload.updated_at,
+    sequence: payload.sequence,
+  };
+}
+
+export function validateLocationRecord(input: unknown): LocationRecord {
+  const payload = validateLocationRecordPayload(input);
+  const signature = (input as Partial<LocationRecord>).signature;
+  if (typeof signature !== "string" || signature.length === 0) {
+    throw new LocationRecordValidationError("signature must be a non-empty string");
+  }
+  return { ...payload, signature };
+}
+
+export async function verifyLocationRecord(
+  input: LocationRecord,
+): Promise<boolean> {
+  const record = validateLocationRecord(input);
+  const payload = canonicalLocationPayload(locationPayloadForRecord(record));
+
+  if (record.subject.startsWith("did:pkh:")) {
+    return verifyPkhSignature(record.subject, payload, record.signature);
+  }
+  if (record.subject.startsWith("did:key:")) {
+    return verifyDidKeySignature(record.subject, payload, record.signature);
+  }
+  return false;
+}
+
+export async function fetchLocationRecord(
+  registryUrl: string,
+  subject: string,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<LocationRecord | null> {
+  const url = `${registryUrl.replace(/\/$/, "")}/v1/locations/${encodeURIComponent(subject)}`;
+  const response = await fetchFn(url);
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`location registry returned HTTP ${response.status}`);
+  }
+  const body = (await response.json()) as { record?: unknown };
+  if (body.record === undefined) {
+    throw new LocationRecordValidationError("registry response missing record");
+  }
+  return validateLocationRecord(body.record);
+}
+
+export async function resolveCloudLocation(
+  subject: string,
+  options: ResolveCloudLocationOptions = {},
+): Promise<ResolvedCloudLocation> {
+  validateSubject(subject);
+  const verifyRecords = options.verifyRecords ?? true;
+  const attempts = await Promise.all([
+    resolveExplicit(subject, options.explicitMultiaddrs),
+    resolveBlockchain(subject, options.blockchain, verifyRecords),
+    resolveCentralized(subject, options, verifyRecords),
+    resolveFallback(subject, options.fallbackMultiaddrs),
+  ]);
+
+  const winner = attempts.find((attempt) => attempt.candidate)?.candidate;
+  if (!winner) {
+    throw new CloudLocationResolutionError(subject, attempts);
+  }
+
+  return {
+    subject,
+    source: winner.source,
+    multiaddrs: [...winner.multiaddrs],
+    ...(winner.record ? { record: winner.record } : {}),
+    attempts,
+    resolvedAt: new Date().toISOString(),
+  };
+}
+
+export function multiaddrToHttpUrl(input: string): string {
+  const uri = multiaddrToUri(multiaddr(input));
+  if (!uri.startsWith("http://") && !uri.startsWith("https://")) {
+    throw new LocationRecordValidationError(
+      `multiaddr does not resolve to http/https: ${input}`,
+    );
+  }
+  return uri;
+}
+
+export function httpUrlToMultiaddr(input: string): string {
+  const url = new URL(input);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new LocationRecordValidationError("URL must use http or https");
+  }
+  return uriToMultiaddr(url.toString()).toString();
+}
+
+async function resolveExplicit(
+  subject: string,
+  multiaddrs: string[] | undefined,
+): Promise<LocationResolutionAttempt> {
+  return resolveAttempt("explicit", async () => {
+    if (multiaddrs === undefined || multiaddrs.length === 0) {
+      return null;
+    }
+    return toCandidate(subject, "explicit", multiaddrs, false);
+  });
+}
+
+async function resolveBlockchain(
+  subject: string,
+  resolver: ResolveCloudLocationOptions["blockchain"],
+  verifyRecords: boolean,
+): Promise<LocationResolutionAttempt> {
+  return resolveAttempt("blockchain", async () => {
+    if (!resolver) {
+      return null;
+    }
+    return toCandidate(subject, "blockchain", await resolver(subject), verifyRecords);
+  });
+}
+
+async function resolveCentralized(
+  subject: string,
+  options: ResolveCloudLocationOptions,
+  verifyRecords: boolean,
+): Promise<LocationResolutionAttempt> {
+  return resolveAttempt("centralized", async () => {
+    if (!options.centralizedRegistryUrl) {
+      return null;
+    }
+    const record = await fetchLocationRecord(
+      options.centralizedRegistryUrl,
+      subject,
+      options.fetch,
+    );
+    return toCandidate(subject, "centralized", record, verifyRecords);
+  });
+}
+
+async function resolveFallback(
+  subject: string,
+  multiaddrs: string[] | undefined,
+): Promise<LocationResolutionAttempt> {
+  return resolveAttempt("fallback", async () => {
+    if (multiaddrs === undefined || multiaddrs.length === 0) {
+      return null;
+    }
+    return toCandidate(subject, "fallback", multiaddrs, false);
+  });
+}
+
+async function resolveAttempt(
+  source: LocationSource,
+  resolve: () => Promise<LocationCandidate | null>,
+): Promise<LocationResolutionAttempt> {
+  try {
+    const candidate = await resolve();
+    return candidate ? { source, candidate } : { source };
+  } catch (error) {
+    return {
+      source,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}
+
+async function toCandidate(
+  subject: string,
+  source: LocationSource,
+  input: LocationCandidateInput | null | undefined,
+  verifyRecord: boolean,
+): Promise<LocationCandidate | null> {
+  if (input === null || input === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(input)) {
+    validateMultiaddrs(input);
+    return { source, multiaddrs: [...input] };
+  }
+
+  const maybeRecord = input as Partial<LocationRecord>;
+  if (maybeRecord.version === 1 && maybeRecord.signature !== undefined) {
+    const record = validateLocationRecord(input);
+    if (record.subject !== subject) {
+      throw new LocationRecordValidationError(
+        "location record subject does not match requested subject",
+      );
+    }
+    if (verifyRecord && !(await verifyLocationRecord(record))) {
+      throw new LocationRecordValidationError("location record signature is invalid");
+    }
+    return { source, multiaddrs: [...record.multiaddrs], record };
+  }
+
+  const candidateInput = input as { multiaddrs?: unknown; record?: unknown };
+  if (!Array.isArray(candidateInput.multiaddrs)) {
+    throw new LocationRecordValidationError("candidate multiaddrs must be an array");
+  }
+  validateMultiaddrs(candidateInput.multiaddrs);
+  if (candidateInput.record !== undefined) {
+    const record = validateLocationRecord(candidateInput.record);
+    if (record.subject !== subject) {
+      throw new LocationRecordValidationError(
+        "location record subject does not match requested subject",
+      );
+    }
+    if (verifyRecord && !(await verifyLocationRecord(record))) {
+      throw new LocationRecordValidationError("location record signature is invalid");
+    }
+    return { source, multiaddrs: [...candidateInput.multiaddrs], record };
+  }
+  return { source, multiaddrs: [...candidateInput.multiaddrs] };
+}
+
+function validateSubject(subject: unknown): asserts subject is string {
+  if (typeof subject !== "string" || subject.length === 0) {
+    throw new LocationRecordValidationError("subject must be a non-empty string");
+  }
+  if (!subject.startsWith("did:pkh:") && !subject.startsWith("did:key:")) {
+    throw new LocationRecordValidationError("subject must be did:pkh or did:key");
+  }
+}
+
+function validateMultiaddrs(input: unknown): asserts input is string[] {
+  if (!Array.isArray(input)) {
+    throw new LocationRecordValidationError("multiaddrs must be an array");
+  }
+  for (const addr of input) {
+    if (typeof addr !== "string" || addr.length === 0) {
+      throw new LocationRecordValidationError(
+        "multiaddr entries must be non-empty strings",
+      );
+    }
+    try {
+      multiaddr(addr);
+    } catch {
+      throw new LocationRecordValidationError(`invalid multiaddr: ${addr}`);
+    }
+  }
+}
+
+async function verifyPkhSignature(
+  did: string,
+  payload: string,
+  signature: string,
+): Promise<boolean> {
+  const address = did.split(":").at(-1);
+  if (!address || !/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    throw new LocationRecordValidationError(
+      "did:pkh subject must end with an EVM address",
+    );
+  }
+  if (!/^0x[0-9a-fA-F]+$/.test(signature)) {
+    throw new LocationRecordValidationError("did:pkh signature must be hex");
+  }
+
+  return verifyMessage({
+    address: address as `0x${string}`,
+    message: payload,
+    signature: signature as `0x${string}`,
+  });
+}
+
+function verifyDidKeySignature(
+  did: string,
+  payload: string,
+  signature: string,
+): boolean {
+  const publicKey = ed25519PublicKeyFromDidKey(did);
+  const signatureBytes = decodeBase64Url(signature);
+  if (signatureBytes.length !== 64) {
+    throw new LocationRecordValidationError(
+      "did:key signature must be a base64url Ed25519 signature",
+    );
+  }
+  return ed25519.verify(signatureBytes, new TextEncoder().encode(payload), publicKey);
+}
+
+function ed25519PublicKeyFromDidKey(did: string): Uint8Array {
+  const identifier = did.slice("did:key:".length);
+  if (!identifier.startsWith("z")) {
+    throw new LocationRecordValidationError("did:key must use base58btc multibase");
+  }
+
+  const bytes = bases.base58btc.decode(identifier);
+  if (bytes.length !== 34 || bytes[0] !== 0xed || bytes[1] !== 0x01) {
+    throw new LocationRecordValidationError("did:key must be an Ed25519 public key");
+  }
+
+  return bytes.slice(2);
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  const alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  let output = "";
+
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i];
+    const b = bytes[i + 1];
+    const c = bytes[i + 2];
+    const triplet = (a << 16) | ((b ?? 0) << 8) | (c ?? 0);
+
+    output += alphabet[(triplet >> 18) & 63];
+    output += alphabet[(triplet >> 12) & 63];
+    if (i + 1 < bytes.length) {
+      output += alphabet[(triplet >> 6) & 63];
+    }
+    if (i + 2 < bytes.length) {
+      output += alphabet[triplet & 63];
+    }
+  }
+
+  return output;
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bits = 0;
+
+  for (const char of value) {
+    const index = alphabet.indexOf(char);
+    if (index < 0) {
+      throw new LocationRecordValidationError(
+        "did:key signature must be base64url",
+      );
+    }
+
+    buffer = (buffer << 6) | index;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((buffer >> bits) & 0xff);
+    }
+  }
+
+  return Uint8Array.from(bytes);
+}

--- a/packages/sdk-core/tsup.config.ts
+++ b/packages/sdk-core/tsup.config.ts
@@ -9,9 +9,15 @@ export default defineConfig({
   splitting: false,
   // Externalize all dependencies — don't bundle them into the output
   external: [
+    '@multiformats/multiaddr',
+    '@multiformats/multiaddr-to-uri',
+    '@multiformats/uri-to-multiaddr',
+    '@noble/curves/ed25519',
     '@tinycloud/sdk-services',
+    'multiformats/basics',
     'ms',
     'siwe',
+    'viem',
     'zod',
     'zod-to-json-schema',
   ],


### PR DESCRIPTION
## Summary
- add signed TinyCloud location record helpers for did:pkh and did:key subjects
- add multiaddr <-> HTTP URL conversion helpers
- add priority-based cloud location resolution across explicit, blockchain, centralized registry, and fallback sources

## Verification
- bun test packages/sdk-core/src/location.test.ts
- bun run --cwd packages/sdk-services build && bun run --cwd packages/sdk-core build