### PR TITLE
Fix manifest registry and capabilities defaults

### DIFF
--- a/.changeset/account-registry-space-detection.md
+++ b/.changeset/account-registry-space-detection.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Check whether the manifest account registry space already exists before hosting it during sign-in, avoiding repeated account-space host prompts.

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -129,6 +129,27 @@ function makeNodeWithSigner(
   });
 }
 
+async function withFetchResponses(
+  responses: Response[],
+  fn: (fetchMock: any) => Promise<void>,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  const fetchMock = mock(async () => {
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("unexpected fetch");
+    }
+    return response;
+  });
+
+  globalThis.fetch = fetchMock as any;
+  try {
+    await fn(fetchMock);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
 /**
  * Stub out the post-prepareSession network calls so signIn can complete
  * without contacting a real server. We monkey-patch the inner auth
@@ -312,6 +333,61 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
         },
       },
     });
+  });
+
+  test("manifest registry write does not re-host existing account space", async () => {
+    const node = makeNodeWithSigner(makeFakeWasmBindings());
+    const auth = (node as any).auth;
+    auth._tinyCloudSession = {
+      delegationHeader: { Authorization: "Bearer fake" },
+    };
+    auth.hostOwnedSpace = mock(async () => true);
+
+    await withFetchResponses(
+      [
+        new Response(JSON.stringify({ activated: ["space://test"], skipped: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ],
+      async () => {
+        await (node as any).ensureOwnedSpaceHosted(
+          "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:account",
+        );
+      },
+    );
+
+    expect(auth.hostOwnedSpace).not.toHaveBeenCalled();
+  });
+
+  test("manifest registry write hosts account space only when activation skips it", async () => {
+    const accountSpaceId =
+      "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:account";
+    const node = makeNodeWithSigner(makeFakeWasmBindings());
+    const auth = (node as any).auth;
+    auth._tinyCloudSession = {
+      delegationHeader: { Authorization: "Bearer fake" },
+    };
+    auth.hostOwnedSpace = mock(async () => true);
+
+    await withFetchResponses(
+      [
+        new Response(JSON.stringify({ activated: [], skipped: [accountSpaceId] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+        new Response(JSON.stringify({ activated: [accountSpaceId], skipped: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ],
+      async () => {
+        await (node as any).ensureOwnedSpaceHosted(accountSpaceId);
+      },
+    );
+
+    expect(auth.hostOwnedSpace).toHaveBeenCalledTimes(1);
+    expect(auth.hostOwnedSpace).toHaveBeenCalledWith(accountSpaceId);
   });
 
   test("multiple manifests → recap unions app caps + delegation caps", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -587,7 +587,7 @@ export class TinyCloudNode {
     }
 
     const accountSpaceId = this.ownedSpaceId(ACCOUNT_REGISTRY_SPACE);
-    await (this.auth as NodeUserAuthorization).hostOwnedSpace(accountSpaceId);
+    await this.ensureOwnedSpaceHosted(accountSpaceId);
 
     const accountKV = this.spaces.get(accountSpaceId).kv;
     for (const record of request.registryRecords) {
@@ -601,6 +601,49 @@ export class TinyCloudNode {
           `Failed to write manifest registry record ${record.key}: ${result.error.message}`,
         );
       }
+    }
+  }
+
+  private async ensureOwnedSpaceHosted(spaceId: string): Promise<void> {
+    if (!this.auth) {
+      throw new Error("Owned space hosting requires wallet mode");
+    }
+
+    const session = this.auth.tinyCloudSession;
+    if (!session) {
+      throw new Error("Owned space hosting requires an active session");
+    }
+
+    const host = this.hosts[0] ?? this.config.host;
+    if (!host) {
+      throw new Error("Owned space hosting requires a TinyCloud host");
+    }
+
+    const activation = await activateSessionWithHost(host, session.delegationHeader);
+    if (activation.success && !activation.skipped?.includes(spaceId)) {
+      return;
+    }
+
+    if (!activation.success && activation.status !== 404) {
+      throw new Error(
+        `Failed to check owned space ${spaceId}: ${activation.error ?? activation.status}`,
+      );
+    }
+
+    const created = await (this.auth as NodeUserAuthorization).hostOwnedSpace(spaceId);
+    if (!created) {
+      throw new Error(`Failed to create owned space: ${spaceId}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const retry = await activateSessionWithHost(host, session.delegationHeader);
+    if (!retry.success || retry.skipped?.includes(spaceId)) {
+      throw new Error(
+        `Failed to activate session after creating owned space ${spaceId}: ${
+          retry.error ?? "space was skipped"
+        }`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Check whether the manifest account registry space is already active before calling hostOwnedSpace during sign-in
- Only host the account registry space when activation skips it or the host reports it missing
- Add implicit space-level tinycloud.capabilities/read grants for every space touched by a manifest request
- Keep capabilities/read unprefixed so the recap resource is space-level, e.g. tinycloud:...:<space>/capabilities
- Add manifest and sign-in tests for account registry detection and implicit capabilities-read defaults

## Testing
- bun test src/manifest.test.ts
- bun run build (packages/sdk-core)
- bun test src/TinyCloudNode.signInManifest.test.ts
- bun run build (packages/node-sdk)
- bun run build (packages/web-sdk)