### PR TITLE
Add manifest capabilities-read defaults

### DIFF
--- a/.changeset/manifest-capabilities-read-default.md
+++ b/.changeset/manifest-capabilities-read-default.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Add implicit space-level `tinycloud.capabilities/read` grants for every space touched by a manifest request.

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -290,7 +290,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
       "com.listen.app/": ["tinycloud.sql/read", "tinycloud.sql/write"],
     });
     expect(cfg.abilities.capabilities).toEqual({
-      "com.listen.app/": ["tinycloud.capabilities/read"],
+      "": ["tinycloud.capabilities/read"],
     });
   });
 
@@ -324,6 +324,9 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     const cfg = (prepareSessionSpy as any).mock.calls[0][0];
     expect(cfg.spaceAbilities).toEqual({
       "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:account": {
+        capabilities: {
+          "": ["tinycloud.capabilities/read"],
+        },
         kv: {
           "applications/": [
             "tinycloud.kv/get",
@@ -451,11 +454,18 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
 
     // The recap union must contain BOTH services. KV from the app's
     // own permissions; SQL from the delegation's permissions.
-    expect(Object.keys(cfg.abilities).sort()).toEqual(["kv", "sql"]);
+    expect(Object.keys(cfg.abilities).sort()).toEqual([
+      "capabilities",
+      "kv",
+      "sql",
+    ]);
 
     // KV path inherits the manifest prefix.
     expect(cfg.abilities.kv).toEqual({
       "com.listen.app/": ["tinycloud.kv/get", "tinycloud.kv/put"],
+    });
+    expect(cfg.abilities.capabilities).toEqual({
+      "": ["tinycloud.capabilities/read"],
     });
 
     // SQL path also inherits the manifest prefix —
@@ -507,6 +517,9 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     expect(prepareSessionSpy).toHaveBeenCalled();
     const cfg = (prepareSessionSpy as any).mock.calls[0][0];
     expect(cfg.abilities).toEqual({
+      capabilities: {
+        "": ["tinycloud.capabilities/read"],
+      },
       kv: {
         "com.demo.app/config": ["tinycloud.kv/get"],
       },

--- a/packages/sdk-core/src/manifest.test.ts
+++ b/packages/sdk-core/src/manifest.test.ts
@@ -209,7 +209,7 @@ describe("resolveManifest — minimum manifest with defaults=true", () => {
     );
   });
 
-  it("includes the three standard default entries (kv, sql, capabilities)", () => {
+  it("includes standard defaults plus space-level capabilities read", () => {
     const services = new Set(resolved.resources.map((r) => r.service));
     expect(services.has("tinycloud.kv")).toBe(true);
     expect(services.has("tinycloud.sql")).toBe(true);
@@ -240,6 +240,8 @@ describe("resolveManifest — minimum manifest with defaults=true", () => {
       (r) => r.service === "tinycloud.capabilities",
     );
     expect(caps?.actions).toContain("tinycloud.capabilities/read");
+    expect(caps?.space).toBe("applications");
+    expect(caps?.path).toBe("");
   });
 });
 
@@ -253,7 +255,7 @@ describe("resolveManifest — defaults tiers", () => {
     expect(resolved.resources).toEqual([]);
   });
 
-  it("admin includes sql/ddl and capabilities/admin", () => {
+  it("admin includes sql/ddl and only implicit capabilities/read", () => {
     const resolved = resolveManifest({
       app_id: "a.b.c",
       name: "x",
@@ -264,7 +266,7 @@ describe("resolveManifest — defaults tiers", () => {
     const caps = resolved.resources.find(
       (r) => r.service === "tinycloud.capabilities",
     );
-    expect(caps?.actions).toContain("tinycloud.capabilities/admin");
+    expect(caps?.actions).toEqual(["tinycloud.capabilities/read"]);
     // DuckDB still opt-in.
     expect(
       resolved.resources.find((r) => r.service === "tinycloud.duckdb"),
@@ -296,6 +298,47 @@ describe("resolveManifest — defaults tiers", () => {
     // Standard tier, not admin or all.
     const sql = resolved.resources.find((r) => r.service === "tinycloud.sql");
     expect(sql?.actions).not.toContain("tinycloud.sql/ddl");
+  });
+
+  it("adds capabilities read for explicit permission spaces", () => {
+    const resolved = resolveManifest({
+      app_id: "a.b.c",
+      name: "x",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.kv",
+          space: "applications",
+          path: "data/",
+          actions: ["get"],
+        },
+        {
+          service: "tinycloud.sql",
+          space: "analytics",
+          path: "events",
+          actions: ["read"],
+        },
+      ],
+    });
+
+    expect(
+      resolved.resources.filter(
+        (resource) => resource.service === "tinycloud.capabilities",
+      ),
+    ).toEqual([
+      {
+        service: "tinycloud.capabilities",
+        space: "applications",
+        path: "",
+        actions: ["tinycloud.capabilities/read"],
+      },
+      {
+        service: "tinycloud.capabilities",
+        space: "analytics",
+        path: "",
+        actions: ["tinycloud.capabilities/read"],
+      },
+    ]);
   });
 });
 
@@ -528,6 +571,18 @@ describe("resolveManifest — end-to-end composition", () => {
             "tinycloud.kv/put",
             "tinycloud.kv/list",
           ],
+        }),
+        expect.objectContaining({
+          service: "tinycloud.capabilities",
+          space: "applications",
+          path: "",
+          actions: ["tinycloud.capabilities/read"],
+        }),
+        expect.objectContaining({
+          service: "tinycloud.capabilities",
+          space: "account",
+          path: "",
+          actions: ["tinycloud.capabilities/read"],
         }),
       ]),
     );

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -61,7 +61,7 @@ export interface PermissionEntry {
  *
  * - `false` → no auto-included permissions
  * - `true` → standard tier (KV + SQL read/write + capabilities:read)
- * - `"admin"` → standard + SQL ddl + capabilities:admin
+ * - `"admin"` → standard + SQL ddl
  * - `"all"` → everything the SDK supports (including DuckDB)
  *
  * Unknown string values silently fall back to `true`. Values are normalized
@@ -261,36 +261,29 @@ export const SERVICE_LONG_TO_SHORT: Readonly<Record<string, string>> =
 /**
  * Default permission entries for the `true` / standard tier.
  *
- * `tinycloud.capabilities:read` is ALWAYS present in any non-false default
- * so delegation chains can be verified.
+ * `tinycloud.capabilities/read` is added separately for every requested
+ * space, without the app path prefix. That keeps capability introspection
+ * space-scoped instead of app-data scoped.
  */
-const DEFAULT_STANDARD_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] =
-  [
-    {
-      service: "tinycloud.kv",
-      space: DEFAULT_MANIFEST_SPACE,
-      path: "/",
-      actions: ["get", "put", "del", "list", "metadata"],
-    },
-    {
-      service: "tinycloud.sql",
-      space: DEFAULT_MANIFEST_SPACE,
-      path: "/",
-      actions: ["read", "write"],
-    },
-    {
-      service: "tinycloud.capabilities",
-      space: DEFAULT_MANIFEST_SPACE,
-      path: "/",
-      actions: ["read"],
-    },
-  ];
+const DEFAULT_STANDARD_ENTRIES: readonly PermissionEntry[] = [
+  {
+    service: "tinycloud.kv",
+    space: DEFAULT_MANIFEST_SPACE,
+    path: "/",
+    actions: ["get", "put", "del", "list", "metadata"],
+  },
+  {
+    service: "tinycloud.sql",
+    space: DEFAULT_MANIFEST_SPACE,
+    path: "/",
+    actions: ["read", "write"],
+  },
+];
 
 /**
- * Default permission entries for the `"admin"` tier: standard + sql/ddl +
- * capabilities/admin.
+ * Default permission entries for the `"admin"` tier: standard + sql/ddl.
  */
-const DEFAULT_ADMIN_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] = [
+const DEFAULT_ADMIN_ENTRIES: readonly PermissionEntry[] = [
   {
     service: "tinycloud.kv",
     space: DEFAULT_MANIFEST_SPACE,
@@ -303,12 +296,6 @@ const DEFAULT_ADMIN_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] = [
     path: "/",
     actions: ["read", "write", "ddl"],
   },
-  {
-    service: "tinycloud.capabilities",
-    space: DEFAULT_MANIFEST_SPACE,
-    path: "/",
-    actions: ["read", "admin"],
-  },
 ];
 
 /**
@@ -317,7 +304,7 @@ const DEFAULT_ADMIN_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] = [
  * DuckDB is opt-in and only appears in this tier or in explicit manifest
  * `permissions` entries.
  */
-const DEFAULT_ALL_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] = [
+const DEFAULT_ALL_ENTRIES: readonly PermissionEntry[] = [
   {
     service: "tinycloud.kv",
     space: DEFAULT_MANIFEST_SPACE,
@@ -335,12 +322,6 @@ const DEFAULT_ALL_ENTRIES: readonly Omit<PermissionEntry, "skipPrefix">[] = [
     space: DEFAULT_MANIFEST_SPACE,
     path: "/",
     actions: ["read", "write"],
-  },
-  {
-    service: "tinycloud.capabilities",
-    space: DEFAULT_MANIFEST_SPACE,
-    path: "/",
-    actions: ["read", "admin"],
   },
 ];
 
@@ -585,6 +566,7 @@ function defaultEntriesForTier(tier: ManifestDefaults): PermissionEntry[] {
     space: e.space,
     path: e.path,
     actions: [...e.actions],
+    ...(e.skipPrefix !== undefined ? { skipPrefix: e.skipPrefix } : {}),
   }));
 }
 
@@ -617,8 +599,8 @@ export function resolveManifest(input: Manifest): ResolvedCapabilities {
   // for the same (service, space, path) tuple override defaults.
   const allEntries: PermissionEntry[] = [...defaultEntries, ...explicitEntries];
 
-  const resources: ResourceCapability[] = allEntries.map((entry) =>
-    resolveEntry(entry, prefix, expiryMs, space),
+  const resources: ResourceCapability[] = withCapabilitiesReadForSpaces(
+    allEntries.map((entry) => resolveEntry(entry, prefix, expiryMs, space)),
   );
 
   const additionalDelegates: ResolvedDelegate[] =
@@ -737,6 +719,29 @@ function dedupeResources(
   return [...byKey.values()];
 }
 
+function capabilitiesReadPermission(space: string): ResourceCapability {
+  return {
+    service: "tinycloud.capabilities",
+    space,
+    path: "",
+    actions: ["tinycloud.capabilities/read"],
+  };
+}
+
+function withCapabilitiesReadForSpaces(
+  resources: readonly ResourceCapability[],
+): ResourceCapability[] {
+  if (resources.length === 0) {
+    return [];
+  }
+
+  const spaces = new Set(resources.map((resource) => resource.space));
+  return dedupeResources([
+    ...resources,
+    ...[...spaces].map(capabilitiesReadPermission),
+  ]);
+}
+
 function accountRegistryPermission(): ResourceCapability {
   return {
     service: "tinycloud.kv",
@@ -776,6 +781,8 @@ export function composeManifestRequest(
   if (includeAccountRegistryPermissions) {
     resources.push(accountRegistryPermission());
   }
+  const resourcesWithImplicitCapabilities =
+    withCapabilitiesReadForSpaces(resources);
 
   const manifestsByAppId = new Map<string, Manifest[]>();
   for (const manifest of manifests) {
@@ -801,7 +808,7 @@ export function composeManifestRequest(
 
   return {
     manifests,
-    resources: dedupeResources(resources),
+    resources: resourcesWithImplicitCapabilities,
     delegationTargets,
     registryRecords,
     expiryMs: Math.max(...resolved.map((entry) => entry.expiryMs)),


### PR DESCRIPTION
## Summary
- Add implicit space-level tinycloud.capabilities/read grants for every space touched by a manifest request
- Keep capabilities/read unprefixed so the recap resource is space-level, e.g. tinycloud:...:<space>/capabilities
- Remove unimplemented tinycloud.capabilities/admin from manifest admin/all defaults
- Add manifest and sign-in tests covering app, account registry, and explicit multi-space permissions

## Testing
- bun test src/manifest.test.ts
- bun run build (packages/sdk-core)
- bun test src/TinyCloudNode.signInManifest.test.ts
- bun run build (packages/node-sdk)
- bun run build (packages/web-sdk)