### PR TITLE
feat: add secrets wrapper api

### DIFF
--- a/.changeset/secrets-wrapper.md
+++ b/.changeset/secrets-wrapper.md
@@ -1,0 +1,8 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/sdk-services": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+---
+
+Add manifest `secrets` declarations and SDK helpers backed by the secrets space vault, including read-default permissions and write/delete escalation.

--- a/packages/node-sdk/src/NodeSecretsService.test.ts
+++ b/packages/node-sdk/src/NodeSecretsService.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  ErrorCodes,
+  type ISecretsService,
+  type Manifest,
+  type PermissionEntry,
+} from "@tinycloud/sdk-core";
+
+import { NodeSecretsService } from "./NodeSecretsService";
+
+function makeBaseSecrets(): ISecretsService {
+  return {
+    vault: {} as ISecretsService["vault"],
+    isUnlocked: true,
+    unlock: mock(async () => ({ ok: true, data: undefined })),
+    lock: mock(() => {}),
+    get: mock(async () => ({ ok: true, data: "stored" })),
+    put: mock(async () => ({ ok: true, data: undefined })),
+    delete: mock(async () => ({ ok: true, data: undefined })),
+    list: mock(async () => ({ ok: true, data: ["ANTHROPIC_API_KEY"] })),
+  };
+}
+
+function readOnlyManifest(): Manifest {
+  return {
+    app_id: "com.food.app",
+    name: "Food",
+    defaults: false,
+    secrets: {
+      ANTHROPIC_API_KEY: true,
+    },
+  };
+}
+
+describe("NodeSecretsService", () => {
+  it("does not autosign reads", async () => {
+    const base = makeBaseSecrets();
+    const signIn = mock(async () => {});
+    const secrets = new NodeSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      setManifest: mock(() => {}),
+      signIn,
+      canEscalate: () => true,
+    });
+
+    const result = await secrets.get("ANTHROPIC_API_KEY");
+
+    expect(result).toEqual({ ok: true, data: "stored" });
+    expect(signIn).not.toHaveBeenCalled();
+  });
+
+  it("autosigns write permission before putting a read-only manifest secret", async () => {
+    const base = makeBaseSecrets();
+    let manifest = readOnlyManifest();
+    const setManifest = mock((next: Manifest | Manifest[]) => {
+      manifest = Array.isArray(next) ? next[0] : next;
+    });
+    const signIn = mock(async () => {});
+    const secrets = new NodeSecretsService({
+      getService: () => base,
+      getManifest: () => manifest,
+      setManifest,
+      signIn,
+      canEscalate: () => true,
+    });
+
+    const result = await secrets.put("ANTHROPIC_API_KEY", "secret");
+
+    expect(result.ok).toBe(true);
+    expect(setManifest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permissions: [
+          {
+            service: "tinycloud.kv",
+            space: "secrets",
+            path: "keys/secrets/ANTHROPIC_API_KEY",
+            actions: ["put"],
+            skipPrefix: true,
+          },
+          {
+            service: "tinycloud.kv",
+            space: "secrets",
+            path: "vault/secrets/ANTHROPIC_API_KEY",
+            actions: ["put"],
+            skipPrefix: true,
+          },
+        ] satisfies PermissionEntry[],
+      }),
+    );
+    expect(signIn).toHaveBeenCalledTimes(1);
+    expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
+  });
+
+  it("skips autosign when the manifest already includes the mutation action", async () => {
+    const base = makeBaseSecrets();
+    const signIn = mock(async () => {});
+    const secrets = new NodeSecretsService({
+      getService: () => base,
+      getManifest: () => ({
+        ...readOnlyManifest(),
+        secrets: {
+          ANTHROPIC_API_KEY: ["read", "delete"],
+        },
+      }),
+      setManifest: mock(() => {}),
+      signIn,
+      canEscalate: () => true,
+    });
+
+    const result = await secrets.delete("ANTHROPIC_API_KEY");
+
+    expect(result.ok).toBe(true);
+    expect(signIn).not.toHaveBeenCalled();
+    expect(base.delete).toHaveBeenCalledWith("ANTHROPIC_API_KEY");
+  });
+
+  it("re-unlocks after autosign when already unlocked", async () => {
+    const base = makeBaseSecrets();
+    const signer = { signMessage: async () => "0xsig" };
+    const secrets = new NodeSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      setManifest: mock(() => {}),
+      signIn: mock(async () => {}),
+      canEscalate: () => true,
+    });
+
+    await secrets.unlock(signer);
+    const result = await secrets.put("ANTHROPIC_API_KEY", "secret");
+
+    expect(result.ok).toBe(true);
+    expect(base.unlock).toHaveBeenCalledTimes(2);
+    expect(base.unlock).toHaveBeenLastCalledWith(signer);
+    expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
+  });
+
+  it("returns a permission error when autosign is unavailable", async () => {
+    const base = makeBaseSecrets();
+    const secrets = new NodeSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      setManifest: mock(() => {}),
+      signIn: mock(async () => {}),
+      canEscalate: () => false,
+    });
+
+    const result = await secrets.put("ANTHROPIC_API_KEY", "secret");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: ErrorCodes.PERMISSION_DENIED,
+        service: "secrets",
+        message:
+          "Cannot autosign tinycloud.kv/put for ANTHROPIC_API_KEY; TinyCloudNode needs wallet mode with a signer or privateKey.",
+      },
+    });
+    expect(base.put).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node-sdk/src/NodeSecretsService.ts
+++ b/packages/node-sdk/src/NodeSecretsService.ts
@@ -1,0 +1,233 @@
+import {
+  ErrorCodes,
+  resolveManifest,
+  type IDataVaultService,
+  type ISecretsService,
+  type Manifest,
+  type PermissionEntry,
+  type Result,
+  type ServiceError,
+  type VaultError,
+} from "@tinycloud/sdk-core";
+
+const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
+const SECRET_PREFIX = "secrets/";
+const SECRETS_SPACE = "secrets";
+
+function ok(): Result<void, ServiceError> {
+  return { ok: true, data: undefined };
+}
+
+function secretsError(
+  code: string,
+  message: string,
+  cause?: Error,
+): Result<never, ServiceError> {
+  return {
+    ok: false,
+    error: {
+      code,
+      service: "secrets",
+      message,
+      ...(cause ? { cause } : {}),
+    },
+  };
+}
+
+function actionUrn(action: "put" | "del"): string {
+  return `tinycloud.kv/${action}`;
+}
+
+function secretResourcePath(base: "keys" | "vault", name: string): string {
+  return `${base}/${SECRET_PREFIX}${name}`;
+}
+
+function secretPermissionEntries(
+  name: string,
+  action: "put" | "del",
+): PermissionEntry[] {
+  return [
+    {
+      service: "tinycloud.kv",
+      space: SECRETS_SPACE,
+      path: secretResourcePath("keys", name),
+      actions: [action],
+      skipPrefix: true,
+    },
+    {
+      service: "tinycloud.kv",
+      space: SECRETS_SPACE,
+      path: secretResourcePath("vault", name),
+      actions: [action],
+      skipPrefix: true,
+    },
+  ];
+}
+
+function isSecretsSpace(space: string): boolean {
+  return space === SECRETS_SPACE || space.endsWith(`:${SECRETS_SPACE}`);
+}
+
+function composeEscalatedManifest(
+  manifest: Manifest | Manifest[],
+  additional: PermissionEntry[],
+): Manifest | Manifest[] {
+  if (Array.isArray(manifest)) {
+    const [primary, ...rest] = manifest;
+    return [
+      {
+        ...primary,
+        permissions: [...(primary.permissions ?? []), ...additional],
+      },
+      ...rest,
+    ];
+  }
+  return {
+    ...manifest,
+    permissions: [...(manifest.permissions ?? []), ...additional],
+  };
+}
+
+export interface NodeSecretsServiceConfig {
+  getService: () => ISecretsService;
+  getManifest: () => Manifest | Manifest[] | undefined;
+  setManifest: (manifest: Manifest | Manifest[]) => void;
+  signIn: () => Promise<void>;
+  canEscalate: () => boolean;
+}
+
+export class NodeSecretsService implements ISecretsService {
+  private unlockSigner?: unknown;
+  private shouldRestoreUnlock = false;
+
+  constructor(private readonly config: NodeSecretsServiceConfig) {}
+
+  get vault(): IDataVaultService {
+    return this.service.vault;
+  }
+
+  get isUnlocked(): boolean {
+    return this.service.isUnlocked;
+  }
+
+  async unlock(signer?: unknown): Promise<Result<void, VaultError>> {
+    if (signer !== undefined) {
+      this.unlockSigner = signer;
+    }
+    const result = await this.service.unlock(signer);
+    if (result.ok) {
+      this.shouldRestoreUnlock = true;
+    }
+    return result;
+  }
+
+  lock(): void {
+    this.shouldRestoreUnlock = false;
+    this.service.lock();
+  }
+
+  get(name: string): ReturnType<ISecretsService["get"]> {
+    return this.service.get(name);
+  }
+
+  async put(name: string, value: string): ReturnType<ISecretsService["put"]> {
+    const permission = await this.ensureMutationPermission(name, "put");
+    if (!permission.ok) return permission;
+    return this.service.put(name, value);
+  }
+
+  async delete(name: string): ReturnType<ISecretsService["delete"]> {
+    const permission = await this.ensureMutationPermission(name, "del");
+    if (!permission.ok) return permission;
+    return this.service.delete(name);
+  }
+
+  list(): ReturnType<ISecretsService["list"]> {
+    return this.service.list();
+  }
+
+  private get service(): ISecretsService {
+    return this.config.getService();
+  }
+
+  private async ensureMutationPermission(
+    name: string,
+    action: "put" | "del",
+  ): Promise<Result<void, ServiceError | VaultError>> {
+    if (!SECRET_NAME_RE.test(name)) {
+      return secretsError(
+        ErrorCodes.INVALID_INPUT,
+        `Invalid secret name ${JSON.stringify(name)}. Secret names must match ${SECRET_NAME_RE.source}.`,
+      );
+    }
+
+    if (this.hasMutationPermission(name, action)) {
+      return ok();
+    }
+
+    if (!this.config.canEscalate()) {
+      return secretsError(
+        ErrorCodes.PERMISSION_DENIED,
+        `Cannot autosign ${actionUrn(action)} for ${name}; TinyCloudNode needs wallet mode with a signer or privateKey.`,
+      );
+    }
+
+    const manifest = this.config.getManifest();
+    if (manifest === undefined) {
+      return secretsError(
+        ErrorCodes.PERMISSION_DENIED,
+        `Cannot autosign ${actionUrn(action)} for ${name}; set a manifest before mutating secrets.`,
+      );
+    }
+
+    try {
+      this.config.setManifest(
+        composeEscalatedManifest(
+          manifest,
+          secretPermissionEntries(name, action),
+        ),
+      );
+      await this.config.signIn();
+      return this.restoreUnlockAfterEscalation();
+    } catch (error) {
+      return secretsError(
+        ErrorCodes.PERMISSION_DENIED,
+        error instanceof Error
+          ? error.message
+          : `Autosign escalation for ${actionUrn(action)} on ${name} failed.`,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private async restoreUnlockAfterEscalation(): Promise<
+    Result<void, ServiceError | VaultError>
+  > {
+    if (!this.shouldRestoreUnlock) {
+      return ok();
+    }
+    return this.service.unlock(this.unlockSigner);
+  }
+
+  private hasMutationPermission(name: string, action: "put" | "del"): boolean {
+    const manifest = this.config.getManifest();
+    if (manifest === undefined) {
+      return false;
+    }
+
+    const manifests = Array.isArray(manifest) ? manifest : [manifest];
+    const requiredAction = actionUrn(action);
+    return manifests.some((entry) => {
+      const resolved = resolveManifest(entry);
+      return (["keys", "vault"] as const).every((base) =>
+        resolved.resources.some(
+          (resource) =>
+            resource.service === "tinycloud.kv" &&
+            isSecretsSpace(resource.space) &&
+            resource.path === secretResourcePath(base, name) &&
+            resource.actions.includes(requiredAction),
+        ),
+      );
+    });
+  }
+}

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -338,6 +338,54 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     });
   });
 
+  test("manifest secrets shorthand is scoped to the secrets space", async () => {
+    const prepareSessionSpy = mock((cfg: any) => ({
+      siwe: "fake-siwe",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: "did:key:z6MkTestSession",
+    }));
+    const wasm = makeFakeWasmBindings({
+      prepareSession: prepareSessionSpy as any,
+    });
+
+    const node = makeNodeWithSigner(wasm, {
+      includeAccountRegistryPermissions: false,
+      manifest: {
+        app_id: "com.listen.app",
+        name: "Listen",
+        defaults: false,
+        secrets: {
+          ANTHROPIC_API_KEY: true,
+        },
+      },
+    });
+    stubAuthNetworkCalls(node);
+
+    const auth = (node as any).auth;
+    try {
+      await auth.signIn();
+    } catch {
+      /* network failure expected */
+    }
+
+    const cfg = (prepareSessionSpy as any).mock.calls[0][0];
+    expect(cfg.spaceAbilities).toEqual({
+      "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:secrets": {
+        capabilities: {
+          "": ["tinycloud.capabilities/read"],
+        },
+        kv: {
+          "keys/secrets/ANTHROPIC_API_KEY": ["tinycloud.kv/get"],
+          "vault/secrets/ANTHROPIC_API_KEY": ["tinycloud.kv/get"],
+        },
+      },
+    });
+    expect(cfg.spaceId).toBe(
+      "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:secrets",
+    );
+  });
+
   test("manifest registry write does not re-host existing account space", async () => {
     const node = makeNodeWithSigner(makeFakeWasmBindings());
     const auth = (node as any).auth;

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -44,6 +44,8 @@ import {
   HooksService,
   DataVaultService,
   IDataVaultService,
+  SecretsService,
+  ISecretsService,
   IHooksService,
   createVaultCrypto,
   ServiceSession,
@@ -61,6 +63,7 @@ import {
   DelegationManager,
   SpaceService,
   ISpaceService,
+  ISpace,
   CapabilityKeyRegistry,
   ICapabilityKeyRegistry,
   SharingService,
@@ -103,6 +106,7 @@ import {
   resolveExpiryMs,
   extractSiweExpiration,
 } from "./delegateToHelpers";
+import { NodeSecretsService } from "./NodeSecretsService";
 
 /** Default TinyCloud host */
 const DEFAULT_HOST = "https://node.tinycloud.xyz";
@@ -240,6 +244,8 @@ export class TinyCloudNode {
   private _duckdb?: DuckDbService;
   private _hooks?: HooksService;
   private _vault?: DataVaultService;
+  private _baseSecrets?: ISecretsService;
+  private _secrets?: ISecretsService;
   /** Cached public KV with proper delegation (set by ensurePublicSpace) */
   private _publicKV?: KVService;
 
@@ -557,6 +563,10 @@ export class TinyCloudNode {
     this._sql = undefined;
     this._duckdb = undefined;
     this._hooks = undefined;
+    this._vault = undefined;
+    this._baseSecrets = undefined;
+    this._secrets = undefined;
+    this._spaceService = undefined;
     this._serviceContext = undefined;
 
     await this.tc.signIn(options);
@@ -673,6 +683,10 @@ export class TinyCloudNode {
     this._sql = undefined;
     this._duckdb = undefined;
     this._hooks = undefined;
+    this._vault = undefined;
+    this._baseSecrets = undefined;
+    this._secrets = undefined;
+    this._spaceService = undefined;
     this._serviceContext = undefined;
 
     if (sessionData.address) {
@@ -720,36 +734,7 @@ export class TinyCloudNode {
     this._serviceContext.setSession(serviceSession);
 
     // Create and register Vault service (matches initializeServices behavior)
-    const wasm = this.wasmBindings;
-    const vaultCrypto = createVaultCrypto({
-      vault_encrypt: wasm.vault_encrypt, vault_decrypt: wasm.vault_decrypt, vault_derive_key: wasm.vault_derive_key,
-      vault_x25519_from_seed: wasm.vault_x25519_from_seed, vault_x25519_dh: wasm.vault_x25519_dh,
-      vault_random_bytes: wasm.vault_random_bytes, vault_sha256: wasm.vault_sha256,
-    });
-    const self = this;
-    this._vault = new DataVaultService({
-      spaceId: sessionData.spaceId,
-      crypto: vaultCrypto,
-      tc: {
-        kv: this._kv!,
-        ensurePublicSpace: async () => {
-          try {
-            await self.ensurePublicSpace();
-            return { ok: true as const, data: undefined };
-          } catch (error) {
-            return { ok: false as const, error: { code: "STORAGE_ERROR", message: error instanceof Error ? error.message : String(error), service: "vault" } };
-          }
-        },
-        get publicKV() { return self._publicKV ?? self.tc!.publicKV; },
-        readPublicSpace: <T>(host: string, spaceId: string, key: string) =>
-          TinyCloud.readPublicSpace<T>(host, spaceId, key),
-        makePublicSpaceId: TinyCloud.makePublicSpaceId,
-        did: this.did,
-        address: sessionData.address ?? this._address ?? "",
-        chainId: sessionData.chainId ?? this._chainId,
-        hosts: [this.config.host!],
-      },
-    });
+    this._vault = this.createVaultService(sessionData.spaceId, this._kv!);
     this._vault.initialize(this._serviceContext);
     this._serviceContext.registerService('vault', this._vault);
 
@@ -935,6 +920,32 @@ export class TinyCloudNode {
     (this.tc!.serviceContext as ServiceContext).setSession(serviceSession);
 
     // Create and register Vault service
+    this._vault = this.createVaultService(session.spaceId, this._kv!);
+    this._vault.initialize(this._serviceContext);
+    this._serviceContext.registerService('vault', this._vault);
+
+    // Initialize v2 services
+    this.initializeV2Services(serviceSession);
+  }
+
+  private createSpaceScopedKVService(spaceId: string): KVService {
+    const kvService = new KVService({});
+    if (this._serviceContext) {
+      const spaceScopedContext = new ServiceContext({
+        invoke: this._serviceContext.invoke,
+        fetch: this._serviceContext.fetch,
+        hosts: this._serviceContext.hosts,
+      });
+      const session = this._serviceContext.session;
+      if (session) {
+        spaceScopedContext.setSession({ ...session, spaceId });
+      }
+      kvService.initialize(spaceScopedContext);
+    }
+    return kvService;
+  }
+
+  private createVaultService(spaceId: string, kv: IKVService): DataVaultService {
     const wasm = this.wasmBindings;
     const vaultCrypto = createVaultCrypto({
       vault_encrypt: wasm.vault_encrypt, vault_decrypt: wasm.vault_decrypt, vault_derive_key: wasm.vault_derive_key,
@@ -942,11 +953,11 @@ export class TinyCloudNode {
       vault_random_bytes: wasm.vault_random_bytes, vault_sha256: wasm.vault_sha256,
     });
     const self = this;
-    this._vault = new DataVaultService({
-      spaceId: session.spaceId,
+    return new DataVaultService({
+      spaceId,
       crypto: vaultCrypto,
       tc: {
-        kv: this._kv!,
+        kv,
         ensurePublicSpace: async () => {
           try {
             await self.ensurePublicSpace();
@@ -956,20 +967,15 @@ export class TinyCloudNode {
           }
         },
         get publicKV() { return self._publicKV ?? self.tc!.publicKV; },
-        readPublicSpace: <T>(host: string, spaceId: string, key: string) =>
-          TinyCloud.readPublicSpace<T>(host, spaceId, key),
+        readPublicSpace: <T>(host: string, targetSpaceId: string, key: string) =>
+          TinyCloud.readPublicSpace<T>(host, targetSpaceId, key),
         makePublicSpaceId: TinyCloud.makePublicSpaceId,
         did: this.did,
-        address: this._address!,
+        address: this._address ?? "",
         chainId: this._chainId,
         hosts: [this.config.host!],
       },
     });
-    this._vault.initialize(this._serviceContext);
-    this._serviceContext.registerService('vault', this._vault);
-
-    // Initialize v2 services
-    this.initializeV2Services(serviceSession);
   }
 
   /**
@@ -1077,21 +1083,15 @@ export class TinyCloudNode {
       capabilityRegistry: this._capabilityRegistry,
       userDid: this.did,
       createKVService: (spaceId: string) => {
-        // Create a new KV service scoped to the specified space
-        const kvService = new KVService({});
+        return this.createSpaceScopedKVService(spaceId);
+      },
+      createVaultService: (spaceId: string) => {
+        const kvService = this.createSpaceScopedKVService(spaceId);
+        const vaultService = this.createVaultService(spaceId, kvService);
         if (this._serviceContext) {
-          const spaceScopedContext = new ServiceContext({
-            invoke: this._serviceContext.invoke,
-            fetch: this._serviceContext.fetch,
-            hosts: this._serviceContext.hosts,
-          });
-          const session = this._serviceContext.session;
-          if (session) {
-            spaceScopedContext.setSession({ ...session, spaceId });
-          }
-          kvService.initialize(spaceScopedContext);
+          vaultService.initialize(this._serviceContext);
         }
-        return kvService;
+        return vaultService;
       },
       // Enable space.delegations.create() via SIWE-based delegation
       createDelegation: async (params) => {
@@ -1378,6 +1378,35 @@ export class TinyCloudNode {
   }
 
   /**
+   * App-facing secrets API backed by the `secrets` space vault.
+   */
+  get secrets(): ISecretsService {
+    if (!this._spaceService) {
+      throw new Error("Not signed in. Call signIn() first.");
+    }
+    if (!this._secrets) {
+      this._secrets = new NodeSecretsService({
+        getService: () => this.getBaseSecrets(),
+        getManifest: () => this.manifest,
+        setManifest: (manifest) => this.setManifest(manifest),
+        signIn: () => this.signIn(),
+        canEscalate: () => this.signer !== undefined && this.tc !== undefined,
+      });
+    }
+    return this._secrets;
+  }
+
+  private getBaseSecrets(): ISecretsService {
+    if (!this._spaceService) {
+      throw new Error("Not signed in. Call signIn() first.");
+    }
+    if (!this._baseSecrets) {
+      this._baseSecrets = new SecretsService(() => this.space("secrets").vault);
+    }
+    return this._baseSecrets;
+  }
+
+  /**
    * Hooks write stream subscription API.
    */
   get hooks(): IHooksService {
@@ -1526,6 +1555,13 @@ export class TinyCloudNode {
    */
   get spaceService(): ISpaceService {
     return this.spaces;
+  }
+
+  /**
+   * Get a Space object by short name or full URI.
+   */
+  space(nameOrUri: string): ISpace {
+    return this.spaces.get(nameOrUri);
   }
 
   /**

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -83,6 +83,7 @@ export {
   type PermissionEntry,
   type Manifest,
   type ManifestDefaults,
+  type ManifestSecretActions,
   type ComposeManifestOptions,
   type ComposedManifestRequest,
   type ManifestRegistryRecord,
@@ -169,10 +170,10 @@ export type {
   ViewInfo,
 } from "@tinycloud/sdk-core";
 
-// Re-export Vault service values
-export { DataVaultService, VaultHeaders, VaultPublicSpaceKVActions, createVaultCrypto } from "@tinycloud/sdk-core";
+// Re-export Vault and Secrets service values
+export { DataVaultService, VaultHeaders, VaultPublicSpaceKVActions, createVaultCrypto, SecretsService } from "@tinycloud/sdk-core";
 
-// Re-export Vault service types
+// Re-export Vault and Secrets service types
 export type {
   IDataVaultService,
   VaultCrypto,
@@ -184,6 +185,9 @@ export type {
   VaultGrantOptions,
   VaultEntry,
   VaultError,
+  ISecretsService,
+  SecretPayload,
+  SecretsError,
 } from "@tinycloud/sdk-core";
 
 // Re-export v2 Delegation service values

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -107,6 +107,7 @@ export {
   type PermissionEntry,
   type Manifest,
   type ManifestDefaults,
+  type ManifestSecretActions,
   type ComposeManifestOptions,
   type ComposedManifestRequest,
   type ManifestRegistryRecord,
@@ -207,9 +208,10 @@ export {
   VaultHeaders,
   VaultPublicSpaceKVActions,
   createVaultCrypto,
+  SecretsService,
 } from "@tinycloud/sdk-core";
 
-// Re-export Vault service types
+// Re-export Vault and Secrets service types
 export type {
   IDataVaultService,
   VaultCrypto,
@@ -221,6 +223,9 @@ export type {
   VaultGrantOptions,
   VaultEntry,
   VaultError,
+  ISecretsService,
+  SecretPayload,
+  SecretsError,
 } from "@tinycloud/sdk-core";
 
 // Re-export Hooks service values

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -169,6 +169,11 @@ export {
   type VaultGrantOptions,
   type VaultEntry,
   type VaultError,
+  // Secrets Service
+  SecretsService,
+  type ISecretsService,
+  type SecretPayload,
+  type SecretsError,
 } from "@tinycloud/sdk-services";
 
 // Space utilities
@@ -294,6 +299,7 @@ export {
   // Types
   type Manifest,
   type ManifestDefaults,
+  type ManifestSecretActions,
   type ComposeManifestOptions,
   type ComposedManifestRequest,
   type ManifestRegistryRecord,

--- a/packages/sdk-core/src/manifest.test.ts
+++ b/packages/sdk-core/src/manifest.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeDefaults,
   parseExpiry,
   resolveManifest,
+  resourceCapabilitiesToSpaceAbilitiesMap,
   validateManifest,
   type Manifest,
   type PermissionEntry,
@@ -179,6 +180,19 @@ describe("validateManifest", () => {
       } as Manifest),
     ).toThrow(ManifestValidationError);
   });
+
+  it("throws on invalid secret names", () => {
+    expect(() =>
+      validateManifest({
+        app_id: "a.b.c",
+        name: "x",
+        defaults: false,
+        secrets: {
+          anthropic_api_key: ["read"],
+        },
+      }),
+    ).toThrow(ManifestValidationError);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -339,6 +353,94 @@ describe("resolveManifest — defaults tiers", () => {
         actions: ["tinycloud.capabilities/read"],
       },
     ]);
+  });
+});
+
+describe("resolveManifest — secrets shorthand", () => {
+  it("defaults secrets to read permissions in the secrets space", () => {
+    const resolved = resolveManifest({
+      app_id: "com.listen.app",
+      name: "Listen",
+      defaults: false,
+      secrets: {
+        ANTHROPIC_API_KEY: true,
+      },
+    });
+
+    expect(resolved.resources).toEqual(
+      expect.arrayContaining([
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "keys/secrets/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/get"],
+        },
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "vault/secrets/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/get"],
+        },
+        {
+          service: "tinycloud.capabilities",
+          space: "secrets",
+          path: "",
+          actions: ["tinycloud.capabilities/read"],
+        },
+      ]),
+    );
+  });
+
+  it("supports object form and preserves per-secret metadata", () => {
+    const resolved = resolveManifest({
+      app_id: "com.listen.app",
+      name: "Listen",
+      defaults: false,
+      secrets: {
+        ANTHROPIC_API_KEY: {
+          expiry: "7d",
+          description: "Call Anthropic.",
+        },
+      },
+    });
+
+    const secretResource = resolved.resources.find(
+      (resource) => resource.path === "vault/secrets/ANTHROPIC_API_KEY",
+    );
+    expect(secretResource?.actions).toEqual(["tinycloud.kv/get"]);
+    expect(secretResource?.expiryMs).toBe(parseExpiry("7d"));
+    expect(secretResource?.description).toBe("Call Anthropic.");
+  });
+
+  it("groups secret capabilities into the secrets space abilities map", () => {
+    const resolved = resolveManifest({
+      app_id: "com.listen.app",
+      name: "Listen",
+      defaults: false,
+      secrets: {
+        ANTHROPIC_API_KEY: ["read", "write", "delete"],
+      },
+    });
+
+    expect(resourceCapabilitiesToSpaceAbilitiesMap(resolved.resources)).toEqual({
+      secrets: {
+        capabilities: {
+          "": ["tinycloud.capabilities/read"],
+        },
+        kv: {
+          "keys/secrets/ANTHROPIC_API_KEY": [
+            "tinycloud.kv/get",
+            "tinycloud.kv/put",
+            "tinycloud.kv/del",
+          ],
+          "vault/secrets/ANTHROPIC_API_KEY": [
+            "tinycloud.kv/get",
+            "tinycloud.kv/put",
+            "tinycloud.kv/del",
+          ],
+        },
+      },
+    });
   });
 });
 

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -56,6 +56,16 @@ export interface PermissionEntry {
   description?: string;
 }
 
+export type ManifestSecretActions =
+  | true
+  | string
+  | string[]
+  | {
+      actions?: string | string[];
+      expiry?: string;
+      description?: string;
+    };
+
 /**
  * The valid values for `Manifest.defaults`.
  *
@@ -109,6 +119,11 @@ export interface Manifest {
    * DuckDB (opt-in), or `skipPrefix: true` entries.
    */
   permissions?: PermissionEntry[];
+  /**
+   * Secret name shorthand. Entries resolve to encrypted vault KV resources in
+   * the `secrets` space.
+   */
+  secrets?: Record<string, ManifestSecretActions>;
 }
 
 /**
@@ -232,6 +247,9 @@ export const ACCOUNT_REGISTRY_SPACE = "account";
 
 /** Account-space KV prefix used for installed-application registry records. */
 export const ACCOUNT_REGISTRY_PATH = "applications/";
+
+const SECRETS_SPACE = "secrets";
+const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
 
 /**
  * Known services and their short-form (recap URI) names. The TinyCloud
@@ -486,7 +504,45 @@ export function validateManifest(input: unknown): Manifest {
       validatePermissionEntry(p, `permissions[${i}]`),
     );
   }
+  if (m.secrets !== undefined) {
+    validateManifestSecrets(m.secrets);
+  }
   return m;
+}
+
+function validateManifestSecrets(secrets: unknown): void {
+  if (secrets === null || typeof secrets !== "object" || Array.isArray(secrets)) {
+    throw new ManifestValidationError("manifest.secrets must be an object");
+  }
+
+  for (const [name, spec] of Object.entries(secrets)) {
+    if (!SECRET_NAME_RE.test(name)) {
+      throw new ManifestValidationError(
+        `manifest.secrets.${name} must match ${SECRET_NAME_RE.source}`,
+      );
+    }
+    const actions = secretActionsFromSpec(name, spec as ManifestSecretActions);
+    if (actions.length === 0) {
+      throw new ManifestValidationError(
+        `manifest.secrets.${name} actions must be non-empty`,
+      );
+    }
+    for (const action of actions) {
+      if (typeof action !== "string" || action.length === 0) {
+        throw new ManifestValidationError(
+          `manifest.secrets.${name} actions must be non-empty strings`,
+        );
+      }
+    }
+    if (
+      spec !== null &&
+      typeof spec === "object" &&
+      !Array.isArray(spec) &&
+      (spec as { expiry?: unknown }).expiry !== undefined
+    ) {
+      parseExpiry((spec as { expiry: string }).expiry);
+    }
+  }
 }
 
 function validatePermissionEntry(p: unknown, path: string): void {
@@ -594,10 +650,15 @@ export function resolveManifest(input: Manifest): ResolvedCapabilities {
 
   const defaultEntries = defaultEntriesForTier(tier);
   const explicitEntries = manifest.permissions ?? [];
+  const secretEntries = secretEntriesForManifest(manifest.secrets);
 
   // Merge order: defaults first, then explicit entries, so explicit entries
   // for the same (service, space, path) tuple override defaults.
-  const allEntries: PermissionEntry[] = [...defaultEntries, ...explicitEntries];
+  const allEntries: PermissionEntry[] = [
+    ...defaultEntries,
+    ...explicitEntries,
+    ...secretEntries,
+  ];
 
   const resources: ResourceCapability[] = withCapabilitiesReadForSpaces(
     allEntries.map((entry) => resolveEntry(entry, prefix, expiryMs, space)),
@@ -624,6 +685,120 @@ export function resolveManifest(input: Manifest): ResolvedCapabilities {
     includePublicSpace,
     additionalDelegates,
   };
+}
+
+function normalizeSecretActions(actions: readonly string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (action: string) => {
+    if (!seen.has(action)) {
+      out.push(action);
+      seen.add(action);
+    }
+  };
+
+  for (const action of actions) {
+    if (action === "read") {
+      add("get");
+      continue;
+    }
+    if (action === "write") {
+      add("put");
+      continue;
+    }
+    if (action === "delete") {
+      add("del");
+      continue;
+    }
+    if (
+      action === "get" ||
+      action === "put" ||
+      action === "del" ||
+      action === "list" ||
+      action === "metadata"
+    ) {
+      add(action);
+      continue;
+    }
+    if (
+      action === "tinycloud.kv/get" ||
+      action === "tinycloud.kv/put" ||
+      action === "tinycloud.kv/del" ||
+      action === "tinycloud.kv/list" ||
+      action === "tinycloud.kv/metadata"
+    ) {
+      add(action);
+      continue;
+    }
+    throw new ManifestValidationError(
+      `unknown secret action ${JSON.stringify(action)}; expected read, write, delete, list, or metadata`,
+    );
+  }
+
+  return out;
+}
+
+function secretActionsFromSpec(
+  name: string,
+  spec: ManifestSecretActions,
+): string[] {
+  if (spec === true) {
+    return ["read"];
+  }
+  if (typeof spec === "string") {
+    return [spec];
+  }
+  if (Array.isArray(spec)) {
+    return spec;
+  }
+  if (spec === null || typeof spec !== "object") {
+    throw new ManifestValidationError(
+      `manifest.secrets.${name} must be true, a string action, an actions array, or an object`,
+    );
+  }
+  if (spec.actions === undefined) {
+    return ["read"];
+  }
+  if (typeof spec.actions === "string") {
+    return [spec.actions];
+  }
+  if (Array.isArray(spec.actions)) {
+    return spec.actions;
+  }
+  throw new ManifestValidationError(
+    `manifest.secrets.${name}.actions must be a string or array`,
+  );
+}
+
+function secretEntriesForManifest(
+  secrets: Manifest["secrets"] | undefined,
+): PermissionEntry[] {
+  if (secrets === undefined) {
+    return [];
+  }
+
+  const entries: PermissionEntry[] = [];
+  for (const [name, spec] of Object.entries(secrets)) {
+    const actions = secretActionsFromSpec(name, spec);
+    const extra: { expiry?: string; description?: string } =
+      spec !== true && typeof spec === "object" && !Array.isArray(spec)
+        ? spec
+        : {};
+    for (const base of ["keys", "vault"]) {
+      entries.push({
+        service: "tinycloud.kv",
+        space: SECRETS_SPACE,
+        path: `${base}/secrets/${name}`,
+        actions: normalizeSecretActions(actions),
+        skipPrefix: true,
+        ...(extra.expiry !== undefined ? { expiry: extra.expiry } : {}),
+        ...(extra.description !== undefined
+          ? { description: extra.description }
+          : {}),
+      });
+    }
+  }
+  return entries;
 }
 
 /**

--- a/packages/sdk-core/src/spaces/Space.test.ts
+++ b/packages/sdk-core/src/spaces/Space.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  IDataVaultService,
+  IKVService,
+  Result,
+  ServiceError,
+} from "@tinycloud/sdk-services";
+
+import { SpaceService, type SpaceServiceConfig } from "./SpaceService";
+
+const session = {
+  delegationHeader: { Authorization: "Bearer test" },
+  delegationCid: "bafy-test",
+  spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+  verificationMethod: "did:key:z6MkTest",
+  jwk: {},
+};
+
+function makeConfig(
+  calls: { kv: string[]; vault: string[] },
+): SpaceServiceConfig {
+  return {
+    hosts: ["https://node.tinycloud.xyz"],
+    session,
+    invoke: () => ({}),
+    userDid: "did:pkh:eip155:1:0x0000000000000000000000000000000000000001",
+    createKVService: (spaceId) => {
+      calls.kv.push(spaceId);
+      return { spaceId } as unknown as IKVService;
+    },
+    createVaultService: (spaceId) => {
+      calls.vault.push(spaceId);
+      return { spaceId } as unknown as IDataVaultService;
+    },
+    createDelegation: async () =>
+      ({
+        ok: false,
+        error: {
+          code: "NOT_IMPLEMENTED",
+          message: "not implemented",
+          service: "delegation",
+        },
+      }) as Result<never, ServiceError>,
+  };
+}
+
+describe("SpaceService space factories", () => {
+  it("creates a space-scoped vault", () => {
+    const calls = { kv: [] as string[], vault: [] as string[] };
+    const spaces = new SpaceService(makeConfig(calls));
+
+    const secrets = spaces.get("secrets");
+
+    expect((secrets.kv as unknown as { spaceId: string }).spaceId).toBe(
+      "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:secrets",
+    );
+    expect((secrets.vault as unknown as { spaceId: string }).spaceId).toBe(
+      "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:secrets",
+    );
+    expect(calls).toEqual({
+      kv: [
+        "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:secrets",
+      ],
+      vault: [
+        "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:secrets",
+      ],
+    });
+  });
+
+  it("caches space instances with their scoped services", () => {
+    const calls = { kv: [] as string[], vault: [] as string[] };
+    const spaces = new SpaceService(makeConfig(calls));
+
+    expect(spaces.get("secrets")).toBe(spaces.get("secrets"));
+    expect(calls.kv).toHaveLength(1);
+    expect(calls.vault).toHaveLength(1);
+  });
+});

--- a/packages/sdk-core/src/spaces/Space.ts
+++ b/packages/sdk-core/src/spaces/Space.ts
@@ -7,7 +7,12 @@
  * @packageDocumentation
  */
 
-import type { IKVService, Result, ServiceError } from "@tinycloud/sdk-services";
+import type {
+  IDataVaultService,
+  IKVService,
+  Result,
+  ServiceError,
+} from "@tinycloud/sdk-services";
 import type { SpaceInfo } from "../delegations/types";
 
 /**
@@ -85,6 +90,11 @@ export interface ISpace {
   readonly kv: IKVService;
 
   /**
+   * Data Vault operations scoped to this space.
+   */
+  readonly vault: IDataVaultService;
+
+  /**
    * Delegation operations scoped to this space.
    */
   readonly delegations: ISpaceScopedDelegations;
@@ -118,6 +128,11 @@ export interface SpaceConfig {
    * Factory function to create a space-scoped KV service.
    */
   createKV: (spaceId: string) => IKVService;
+
+  /**
+   * Factory function to create a space-scoped Data Vault service.
+   */
+  createVault: (spaceId: string) => IDataVaultService;
 
   /**
    * Factory function to create space-scoped delegations.
@@ -161,6 +176,7 @@ export class Space implements ISpace {
   private readonly _id: string;
   private readonly _name: string;
   private readonly _kv: IKVService;
+  private readonly _vault: IDataVaultService;
   private readonly _delegations: ISpaceScopedDelegations;
   private readonly _sharing: ISpaceScopedSharing;
   private readonly _getInfo: (spaceId: string) => Promise<Result<SpaceInfo, ServiceError>>;
@@ -174,6 +190,7 @@ export class Space implements ISpace {
     this._id = config.id;
     this._name = config.name;
     this._kv = config.createKV(config.id);
+    this._vault = config.createVault(config.id);
     this._delegations = config.createDelegations(config.id);
     this._sharing = config.createSharing(config.id);
     this._getInfo = config.getInfo;
@@ -198,6 +215,13 @@ export class Space implements ISpace {
    */
   get kv(): IKVService {
     return this._kv;
+  }
+
+  /**
+   * Data Vault operations scoped to this space.
+   */
+  get vault(): IDataVaultService {
+    return this._vault;
   }
 
   /**

--- a/packages/sdk-core/src/spaces/SpaceService.ts
+++ b/packages/sdk-core/src/spaces/SpaceService.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  IDataVaultService,
   IKVService,
   Result,
   ServiceError,
@@ -107,6 +108,8 @@ export interface SpaceServiceConfig {
   capabilityRegistry?: ICapabilityKeyRegistry;
   /** Factory function to create a space-scoped KV service */
   createKVService?: (spaceId: string) => IKVService;
+  /** Factory function to create a space-scoped Data Vault service */
+  createVaultService?: (spaceId: string) => IDataVaultService;
   /** User's PKH DID (derived from address or provided explicitly) */
   userDid?: string;
   /** Optional SharingService for v2 sharing links (client-side) */
@@ -349,6 +352,7 @@ export class SpaceService implements ISpaceService {
   private fetchFn: FetchFunction;
   private capabilityRegistry?: ICapabilityKeyRegistry;
   private createKVServiceFn?: (spaceId: string) => IKVService;
+  private createVaultServiceFn?: (spaceId: string) => IDataVaultService;
   private _userDid?: string;
   private sharingService?: ISharingService;
   private createDelegationFn?: CreateDelegationFunction;
@@ -374,6 +378,7 @@ export class SpaceService implements ISpaceService {
     this.fetchFn = config.fetch ?? globalThis.fetch.bind(globalThis);
     this.capabilityRegistry = config.capabilityRegistry;
     this.createKVServiceFn = config.createKVService;
+    this.createVaultServiceFn = config.createVaultService;
     this._userDid = config.userDid;
     this.sharingService = config.sharingService;
     this.createDelegationFn = config.createDelegation;
@@ -389,6 +394,7 @@ export class SpaceService implements ISpaceService {
     if (config.fetch) this.fetchFn = config.fetch;
     if (config.capabilityRegistry) this.capabilityRegistry = config.capabilityRegistry;
     if (config.createKVService) this.createKVServiceFn = config.createKVService;
+    if (config.createVaultService) this.createVaultServiceFn = config.createVaultService;
     if (config.userDid !== undefined) this._userDid = config.userDid;
     if (config.sharingService) this.sharingService = config.sharingService;
     if (config.createDelegation) this.createDelegationFn = config.createDelegation;
@@ -738,6 +744,7 @@ export class SpaceService implements ISpaceService {
       id: spaceId,
       name,
       createKV: this.createSpaceScopedKV.bind(this),
+      createVault: this.createSpaceScopedVault.bind(this),
       createDelegations: this.createSpaceScopedDelegations.bind(this),
       createSharing: this.createSpaceScopedSharing.bind(this),
       getInfo: this.getSpaceInfo.bind(this),
@@ -899,6 +906,23 @@ export class SpaceService implements ISpaceService {
       get: () => {
         throw new Error(
           "KV service factory not configured. Provide createKVService in SpaceServiceConfig."
+        );
+      },
+    });
+  }
+
+  /**
+   * Create a space-scoped Data Vault service.
+   */
+  private createSpaceScopedVault(spaceId: string): IDataVaultService {
+    if (this.createVaultServiceFn) {
+      return this.createVaultServiceFn(spaceId);
+    }
+
+    return new Proxy({} as IDataVaultService, {
+      get: () => {
+        throw new Error(
+          "Vault service factory not configured. Provide createVaultService in SpaceServiceConfig."
         );
       },
     });

--- a/packages/sdk-core/src/spaces/spaces.schema.test.ts
+++ b/packages/sdk-core/src/spaces/spaces.schema.test.ts
@@ -23,6 +23,7 @@ const validSpaceConfig = {
   id: "tinycloud:pkh:eip155:1:0x1234567890123456789012345678901234567890:default",
   name: "default",
   createKV: mockFunction,
+  createVault: mockFunction,
   createDelegations: mockFunction,
   createSharing: mockFunction,
   getInfo: mockAsyncFunction,
@@ -35,6 +36,7 @@ const validSpaceServiceConfig = {
   fetch: mockFunction,
   capabilityRegistry: {},
   createKVService: mockFunction,
+  createVaultService: mockFunction,
   userDid: "did:pkh:eip155:1:0x1234567890123456789012345678901234567890",
   sharingService: {},
   createDelegation: mockAsyncFunction,
@@ -75,6 +77,7 @@ describe("SpaceConfigSchema", () => {
       const data = {
         ...validSpaceConfig,
         createKV: (spaceId: string) => ({ spaceId }),
+        createVault: (spaceId: string) => ({ spaceId }),
         createDelegations: (spaceId: string) => ({ spaceId }),
         createSharing: (spaceId: string) => ({ spaceId }),
         getInfo: async (spaceId: string) => ({ ok: true, data: { id: spaceId } }),
@@ -106,6 +109,13 @@ describe("SpaceConfigSchema", () => {
       expect(result.success).toBe(false);
     });
 
+    it("rejects missing createVault factory", () => {
+      const data = { ...validSpaceConfig };
+      delete (data as Record<string, unknown>).createVault;
+      const result = SpaceConfigSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
     it("rejects missing createDelegations factory", () => {
       const data = { ...validSpaceConfig };
       delete (data as Record<string, unknown>).createDelegations;
@@ -129,6 +139,12 @@ describe("SpaceConfigSchema", () => {
 
     it("rejects non-function createKV", () => {
       const data = { ...validSpaceConfig, createKV: "not a function" };
+      const result = SpaceConfigSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects non-function createVault", () => {
+      const data = { ...validSpaceConfig, createVault: "not a function" };
       const result = SpaceConfigSchema.safeParse(data);
       expect(result.success).toBe(false);
     });

--- a/packages/sdk-core/src/spaces/spaces.schema.ts
+++ b/packages/sdk-core/src/spaces/spaces.schema.ts
@@ -43,6 +43,8 @@ export const SpaceConfigSchema = z.object({
   name: z.string(),
   /** Factory function to create a space-scoped KV service */
   createKV: z.function(),
+  /** Factory function to create a space-scoped Data Vault service */
+  createVault: z.function(),
   /** Factory function to create space-scoped delegations */
   createDelegations: z.function(),
   /** Factory function to create space-scoped sharing */
@@ -76,6 +78,8 @@ export const SpaceServiceConfigSchema = z.object({
   capabilityRegistry: z.unknown().optional(),
   /** Factory function to create a space-scoped KV service */
   createKVService: z.function().optional(),
+  /** Factory function to create a space-scoped Data Vault service */
+  createVaultService: z.function().optional(),
   /** User's PKH DID (derived from address or provided explicitly) */
   userDid: z.string().optional(),
   /** Optional SharingService for v2 sharing links (client-side) */

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -237,3 +237,10 @@ export type {
   VaultEntry,
   VaultError,
 } from "./vault";
+
+export { SecretsService } from "./secrets";
+export type {
+  ISecretsService,
+  SecretPayload,
+  SecretsError,
+} from "./secrets";

--- a/packages/sdk-services/src/secrets/ISecretsService.ts
+++ b/packages/sdk-services/src/secrets/ISecretsService.ts
@@ -1,0 +1,22 @@
+import type { IDataVaultService } from "../vault/IDataVaultService";
+import type { VaultError } from "../vault/types";
+import type { Result, ServiceError } from "../types";
+
+export interface SecretPayload {
+  value: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type SecretsError = VaultError | ServiceError;
+
+export interface ISecretsService {
+  readonly vault: IDataVaultService;
+  unlock(signer?: unknown): Promise<Result<void, VaultError>>;
+  lock(): void;
+  readonly isUnlocked: boolean;
+  get(name: string): Promise<Result<string, SecretsError>>;
+  put(name: string, value: string): Promise<Result<void, SecretsError>>;
+  delete(name: string): Promise<Result<void, SecretsError>>;
+  list(): Promise<Result<string[], SecretsError>>;
+}

--- a/packages/sdk-services/src/secrets/SecretsService.test.ts
+++ b/packages/sdk-services/src/secrets/SecretsService.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import type { Result } from "../types";
+import type { IDataVaultService } from "../vault/IDataVaultService";
+import type {
+  VaultEntry,
+  VaultError,
+  VaultGetOptions,
+  VaultGrantOptions,
+  VaultListOptions,
+  VaultPutOptions,
+} from "../vault/types";
+import { SecretsService } from "./index";
+
+class MockVault implements IDataVaultService {
+  readonly config = {};
+  isUnlocked = false;
+  publicKey = new Uint8Array([1, 2, 3]);
+  unlock = mock(async () => {
+    this.isUnlocked = true;
+    return { ok: true, data: undefined } as Result<void, VaultError>;
+  });
+  clearCache = mock(async () => {});
+  lock = mock(() => {
+    this.isUnlocked = false;
+  });
+  put = mock(
+    async (
+      _key: string,
+      _value: unknown,
+      _options?: VaultPutOptions,
+    ): Promise<Result<void, VaultError>> => ({ ok: true, data: undefined }),
+  );
+  get = mock(
+    async <T = unknown>(
+      _key: string,
+      _options?: VaultGetOptions<T>,
+    ): Promise<Result<VaultEntry<T>, VaultError>> => ({
+      ok: true,
+      data: {
+        value: {
+          value: "stored-value",
+          createdAt: "2026-05-04T00:00:00.000Z",
+          updatedAt: "2026-05-04T00:00:00.000Z",
+        } as T,
+        metadata: {},
+        keyId: "key",
+      },
+    }),
+  );
+  delete = mock(
+    async (_key: string): Promise<Result<void, VaultError>> => ({
+      ok: true,
+      data: undefined,
+    }),
+  );
+  list = mock(
+    async (_options?: VaultListOptions): Promise<Result<string[], VaultError>> => ({
+      ok: true,
+      data: ["ANTHROPIC_API_KEY", "invalid-name"],
+    }),
+  );
+  head = mock(async (): Promise<Result<Record<string, string>, VaultError>> => ({
+    ok: true,
+    data: {},
+  }));
+  putMany = mock(async () => []);
+  getMany = mock(async () => []);
+  grant = mock(
+    async (
+      _key: string,
+      _recipientDID: string,
+      _options?: VaultGrantOptions,
+    ): Promise<Result<void, VaultError>> => ({ ok: true, data: undefined }),
+  );
+  reencrypt = this.grant;
+  revoke = this.grant;
+  listGrants = mock(async (): Promise<Result<string[], VaultError>> => ({
+    ok: true,
+    data: [],
+  }));
+  getShared = this.get;
+  resolvePublicKey = mock(
+    async (): Promise<Result<Uint8Array, VaultError>> => ({
+      ok: true,
+      data: new Uint8Array([1]),
+    }),
+  );
+  initialize = mock(() => {});
+  onSessionChange = mock(() => {});
+  onSignOut = mock(() => {});
+}
+
+describe("SecretsService", () => {
+  it("maps put/get/delete to secrets vault keys", async () => {
+    const vault = new MockVault();
+    const secrets = new SecretsService(vault);
+
+    const putResult = await secrets.put("ANTHROPIC_API_KEY", "secret");
+    expect(putResult.ok).toBe(true);
+    expect(vault.put).toHaveBeenCalledWith(
+      "secrets/ANTHROPIC_API_KEY",
+      expect.objectContaining({
+        value: "secret",
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+      }),
+    );
+
+    const getResult = await secrets.get("ANTHROPIC_API_KEY");
+    expect(getResult).toEqual({ ok: true, data: "stored-value" });
+    expect(vault.get).toHaveBeenCalledWith("secrets/ANTHROPIC_API_KEY");
+
+    const deleteResult = await secrets.delete("ANTHROPIC_API_KEY");
+    expect(deleteResult.ok).toBe(true);
+    expect(vault.delete).toHaveBeenCalledWith("secrets/ANTHROPIC_API_KEY");
+  });
+
+  it("validates env-style names before calling the vault", async () => {
+    const vault = new MockVault();
+    const secrets = new SecretsService(vault);
+
+    const result = await secrets.put("anthropic_api_key", "secret");
+
+    expect(result.ok).toBe(false);
+    expect(vault.put).not.toHaveBeenCalled();
+  });
+
+  it("lists only valid secret names under the secrets prefix", async () => {
+    const vault = new MockVault();
+    const secrets = new SecretsService(vault);
+
+    const result = await secrets.list();
+
+    expect(result).toEqual({ ok: true, data: ["ANTHROPIC_API_KEY"] });
+    expect(vault.list).toHaveBeenCalledWith({
+      prefix: "secrets/",
+      removePrefix: true,
+    });
+  });
+
+  it("forwards lock state to the backing vault", async () => {
+    const vault = new MockVault();
+    const secrets = new SecretsService(vault);
+
+    await secrets.unlock();
+    expect(secrets.isUnlocked).toBe(true);
+    secrets.lock();
+    expect(secrets.isUnlocked).toBe(false);
+  });
+});

--- a/packages/sdk-services/src/secrets/SecretsService.ts
+++ b/packages/sdk-services/src/secrets/SecretsService.ts
@@ -1,0 +1,100 @@
+import {
+  ErrorCodes,
+  err,
+  type Result,
+  type ServiceError,
+} from "../types";
+import type { IDataVaultService } from "../vault/IDataVaultService";
+import type { VaultError } from "../vault/types";
+import type {
+  ISecretsService,
+  SecretPayload,
+  SecretsError,
+} from "./ISecretsService";
+
+const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
+const SECRET_PREFIX = "secrets/";
+
+function invalidSecretName(name: string): Result<never, ServiceError> {
+  return err({
+    code: ErrorCodes.INVALID_INPUT,
+    service: "secrets",
+    message:
+      `Invalid secret name ${JSON.stringify(name)}. Secret names must match ${SECRET_NAME_RE.source}.`,
+  });
+}
+
+function secretKey(name: string): string {
+  return `${SECRET_PREFIX}${name}`;
+}
+
+export class SecretsService implements ISecretsService {
+  private readonly getVault: () => IDataVaultService;
+
+  constructor(vault: IDataVaultService | (() => IDataVaultService)) {
+    this.getVault = typeof vault === "function" ? vault : () => vault;
+  }
+
+  get vault(): IDataVaultService {
+    return this.getVault();
+  }
+
+  get isUnlocked(): boolean {
+    return this.vault.isUnlocked;
+  }
+
+  unlock(signer?: unknown): Promise<Result<void, VaultError>> {
+    return this.vault.unlock(signer);
+  }
+
+  lock(): void {
+    this.vault.lock();
+  }
+
+  async get(name: string): Promise<Result<string, SecretsError>> {
+    if (!SECRET_NAME_RE.test(name)) {
+      return invalidSecretName(name);
+    }
+
+    const result = await this.vault.get<SecretPayload>(secretKey(name));
+    if (!result.ok) {
+      return result;
+    }
+    return { ok: true, data: result.data.value.value };
+  }
+
+  async put(name: string, value: string): Promise<Result<void, SecretsError>> {
+    if (!SECRET_NAME_RE.test(name)) {
+      return invalidSecretName(name);
+    }
+
+    const now = new Date().toISOString();
+    return this.vault.put(secretKey(name), {
+      value,
+      createdAt: now,
+      updatedAt: now,
+    } satisfies SecretPayload);
+  }
+
+  async delete(name: string): Promise<Result<void, SecretsError>> {
+    if (!SECRET_NAME_RE.test(name)) {
+      return invalidSecretName(name);
+    }
+
+    return this.vault.delete(secretKey(name));
+  }
+
+  async list(): Promise<Result<string[], SecretsError>> {
+    const result = await this.vault.list({
+      prefix: SECRET_PREFIX,
+      removePrefix: true,
+    });
+    if (!result.ok) {
+      return result;
+    }
+    return {
+      ok: true,
+      data: result.data.filter((name) => SECRET_NAME_RE.test(name)),
+    };
+  }
+}

--- a/packages/sdk-services/src/secrets/index.ts
+++ b/packages/sdk-services/src/secrets/index.ts
@@ -1,0 +1,6 @@
+export { SecretsService } from "./SecretsService";
+export type {
+  ISecretsService,
+  SecretPayload,
+  SecretsError,
+} from "./ISecretsService";

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -164,6 +164,7 @@ export {
   DataVaultService,
   VaultPublicSpaceKVActions,
   createVaultCrypto,
+  SecretsService,
   type WasmVaultFunctions,
   type VaultHeaders,
   type IDataVaultService,
@@ -175,6 +176,9 @@ export {
   type VaultGrantOptions,
   type VaultEntry,
   type VaultError,
+  type ISecretsService,
+  type SecretPayload,
+  type SecretsError,
 } from '@tinycloud/sdk-core';
 
 // Adapter for web-sdk
@@ -201,6 +205,7 @@ export {
   // Manifest shapes — PermissionEntry is what callers pass to delegateTo.
   type Manifest,
   type ManifestDefaults,
+  type ManifestSecretActions,
   type ComposeManifestOptions,
   type ComposedManifestRequest,
   type ManifestRegistryRecord,

--- a/packages/web-sdk/src/modules/WebSecretsService.ts
+++ b/packages/web-sdk/src/modules/WebSecretsService.ts
@@ -1,0 +1,202 @@
+import {
+  ErrorCodes,
+  resolveManifest,
+  type IDataVaultService,
+  type ISecretsService,
+  type Manifest,
+  type PermissionEntry,
+  type Result,
+  type ServiceError,
+} from "@tinycloud/sdk-core";
+import type { VaultError } from "@tinycloud/sdk-core";
+
+type RequestPermissions = (
+  additional: PermissionEntry[],
+) => Promise<{ approved: boolean }>;
+
+const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
+const SECRET_PREFIX = "secrets/";
+const SECRETS_SPACE = "secrets";
+
+function ok(): Result<void, ServiceError> {
+  return { ok: true, data: undefined };
+}
+
+function secretsError(
+  code: string,
+  message: string,
+  cause?: Error,
+): Result<never, ServiceError> {
+  return {
+    ok: false,
+    error: {
+      code,
+      service: "secrets",
+      message,
+      ...(cause ? { cause } : {}),
+    },
+  };
+}
+
+function actionUrn(action: "put" | "del"): string {
+  return `tinycloud.kv/${action}`;
+}
+
+function secretResourcePath(base: "keys" | "vault", name: string): string {
+  return `${base}/${SECRET_PREFIX}${name}`;
+}
+
+function secretPermissionEntries(
+  name: string,
+  action: "put" | "del",
+): PermissionEntry[] {
+  return [
+    {
+      service: "tinycloud.kv",
+      space: SECRETS_SPACE,
+      path: secretResourcePath("keys", name),
+      actions: [action],
+      skipPrefix: true,
+    },
+    {
+      service: "tinycloud.kv",
+      space: SECRETS_SPACE,
+      path: secretResourcePath("vault", name),
+      actions: [action],
+      skipPrefix: true,
+    },
+  ];
+}
+
+function isSecretsSpace(space: string): boolean {
+  return space === SECRETS_SPACE || space.endsWith(`:${SECRETS_SPACE}`);
+}
+
+export interface WebSecretsServiceConfig {
+  getService: () => ISecretsService;
+  getManifest: () => Manifest | Manifest[] | undefined;
+  requestPermissions: RequestPermissions;
+}
+
+export class WebSecretsService implements ISecretsService {
+  private unlockSigner?: unknown;
+  private shouldRestoreUnlock = false;
+
+  constructor(private readonly config: WebSecretsServiceConfig) {}
+
+  get vault(): IDataVaultService {
+    return this.service.vault;
+  }
+
+  get isUnlocked(): boolean {
+    return this.service.isUnlocked;
+  }
+
+  async unlock(signer?: unknown): Promise<Result<void, VaultError>> {
+    if (signer !== undefined) {
+      this.unlockSigner = signer;
+    }
+    const result = await this.service.unlock(signer);
+    if (result.ok) {
+      this.shouldRestoreUnlock = true;
+    }
+    return result;
+  }
+
+  lock(): void {
+    this.shouldRestoreUnlock = false;
+    this.service.lock();
+  }
+
+  get(name: string): ReturnType<ISecretsService["get"]> {
+    return this.service.get(name);
+  }
+
+  async put(name: string, value: string): ReturnType<ISecretsService["put"]> {
+    const permission = await this.ensureMutationPermission(name, "put");
+    if (!permission.ok) return permission;
+    return this.service.put(name, value);
+  }
+
+  async delete(name: string): ReturnType<ISecretsService["delete"]> {
+    const permission = await this.ensureMutationPermission(name, "del");
+    if (!permission.ok) return permission;
+    return this.service.delete(name);
+  }
+
+  list(): ReturnType<ISecretsService["list"]> {
+    return this.service.list();
+  }
+
+  private get service(): ISecretsService {
+    return this.config.getService();
+  }
+
+  private async ensureMutationPermission(
+    name: string,
+    action: "put" | "del",
+  ): Promise<Result<void, ServiceError | VaultError>> {
+    if (!SECRET_NAME_RE.test(name)) {
+      return secretsError(
+        ErrorCodes.INVALID_INPUT,
+        `Invalid secret name ${JSON.stringify(name)}. Secret names must match ${SECRET_NAME_RE.source}.`,
+      );
+    }
+
+    if (this.hasMutationPermission(name, action)) {
+      return ok();
+    }
+
+    try {
+      const result = await this.config.requestPermissions(
+        secretPermissionEntries(name, action),
+      );
+      if (!result.approved) {
+        return secretsError(
+          ErrorCodes.PERMISSION_DENIED,
+          `Permission request for ${actionUrn(action)} on ${name} was declined.`,
+        );
+      }
+      return this.restoreUnlockAfterEscalation();
+    } catch (error) {
+      return secretsError(
+        ErrorCodes.PERMISSION_DENIED,
+        error instanceof Error
+          ? error.message
+          : `Permission request for ${actionUrn(action)} on ${name} failed.`,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private async restoreUnlockAfterEscalation(): Promise<
+    Result<void, ServiceError | VaultError>
+  > {
+    if (!this.shouldRestoreUnlock) {
+      return ok();
+    }
+    return this.service.unlock(this.unlockSigner);
+  }
+
+  private hasMutationPermission(name: string, action: "put" | "del"): boolean {
+    const manifest = this.config.getManifest();
+    if (manifest === undefined) {
+      return false;
+    }
+
+    const manifests = Array.isArray(manifest) ? manifest : [manifest];
+    const requiredAction = actionUrn(action);
+    return manifests.some((entry) => {
+      const resolved = resolveManifest(entry);
+      return (["keys", "vault"] as const).every((base) =>
+        resolved.resources.some(
+          (resource) =>
+            resource.service === "tinycloud.kv" &&
+            isSecretsSpace(resource.space) &&
+            resource.path === secretResourcePath(base, name) &&
+            resource.actions.includes(requiredAction),
+        ),
+      );
+    });
+  }
+}

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -21,6 +21,7 @@ import {
   ISQLService,
   IDuckDbService,
   IDataVaultService,
+  ISecretsService,
   ISpaceService,
   ISpace,
   ISharingService,
@@ -50,6 +51,7 @@ import {
   requestPermissionsCore,
   validateAdditionalPermissions,
 } from "./requestPermissionsCore";
+import { WebSecretsService } from "./WebSecretsService";
 import type { providers } from "ethers";
 
 import { BrowserWalletSigner } from "../adapters/BrowserWalletSigner";
@@ -212,6 +214,7 @@ export class TinyCloudWeb {
 
   /** Browser wallet signer */
   private walletSigner?: BrowserWalletSigner;
+  private _secrets?: ISecretsService;
 
   /** Promise that resolves when WASM + node are ready */
   private _initPromise: Promise<void>;
@@ -360,6 +363,16 @@ export class TinyCloudWeb {
   get duckdb(): IDuckDbService { return this.node.duckdb; }
   get hooks(): IHooksService { return this.node.hooks; }
   get vault(): IDataVaultService { return this.node.vault; }
+  get secrets(): ISecretsService {
+    if (!this._secrets) {
+      this._secrets = new WebSecretsService({
+        getService: () => this.node.secrets,
+        getManifest: () => this._manifest,
+        requestPermissions: (additional) => this.requestPermissions(additional),
+      });
+    }
+    return this._secrets;
+  }
   get spaces(): ISpaceService { return this.node.spaces; }
   get sharing(): ISharingService { return this.node.sharing; }
   get delegations(): DelegationManager { return this.node.delegationManager; }

--- a/packages/web-sdk/tests/WebSecretsService.test.ts
+++ b/packages/web-sdk/tests/WebSecretsService.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  ErrorCodes,
+  type ISecretsService,
+  type Manifest,
+  type PermissionEntry,
+} from "@tinycloud/sdk-core";
+
+import { WebSecretsService } from "../src/modules/WebSecretsService";
+
+function makeBaseSecrets(): ISecretsService {
+  return {
+    vault: {} as ISecretsService["vault"],
+    isUnlocked: true,
+    unlock: mock(async () => ({ ok: true, data: undefined })),
+    lock: mock(() => {}),
+    get: mock(async () => ({ ok: true, data: "stored" })),
+    put: mock(async () => ({ ok: true, data: undefined })),
+    delete: mock(async () => ({ ok: true, data: undefined })),
+    list: mock(async () => ({ ok: true, data: ["ANTHROPIC_API_KEY"] })),
+  };
+}
+
+function readOnlyManifest(): Manifest {
+  return {
+    app_id: "com.food.app",
+    name: "Food",
+    defaults: false,
+    secrets: {
+      ANTHROPIC_API_KEY: true,
+    },
+  };
+}
+
+describe("WebSecretsService", () => {
+  it("does not escalate reads", async () => {
+    const base = makeBaseSecrets();
+    const requested: PermissionEntry[][] = [];
+    const secrets = new WebSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      requestPermissions: async (additional) => {
+        requested.push(additional);
+        return { approved: true };
+      },
+    });
+
+    const result = await secrets.get("ANTHROPIC_API_KEY");
+
+    expect(result).toEqual({ ok: true, data: "stored" });
+    expect(requested).toEqual([]);
+  });
+
+  it("requests write permission before putting a read-only manifest secret", async () => {
+    const base = makeBaseSecrets();
+    const requested: PermissionEntry[][] = [];
+    const secrets = new WebSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      requestPermissions: async (additional) => {
+        requested.push(additional);
+        return { approved: true };
+      },
+    });
+
+    const result = await secrets.put("ANTHROPIC_API_KEY", "secret");
+
+    expect(result.ok).toBe(true);
+    expect(requested).toEqual([
+      [
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "keys/secrets/ANTHROPIC_API_KEY",
+          actions: ["put"],
+          skipPrefix: true,
+        },
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "vault/secrets/ANTHROPIC_API_KEY",
+          actions: ["put"],
+          skipPrefix: true,
+        },
+      ],
+    ]);
+    expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
+  });
+
+  it("skips escalation when the manifest already includes the mutation action", async () => {
+    const base = makeBaseSecrets();
+    const requestPermissions = mock(async () => ({ approved: true }));
+    const secrets = new WebSecretsService({
+      getService: () => base,
+      getManifest: () => ({
+        ...readOnlyManifest(),
+        secrets: {
+          ANTHROPIC_API_KEY: ["read", "write"],
+        },
+      }),
+      requestPermissions,
+    });
+
+    const result = await secrets.put("ANTHROPIC_API_KEY", "secret");
+
+    expect(result.ok).toBe(true);
+    expect(requestPermissions).not.toHaveBeenCalled();
+    expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
+  });
+
+  it("re-unlocks after approved escalation when already unlocked", async () => {
+    const base = makeBaseSecrets();
+    const signer = { signMessage: async () => "0xsig" };
+    const secrets = new WebSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      requestPermissions: async () => ({ approved: true }),
+    });
+
+    await secrets.unlock(signer);
+    const result = await secrets.put("ANTHROPIC_API_KEY", "secret");
+
+    expect(result.ok).toBe(true);
+    expect(base.unlock).toHaveBeenCalledTimes(2);
+    expect(base.unlock).toHaveBeenLastCalledWith(signer);
+    expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
+  });
+
+  it("returns a permission error when delete escalation is declined", async () => {
+    const base = makeBaseSecrets();
+    const secrets = new WebSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      requestPermissions: async () => ({ approved: false }),
+    });
+
+    const result = await secrets.delete("ANTHROPIC_API_KEY");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: ErrorCodes.PERMISSION_DENIED,
+        service: "secrets",
+        message:
+          "Permission request for tinycloud.kv/del on ANTHROPIC_API_KEY was declined.",
+      },
+    });
+    expect(base.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add manifest `secrets` declarations backed by the `secrets` space vault
- add `tc.secrets` / `tc.space("secrets").vault` SDK APIs plus service wrappers
- support read-default secret permissions with write/delete escalation in web and Node SDKs
- add a minor changeset for the public SDK and manifest API

## Verification
- `bun test packages/sdk-core/src/manifest.test.ts packages/sdk-core/src/spaces/Space.test.ts packages/sdk-core/src/spaces/spaces.schema.test.ts packages/sdk-services/src/secrets/SecretsService.test.ts packages/node-sdk/src/NodeSecretsService.test.ts packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts packages/web-sdk/tests/WebSecretsService.test.ts`
- `bunx turbo build --filter=@tinycloud/node-sdk --filter=@tinycloud/web-sdk`
- `git diff --check`