### PR TITLE
feat(sdk): resolve TinyCloud hosts during sign-in

### DIFF
--- a/.changeset/default-cloud-host-resolution.md
+++ b/.changeset/default-cloud-host-resolution.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/sdk-core": minor
+---
+
+Add a default TinyCloud host resolver that uses registry discovery and hosted node fallback without app-level configuration.

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -124,6 +124,7 @@ function makeNodeWithSigner(
   return new TinyCloudNode({
     wasmBindings: wasm,
     signer: fakeSigner as any,
+    host: "https://tinycloud.test",
     ...config,
   });
 }

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -116,8 +116,12 @@ export interface TinyCloudNodeConfig {
   privateKey?: string;
   /** Custom signer implementation. If provided, takes precedence over privateKey. */
   signer?: ISigner;
-  /** TinyCloud server URL (default: "https://node.tinycloud.xyz") */
+  /** Explicit TinyCloud server URL. When omitted, signIn resolves the user's host. */
   host?: string;
+  /** TinyCloud location registry URL. Default: https://registry.tinycloud.xyz. */
+  tinycloudRegistryUrl?: string | null;
+  /** Fallback TinyCloud hosts. Default: hosted TinyCloud node. */
+  tinycloudFallbackHosts?: string[] | null;
   /** Space prefix for this user's space. Optional - only needed for signIn() */
   prefix?: string;
   /** Domain for SIWE messages (default: derived from host) */
@@ -222,6 +226,7 @@ export class TinyCloudNode {
   }
 
   private config: TinyCloudNodeConfig;
+  private readonly explicitHost?: string;
   private signer: ISigner | null = null;
   private auth: NodeUserAuthorization | null = null;
   private tc: TinyCloud | null = null;
@@ -287,6 +292,8 @@ export class TinyCloudNode {
    * ```
    */
   constructor(config: TinyCloudNodeConfig = {}) {
+    this.explicitHost = config.host;
+
     // Store config with default host
     this.config = {
       ...config,
@@ -385,8 +392,6 @@ export class TinyCloudNode {
    * @internal
    */
   private setupAuth(config: TinyCloudNodeConfig): void {
-    const host = this.config.host!;
-
     this.auth = new NodeUserAuthorization({
       signer: this.signer!,
       signStrategy: { type: "auto-sign" },
@@ -395,7 +400,9 @@ export class TinyCloudNode {
       domain: this.siweDomain,
       spacePrefix: config.prefix,
       sessionExpirationMs: config.sessionExpirationMs ?? 60 * 60 * 1000,
-      tinycloudHosts: [host],
+      tinycloudHosts: this.explicitHost ? [this.explicitHost] : undefined,
+      tinycloudRegistryUrl: config.tinycloudRegistryUrl,
+      tinycloudFallbackHosts: config.tinycloudFallbackHosts,
       autoCreateSpace: config.autoCreateSpace,
       enablePublicSpace: config.enablePublicSpace ?? true,
       spaceCreationHandler: config.spaceCreationHandler,
@@ -409,6 +416,13 @@ export class TinyCloudNode {
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.wasmBindings.invokeAny,
     });
+  }
+
+  private syncResolvedHostFromAuth(): void {
+    const host = this.auth?.hosts[0];
+    if (host) {
+      this.config.host = host;
+    }
   }
 
   /**
@@ -453,6 +467,11 @@ export class TinyCloudNode {
 
   get capabilityRequest(): ComposedManifestRequest | undefined {
     return this.auth?.capabilityRequest;
+  }
+
+  get hosts(): string[] {
+    const authHosts = this.auth?.hosts ?? [];
+    return authHosts.length > 0 ? authHosts : [this.config.host!];
   }
 
   /**
@@ -541,6 +560,7 @@ export class TinyCloudNode {
     this._serviceContext = undefined;
 
     await this.tc.signIn(options);
+    this.syncResolvedHostFromAuth();
 
     // Initialize service context with session
     this.initializeServices();
@@ -725,7 +745,6 @@ export class TinyCloudNode {
     }
 
     const prefix = options?.prefix ?? "default";
-    const host = this.config.host!;
 
     // Create signer from private key
     if (!TinyCloudNode.nodeDefaults) {
@@ -745,7 +764,9 @@ export class TinyCloudNode {
       domain: this.siweDomain,
       spacePrefix: prefix,
       sessionExpirationMs: this.config.sessionExpirationMs ?? 60 * 60 * 1000,
-      tinycloudHosts: [host],
+      tinycloudHosts: this.explicitHost ? [this.explicitHost] : undefined,
+      tinycloudRegistryUrl: this.config.tinycloudRegistryUrl,
+      tinycloudFallbackHosts: this.config.tinycloudFallbackHosts,
       autoCreateSpace: this.config.autoCreateSpace,
       enablePublicSpace: this.config.enablePublicSpace ?? true,
       spaceCreationHandler: this.config.spaceCreationHandler,
@@ -784,7 +805,6 @@ export class TinyCloudNode {
     }
 
     const prefix = options?.prefix ?? "default";
-    const host = this.config.host!;
 
     this.signer = signer;
 
@@ -796,7 +816,9 @@ export class TinyCloudNode {
       domain: this.siweDomain,
       spacePrefix: prefix,
       sessionExpirationMs: this.config.sessionExpirationMs ?? 60 * 60 * 1000,
-      tinycloudHosts: [host],
+      tinycloudHosts: this.explicitHost ? [this.explicitHost] : undefined,
+      tinycloudRegistryUrl: this.config.tinycloudRegistryUrl,
+      tinycloudFallbackHosts: this.config.tinycloudFallbackHosts,
       autoCreateSpace: this.config.autoCreateSpace,
       enablePublicSpace: this.config.enablePublicSpace ?? true,
       spaceCreationHandler: this.config.spaceCreationHandler,

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, expect, test } from "bun:test";
 import {
+  DEFAULT_TINYCLOUD_FALLBACK_HOST,
+  DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL,
   type IWasmBindings,
   type ISessionManager,
   type ISigner,
@@ -180,4 +182,51 @@ test("NodeUserAuthorization.signIn lets a per-call nonce override siweConfig.non
   expect(captured[0]?.nonce).toBe("call-nonce");
   expect(captured[0]?.nonce).not.toBe("constructor-nonce");
   expect(signedMessages[0]).toContain("Nonce: call-nonce");
+});
+
+test("NodeUserAuthorization.signIn resolves TinyCloud hosts when none are explicit", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const signedMessages: string[] = [];
+  const requests: string[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).__originalFetch = originalFetch;
+  globalThis.fetch = async (input: any, init?: any) => {
+    const url = String(input);
+    requests.push(url);
+    if (url.startsWith(`${DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL}/v1/locations/`)) {
+      return new Response("{}", { status: 404 });
+    }
+    if (url.endsWith("/info")) {
+      return new Response(
+        JSON.stringify({ protocol: 1, version: "1.0.0", features: [] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url.endsWith("/delegate") && init?.method === "POST") {
+      return new Response(JSON.stringify({ activated: ["space"], skipped: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  const auth = new NodeUserAuthorization({
+    signer: createSigner(signedMessages),
+    wasmBindings: createWasmBindings(captured),
+    signStrategy: { type: "auto-sign" },
+    domain: "example.com",
+    sessionStorage: new MemorySessionStorage(),
+    siweConfig: { nonce: "constructor-nonce" },
+  });
+
+  await auth.signIn();
+
+  expect(auth.hosts).toEqual([DEFAULT_TINYCLOUD_FALLBACK_HOST]);
+  expect(requests).toContain(
+    `${DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL}/v1/locations/${encodeURIComponent(
+      "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
+    )}`,
+  );
+  expect(requests).toContain(`${DEFAULT_TINYCLOUD_FALLBACK_HOST}/info`);
 });

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -24,6 +24,7 @@ import {
   composeManifestRequest,
   resourceCapabilitiesToAbilitiesMap,
   resourceCapabilitiesToSpaceAbilitiesMap,
+  resolveTinyCloudHosts,
 } from "@tinycloud/sdk-core";
 import {
   SignStrategy,
@@ -59,8 +60,12 @@ export interface NodeUserAuthorizationConfig {
   autoCreateSpace?: boolean;
   /** Custom space creation handler. If provided, takes precedence over autoCreateSpace. */
   spaceCreationHandler?: ISpaceCreationHandler;
-  /** TinyCloud server endpoints (default: ["https://node.tinycloud.xyz"]) */
+  /** Explicit TinyCloud server endpoints. When omitted, signIn resolves the user's host. */
   tinycloudHosts?: string[];
+  /** TinyCloud location registry URL. Default: https://registry.tinycloud.xyz. */
+  tinycloudRegistryUrl?: string | null;
+  /** Fallback TinyCloud hosts. Default: hosted TinyCloud node. */
+  tinycloudFallbackHosts?: string[] | null;
   /** Whether to include public space capabilities in the session (default: true) */
   enablePublicSpace?: boolean;
   /** WASM bindings for cryptographic operations. Required. */
@@ -141,7 +146,9 @@ export class NodeUserAuthorization implements IUserAuthorization {
   private readonly sessionExpirationMs: number;
   private readonly autoCreateSpace: boolean;
   private readonly spaceCreationHandler?: ISpaceCreationHandler;
-  private readonly tinycloudHosts: string[];
+  private tinycloudHosts?: string[];
+  private readonly tinycloudRegistryUrl?: string | null;
+  private readonly tinycloudFallbackHosts?: string[] | null;
   private readonly enablePublicSpace: boolean;
   private readonly nonce?: string;
   private readonly siweConfig?: SiweConfig;
@@ -217,9 +224,9 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this.sessionExpirationMs = config.sessionExpirationMs ?? 60 * 60 * 1000;
     this.autoCreateSpace = config.autoCreateSpace ?? false;
     this.spaceCreationHandler = config.spaceCreationHandler;
-    this.tinycloudHosts = config.tinycloudHosts ?? [
-      "https://node.tinycloud.xyz",
-    ];
+    this.tinycloudHosts = config.tinycloudHosts;
+    this.tinycloudRegistryUrl = config.tinycloudRegistryUrl;
+    this.tinycloudFallbackHosts = config.tinycloudFallbackHosts;
     this.enablePublicSpace = config.enablePublicSpace ?? true;
     this.nonce = config.nonce;
     this.siweConfig = config.siweConfig;
@@ -244,6 +251,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
   get capabilityRequest(): ComposedManifestRequest | undefined {
     return this.getCapabilityRequest();
+  }
+
+  get hosts(): string[] {
+    return this.tinycloudHosts ? [...this.tinycloudHosts] : [];
   }
 
   /**
@@ -272,6 +283,33 @@ export class NodeUserAuthorization implements IUserAuthorization {
    */
   get tinyCloudSession(): TinyCloudSession | undefined {
     return this._tinyCloudSession;
+  }
+
+  private async resolveTinyCloudHostsForSignIn(
+    address: string,
+    chainId: number,
+  ): Promise<void> {
+    if (this.tinycloudHosts && this.tinycloudHosts.length > 0) {
+      return;
+    }
+
+    const subject = `did:pkh:eip155:${chainId}:${address}`;
+    const resolved = await resolveTinyCloudHosts(subject, {
+      registryUrl: this.tinycloudRegistryUrl,
+      fallbackHosts: this.tinycloudFallbackHosts,
+    });
+    this.tinycloudHosts = resolved.hosts;
+  }
+
+  private requireTinyCloudHosts(): string[] {
+    if (!this.tinycloudHosts || this.tinycloudHosts.length === 0) {
+      throw new Error("TinyCloud hosts have not been resolved. Call signIn() first.");
+    }
+    return this.tinycloudHosts;
+  }
+
+  private get primaryTinyCloudHost(): string {
+    return this.requireTinyCloudHosts()[0];
   }
 
   get nodeFeatures(): string[] {
@@ -438,7 +476,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       throw new Error("Must be signed in to host space");
     }
 
-    const host = this.tinycloudHosts[0];
+    const host = this.primaryTinyCloudHost;
     const spaceId = targetSpaceId ?? this._tinyCloudSession.spaceId;
 
     // Get peer ID from TinyCloud server
@@ -493,7 +531,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       throw new Error("Must be signed in to ensure space exists");
     }
 
-    const host = this.tinycloudHosts[0];
+    const host = this.primaryTinyCloudHost;
     const primarySpaceId = this._tinyCloudSession.spaceId;
 
     // Try to activate the session
@@ -642,6 +680,8 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const address = this.wasm.ensureEip55(this._address);
     const chainId = this._chainId;
 
+    await this.resolveTinyCloudHostsForSignIn(address, chainId);
+
     // Create a session key
     const keyId = `session-${Date.now()}`;
     this.sessionManager.renameSessionKeyId("default", keyId);
@@ -757,7 +797,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
     // Verify SDK-node protocol compatibility and discover supported features
     const nodeInfo = await checkNodeInfo(
-      this.tinycloudHosts[0],
+      this.primaryTinyCloudHost,
       this.wasm.protocolVersion(),
     );
     this._nodeFeatures = nodeInfo.features;
@@ -928,6 +968,8 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const address = this.wasm.ensureEip55(await this.signer.getAddress());
     const chainId = await this.signer.getChainId();
 
+    await this.resolveTinyCloudHostsForSignIn(address, chainId);
+
     // Create client session (web-core compatible)
     const clientSession: ClientSession = {
       address,
@@ -996,7 +1038,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
     // Verify SDK-node protocol compatibility and discover supported features
     const nodeInfo = await checkNodeInfo(
-      this.tinycloudHosts[0],
+      this.primaryTinyCloudHost,
       this.wasm.protocolVersion(),
     );
     this._nodeFeatures = nodeInfo.features;

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -332,6 +332,8 @@ export {
 // TinyCloud location registry helpers
 export {
   CloudLocationResolutionError,
+  DEFAULT_TINYCLOUD_FALLBACK_HOST,
+  DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL,
   LocationRecordValidationError,
   canonicalLocationPayload,
   fetchLocationRecord,
@@ -339,6 +341,7 @@ export {
   locationPayloadForRecord,
   multiaddrToHttpUrl,
   resolveCloudLocation,
+  resolveTinyCloudHosts,
   signLocationRecord,
   validateLocationRecord,
   validateLocationRecordPayload,
@@ -351,7 +354,9 @@ export {
   type LocationResolutionAttempt,
   type LocationSource,
   type ResolveCloudLocationOptions,
+  type ResolveTinyCloudHostsOptions,
   type ResolvedCloudLocation,
+  type ResolvedTinyCloudHosts,
 } from "./location";
 
 // Capability subset checking and recap parsing

--- a/packages/sdk-core/src/location.test.ts
+++ b/packages/sdk-core/src/location.test.ts
@@ -3,11 +3,14 @@ import { ed25519 } from "@noble/curves/ed25519";
 import { bases } from "multiformats/basics";
 import { privateKeyToAccount } from "viem/accounts";
 import {
+  DEFAULT_TINYCLOUD_FALLBACK_HOST,
+  DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL,
   canonicalLocationPayload,
   httpUrlToMultiaddr,
   locationPayloadForRecord,
   multiaddrToHttpUrl,
   resolveCloudLocation,
+  resolveTinyCloudHosts,
   signLocationRecord,
   validateLocationRecord,
   verifyLocationRecord,
@@ -34,9 +37,9 @@ describe("location records", () => {
 
     expect(validateLocationRecord(record)).toEqual(record);
     expect(await verifyLocationRecord(record)).toBe(true);
-    expect(canonicalLocationPayload(locationPayloadForRecord(record))).not.toContain(
-      "signature",
-    );
+    expect(
+      canonicalLocationPayload(locationPayloadForRecord(record)),
+    ).not.toContain("signature");
   });
 
   it("signs and verifies did:key records", async () => {
@@ -68,9 +71,73 @@ describe("location records", () => {
   });
 });
 
+describe("resolveTinyCloudHosts", () => {
+  it("uses the default registry and hosted node fallback", async () => {
+    const subject =
+      "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
+    const requests: string[] = [];
+
+    const resolved = await resolveTinyCloudHosts(subject, {
+      fetch: async (input) => {
+        requests.push(String(input));
+        return new Response("{}", { status: 404 });
+      },
+    });
+
+    expect(requests).toEqual([
+      `${DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL}/v1/locations/${encodeURIComponent(subject)}`,
+    ]);
+    expect(resolved.location.source).toBe("fallback");
+    expect(resolved.hosts).toEqual([DEFAULT_TINYCLOUD_FALLBACK_HOST]);
+  });
+
+  it("lets explicit hosts override registry and fallback defaults", async () => {
+    const subject =
+      "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
+    const resolved = await resolveTinyCloudHosts(subject, {
+      explicitHosts: ["https://local.node.test"],
+      fetch: async () => new Response("{}", { status: 404 }),
+    });
+
+    expect(resolved.location.source).toBe("explicit");
+    expect(resolved.hosts).toEqual(["https://local.node.test"]);
+  });
+
+  it("allows a custom registry URL", async () => {
+    const subject =
+      "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
+    const registryUrl = "https://registry.example";
+    const record = {
+      version: 1,
+      subject,
+      multiaddrs: ["/dns4/registry.node.test/tcp/443/https"],
+      updated_at: "2026-04-28T16:00:00.000Z",
+      sequence: 1,
+      signature: "test-signature",
+    };
+    const requests: string[] = [];
+
+    const resolved = await resolveTinyCloudHosts(subject, {
+      registryUrl,
+      verifyRecords: false,
+      fetch: async (input) => {
+        requests.push(String(input));
+        return Response.json({ record });
+      },
+    });
+
+    expect(requests).toEqual([
+      `${registryUrl}/v1/locations/${encodeURIComponent(subject)}`,
+    ]);
+    expect(resolved.location.source).toBe("centralized");
+    expect(resolved.hosts).toEqual(["https://registry.node.test"]);
+  });
+});
+
 describe("resolveCloudLocation", () => {
   it("queries sources concurrently but ranks explicit first", async () => {
-    const subject = "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
+    const subject =
+      "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
     const resolved = await resolveCloudLocation(subject, {
       explicitMultiaddrs: ["/dns4/explicit.tinycloud.xyz/tcp/443/https"],
       blockchain: async (requestedSubject) => {
@@ -93,7 +160,8 @@ describe("resolveCloudLocation", () => {
   });
 
   it("falls through when a higher-priority source fails", async () => {
-    const subject = "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
+    const subject =
+      "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
     const resolved = await resolveCloudLocation(subject, {
       blockchain: async () => {
         throw new Error("chain unavailable");

--- a/packages/sdk-core/src/location.ts
+++ b/packages/sdk-core/src/location.ts
@@ -24,7 +24,15 @@ export interface LocationRecord extends LocationRecordPayload {
   signature: string;
 }
 
-export type LocationSource = "explicit" | "blockchain" | "centralized" | "fallback";
+export type LocationSource =
+  | "explicit"
+  | "blockchain"
+  | "centralized"
+  | "fallback";
+
+export const DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL =
+  "https://registry.tinycloud.xyz";
+export const DEFAULT_TINYCLOUD_FALLBACK_HOST = "https://node.tinycloud.xyz";
 
 export interface LocationCandidate {
   source: LocationSource;
@@ -58,6 +66,26 @@ export interface ResolveCloudLocationOptions {
   centralizedRegistryUrl?: string;
   /** Lowest-priority fallback location. */
   fallbackMultiaddrs?: string[];
+  /** Custom fetch implementation. Defaults to globalThis.fetch. */
+  fetch?: typeof fetch;
+  /** Verify centralized/blockchain record signatures. Default true. */
+  verifyRecords?: boolean;
+}
+
+export interface ResolvedTinyCloudHosts {
+  hosts: string[];
+  location: ResolvedCloudLocation;
+}
+
+export interface ResolveTinyCloudHostsOptions {
+  /** Highest-priority TinyCloud HTTP host URLs or multiaddrs supplied directly. */
+  explicitHosts?: string[];
+  /** Optional blockchain resolver adapter. */
+  blockchain?: ResolveCloudLocationOptions["blockchain"];
+  /** Centralized location registry URL. Default https://registry.tinycloud.xyz. */
+  registryUrl?: string | null;
+  /** Lowest-priority fallback HTTP host URLs or multiaddrs. Default hosted TinyCloud node. */
+  fallbackHosts?: string[] | null;
   /** Custom fetch implementation. Defaults to globalThis.fetch. */
   fetch?: typeof fetch;
   /** Verify centralized/blockchain record signatures. Default true. */
@@ -132,7 +160,9 @@ export async function signLocationRecord(
   const signature =
     signer.type === "did:pkh"
       ? await signer.signMessage(message)
-      : base64UrlEncode(await signer.signBytes(new TextEncoder().encode(message)));
+      : base64UrlEncode(
+          await signer.signBytes(new TextEncoder().encode(message)),
+        );
   return { ...payload, signature };
 }
 
@@ -153,7 +183,9 @@ export function validateLocationRecordPayload(
     typeof payload.updated_at !== "string" ||
     Number.isNaN(Date.parse(payload.updated_at))
   ) {
-    throw new LocationRecordValidationError("updated_at must be an ISO timestamp");
+    throw new LocationRecordValidationError(
+      "updated_at must be an ISO timestamp",
+    );
   }
   if (
     typeof payload.sequence !== "number" ||
@@ -178,7 +210,9 @@ export function validateLocationRecord(input: unknown): LocationRecord {
   const payload = validateLocationRecordPayload(input);
   const signature = (input as Partial<LocationRecord>).signature;
   if (typeof signature !== "string" || signature.length === 0) {
-    throw new LocationRecordValidationError("signature must be a non-empty string");
+    throw new LocationRecordValidationError(
+      "signature must be a non-empty string",
+    );
   }
   return { ...payload, signature };
 }
@@ -246,6 +280,32 @@ export async function resolveCloudLocation(
   };
 }
 
+export async function resolveTinyCloudHosts(
+  subject: string,
+  options: ResolveTinyCloudHostsOptions = {},
+): Promise<ResolvedTinyCloudHosts> {
+  const location = await resolveCloudLocation(subject, {
+    explicitMultiaddrs: hostsToMultiaddrs(options.explicitHosts),
+    blockchain: options.blockchain,
+    centralizedRegistryUrl:
+      options.registryUrl === null
+        ? undefined
+        : (options.registryUrl ?? DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL),
+    fallbackMultiaddrs: hostsToMultiaddrs(
+      options.fallbackHosts === null
+        ? undefined
+        : (options.fallbackHosts ?? [DEFAULT_TINYCLOUD_FALLBACK_HOST]),
+    ),
+    fetch: options.fetch,
+    verifyRecords: options.verifyRecords,
+  });
+
+  return {
+    hosts: location.multiaddrs.map((addr) => multiaddrToHttpUrl(addr)),
+    location,
+  };
+}
+
 export function multiaddrToHttpUrl(input: string): string {
   const uri = multiaddrToUri(multiaddr(input));
   if (!uri.startsWith("http://") && !uri.startsWith("https://")) {
@@ -262,6 +322,15 @@ export function httpUrlToMultiaddr(input: string): string {
     throw new LocationRecordValidationError("URL must use http or https");
   }
   return uriToMultiaddr(url.toString()).toString();
+}
+
+function hostsToMultiaddrs(hosts: string[] | undefined): string[] | undefined {
+  if (hosts === undefined || hosts.length === 0) {
+    return undefined;
+  }
+  return hosts.map((host) =>
+    host.startsWith("/") ? host : httpUrlToMultiaddr(host),
+  );
 }
 
 async function resolveExplicit(
@@ -285,7 +354,12 @@ async function resolveBlockchain(
     if (!resolver) {
       return null;
     }
-    return toCandidate(subject, "blockchain", await resolver(subject), verifyRecords);
+    return toCandidate(
+      subject,
+      "blockchain",
+      await resolver(subject),
+      verifyRecords,
+    );
   });
 }
 
@@ -358,14 +432,18 @@ async function toCandidate(
       );
     }
     if (verifyRecord && !(await verifyLocationRecord(record))) {
-      throw new LocationRecordValidationError("location record signature is invalid");
+      throw new LocationRecordValidationError(
+        "location record signature is invalid",
+      );
     }
     return { source, multiaddrs: [...record.multiaddrs], record };
   }
 
   const candidateInput = input as { multiaddrs?: unknown; record?: unknown };
   if (!Array.isArray(candidateInput.multiaddrs)) {
-    throw new LocationRecordValidationError("candidate multiaddrs must be an array");
+    throw new LocationRecordValidationError(
+      "candidate multiaddrs must be an array",
+    );
   }
   validateMultiaddrs(candidateInput.multiaddrs);
   if (candidateInput.record !== undefined) {
@@ -376,7 +454,9 @@ async function toCandidate(
       );
     }
     if (verifyRecord && !(await verifyLocationRecord(record))) {
-      throw new LocationRecordValidationError("location record signature is invalid");
+      throw new LocationRecordValidationError(
+        "location record signature is invalid",
+      );
     }
     return { source, multiaddrs: [...candidateInput.multiaddrs], record };
   }
@@ -385,10 +465,14 @@ async function toCandidate(
 
 function validateSubject(subject: unknown): asserts subject is string {
   if (typeof subject !== "string" || subject.length === 0) {
-    throw new LocationRecordValidationError("subject must be a non-empty string");
+    throw new LocationRecordValidationError(
+      "subject must be a non-empty string",
+    );
   }
   if (!subject.startsWith("did:pkh:") && !subject.startsWith("did:key:")) {
-    throw new LocationRecordValidationError("subject must be did:pkh or did:key");
+    throw new LocationRecordValidationError(
+      "subject must be did:pkh or did:key",
+    );
   }
 }
 
@@ -444,18 +528,26 @@ function verifyDidKeySignature(
       "did:key signature must be a base64url Ed25519 signature",
     );
   }
-  return ed25519.verify(signatureBytes, new TextEncoder().encode(payload), publicKey);
+  return ed25519.verify(
+    signatureBytes,
+    new TextEncoder().encode(payload),
+    publicKey,
+  );
 }
 
 function ed25519PublicKeyFromDidKey(did: string): Uint8Array {
   const identifier = did.slice("did:key:".length);
   if (!identifier.startsWith("z")) {
-    throw new LocationRecordValidationError("did:key must use base58btc multibase");
+    throw new LocationRecordValidationError(
+      "did:key must use base58btc multibase",
+    );
   }
 
   const bytes = bases.base58btc.decode(identifier);
   if (bytes.length !== 34 || bytes[0] !== 0xed || bytes[1] !== 0x01) {
-    throw new LocationRecordValidationError("did:key must be an Ed25519 public key");
+    throw new LocationRecordValidationError(
+      "did:key must be an Ed25519 public key",
+    );
   }
 
   return bytes.slice(2);

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -89,8 +89,12 @@ export interface Config extends ClientConfig {
   /** Prefix for space names when creating spaces */
   spacePrefix?: string;
 
-  /** TinyCloud server hosts (default: ['https://node.tinycloud.xyz']) */
+  /** Explicit TinyCloud server hosts. When omitted, signIn resolves the user's host. */
   tinycloudHosts?: string[];
+  /** TinyCloud location registry URL. Default: https://registry.tinycloud.xyz. */
+  tinycloudRegistryUrl?: string | null;
+  /** Fallback TinyCloud hosts. Default: hosted TinyCloud node. */
+  tinycloudFallbackHosts?: string[] | null;
 
   /** Whether to auto-create space on sign-in (default: true) */
   autoCreateSpace?: boolean;
@@ -276,7 +280,9 @@ export class TinyCloudWeb {
     await this.wasmBindings.ensureInitialized();
 
     const nodeConfig: TinyCloudNodeConfig = {
-      host: this.config.tinycloudHosts?.[0] ?? "https://node.tinycloud.xyz",
+      host: this.config.tinycloudHosts?.[0],
+      tinycloudRegistryUrl: this.config.tinycloudRegistryUrl,
+      tinycloudFallbackHosts: this.config.tinycloudFallbackHosts,
       domain: this.config.domain ?? (typeof window !== 'undefined' ? window.location.hostname : 'app.tinycloud.xyz'),
       prefix: this.config.spacePrefix,
       autoCreateSpace: this.config.autoCreateSpace ?? true,
@@ -359,6 +365,7 @@ export class TinyCloudWeb {
   get delegations(): DelegationManager { return this.node.delegationManager; }
   get capabilityRegistry(): ICapabilityKeyRegistry { return this.node.capabilityRegistry; }
   get spaceId(): string | undefined { return this._node?.spaceId; }
+  get hosts(): string[] { return this.node.hosts; }
 
   space(nameOrUri: string): ISpace { return this.spaces.get(nameOrUri); }
   get kvPrefix(): string { return this.config.kvPrefix || ""; }


### PR DESCRIPTION
## Summary
- add default TinyCloud host discovery in sdk-core with registry.tinycloud.xyz and hosted-node fallback
- move host resolution into NodeUserAuthorization.signIn() / signInWithPreparedSession() when no explicit host is configured
- pass registry/fallback overrides through TinyCloudNode and TinyCloudWeb while keeping app code on the existing signIn flow
- expose resolved hosts on TinyCloudNode/TinyCloudWeb for post-sign-in consumers that need the active endpoint

## Verification
- bun test packages/sdk-core/src/location.test.ts packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
- bun run --cwd packages/sdk-services build && bun run --cwd packages/sdk-core build && bun run --cwd packages/node-sdk build
- bun run --cwd packages/web-sdk build