### PR TITLE
Fix web-sdk bundle for OpenKey build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "turbo build",
-    "build:release": "turbo build --filter=!tinycloud-openkey-example-app",
+    "build:release": "turbo build",
     "dev": "turbo dev",
     "test": "turbo test",
     "lint": "turbo lint",

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -24,7 +24,7 @@
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
   "scripts": {
-    "build": "webpack --mode production --config webpack.config.cjs",
+    "build": "rimraf dist && webpack --mode production --config webpack.config.cjs",
     "dev": "webpack --watch --config webpack.config.cjs",
     "watch": "webpack --watch --config webpack.config.cjs",
     "doc": "bun run doc:extractor && bun run doc:documenter",

--- a/packages/web-sdk/webpack.config.cjs
+++ b/packages/web-sdk/webpack.config.cjs
@@ -94,13 +94,19 @@ const baseConfig = {
   module: { rules },
   resolve: resolveConfig,
   optimization: {
+    splitChunks: false,
+    runtimeChunk: false,
     // Disable HMR and development optimizations in production
     ...(isProduction && {
       minimize: true,
       sideEffects: false,
     }),
   },
-  plugins,
+  plugins: [
+    ...plugins,
+    // Keep the package bundle self-contained for downstream bundlers like CRA.
+    new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
+  ],
   // Prevent webpack from injecting Node.js polyfills for global, __filename, __dirname
   node: false,
 };


### PR DESCRIPTION
## Summary
- clean the web-sdk dist directory before rebuilding
- force the web-sdk webpack library output to a single chunk so downstream bundlers do not create a dynamic context over dist

## Verification
- bun run --cwd packages/web-sdk build
- bun run openkey-demo:build
- bun run build