### PR TITLE
feat: add runtime permission delegations

### DIFF
--- a/.changeset/runtime-permission-delegations.md
+++ b/.changeset/runtime-permission-delegations.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+---
+
+Store approved runtime permissions as narrow portable delegations and route matching invocations through them instead of expanding the app manifest and re-signing the whole session. `delegateTo()` can now derive from an installed runtime delegation, web permission requests return any created runtime delegations, and the secrets wrapper can use the SDK's connected signer when unlocking the backing vault.

--- a/packages/node-sdk/src/NodeSecretsService.test.ts
+++ b/packages/node-sdk/src/NodeSecretsService.test.ts
@@ -35,66 +35,55 @@ function readOnlyManifest(): Manifest {
 describe("NodeSecretsService", () => {
   it("does not autosign reads", async () => {
     const base = makeBaseSecrets();
-    const signIn = mock(async () => {});
+    const grantPermissions = mock(async () => {});
     const secrets = new NodeSecretsService({
       getService: () => base,
       getManifest: readOnlyManifest,
-      setManifest: mock(() => {}),
-      signIn,
+      grantPermissions,
       canEscalate: () => true,
     });
 
     const result = await secrets.get("ANTHROPIC_API_KEY");
 
     expect(result).toEqual({ ok: true, data: "stored" });
-    expect(signIn).not.toHaveBeenCalled();
+    expect(grantPermissions).not.toHaveBeenCalled();
   });
 
-  it("autosigns write permission before putting a read-only manifest secret", async () => {
+  it("grants write permission before putting a read-only manifest secret", async () => {
     const base = makeBaseSecrets();
-    let manifest = readOnlyManifest();
-    const setManifest = mock((next: Manifest | Manifest[]) => {
-      manifest = Array.isArray(next) ? next[0] : next;
-    });
-    const signIn = mock(async () => {});
+    const grantPermissions = mock(async () => {});
     const secrets = new NodeSecretsService({
       getService: () => base,
-      getManifest: () => manifest,
-      setManifest,
-      signIn,
+      getManifest: readOnlyManifest,
+      grantPermissions,
       canEscalate: () => true,
     });
 
     const result = await secrets.put("ANTHROPIC_API_KEY", "secret");
 
     expect(result.ok).toBe(true);
-    expect(setManifest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        permissions: [
-          {
-            service: "tinycloud.kv",
-            space: "secrets",
-            path: "keys/secrets/ANTHROPIC_API_KEY",
-            actions: ["put"],
-            skipPrefix: true,
-          },
-          {
-            service: "tinycloud.kv",
-            space: "secrets",
-            path: "vault/secrets/ANTHROPIC_API_KEY",
-            actions: ["put"],
-            skipPrefix: true,
-          },
-        ] satisfies PermissionEntry[],
-      }),
-    );
-    expect(signIn).toHaveBeenCalledTimes(1);
+    expect(grantPermissions).toHaveBeenCalledWith([
+      {
+        service: "tinycloud.kv",
+        space: "secrets",
+        path: "keys/secrets/ANTHROPIC_API_KEY",
+        actions: ["put"],
+        skipPrefix: true,
+      },
+      {
+        service: "tinycloud.kv",
+        space: "secrets",
+        path: "vault/secrets/ANTHROPIC_API_KEY",
+        actions: ["put"],
+        skipPrefix: true,
+      },
+    ] satisfies PermissionEntry[]);
     expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
   });
 
   it("skips autosign when the manifest already includes the mutation action", async () => {
     const base = makeBaseSecrets();
-    const signIn = mock(async () => {});
+    const grantPermissions = mock(async () => {});
     const secrets = new NodeSecretsService({
       getService: () => base,
       getManifest: () => ({
@@ -103,15 +92,14 @@ describe("NodeSecretsService", () => {
           ANTHROPIC_API_KEY: ["read", "delete"],
         },
       }),
-      setManifest: mock(() => {}),
-      signIn,
+      grantPermissions,
       canEscalate: () => true,
     });
 
     const result = await secrets.delete("ANTHROPIC_API_KEY");
 
     expect(result.ok).toBe(true);
-    expect(signIn).not.toHaveBeenCalled();
+    expect(grantPermissions).not.toHaveBeenCalled();
     expect(base.delete).toHaveBeenCalledWith("ANTHROPIC_API_KEY");
   });
 
@@ -121,8 +109,7 @@ describe("NodeSecretsService", () => {
     const secrets = new NodeSecretsService({
       getService: () => base,
       getManifest: readOnlyManifest,
-      setManifest: mock(() => {}),
-      signIn: mock(async () => {}),
+      grantPermissions: mock(async () => {}),
       canEscalate: () => true,
     });
 
@@ -135,13 +122,29 @@ describe("NodeSecretsService", () => {
     expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
   });
 
+  it("uses the configured signer when unlock is called without one", async () => {
+    const base = makeBaseSecrets();
+    const signer = { signMessage: async () => "0xsig" };
+    const secrets = new NodeSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      grantPermissions: mock(async () => {}),
+      canEscalate: () => true,
+      getUnlockSigner: () => signer,
+    });
+
+    const result = await secrets.unlock();
+
+    expect(result.ok).toBe(true);
+    expect(base.unlock).toHaveBeenCalledWith(signer);
+  });
+
   it("returns a permission error when autosign is unavailable", async () => {
     const base = makeBaseSecrets();
     const secrets = new NodeSecretsService({
       getService: () => base,
       getManifest: readOnlyManifest,
-      setManifest: mock(() => {}),
-      signIn: mock(async () => {}),
+      grantPermissions: mock(async () => {}),
       canEscalate: () => false,
     });
 

--- a/packages/node-sdk/src/NodeSecretsService.ts
+++ b/packages/node-sdk/src/NodeSecretsService.ts
@@ -68,32 +68,12 @@ function isSecretsSpace(space: string): boolean {
   return space === SECRETS_SPACE || space.endsWith(`:${SECRETS_SPACE}`);
 }
 
-function composeEscalatedManifest(
-  manifest: Manifest | Manifest[],
-  additional: PermissionEntry[],
-): Manifest | Manifest[] {
-  if (Array.isArray(manifest)) {
-    const [primary, ...rest] = manifest;
-    return [
-      {
-        ...primary,
-        permissions: [...(primary.permissions ?? []), ...additional],
-      },
-      ...rest,
-    ];
-  }
-  return {
-    ...manifest,
-    permissions: [...(manifest.permissions ?? []), ...additional],
-  };
-}
-
 export interface NodeSecretsServiceConfig {
   getService: () => ISecretsService;
   getManifest: () => Manifest | Manifest[] | undefined;
-  setManifest: (manifest: Manifest | Manifest[]) => void;
-  signIn: () => Promise<void>;
+  grantPermissions: (additional: PermissionEntry[]) => Promise<unknown>;
   canEscalate: () => boolean;
+  getUnlockSigner?: () => unknown;
 }
 
 export class NodeSecretsService implements ISecretsService {
@@ -111,10 +91,11 @@ export class NodeSecretsService implements ISecretsService {
   }
 
   async unlock(signer?: unknown): Promise<Result<void, VaultError>> {
-    if (signer !== undefined) {
-      this.unlockSigner = signer;
+    const effectiveSigner = signer ?? this.config.getUnlockSigner?.();
+    if (effectiveSigner !== undefined) {
+      this.unlockSigner = effectiveSigner;
     }
-    const result = await this.service.unlock(signer);
+    const result = await this.service.unlock(effectiveSigner);
     if (result.ok) {
       this.shouldRestoreUnlock = true;
     }
@@ -172,22 +153,8 @@ export class NodeSecretsService implements ISecretsService {
       );
     }
 
-    const manifest = this.config.getManifest();
-    if (manifest === undefined) {
-      return secretsError(
-        ErrorCodes.PERMISSION_DENIED,
-        `Cannot autosign ${actionUrn(action)} for ${name}; set a manifest before mutating secrets.`,
-      );
-    }
-
     try {
-      this.config.setManifest(
-        composeEscalatedManifest(
-          manifest,
-          secretPermissionEntries(name, action),
-        ),
-      );
-      await this.config.signIn();
+      await this.config.grantPermissions(secretPermissionEntries(name, action));
       return this.restoreUnlockAfterEscalation();
     } catch (error) {
       return secretsError(

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  type ISessionManager,
+  type IWasmBindings,
+  type PermissionEntry,
+} from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+function makeFakeSessionManager(): ISessionManager {
+  return {
+    createSessionKey: (id: string) => id,
+    renameSessionKeyId: () => {},
+    getDID: (keyId: string) => `did:key:${keyId}`,
+    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+  };
+}
+
+function makeFakeWasmBindings(
+  invoke: IWasmBindings["invoke"],
+): IWasmBindings {
+  return {
+    invoke,
+    invokeAny: mock(() => ({})) as any,
+    prepareSession: mock((cfg: any) => ({
+      siwe: "runtime-siwe",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: "did:key:runtime",
+    })),
+    completeSessionSetup: mock((cfg: any) => ({
+      delegationHeader: { Authorization: "runtime-token" },
+      delegationCid: "runtime-cid",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: cfg.verificationMethod,
+    })),
+    ensureEip55: (address: string) => address,
+    makeSpaceId: (address: string, chainId: number, name: string) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${name}`,
+    createDelegation: mock((_session, delegateDID, spaceId, abilities) => {
+      const service = Object.keys(abilities)[0];
+      const path = Object.keys(abilities[service])[0];
+      return {
+        delegation: "child-runtime-token",
+        cid: "child-runtime-cid",
+        delegateDid: delegateDID,
+        expiry: Math.floor((Date.now() + 3600_000) / 1000),
+        resources: [
+          {
+            service,
+            space: spaceId,
+            path,
+            actions: abilities[service][path],
+          },
+        ],
+      };
+    }),
+    parseRecapFromSiwe: mock(() => []),
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(),
+      privateKey: new Uint8Array(),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array()),
+    vault_sha256: mock(() => new Uint8Array()),
+    createSessionManager: makeFakeSessionManager,
+  };
+}
+
+function makeNode(invoke: IWasmBindings["invoke"]): TinyCloudNode {
+  const signer = {
+    getAddress: async () => "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+    getChainId: async () => 1,
+    signMessage: mock(async () => "0xsig"),
+  };
+  const node = new TinyCloudNode({
+    host: "https://tinycloud.test",
+    signer: signer as any,
+    wasmBindings: makeFakeWasmBindings(invoke),
+  });
+  const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+  const siwe = `tinycloud.test wants you to sign in with your Ethereum account:
+${address}
+
+Sign in.
+
+URI: https://tinycloud.test
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2026-05-05T00:00:00.000Z
+Expiration Time: 2999-01-01T00:00:00.000Z`;
+  (node as any).auth = {
+    tinyCloudSession: {
+      address,
+      chainId: 1,
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      jwk: { kty: "OKP", crv: "Ed25519", x: "test" },
+      sessionKey: "default",
+      siwe,
+      spaceId: `tinycloud:pkh:eip155:1:${address}:default`,
+      verificationMethod: "did:key:default",
+    },
+  };
+  return node;
+}
+
+async function withActivatedDelegations(fn: () => Promise<void>): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mock(async () =>
+    new Response(JSON.stringify({ activated: ["runtime-cid"] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  ) as any;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+describe("TinyCloudNode runtime permission delegations", () => {
+  test("uses a stored runtime delegation for matching invocations", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const secretsSpaceId = `tinycloud:pkh:eip155:1:${address}:secrets`;
+    const permission: PermissionEntry = {
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "vault/secrets/ANTHROPIC_API_KEY",
+      actions: ["tinycloud.kv/put"],
+    };
+
+    await withActivatedDelegations(async () => {
+      const delegations = await node.grantRuntimePermissions([permission]);
+      expect(delegations).toHaveLength(1);
+      expect(delegations[0].delegateDID).toBe("did:key:default");
+      expect(delegations[0].resources).toEqual([
+        {
+          service: "kv",
+          space: secretsSpaceId,
+          path: "vault/secrets/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/put"],
+        },
+      ]);
+    });
+
+    expect(node.hasRuntimePermissions([permission])).toBe(true);
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: secretsSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/put",
+    );
+    expect(invoke.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "runtime-token",
+    );
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/get",
+    );
+    expect(invoke.mock.calls[1][0].delegationHeader.Authorization).toBe(
+      "base-token",
+    );
+  });
+
+  test("delegateTo can derive from a stored runtime delegation", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const permission: PermissionEntry = {
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "vault/secrets/ANTHROPIC_API_KEY",
+      actions: ["tinycloud.kv/put"],
+    };
+
+    await withActivatedDelegations(async () => {
+      await node.grantRuntimePermissions([permission]);
+      const result = await node.delegateTo("did:key:backend", [permission]);
+
+      expect(result.prompted).toBe(false);
+      expect(result.delegation.delegateDID).toBe("did:key:backend");
+      expect(result.delegation.delegationHeader.Authorization).toBe(
+        "child-runtime-token",
+      );
+    });
+
+    const createDelegation = (node as any).wasmBindings.createDelegation;
+    expect(createDelegation).toHaveBeenCalledTimes(1);
+    expect(createDelegation.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "runtime-token",
+    );
+  });
+
+  test("can reinstall a portable runtime delegation", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const permission: PermissionEntry = {
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "vault/secrets/ANTHROPIC_API_KEY",
+      actions: ["tinycloud.kv/put"],
+    };
+
+    let runtimeDelegation: any;
+    await withActivatedDelegations(async () => {
+      [runtimeDelegation] = await node.grantRuntimePermissions([permission]);
+      (node as any).runtimePermissionGrants = [];
+      expect(node.hasRuntimePermissions([permission])).toBe(false);
+      await node.useRuntimeDelegation(runtimeDelegation!);
+    });
+
+    expect(node.hasRuntimePermissions([permission])).toBe(true);
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -52,6 +52,8 @@ import {
   ServiceContext,
   ISessionStorage,
   ISigner,
+  type InvokeAnyFunction,
+  type InvokeFunction,
   INotificationHandler,
   SilentNotificationHandler,
   IENSResolver,
@@ -77,6 +79,7 @@ import {
   DelegationResult,
   CreateDelegationWasmParams,
   CreateDelegationWasmResult,
+  type DelegatedResource,
   UnsupportedFeatureError,
   makePublicSpaceId,
   ACCOUNT_REGISTRY_SPACE,
@@ -209,6 +212,28 @@ export interface DelegateToResult {
 }
 
 /**
+ * Options for runtime permission escalation.
+ */
+export interface RuntimePermissionGrantOptions {
+  /** Override expiry. ms-format string ("7d", "1h") or raw milliseconds. */
+  expiry?: string | number;
+}
+
+interface RuntimePermissionOperation {
+  spaceId: string;
+  service: string;
+  path: string;
+  action: string;
+}
+
+interface RuntimePermissionGrant {
+  session: ServiceSession;
+  delegation: PortableDelegation;
+  operations: RuntimePermissionOperation[];
+  expiresAt: Date;
+}
+
+/**
  * High-level TinyCloud API for Node.js environments.
  *
  * Each user creates their own TinyCloudNode instance with their private key.
@@ -264,6 +289,7 @@ export class TinyCloudNode {
   // These are initialized after signIn()
   private _delegationManager?: DelegationManager;
   private _spaceService?: SpaceService;
+  private runtimePermissionGrants: RuntimePermissionGrant[] = [];
 
   private get nodeFeatures(): string[] {
     return this.auth?.nodeFeatures ?? [];
@@ -273,6 +299,41 @@ export class TinyCloudNode {
   private get siweDomain(): string {
     return this.config.domain ?? 'app.tinycloud.xyz';
   }
+
+  private readonly invokeWithRuntimePermissions: InvokeFunction = (
+    session,
+    service,
+    path,
+    action,
+    facts,
+  ) => {
+    return this.wasmBindings.invoke(
+      this.selectInvocationSession(session, service, path, action),
+      service,
+      path,
+      action,
+      facts,
+    );
+  };
+
+  private readonly invokeAnyWithRuntimePermissions: InvokeAnyFunction = (
+    session,
+    entries,
+    facts,
+  ) => {
+    if (!this.wasmBindings.invokeAny) {
+      throw new Error("WASM binding does not support invokeAny");
+    }
+    const grant = this.findGrantForOperations(
+      entries.map((entry) => ({
+        spaceId: entry.spaceId,
+        service: this.invocationServiceName(entry.service),
+        path: entry.path,
+        action: entry.action,
+      })),
+    );
+    return this.wasmBindings.invokeAny(grant?.session ?? session, entries, facts);
+  };
 
   /**
    * Create a new TinyCloudNode instance.
@@ -355,7 +416,7 @@ export class TinyCloudNode {
     this._sharingService = new SharingService({
       hosts: [this.config.host!],
       // session: undefined - not needed for receive()
-      invoke: this.wasmBindings.invoke,
+      invoke: this.invokeWithRuntimePermissions,
       fetch: globalThis.fetch.bind(globalThis),
       keyProvider: this._keyProvider,
       registry: this._capabilityRegistry,
@@ -420,7 +481,7 @@ export class TinyCloudNode {
     });
 
     this.tc = new TinyCloud(this.auth, {
-      invokeAny: this.wasmBindings.invokeAny,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
     });
   }
 
@@ -568,6 +629,7 @@ export class TinyCloudNode {
     this._secrets = undefined;
     this._spaceService = undefined;
     this._serviceContext = undefined;
+    this.runtimePermissionGrants = [];
 
     await this.tc.signIn(options);
     this.syncResolvedHostFromAuth();
@@ -688,6 +750,7 @@ export class TinyCloudNode {
     this._secrets = undefined;
     this._spaceService = undefined;
     this._serviceContext = undefined;
+    this.runtimePermissionGrants = [];
 
     if (sessionData.address) {
       this._address = sessionData.address;
@@ -698,8 +761,8 @@ export class TinyCloudNode {
 
     // Create service context
     this._serviceContext = new ServiceContext({
-      invoke: this.wasmBindings.invoke,
-      invokeAny: this.wasmBindings.invokeAny,
+      invoke: this.invokeWithRuntimePermissions,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
       fetch: globalThis.fetch.bind(globalThis),
       hosts: [this.config.host!],
     });
@@ -807,7 +870,7 @@ export class TinyCloudNode {
 
     // Create TinyCloud instance
     this.tc = new TinyCloud(this.auth, {
-      invokeAny: this.wasmBindings.invokeAny,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
     });
 
     // Update config with prefix
@@ -858,7 +921,7 @@ export class TinyCloudNode {
     });
 
     this.tc = new TinyCloud(this.auth, {
-      invokeAny: this.wasmBindings.invokeAny,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
     });
     this.config.prefix = prefix;
   }
@@ -874,12 +937,12 @@ export class TinyCloudNode {
     }
 
     // Initialize TinyCloud core services (needed for publicKV, ensurePublicSpace)
-    this.tc!.initializeServices(this.wasmBindings.invoke, [this.config.host!]);
+    this.tc!.initializeServices(this.invokeWithRuntimePermissions, [this.config.host!]);
 
     // Create service context
     this._serviceContext = new ServiceContext({
-      invoke: this.wasmBindings.invoke,
-      invokeAny: this.wasmBindings.invokeAny,
+      invoke: this.invokeWithRuntimePermissions,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
       fetch: globalThis.fetch.bind(globalThis),
       hosts: [this.config.host!],
     });
@@ -1070,7 +1133,7 @@ export class TinyCloudNode {
     this._delegationManager = new DelegationManager({
       hosts: [this.config.host!],
       session: serviceSession,
-      invoke: this.wasmBindings.invoke,
+      invoke: this.invokeWithRuntimePermissions,
       fetch: globalThis.fetch.bind(globalThis),
     });
 
@@ -1388,9 +1451,9 @@ export class TinyCloudNode {
       this._secrets = new NodeSecretsService({
         getService: () => this.getBaseSecrets(),
         getManifest: () => this.manifest,
-        setManifest: (manifest) => this.setManifest(manifest),
-        signIn: () => this.signIn(),
+        grantPermissions: (additional) => this.grantRuntimePermissions(additional),
         canEscalate: () => this.signer !== undefined && this.tc !== undefined,
+        getUnlockSigner: () => this.signer ?? undefined,
       });
     }
     return this._secrets;
@@ -1484,6 +1547,196 @@ export class TinyCloudNode {
         return entry?.delegation;
       },
     };
+  }
+
+  /**
+   * Check whether the current session or an approved runtime delegation covers
+   * every requested permission.
+   */
+  hasRuntimePermissions(permissions: PermissionEntry[]): boolean {
+    const session = this.auth?.tinyCloudSession;
+    if (!session || !Array.isArray(permissions) || permissions.length === 0) {
+      return false;
+    }
+
+    const expanded = this.expandPermissionEntries(permissions);
+    if (this.sessionCoversPermissionEntries(session, expanded)) {
+      return true;
+    }
+
+    return this.findRuntimeGrantsForPermissionEntries(expanded, session).length > 0;
+  }
+
+  /**
+   * Return installed runtime permission delegations. When `permissions` is
+   * provided, only delegations currently covering those permissions are
+   * returned. Base-session manifest permissions are not represented here.
+   */
+  getRuntimePermissionDelegations(
+    permissions?: PermissionEntry[],
+  ): PortableDelegation[] {
+    this.pruneExpiredRuntimePermissionGrants();
+    if (permissions === undefined) {
+      return this.runtimePermissionGrants.map((grant) => grant.delegation);
+    }
+
+    const session = this.auth?.tinyCloudSession;
+    if (!session || !Array.isArray(permissions) || permissions.length === 0) {
+      return [];
+    }
+    const expanded = this.expandPermissionEntries(permissions);
+    return this.findRuntimeGrantsForPermissionEntries(expanded, session).map(
+      (grant) => grant.delegation,
+    );
+  }
+
+  /**
+   * Install a portable runtime permission delegation into this SDK instance so
+   * matching service calls and downstream `delegateTo()` calls can use it.
+   */
+  async useRuntimeDelegation(delegation: PortableDelegation): Promise<void> {
+    const session = this.auth?.tinyCloudSession;
+    if (!session) {
+      throw new SessionExpiredError(new Date(0));
+    }
+    if (delegation.expiry.getTime() <= Date.now()) {
+      throw new SessionExpiredError(delegation.expiry);
+    }
+
+    const expectedDids = new Set([session.verificationMethod, this.sessionDid]);
+    if (!expectedDids.has(delegation.delegateDID)) {
+      throw new Error(
+        `Runtime delegation targets ${delegation.delegateDID} but this session key is ${session.verificationMethod}.`,
+      );
+    }
+
+    const targetHost = delegation.host ?? this.config.host!;
+    const activateResult = await activateSessionWithHost(
+      targetHost,
+      delegation.delegationHeader,
+    );
+    if (!activateResult.success) {
+      throw new Error(
+        `Failed to activate runtime permission delegation: ${activateResult.error}`,
+      );
+    }
+
+    this.runtimePermissionGrants = this.runtimePermissionGrants.filter(
+      (grant) => grant.delegation.cid !== delegation.cid,
+    );
+    this.runtimePermissionGrants.push(
+      this.runtimeGrantFromDelegation(delegation, session),
+    );
+  }
+
+  /**
+   * Store additional permissions as narrow delegations to the current session
+   * key. Future service invocations automatically use a stored delegation when
+   * its `(space, service, path, action)` covers the request.
+   */
+  async grantRuntimePermissions(
+    permissions: PermissionEntry[],
+    options?: RuntimePermissionGrantOptions,
+  ): Promise<PortableDelegation[]> {
+    if (!Array.isArray(permissions) || permissions.length === 0) {
+      throw new Error("grantRuntimePermissions requires a non-empty permissions array");
+    }
+    const session = this.auth?.tinyCloudSession;
+    if (!session) {
+      throw new SessionExpiredError(new Date(0));
+    }
+
+    const sessionExpiry = extractSiweExpiration(session.siwe);
+    if (sessionExpiry !== undefined) {
+      const marginMs = TinyCloudNode.SESSION_EXPIRY_SAFETY_MARGIN_MS;
+      if (sessionExpiry.getTime() <= Date.now() + marginMs) {
+        throw new SessionExpiredError(sessionExpiry);
+      }
+    }
+
+    const expanded = this.expandPermissionEntries(permissions);
+    if (this.sessionCoversPermissionEntries(session, expanded)) {
+      return [];
+    }
+
+    const existingGrants = this.findRuntimeGrantsForPermissionEntries(expanded, session);
+    if (existingGrants.length > 0) {
+      return existingGrants.map((grant) => grant.delegation);
+    }
+    if (!this.signer) {
+      throw new Error(
+        "grantRuntimePermissions requires wallet mode with a signer or privateKey.",
+      );
+    }
+
+    const bySpace = new Map<string, PermissionEntry[]>();
+    for (const entry of expanded) {
+      const spaceId = this.resolvePermissionSpace(entry.space, session);
+      const current = bySpace.get(spaceId) ?? [];
+      current.push(entry);
+      bySpace.set(spaceId, current);
+    }
+
+    const now = new Date();
+    const requestedExpiryMs = resolveExpiryMs(options?.expiry);
+    let expiresAt = new Date(now.getTime() + requestedExpiryMs);
+    if (sessionExpiry !== undefined && sessionExpiry < expiresAt) {
+      expiresAt = sessionExpiry;
+    }
+
+    const delegations: PortableDelegation[] = [];
+    for (const [spaceId, entries] of bySpace) {
+      const abilities = this.permissionsToAbilities(entries);
+      const prepared = this.wasmBindings.prepareSession({
+        abilities,
+        address: this.wasmBindings.ensureEip55(session.address),
+        chainId: session.chainId,
+        domain: this.siweDomain,
+        issuedAt: now.toISOString(),
+        expirationTime: expiresAt.toISOString(),
+        spaceId,
+        jwk: session.jwk,
+      });
+
+      const signature = await this.signer.signMessage(prepared.siwe);
+      const delegatedSession = this.wasmBindings.completeSessionSetup({
+        ...prepared,
+        signature,
+      });
+
+      const activateResult = await activateSessionWithHost(
+        this.config.host!,
+        delegatedSession.delegationHeader,
+      );
+      if (!activateResult.success) {
+        throw new Error(
+          `Failed to activate runtime permission delegation: ${activateResult.error}`,
+        );
+      }
+
+      const delegation = this.runtimeDelegationFromSession(
+        delegatedSession,
+        entries,
+        spaceId,
+        session,
+        expiresAt,
+      );
+      this.runtimePermissionGrants.push({
+        session: {
+          delegationHeader: delegatedSession.delegationHeader,
+          delegationCid: delegatedSession.delegationCid,
+          spaceId,
+          verificationMethod: session.verificationMethod,
+          jwk: session.jwk,
+        },
+        delegation,
+        operations: this.permissionOperations(entries, spaceId),
+        expiresAt,
+      });
+      delegations.push(delegation);
+    }
+
+    return delegations;
   }
 
   /**
@@ -1701,7 +1954,7 @@ export class TinyCloudNode {
     if (this._serviceContext) {
       const publicKV = new KVService({ prefix: "" });
       const publicContext = new ServiceContext({
-        invoke: this.wasmBindings.invoke,
+        invoke: this.invokeWithRuntimePermissions,
         fetch: this._serviceContext.fetch,
         hosts: this._serviceContext.hosts,
       });
@@ -1809,8 +2062,9 @@ export class TinyCloudNode {
    * Issue a delegation using the capability-chain flow.
    *
    * When every requested permission is a subset of the current
-   * session's recap, the delegation is signed by the session key via
-   * WASM — no wallet prompt. When at least one is NOT derivable, a
+   * session's recap, or of one installed runtime permission delegation,
+   * the delegation is signed by the session key via WASM — no wallet
+   * prompt. When at least one is NOT derivable, a
    * {@link PermissionNotInManifestError} is raised (carrying the
    * missing entries) so the caller can trigger an escalation flow
    * (e.g. `TinyCloudWeb.requestPermissions`). Passing
@@ -1933,6 +2187,26 @@ export class TinyCloudNode {
     const { subset, missing } = isCapabilitySubset(expandedEntries, granted);
 
     if (!subset) {
+      const runtimeGrant = this.findGrantForOperations(
+        this.permissionEntriesToOperations(expandedEntries, session),
+      );
+      if (runtimeGrant) {
+        const marginMs = TinyCloudNode.SESSION_EXPIRY_SAFETY_MARGIN_MS;
+        if (runtimeGrant.expiresAt.getTime() <= Date.now() + marginMs) {
+          throw new SessionExpiredError(runtimeGrant.expiresAt);
+        }
+        const runtimeExpiration =
+          runtimeGrant.expiresAt < effectiveExpiration
+            ? runtimeGrant.expiresAt
+            : effectiveExpiration;
+        const delegation = await this.createDelegationViaRuntimeGrant(
+          did,
+          expandedEntries,
+          runtimeExpiration,
+          runtimeGrant,
+        );
+        return { delegation, prompted: false };
+      }
       throw new PermissionNotInManifestError(missing, granted);
     }
 
@@ -2134,6 +2408,49 @@ export class TinyCloudNode {
     };
   }
 
+  private async createDelegationViaRuntimeGrant(
+    did: string,
+    entries: PermissionEntry[],
+    expirationTime: Date,
+    grant: RuntimePermissionGrant,
+  ): Promise<PortableDelegation> {
+    const result = this.createDelegationWrapper({
+      session: grant.session,
+      delegateDID: did,
+      spaceId: grant.session.spaceId,
+      abilities: this.permissionsToAbilities(entries),
+      expirationSecs: Math.floor(expirationTime.getTime() / 1000),
+    });
+
+    const primary = result.resources[0];
+    const delegationHeader = { Authorization: result.delegation };
+    const targetHost = grant.delegation.host ?? this.config.host!;
+    const activateResult = await activateSessionWithHost(
+      targetHost,
+      delegationHeader,
+    );
+    if (!activateResult.success) {
+      throw new Error(
+        `Failed to activate delegation with host: ${activateResult.error}`,
+      );
+    }
+
+    return {
+      cid: result.cid,
+      delegationHeader,
+      spaceId: grant.session.spaceId,
+      path: primary.path,
+      actions: primary.actions,
+      resources: result.resources,
+      disableSubDelegation: false,
+      expiry: result.expiry,
+      delegateDID: did,
+      ownerAddress: grant.delegation.ownerAddress,
+      chainId: grant.delegation.chainId,
+      host: targetHost,
+    };
+  }
+
   private resolvePermissionSpace(
     space: string | undefined,
     session: TinyCloudSession,
@@ -2152,6 +2469,298 @@ export class TinyCloudNode {
       return space;
     }
     return this.wasmBindings.makeSpaceId(session.address, session.chainId, space);
+  }
+
+  private expandPermissionEntries(
+    permissions: PermissionEntry[],
+  ): PermissionEntry[] {
+    return permissions.map((entry) => ({
+      ...entry,
+      actions: expandActionShortNames(entry.service, entry.actions),
+    }));
+  }
+
+  private shortServiceName(service: string): string {
+    const short = SERVICE_LONG_TO_SHORT[service];
+    if (short === undefined) {
+      throw new Error(
+        `unknown service '${service}' — no short-form mapping`,
+      );
+    }
+    return short;
+  }
+
+  private permissionsToAbilities(entries: PermissionEntry[]): AbilitiesMap {
+    const abilities: AbilitiesMap = {};
+    for (const entry of entries) {
+      const service = this.shortServiceName(entry.service);
+      abilities[service] ??= {};
+      const existing = abilities[service][entry.path] ?? [];
+      const seen = new Set(existing);
+      for (const action of entry.actions) {
+        if (!seen.has(action)) {
+          existing.push(action);
+          seen.add(action);
+        }
+      }
+      abilities[service][entry.path] = existing;
+    }
+    return abilities;
+  }
+
+  private permissionOperations(
+    entries: PermissionEntry[],
+    spaceId: string,
+  ): RuntimePermissionOperation[] {
+    return entries.flatMap((entry) => {
+      const service = this.shortServiceName(entry.service);
+      return entry.actions.map((action) => ({
+        spaceId,
+        service,
+        path: entry.path,
+        action,
+      }));
+    });
+  }
+
+  private sessionCoversPermissionEntries(
+    session: TinyCloudSession,
+    entries: PermissionEntry[],
+  ): boolean {
+    try {
+      const granted = parseRecapCapabilities(
+        (siwe: string) => this.wasmBindings.parseRecapFromSiwe(siwe),
+        session.siwe,
+      );
+      return isCapabilitySubset(entries, granted).subset;
+    } catch {
+      return false;
+    }
+  }
+
+  private permissionEntriesToOperations(
+    entries: PermissionEntry[],
+    session: TinyCloudSession,
+  ): RuntimePermissionOperation[] {
+    return entries.flatMap((entry) => {
+      const spaceId = this.resolvePermissionSpace(entry.space, session);
+      const service = this.shortServiceName(entry.service);
+      return entry.actions.map((action) => ({
+        spaceId,
+        service,
+        path: entry.path,
+        action,
+      }));
+    });
+  }
+
+  private findRuntimeGrantsForPermissionEntries(
+    entries: PermissionEntry[],
+    session: TinyCloudSession,
+  ): RuntimePermissionGrant[] {
+    const grants: RuntimePermissionGrant[] = [];
+    const operations = this.permissionEntriesToOperations(entries, session);
+    if (operations.length === 0) {
+      return grants;
+    }
+
+    for (const operation of operations) {
+      const grant = this.findGrantForOperation(operation);
+      if (!grant) {
+        return [];
+      }
+      if (!grants.includes(grant)) {
+        grants.push(grant);
+      }
+    }
+    return grants;
+  }
+
+  private runtimeDelegationFromSession(
+    delegatedSession: {
+      delegationHeader: { Authorization: string };
+      delegationCid: string;
+    },
+    entries: PermissionEntry[],
+    spaceId: string,
+    session: TinyCloudSession,
+    expiresAt: Date,
+  ): PortableDelegation {
+    const resources = this.delegatedResourcesForEntries(entries, spaceId);
+    const primary = resources[0];
+    return {
+      cid: delegatedSession.delegationCid,
+      delegationHeader: delegatedSession.delegationHeader,
+      spaceId,
+      path: primary.path,
+      actions: primary.actions,
+      resources,
+      disableSubDelegation: false,
+      expiry: expiresAt,
+      delegateDID: session.verificationMethod,
+      ownerAddress: session.address,
+      chainId: session.chainId,
+      host: this.config.host,
+    };
+  }
+
+  private runtimeGrantFromDelegation(
+    delegation: PortableDelegation,
+    session: TinyCloudSession,
+  ): RuntimePermissionGrant {
+    const operations = this.operationsFromDelegation(delegation);
+    return {
+      session: {
+        delegationHeader: delegation.delegationHeader,
+        delegationCid: delegation.cid,
+        spaceId: delegation.spaceId,
+        verificationMethod: session.verificationMethod,
+        jwk: session.jwk,
+      },
+      delegation,
+      operations,
+      expiresAt: delegation.expiry,
+    };
+  }
+
+  private delegatedResourcesForEntries(
+    entries: PermissionEntry[],
+    spaceId: string,
+  ): DelegatedResource[] {
+    return entries.map((entry) => ({
+      service: this.shortServiceName(entry.service),
+      space: spaceId,
+      path: entry.path,
+      actions: [...entry.actions],
+    }));
+  }
+
+  private operationsFromDelegation(
+    delegation: PortableDelegation,
+  ): RuntimePermissionOperation[] {
+    const resources =
+      delegation.resources !== undefined && delegation.resources.length > 0
+        ? delegation.resources
+        : this.flatDelegationResources(delegation);
+
+    return resources.flatMap((resource) =>
+      resource.actions.map((action) => ({
+        spaceId: resource.space,
+        service: this.invocationServiceName(resource.service),
+        path: resource.path,
+        action,
+      })),
+    );
+  }
+
+  private flatDelegationResources(
+    delegation: PortableDelegation,
+  ): DelegatedResource[] {
+    const byService = new Map<string, string[]>();
+    for (const action of delegation.actions) {
+      const service = this.shortServiceName(action.split("/")[0]);
+      const actions = byService.get(service) ?? [];
+      actions.push(action);
+      byService.set(service, actions);
+    }
+    return [...byService.entries()].map(([service, actions]) => ({
+      service,
+      space: delegation.spaceId,
+      path: delegation.path,
+      actions,
+    }));
+  }
+
+  private selectInvocationSession(
+    fallback: ServiceSession,
+    service: string,
+    path: string,
+    action: string,
+  ): ServiceSession {
+    const grant = this.findGrantForOperation({
+      spaceId: fallback.spaceId,
+      service: this.invocationServiceName(service),
+      path,
+      action,
+    });
+    return grant?.session ?? fallback;
+  }
+
+  private findGrantForOperations(
+    operations: RuntimePermissionOperation[],
+  ): RuntimePermissionGrant | undefined {
+    if (operations.length === 0) {
+      return undefined;
+    }
+    this.pruneExpiredRuntimePermissionGrants();
+    return this.runtimePermissionGrants.find((grant) => {
+      return operations.every((operation) =>
+        grant.operations.some((granted) =>
+          this.operationCovers(granted, operation),
+        ),
+      );
+    });
+  }
+
+  private findGrantForOperation(
+    operation: RuntimePermissionOperation,
+  ): RuntimePermissionGrant | undefined {
+    return this.findGrantForOperations([operation]);
+  }
+
+  private pruneExpiredRuntimePermissionGrants(): void {
+    const now = Date.now();
+    this.runtimePermissionGrants = this.runtimePermissionGrants.filter(
+      (grant) => grant.expiresAt.getTime() > now,
+    );
+  }
+
+  private operationCovers(
+    granted: RuntimePermissionOperation,
+    requested: RuntimePermissionOperation,
+  ): boolean {
+    return granted.spaceId === requested.spaceId &&
+      granted.service === requested.service &&
+      this.actionContains(granted.action, requested.action) &&
+      this.pathContains(granted.path, requested.path);
+  }
+
+  private actionContains(grantedAction: string, requestedAction: string): boolean {
+    if (grantedAction === requestedAction) {
+      return true;
+    }
+    if (grantedAction.endsWith("/*")) {
+      const prefix = grantedAction.slice(0, -2);
+      return requestedAction.startsWith(`${prefix}/`);
+    }
+    return false;
+  }
+
+  private invocationServiceName(service: string): string {
+    return service.startsWith("tinycloud.")
+      ? this.shortServiceName(service)
+      : service;
+  }
+
+  private pathContains(grantedPath: string, requestedPath: string): boolean {
+    if (grantedPath === "" || grantedPath === "/") {
+      return true;
+    }
+    if (grantedPath.endsWith("/**")) {
+      return requestedPath.startsWith(grantedPath.slice(0, -3));
+    }
+    if (grantedPath.endsWith("/*")) {
+      const prefix = grantedPath.slice(0, -2);
+      if (!requestedPath.startsWith(prefix)) {
+        return false;
+      }
+      const remainder = requestedPath.slice(prefix.length);
+      return !remainder.includes("/") || remainder === "/";
+    }
+    if (grantedPath.endsWith("/")) {
+      return requestedPath.startsWith(grantedPath);
+    }
+    return grantedPath === requestedPath;
   }
 
   /**

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -70,9 +70,10 @@ export type {
 // High-level API
 export {
   TinyCloudNode,
-  TinyCloudNodeConfig,
+  type TinyCloudNodeConfig,
   type DelegateToOptions,
   type DelegateToResult,
+  type RuntimePermissionGrantOptions,
 } from "./TinyCloudNode";
 
 // Capability-chain primitives (spec: .claude/specs/capability-chain.md).
@@ -111,10 +112,10 @@ export {
 // Delegation
 export { DelegatedAccess } from "./DelegatedAccess";
 export {
-  PortableDelegation,
   serializeDelegation,
   deserializeDelegation,
 } from "./delegation";
+export type { PortableDelegation } from "./delegation";
 
 // Re-export KV service values
 export { KVService, PrefixedKVService } from "@tinycloud/sdk-core";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -97,9 +97,10 @@ export type {
 // High-level API
 export {
   TinyCloudNode,
-  TinyCloudNodeConfig,
+  type TinyCloudNodeConfig,
   type DelegateToOptions,
   type DelegateToResult,
+  type RuntimePermissionGrantOptions,
 } from "./TinyCloudNode";
 
 // Capability-chain primitives (spec: .claude/specs/capability-chain.md).
@@ -139,10 +140,10 @@ export { NodeWasmBindings } from "./NodeWasmBindings";
 export { DelegatedAccess } from "./DelegatedAccess";
 export type { RestorableSession } from "./DelegatedAccess";
 export {
-  PortableDelegation,
   serializeDelegation,
   deserializeDelegation,
 } from "./delegation";
+export type { PortableDelegation } from "./delegation";
 
 // Re-export KV service values
 export { KVService, PrefixedKVService } from "@tinycloud/sdk-core";

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -186,18 +186,19 @@ export { createKVService } from './modules/Storage/tinycloud/KVServiceAdapter';
 
 // Delegation Transport Types (re-exported from node-sdk for compatibility)
 export {
-  PortableDelegation,
   DelegatedAccess,
   serializeDelegation,
   deserializeDelegation,
 } from '@tinycloud/node-sdk/core';
+export type { PortableDelegation } from '@tinycloud/node-sdk/core';
 
 // TinyCloudNode re-export (for advanced usage)
 export {
   TinyCloudNode,
-  TinyCloudNodeConfig,
+  type TinyCloudNodeConfig,
   type DelegateToOptions,
   type DelegateToResult,
+  type RuntimePermissionGrantOptions,
 } from '@tinycloud/node-sdk/core';
 
 // Capability-chain delegation types and errors (spec: .claude/specs/capability-chain.md)

--- a/packages/web-sdk/src/modules/WebSecretsService.ts
+++ b/packages/web-sdk/src/modules/WebSecretsService.ts
@@ -12,7 +12,7 @@ import type { VaultError } from "@tinycloud/sdk-core";
 
 type RequestPermissions = (
   additional: PermissionEntry[],
-) => Promise<{ approved: boolean }>;
+) => Promise<{ approved: boolean; delegations?: readonly unknown[] }>;
 
 const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
 const SECRET_PREFIX = "secrets/";
@@ -76,6 +76,7 @@ export interface WebSecretsServiceConfig {
   getService: () => ISecretsService;
   getManifest: () => Manifest | Manifest[] | undefined;
   requestPermissions: RequestPermissions;
+  getUnlockSigner?: () => unknown;
 }
 
 export class WebSecretsService implements ISecretsService {
@@ -93,10 +94,11 @@ export class WebSecretsService implements ISecretsService {
   }
 
   async unlock(signer?: unknown): Promise<Result<void, VaultError>> {
-    if (signer !== undefined) {
-      this.unlockSigner = signer;
+    const effectiveSigner = signer ?? this.config.getUnlockSigner?.();
+    if (effectiveSigner !== undefined) {
+      this.unlockSigner = effectiveSigner;
     }
-    const result = await this.service.unlock(signer);
+    const result = await this.service.unlock(effectiveSigner);
     if (result.ok) {
       this.shouldRestoreUnlock = true;
     }

--- a/packages/web-sdk/src/modules/requestPermissionsCore.ts
+++ b/packages/web-sdk/src/modules/requestPermissionsCore.ts
@@ -2,7 +2,7 @@
  * Pure core of the `TinyCloudWeb.requestPermissions` escalation flow.
  *
  * Exposed as a standalone function so unit tests can exercise the
- * control flow (validation → modal → compose → signOut → signIn) without
+ * control flow (validation → modal → grant) without
  * instantiating the full `TinyCloudWeb` class (which wants a real WASM
  * binding and browser wallet signer).
  *
@@ -11,11 +11,8 @@
  * @packageDocumentation
  */
 
-import type {
-  ClientSession,
-  Manifest,
-  PermissionEntry,
-} from "@tinycloud/sdk-core";
+import type { Manifest, PermissionEntry } from "@tinycloud/sdk-core";
+import type { PortableDelegation } from "@tinycloud/node-sdk/core";
 
 export interface RequestPermissionsCoreDeps {
   /** Current stored manifest. Must be defined — caller validates first. */
@@ -30,26 +27,15 @@ export interface RequestPermissionsCoreDeps {
     appIcon?: string;
     additional: PermissionEntry[];
   }) => Promise<{ approved: boolean }>;
-  /**
-   * Tear down the SDK-side session state. Wallet stays connected.
-   */
-  signOut: () => Promise<void>;
-  /**
-   * Run a fresh sign-in with the composed manifest already stored on
-   * the caller. Returns the new client session on success.
-   */
-  signIn: () => Promise<ClientSession>;
-  /**
-   * Write-through hook so the caller can update its stored manifest
-   * before the new sign-in runs. Called once, with the composed manifest,
-   * only on the approve path.
-   */
-  writeManifest: (next: Manifest) => void;
+  /** Store approved permissions as runtime delegations. */
+  grantPermissions: (
+    additional: PermissionEntry[],
+  ) => Promise<readonly PortableDelegation[] | void>;
 }
 
 export interface RequestPermissionsCoreResult {
   approved: boolean;
-  session?: ClientSession;
+  delegations?: readonly PortableDelegation[];
 }
 
 /**
@@ -87,18 +73,9 @@ export async function requestPermissionsCore(
     return { approved: false };
   }
 
-  // Union existing permissions with the newly-approved entries. We don't
-  // deduplicate — downstream `resolveManifest` merges entries
-  // deterministically and the server builds a single recap from the
-  // resolved list.
-  const composedManifest: Manifest = {
-    ...deps.manifest,
-    permissions: [...(deps.manifest.permissions ?? []), ...additional],
-  };
-  deps.writeManifest(composedManifest);
+  const delegations = await deps.grantPermissions(additional);
 
-  await deps.signOut();
-  const session = await deps.signIn();
-
-  return { approved: true, session };
+  return Array.isArray(delegations)
+    ? { approved: true, delegations }
+    : { approved: true };
 }

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -122,11 +122,9 @@ export interface Config extends ClientConfig {
    * the session-key UCAN path (no wallet prompt).
    *
    * When provided, {@link TinyCloudWeb.requestPermissions} uses the
-   * manifest's `name` and `icon` to title the permission modal and
-   * composes escalation requests against the manifest's existing
-   * permission set. The manifest is forwarded into the underlying
-   * {@link TinyCloudNode} so `signIn()` drives its SIWE recap from
-   * it directly.
+   * manifest's `name` and `icon` to title the permission modal. The
+   * manifest is forwarded into the underlying {@link TinyCloudNode}
+   * so `signIn()` drives its SIWE recap from it directly.
    */
   manifest?: Manifest | Manifest[];
   /** Pre-composed manifest request. Takes precedence over `manifest`. */
@@ -136,13 +134,14 @@ export interface Config extends ClientConfig {
 }
 
 /**
- * Result of {@link TinyCloudWeb.requestPermissions}. Populated with the
- * fresh session on approve; empty on decline so callers can branch on
- * `approved` without dereferencing a stale session.
+ * Result of {@link TinyCloudWeb.requestPermissions}. On approve, `session`
+ * is the current session that received the runtime permission delegation.
+ * On decline, `session` is omitted so callers can branch on `approved`.
  */
 export interface RequestPermissionsResult {
   approved: boolean;
   session?: ClientSession;
+  delegations?: readonly PortableDelegation[];
 }
 
 // Share Link Utilities (static, no auth required)
@@ -225,12 +224,11 @@ export class TinyCloudWeb {
   /**
    * App manifest stored from config (or updated via `setManifest`).
    *
-   * `requestPermissions` reads this for the modal title/icon and for
-   * composing an expanded manifest on approve. `_init` forwards this
-   * value into the underlying {@link TinyCloudNode} so `signIn()`
-   * drives its SIWE recap from the manifest. `setManifest` mirrors
-   * any post-construction updates onto the node so the next sign-in
-   * picks them up.
+   * `requestPermissions` reads this for the modal title/icon. `_init`
+   * forwards this value into the underlying {@link TinyCloudNode} so
+   * `signIn()` drives its SIWE recap from the manifest. `setManifest`
+   * mirrors any post-construction updates onto the node so the next
+   * sign-in picks them up.
    */
   private _manifest?: Manifest | Manifest[];
   private _capabilityRequest?: ComposedManifestRequest;
@@ -249,8 +247,10 @@ export class TinyCloudWeb {
       appIcon?: string;
       additional: PermissionEntry[];
     }) => Promise<{ approved: boolean }>;
-    signIn?: () => Promise<ClientSession>;
-    signOut?: () => Promise<void>;
+    hasRuntimePermissions?: (additional: PermissionEntry[]) => boolean;
+    grantPermissions?: (
+      additional: PermissionEntry[],
+    ) => Promise<readonly PortableDelegation[] | void>;
   };
 
   constructor(config: Config = {}) {
@@ -369,6 +369,7 @@ export class TinyCloudWeb {
         getService: () => this.node.secrets,
         getManifest: () => this._manifest,
         requestPermissions: (additional) => this.requestPermissions(additional),
+        getUnlockSigner: () => this.walletSigner,
       });
     }
     return this._secrets;
@@ -548,18 +549,15 @@ export class TinyCloudWeb {
 
   /**
    * Request additional permissions on top of the currently-signed
-   * session. Shows a confirmation modal; on approve, signs out the
-   * current session (without disconnecting the wallet) and runs a fresh
-   * `signIn` with the composed manifest. On decline, returns
-   * `{ approved: false }` with no state changes.
+   * session. Shows a confirmation modal; on approve, stores a narrow
+   * runtime delegation that matching service calls can use. On decline,
+   * returns `{ approved: false }` with no state changes.
    *
    * Spec: `.claude/specs/capability-chain.md` §requestPermissions.
    *
-   * On approve, this composes the expanded manifest, signs out the
-   * current session, and calls `signIn()` — which now drives its
-   * SIWE recap from `this._manifest` directly, so the fresh session
-   * is signed with the expanded capability set in a single wallet
-   * prompt.
+   * On approve, this does not mutate the manifest or force a new sign-in.
+   * The underlying node creates a secondary delegation to the current
+   * session key and records it in the invocation permission map.
    */
   async requestPermissions(
     additional: PermissionEntry[],
@@ -572,35 +570,52 @@ export class TinyCloudWeb {
     const manifest = Array.isArray(this._manifest)
       ? this._manifest[0]
       : this._manifest;
-    // Escalation requires a stored manifest because we need to
-    // compose the expanded permission set from the current app's
-    // declared permissions. Apps that signed in without a manifest
-    // must set one via `setManifest` before escalating.
+    // Escalation requires a stored manifest so the confirmation modal can
+    // identify the app asking for additional permissions. Apps that signed
+    // in without a manifest must set one via `setManifest` before escalating.
     if (manifest === undefined) {
       throw new Error(
         "requestPermissions requires a stored manifest. Pass `manifest` in the TinyCloudWeb config or call setManifest() before requesting escalation.",
       );
     }
 
-    // Delegate to the pure core with injected dependencies. Test hooks
-    // override any or all of them; production defaults wire to the real
-    // modal manager and the class's own signOut/signIn methods.
-    //
-    // `writeManifest` mirrors the updated manifest onto BOTH `_manifest`
-    // and the underlying node so the subsequent `signIn()` call picks
-    // it up automatically. Updating only `_manifest` would leave the
-    // node still configured with the pre-escalation manifest, and the
-    // new sign-in would grant the old capability set.
-    return requestPermissionsCore(additional, {
+    const node = await this.ensureNode();
+    const hasRuntimePermissions =
+      this._testHooks?.hasRuntimePermissions ?? ((requested) =>
+        node.hasRuntimePermissions(requested));
+    if (hasRuntimePermissions(additional)) {
+      const delegations = node.getRuntimePermissionDelegations(additional);
+      return delegations.length > 0
+        ? { approved: true, session: this.session(), delegations }
+        : { approved: true, session: this.session() };
+    }
+
+    const result = await requestPermissionsCore(additional, {
       manifest,
       showModal: this._testHooks?.showModal ?? showPermissionRequestModal,
-      signOut: this._testHooks?.signOut ?? (() => this.signOut()),
-      signIn: this._testHooks?.signIn ?? (() => this.signIn()),
-      writeManifest: (next) => {
-        this._manifest = next;
-        this._node?.setManifest(next);
-      },
+      grantPermissions: this._testHooks?.grantPermissions ??
+        ((approved) => node.grantRuntimePermissions(approved)),
     });
+    return result.approved
+      ? {
+          approved: true,
+          session: this.session(),
+          ...(result.delegations !== undefined
+            ? { delegations: result.delegations }
+            : {}),
+        }
+      : result;
+  }
+
+  getRuntimePermissionDelegations(
+    permissions?: PermissionEntry[],
+  ): readonly PortableDelegation[] {
+    return this.node.getRuntimePermissionDelegations(permissions);
+  }
+
+  async useRuntimeDelegation(delegation: PortableDelegation): Promise<void> {
+    const node = await this.ensureNode();
+    await node.useRuntimeDelegation(delegation);
   }
 
   async useDelegation(delegation: PortableDelegation): Promise<DelegatedAccess> {

--- a/packages/web-sdk/src/notifications/PermissionRequestModal.ts
+++ b/packages/web-sdk/src/notifications/PermissionRequestModal.ts
@@ -3,9 +3,8 @@
  *
  * Web Component that shows the user a list of additional capabilities an
  * app wants to request on top of the currently-signed session. Used by
- * `TinyCloudWeb.requestPermissions` as the confirmation step before we
- * tear down the current session and run a fresh signIn with an expanded
- * manifest.
+ * `TinyCloudWeb.requestPermissions` as the confirmation step before the
+ * SDK installs a scoped runtime permission delegation.
  *
  * Matches the `SpaceCreationModal` pattern: a Web Component with a shadow
  * DOM, returning a completion promise via `getCompletionPromise()`. The
@@ -97,7 +96,7 @@ export class TinyCloudPermissionRequestModal extends HTMLElement {
 
             <div class="modal-body">
               <p class="modal-description">
-                Approving will sign you out of your current session and start a new one with the expanded permissions.
+                Approving adds a scoped runtime permission for this session. You will stay signed in.
               </p>
               <ul class="permission-list">${entriesHtml}</ul>
             </div>

--- a/packages/web-sdk/tests/WebSecretsService.test.ts
+++ b/packages/web-sdk/tests/WebSecretsService.test.ts
@@ -126,6 +126,22 @@ describe("WebSecretsService", () => {
     expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
   });
 
+  it("uses the configured signer when unlock is called without one", async () => {
+    const base = makeBaseSecrets();
+    const signer = { signMessage: async () => "0xsig" };
+    const secrets = new WebSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      requestPermissions: async () => ({ approved: true }),
+      getUnlockSigner: () => signer,
+    });
+
+    const result = await secrets.unlock();
+
+    expect(result.ok).toBe(true);
+    expect(base.unlock).toHaveBeenCalledWith(signer);
+  });
+
   it("returns a permission error when delete escalation is declined", async () => {
     const base = makeBaseSecrets();
     const secrets = new WebSecretsService({

--- a/packages/web-sdk/tests/requestPermissionsCore.test.ts
+++ b/packages/web-sdk/tests/requestPermissionsCore.test.ts
@@ -8,11 +8,7 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
-import type {
-  ClientSession,
-  Manifest,
-  PermissionEntry,
-} from "@tinycloud/sdk-core";
+import type { Manifest, PermissionEntry } from "@tinycloud/sdk-core";
 
 import {
   requestPermissionsCore,
@@ -46,17 +42,6 @@ const additional: PermissionEntry[] = [
   },
 ];
 
-function fakeSession(): ClientSession {
-  return {
-    address: "0x0000000000000000000000000000000000000001",
-    walletAddress: "0x0000000000000000000000000000000000000001",
-    chainId: 1,
-    sessionKey: "default",
-    siwe: "fake-siwe",
-    signature: "0xfake",
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
@@ -83,25 +68,19 @@ describe("validateAdditionalPermissions", () => {
 // ---------------------------------------------------------------------------
 
 describe("requestPermissionsCore: decline", () => {
-  test("returns { approved: false } and does not sign out / sign in", async () => {
+  test("returns { approved: false } and does not grant permissions", async () => {
     const showModal = mock(() => Promise.resolve({ approved: false }));
-    const signOut = mock(() => Promise.resolve());
-    const signIn = mock(() => Promise.resolve(fakeSession()));
-    const writeManifest = mock(() => {});
+    const grantPermissions = mock(() => Promise.resolve());
 
     const result = await requestPermissionsCore(additional, {
       manifest: baseManifest,
       showModal: showModal as any,
-      signOut,
-      signIn,
-      writeManifest,
+      grantPermissions,
     });
 
     expect(result).toEqual({ approved: false });
     expect(showModal).toHaveBeenCalledTimes(1);
-    expect(signOut).not.toHaveBeenCalled();
-    expect(signIn).not.toHaveBeenCalled();
-    expect(writeManifest).not.toHaveBeenCalled();
+    expect(grantPermissions).not.toHaveBeenCalled();
   });
 
   test("passes the manifest name + icon + additional to the modal", async () => {
@@ -114,9 +93,7 @@ describe("requestPermissionsCore: decline", () => {
     await requestPermissionsCore(additional, {
       manifest: baseManifest,
       showModal: showModal as any,
-      signOut: async () => {},
-      signIn: async () => fakeSession(),
-      writeManifest: () => {},
+      grantPermissions: async () => {},
     });
 
     expect(seenOpts.appName).toBe("Test App");
@@ -130,10 +107,9 @@ describe("requestPermissionsCore: decline", () => {
 // ---------------------------------------------------------------------------
 
 describe("requestPermissionsCore: approve", () => {
-  test("composes expanded manifest, signs out, signs in, returns session", async () => {
+  test("stores approved runtime permissions", async () => {
     const order: string[] = [];
-    const newSession = fakeSession();
-    let writtenManifest: Manifest | undefined;
+    let granted: PermissionEntry[] | undefined;
 
     const result = await requestPermissionsCore(additional, {
       manifest: baseManifest,
@@ -141,67 +117,58 @@ describe("requestPermissionsCore: approve", () => {
         order.push("modal");
         return { approved: true };
       },
-      signOut: async () => {
-        order.push("signOut");
-      },
-      signIn: async () => {
-        order.push("signIn");
-        return newSession;
-      },
-      writeManifest: (next) => {
-        order.push("writeManifest");
-        writtenManifest = next;
+      grantPermissions: async (next) => {
+        order.push("grantPermissions");
+        granted = next;
       },
     });
 
-    expect(result).toEqual({ approved: true, session: newSession });
-
-    // Order: modal → writeManifest → signOut → signIn. writeManifest
-    // must come before signOut so a Phase 5 signIn refactor that reads
-    // `_manifest` at the start of signIn sees the composed manifest.
-    expect(order).toEqual(["modal", "writeManifest", "signOut", "signIn"]);
-
-    // Composed manifest contains the original + additional entries.
-    expect(writtenManifest?.permissions).toEqual([
-      ...(baseManifest.permissions ?? []),
-      ...additional,
-    ]);
-    // Other manifest fields pass through unchanged.
-    expect(writtenManifest?.app_id).toBe(baseManifest.app_id);
-    expect(writtenManifest?.name).toBe(baseManifest.name);
+    expect(result).toEqual({ approved: true });
+    expect(order).toEqual(["modal", "grantPermissions"]);
+    expect(granted).toEqual(additional);
   });
 
-  test("handles a manifest with no pre-existing permissions array", async () => {
+  test("returns runtime delegations from the grant step", async () => {
+    const delegation = { cid: "runtime-cid" } as any;
+
+    const result = await requestPermissionsCore(additional, {
+      manifest: baseManifest,
+      showModal: async () => ({ approved: true }),
+      grantPermissions: async () => [delegation],
+    });
+
+    expect(result).toEqual({
+      approved: true,
+      delegations: [delegation],
+    });
+  });
+
+  test("does not mutate a manifest with no pre-existing permissions array", async () => {
     const manifestNoPerms: Manifest = {
       app_id: "com.test.app",
       name: "Test",
     };
-    let written: Manifest | undefined;
+    const grantPermissions = mock(async () => {});
 
     await requestPermissionsCore(additional, {
       manifest: manifestNoPerms,
       showModal: async () => ({ approved: true }),
-      signOut: async () => {},
-      signIn: async () => fakeSession(),
-      writeManifest: (next) => {
-        written = next;
-      },
+      grantPermissions,
     });
 
-    expect(written?.permissions).toEqual(additional);
+    expect(manifestNoPerms.permissions).toBeUndefined();
+    expect(grantPermissions).toHaveBeenCalledWith(additional);
   });
 
-  test("propagates signIn errors without swallowing", async () => {
-    const err = new Error("signIn failed");
+  test("propagates grant errors without swallowing", async () => {
+    const err = new Error("grant failed");
     await expect(
       requestPermissionsCore(additional, {
         manifest: baseManifest,
         showModal: async () => ({ approved: true }),
-        signOut: async () => {},
-        signIn: async () => {
+        grantPermissions: async () => {
           throw err;
         },
-        writeManifest: () => {},
       }),
     ).rejects.toBe(err);
   });
@@ -218,9 +185,7 @@ describe("requestPermissionsCore: validation", () => {
       requestPermissionsCore([], {
         manifest: baseManifest,
         showModal: showModal as any,
-        signOut: async () => {},
-        signIn: async () => fakeSession(),
-        writeManifest: () => {},
+        grantPermissions: async () => {},
       }),
     ).rejects.toThrow(/non-empty/);
     expect(showModal).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- store approved runtime permissions as narrow portable delegations instead of expanding the manifest and re-signing the session
- let matching invocations and delegateTo() use installed runtime delegations as authority
- return runtime delegations from web requestPermissions(), add install/get APIs, and update the permission modal copy
- let secrets unlock use the SDK-connected signer by default

## Validation
- bun test packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts packages/node-sdk/src/NodeSecretsService.test.ts packages/web-sdk/tests/requestPermissionsCore.test.ts packages/web-sdk/tests/WebSecretsService.test.ts
- bun test packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts packages/node-sdk/src/NodeSecretsService.test.ts packages/web-sdk/tests/requestPermissionsCore.test.ts packages/web-sdk/tests/WebSecretsService.test.ts packages/sdk-core/src/manifest.test.ts packages/sdk-core/src/spaces/Space.test.ts packages/sdk-core/src/spaces/spaces.schema.test.ts packages/sdk-services/src/secrets/SecretsService.test.ts packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
- bun run --cwd packages/node-sdk build
- bun run --cwd packages/web-sdk build (passes with existing bundle-size warnings)
- git diff --check