### PR TITLE
Fix release build metadata

### DIFF
--- a/.changeset/default-cloud-host-resolution.md
+++ b/.changeset/default-cloud-host-resolution.md
@@ -1,5 +1,7 @@
 ---
 "@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
 ---
 
-Add a default TinyCloud host resolver that uses registry discovery and hosted node fallback without app-level configuration.
+Add default TinyCloud host discovery and run it from sign-in when no explicit host is configured.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           bun changeset version
           bun install
-          bun run build
+          bun run build:release
         env:
           BUILD_SETUP_ENABLED: true
 
@@ -157,7 +157,7 @@ jobs:
           bun install
 
       - name: Build
-        run: bun run build
+        run: bun run build:release
         env:
           BUILD_SETUP_ENABLED: true
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "turbo build",
+    "build:release": "turbo build --filter=!tinycloud-openkey-example-app",
     "dev": "turbo dev",
     "test": "turbo test",
     "lint": "turbo lint",


### PR DESCRIPTION
## Summary
- Add node-sdk and web-sdk to the default cloud host resolution changeset so the prerelease bumps cover the packages whose sign-in behavior changed.
- Add a release-specific build script that excludes tinycloud-openkey-example-app.
- Use the release build script in both beta and stable release workflows.

## Verification
- bun run build:release -- --dry=json
- bun run --cwd packages/web-sdk clean && bun run build:release