### PR TITLE
feat: add vault permission shorthand

### DIFF
--- a/.changeset/vault-permission-shorthand.md
+++ b/.changeset/vault-permission-shorthand.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+---
+
+Add `tinycloud.vault` as an SDK permission shorthand that expands to the backing KV permissions used by encrypted vault operations, including runtime permission escalation.

--- a/packages/node-sdk/src/NodeSecretsService.test.ts
+++ b/packages/node-sdk/src/NodeSecretsService.test.ts
@@ -64,17 +64,10 @@ describe("NodeSecretsService", () => {
     expect(result.ok).toBe(true);
     expect(grantPermissions).toHaveBeenCalledWith([
       {
-        service: "tinycloud.kv",
+        service: "tinycloud.vault",
         space: "secrets",
-        path: "keys/secrets/ANTHROPIC_API_KEY",
-        actions: ["put"],
-        skipPrefix: true,
-      },
-      {
-        service: "tinycloud.kv",
-        space: "secrets",
-        path: "vault/secrets/ANTHROPIC_API_KEY",
-        actions: ["put"],
+        path: "secrets/ANTHROPIC_API_KEY",
+        actions: ["write"],
         skipPrefix: true,
       },
     ] satisfies PermissionEntry[]);
@@ -156,7 +149,7 @@ describe("NodeSecretsService", () => {
         code: ErrorCodes.PERMISSION_DENIED,
         service: "secrets",
         message:
-          "Cannot autosign tinycloud.kv/put for ANTHROPIC_API_KEY; TinyCloudNode needs wallet mode with a signer or privateKey.",
+          "Cannot autosign tinycloud.vault/write for ANTHROPIC_API_KEY; TinyCloudNode needs wallet mode with a signer or privateKey.",
       },
     });
     expect(base.put).not.toHaveBeenCalled();

--- a/packages/node-sdk/src/NodeSecretsService.ts
+++ b/packages/node-sdk/src/NodeSecretsService.ts
@@ -34,12 +34,12 @@ function secretsError(
   };
 }
 
-function actionUrn(action: "put" | "del"): string {
-  return `tinycloud.kv/${action}`;
+function displayActionUrn(action: "put" | "del"): string {
+  return action === "put" ? "tinycloud.vault/write" : "tinycloud.vault/delete";
 }
 
-function secretResourcePath(base: "keys" | "vault", name: string): string {
-  return `${base}/${SECRET_PREFIX}${name}`;
+function kvActionUrn(action: "put" | "del"): string {
+  return `tinycloud.kv/${action}`;
 }
 
 function secretPermissionEntries(
@@ -48,20 +48,17 @@ function secretPermissionEntries(
 ): PermissionEntry[] {
   return [
     {
-      service: "tinycloud.kv",
+      service: "tinycloud.vault",
       space: SECRETS_SPACE,
-      path: secretResourcePath("keys", name),
-      actions: [action],
-      skipPrefix: true,
-    },
-    {
-      service: "tinycloud.kv",
-      space: SECRETS_SPACE,
-      path: secretResourcePath("vault", name),
-      actions: [action],
+      path: `${SECRET_PREFIX}${name}`,
+      actions: [action === "put" ? "write" : "delete"],
       skipPrefix: true,
     },
   ];
+}
+
+function secretResourcePath(base: "keys" | "vault", name: string): string {
+  return `${base}/${SECRET_PREFIX}${name}`;
 }
 
 function isSecretsSpace(space: string): boolean {
@@ -149,7 +146,7 @@ export class NodeSecretsService implements ISecretsService {
     if (!this.config.canEscalate()) {
       return secretsError(
         ErrorCodes.PERMISSION_DENIED,
-        `Cannot autosign ${actionUrn(action)} for ${name}; TinyCloudNode needs wallet mode with a signer or privateKey.`,
+        `Cannot autosign ${displayActionUrn(action)} for ${name}; TinyCloudNode needs wallet mode with a signer or privateKey.`,
       );
     }
 
@@ -161,7 +158,7 @@ export class NodeSecretsService implements ISecretsService {
         ErrorCodes.PERMISSION_DENIED,
         error instanceof Error
           ? error.message
-          : `Autosign escalation for ${actionUrn(action)} on ${name} failed.`,
+          : `Autosign escalation for ${displayActionUrn(action)} on ${name} failed.`,
         error instanceof Error ? error : undefined,
       );
     }
@@ -183,7 +180,7 @@ export class NodeSecretsService implements ISecretsService {
     }
 
     const manifests = Array.isArray(manifest) ? manifest : [manifest];
-    const requiredAction = actionUrn(action);
+    const requiredAction = kvActionUrn(action);
     return manifests.some((entry) => {
       const resolved = resolveManifest(entry);
       return (["keys", "vault"] as const).every((base) =>

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -188,6 +188,87 @@ describe("TinyCloudNode runtime permission delegations", () => {
     );
   });
 
+  test("expands vault shorthand before storing runtime delegation operations", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const secretsSpaceId = `tinycloud:pkh:eip155:1:${address}:secrets`;
+    const permission: PermissionEntry = {
+      service: "tinycloud.vault",
+      space: "secrets",
+      path: "secrets/ANTHROPIC_API_KEY",
+      actions: ["write"],
+    };
+
+    await withActivatedDelegations(async () => {
+      const delegations = await node.grantRuntimePermissions([permission]);
+      expect(delegations).toHaveLength(1);
+      expect(delegations[0].resources).toEqual([
+        {
+          service: "kv",
+          space: secretsSpaceId,
+          path: "keys/secrets/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/put"],
+        },
+        {
+          service: "kv",
+          space: secretsSpaceId,
+          path: "vault/secrets/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/put"],
+        },
+      ]);
+    });
+
+    expect(node.hasRuntimePermissions([permission])).toBe(true);
+    const prepareSession = (node as any).wasmBindings.prepareSession;
+    expect(prepareSession.mock.calls[0][0].abilities).toEqual({
+      kv: {
+        "keys/secrets/ANTHROPIC_API_KEY": ["tinycloud.kv/put"],
+        "vault/secrets/ANTHROPIC_API_KEY": ["tinycloud.kv/put"],
+      },
+    });
+
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: secretsSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "keys/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/put",
+    );
+    expect(invoke.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "runtime-token",
+    );
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/put",
+    );
+    expect(invoke.mock.calls[1][0].delegationHeader.Authorization).toBe(
+      "runtime-token",
+    );
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/del",
+    );
+    expect(invoke.mock.calls[2][0].delegationHeader.Authorization).toBe(
+      "base-token",
+    );
+  });
+
   test("delegateTo can derive from a stored runtime delegation", async () => {
     const invoke = mock((session: any) => ({
       Authorization: session.delegationHeader.Authorization,

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -89,7 +89,7 @@ import {
   type PermissionEntry,
   PermissionNotInManifestError,
   SessionExpiredError,
-  expandActionShortNames,
+  expandPermissionEntries as expandPermissionEntriesCore,
   isCapabilitySubset,
   parseRecapCapabilities,
   // Manifest-driven sign-in
@@ -2128,10 +2128,7 @@ export class TinyCloudNode {
     //    for every entry so the subset check and downstream WASM call
     //    both see canonical form. This also deep-copies the entries so
     //    we don't mutate caller-owned data.
-    const expandedEntries: PermissionEntry[] = permissions.map((entry) => ({
-      ...entry,
-      actions: expandActionShortNames(entry.service, entry.actions),
-    }));
+    const expandedEntries = this.expandPermissionEntries(permissions);
 
     // 4. Compute expiration. `options.expiry` overrides the default 1h.
     //    ms-format ("7d") or raw millisecond count both accepted. Cap
@@ -2474,10 +2471,7 @@ export class TinyCloudNode {
   private expandPermissionEntries(
     permissions: PermissionEntry[],
   ): PermissionEntry[] {
-    return permissions.map((entry) => ({
-      ...entry,
-      actions: expandActionShortNames(entry.service, entry.actions),
-    }));
+    return expandPermissionEntriesCore(permissions);
   }
 
   private shortServiceName(service: string): string {

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -96,6 +96,7 @@ export {
   ACCOUNT_REGISTRY_SPACE,
   DEFAULT_MANIFEST_SPACE,
   DEFAULT_MANIFEST_VERSION,
+  VAULT_PERMISSION_SERVICE,
   PermissionNotInManifestError,
   SessionExpiredError,
   ManifestValidationError,
@@ -105,6 +106,8 @@ export {
   loadManifest,
   isCapabilitySubset,
   expandActionShortNames,
+  expandPermissionEntries,
+  expandPermissionEntry,
   parseExpiry,
   resourceCapabilitiesToSpaceAbilitiesMap,
 } from "@tinycloud/sdk-core";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -120,6 +120,7 @@ export {
   ACCOUNT_REGISTRY_SPACE,
   DEFAULT_MANIFEST_SPACE,
   DEFAULT_MANIFEST_VERSION,
+  VAULT_PERMISSION_SERVICE,
   PermissionNotInManifestError,
   SessionExpiredError,
   ManifestValidationError,
@@ -129,6 +130,8 @@ export {
   loadManifest,
   isCapabilitySubset,
   expandActionShortNames,
+  expandPermissionEntries,
+  expandPermissionEntry,
   parseExpiry,
   resourceCapabilitiesToSpaceAbilitiesMap,
 } from "@tinycloud/sdk-core";

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -319,12 +319,15 @@ export {
   DEFAULT_MANIFEST_VERSION,
   SERVICE_LONG_TO_SHORT,
   SERVICE_SHORT_TO_LONG,
+  VAULT_PERMISSION_SERVICE,
   // Types
   type AbilitiesMap,
   // Functions
   applyPrefix,
   composeManifestRequest,
   expandActionShortNames,
+  expandPermissionEntries,
+  expandPermissionEntry,
   loadManifest,
   manifestAbilitiesUnion,
   normalizeDefaults,

--- a/packages/sdk-core/src/manifest.test.ts
+++ b/packages/sdk-core/src/manifest.test.ts
@@ -13,6 +13,7 @@ import {
   applyPrefix,
   composeManifestRequest,
   expandActionShortNames,
+  expandPermissionEntries,
   normalizeDefaults,
   parseExpiry,
   resolveManifest,
@@ -72,6 +73,73 @@ describe("expandActionShortNames", () => {
     expect(expandActionShortNames("tinycloud.sql", ["read", "ddl"])).toEqual([
       "tinycloud.sql/read",
       "tinycloud.sql/ddl",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandPermissionEntries
+// ---------------------------------------------------------------------------
+
+describe("expandPermissionEntries", () => {
+  it("expands tinycloud.vault entries into backing KV permissions", () => {
+    expect(
+      expandPermissionEntries([
+        {
+          service: "tinycloud.vault",
+          space: "secrets",
+          path: "secrets/ANTHROPIC_API_KEY",
+          actions: ["read", "write", "delete"],
+        },
+      ]),
+    ).toEqual([
+      {
+        service: "tinycloud.kv",
+        space: "secrets",
+        path: "keys/secrets/ANTHROPIC_API_KEY",
+        actions: [
+          "tinycloud.kv/get",
+          "tinycloud.kv/put",
+          "tinycloud.kv/del",
+        ],
+        skipPrefix: true,
+      },
+      {
+        service: "tinycloud.kv",
+        space: "secrets",
+        path: "vault/secrets/ANTHROPIC_API_KEY",
+        actions: [
+          "tinycloud.kv/get",
+          "tinycloud.kv/put",
+          "tinycloud.kv/del",
+        ],
+        skipPrefix: true,
+      },
+    ]);
+  });
+
+  it("maps vault list/head/metadata to the encrypted value resource", () => {
+    expect(
+      expandPermissionEntries([
+        {
+          service: "tinycloud.vault",
+          space: "default",
+          path: "profiles/",
+          actions: ["list", "head", "metadata"],
+        },
+      ]),
+    ).toEqual([
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "vault/profiles/",
+        actions: [
+          "tinycloud.kv/list",
+          "tinycloud.kv/get",
+          "tinycloud.kv/metadata",
+        ],
+        skipPrefix: true,
+      },
     ]);
   });
 });
@@ -441,6 +509,78 @@ describe("resolveManifest — secrets shorthand", () => {
         },
       },
     });
+  });
+});
+
+describe("resolveManifest — vault shorthand", () => {
+  it("compiles tinycloud.vault manifest permissions into KV resources", () => {
+    const resolved = resolveManifest({
+      app_id: "com.listen.app",
+      name: "Listen",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.vault",
+          space: "secrets",
+          path: "secrets/ANTHROPIC_API_KEY",
+          actions: ["read", "write"],
+          skipPrefix: true,
+        },
+      ],
+    });
+
+    expect(resolved.resources).toEqual(
+      expect.arrayContaining([
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "keys/secrets/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+        },
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "vault/secrets/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+        },
+        {
+          service: "tinycloud.capabilities",
+          space: "secrets",
+          path: "",
+          actions: ["tinycloud.capabilities/read"],
+        },
+      ]),
+    );
+  });
+
+  it("applies the manifest prefix before expanding vault storage paths", () => {
+    const resolved = resolveManifest({
+      app_id: "com.listen.app",
+      name: "Listen",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.vault",
+          path: "profiles/current",
+          actions: ["read"],
+        },
+      ],
+    });
+
+    expect(resolved.resources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          service: "tinycloud.kv",
+          path: "keys/com.listen.app/profiles/current",
+          actions: ["tinycloud.kv/get"],
+        }),
+        expect.objectContaining({
+          service: "tinycloud.kv",
+          path: "vault/com.listen.app/profiles/current",
+          actions: ["tinycloud.kv/get"],
+        }),
+      ]),
+    );
   });
 });
 

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -26,8 +26,9 @@ import ms from "ms";
  * in their `manifest.json` and the shape we compare against when performing
  * the capability-subset derivability check in the delegation flow.
  *
- * `service` uses the long form (e.g. `"tinycloud.kv"`, `"tinycloud.sql"`)
- * which matches the ability-namespace half of the full action URN.
+ * `service` uses the long form (e.g. `"tinycloud.kv"`, `"tinycloud.sql"`).
+ * `"tinycloud.vault"` is an SDK-only shorthand that expands to the KV
+ * resources the vault service uses; it is never encoded as a recap service.
  */
 export interface PermissionEntry {
   /** Service namespace, e.g. "tinycloud.kv", "tinycloud.sql", "tinycloud.duckdb", "tinycloud.capabilities". */
@@ -251,6 +252,16 @@ export const ACCOUNT_REGISTRY_PATH = "applications/";
 const SECRETS_SPACE = "secrets";
 const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
 
+/** SDK-only permission service for encrypted vault resources. */
+export const VAULT_PERMISSION_SERVICE = "tinycloud.vault";
+
+type VaultKVBase = "keys" | "vault";
+
+interface VaultActionExpansion {
+  bases: readonly VaultKVBase[];
+  action: string;
+}
+
 /**
  * Known services and their short-form (recap URI) names. The TinyCloud
  * node encodes the recap resource URI with the short service name, while
@@ -392,6 +403,39 @@ export function expandActionShortNames(
     }
     return `${service}/${a}`;
   });
+}
+
+/**
+ * Expand SDK virtual permission services into concrete recap-capable services.
+ *
+ * Today this handles `"tinycloud.vault"`, which is backed by KV resources:
+ * - read/get: `keys/<path>` + `vault/<path>` with `tinycloud.kv/get`
+ * - write/put: `keys/<path>` + `vault/<path>` with `tinycloud.kv/put`
+ * - delete/del: `keys/<path>` + `vault/<path>` with `tinycloud.kv/del`
+ * - list: `vault/<path>` with `tinycloud.kv/list`
+ * - head: `vault/<path>` with `tinycloud.kv/get`
+ * - metadata: `vault/<path>` with `tinycloud.kv/metadata`
+ */
+export function expandPermissionEntry(entry: PermissionEntry): PermissionEntry[] {
+  if (entry.service !== VAULT_PERMISSION_SERVICE) {
+    return [
+      {
+        ...entry,
+        actions: expandActionShortNames(entry.service, entry.actions),
+      },
+    ];
+  }
+
+  return expandVaultPermissionEntry(entry);
+}
+
+/**
+ * Expand a list of permission entries using {@link expandPermissionEntry}.
+ */
+export function expandPermissionEntries(
+  entries: readonly PermissionEntry[],
+): PermissionEntry[] {
+  return entries.flatMap(expandPermissionEntry);
 }
 
 /**
@@ -571,6 +615,16 @@ function validatePermissionEntry(p: unknown, path: string): void {
       `${path}.actions must be a non-empty array`,
     );
   }
+  for (const action of entry.actions) {
+    if (typeof action !== "string" || action.length === 0) {
+      throw new ManifestValidationError(
+        `${path}.actions must contain non-empty strings`,
+      );
+    }
+    if (entry.service === VAULT_PERMISSION_SERVICE) {
+      vaultActionExpansion(action);
+    }
+  }
   if (entry.expiry !== undefined) {
     parseExpiry(entry.expiry);
   }
@@ -661,7 +715,7 @@ export function resolveManifest(input: Manifest): ResolvedCapabilities {
   ];
 
   const resources: ResourceCapability[] = withCapabilitiesReadForSpaces(
-    allEntries.map((entry) => resolveEntry(entry, prefix, expiryMs, space)),
+    allEntries.flatMap((entry) => resolveEntry(entry, prefix, expiryMs, space)),
   );
 
   const additionalDelegates: ResolvedDelegate[] =
@@ -810,20 +864,24 @@ function resolveEntry(
   prefix: string,
   _inheritedExpiryMs: number,
   inheritedSpace: string,
-): ResourceCapability {
+): ResourceCapability[] {
   const resolvedPath = applyPrefix(
     prefix,
     entry.path,
     entry.skipPrefix === true,
   );
-  const resolvedActions = expandActionShortNames(entry.service, entry.actions);
   const entryExpiryMs =
     entry.expiry !== undefined ? parseExpiry(entry.expiry) : undefined;
-  return {
-    service: entry.service,
+  return expandPermissionEntry({
+    ...entry,
     space: entry.space ?? inheritedSpace,
     path: resolvedPath,
-    actions: resolvedActions,
+    skipPrefix: true,
+  }).map((expanded) => ({
+    service: expanded.service,
+    space: expanded.space ?? inheritedSpace,
+    path: expanded.path,
+    actions: expanded.actions,
     // Only populate `expiryMs` when the entry had its own expiry override.
     // When absent, callers use the parent (delegation or manifest) expiry
     // which is carried on ResolvedDelegate.expiryMs / ResolvedCapabilities.expiryMs.
@@ -831,7 +889,76 @@ function resolveEntry(
     ...(entry.description !== undefined
       ? { description: entry.description }
       : {}),
-  };
+  }));
+}
+
+function expandVaultPermissionEntry(entry: PermissionEntry): PermissionEntry[] {
+  const byBase = new Map<VaultKVBase, string[]>();
+
+  for (const action of entry.actions) {
+    const expansion = vaultActionExpansion(action);
+    for (const base of expansion.bases) {
+      const actions = byBase.get(base) ?? [];
+      if (!actions.includes(expansion.action)) {
+        actions.push(expansion.action);
+      }
+      byBase.set(base, actions);
+    }
+  }
+
+  return [...byBase.entries()].map(([base, actions]) => ({
+    ...entry,
+    service: "tinycloud.kv",
+    path: vaultKVPath(base, entry.path),
+    actions,
+    skipPrefix: true,
+  }));
+}
+
+function vaultActionExpansion(action: string): VaultActionExpansion {
+  const normalized = normalizeVaultAction(action);
+  if (normalized === "read" || normalized === "get") {
+    return { bases: ["keys", "vault"], action: "tinycloud.kv/get" };
+  }
+  if (normalized === "write" || normalized === "put") {
+    return { bases: ["keys", "vault"], action: "tinycloud.kv/put" };
+  }
+  if (normalized === "delete" || normalized === "del") {
+    return { bases: ["keys", "vault"], action: "tinycloud.kv/del" };
+  }
+  if (normalized === "list") {
+    return { bases: ["vault"], action: "tinycloud.kv/list" };
+  }
+  if (normalized === "head") {
+    return { bases: ["vault"], action: "tinycloud.kv/get" };
+  }
+  if (normalized === "metadata") {
+    return { bases: ["vault"], action: "tinycloud.kv/metadata" };
+  }
+
+  throw new ManifestValidationError(
+    `unknown vault action ${JSON.stringify(action)}; expected read, write, delete, get, put, del, list, head, or metadata`,
+  );
+}
+
+function normalizeVaultAction(action: string): string {
+  if (action.startsWith(`${VAULT_PERMISSION_SERVICE}/`)) {
+    return action.slice(`${VAULT_PERMISSION_SERVICE}/`.length);
+  }
+  if (action.startsWith("tinycloud.kv/")) {
+    return action.slice("tinycloud.kv/".length);
+  }
+  if (action.includes("/")) {
+    throw new ManifestValidationError(
+      `unknown vault action ${JSON.stringify(action)}; expected a tinycloud.vault or tinycloud.kv action`,
+    );
+  }
+  return action;
+}
+
+function vaultKVPath(base: VaultKVBase, path: string): string {
+  const normalized = path.startsWith("/") ? path.slice(1) : path;
+  return `${base}/${normalized}`;
 }
 
 function cloneResourceCapability(

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -219,6 +219,7 @@ export {
   ACCOUNT_REGISTRY_SPACE,
   DEFAULT_MANIFEST_SPACE,
   DEFAULT_MANIFEST_VERSION,
+  VAULT_PERMISSION_SERVICE,
   // Errors raised by delegateTo / requestPermissions.
   PermissionNotInManifestError,
   SessionExpiredError,
@@ -231,6 +232,8 @@ export {
   loadManifest,
   isCapabilitySubset,
   expandActionShortNames,
+  expandPermissionEntries,
+  expandPermissionEntry,
   parseExpiry,
   resourceCapabilitiesToSpaceAbilitiesMap,
 } from '@tinycloud/sdk-core';

--- a/packages/web-sdk/src/modules/WebSecretsService.ts
+++ b/packages/web-sdk/src/modules/WebSecretsService.ts
@@ -38,12 +38,12 @@ function secretsError(
   };
 }
 
-function actionUrn(action: "put" | "del"): string {
-  return `tinycloud.kv/${action}`;
+function displayActionUrn(action: "put" | "del"): string {
+  return action === "put" ? "tinycloud.vault/write" : "tinycloud.vault/delete";
 }
 
-function secretResourcePath(base: "keys" | "vault", name: string): string {
-  return `${base}/${SECRET_PREFIX}${name}`;
+function kvActionUrn(action: "put" | "del"): string {
+  return `tinycloud.kv/${action}`;
 }
 
 function secretPermissionEntries(
@@ -52,20 +52,17 @@ function secretPermissionEntries(
 ): PermissionEntry[] {
   return [
     {
-      service: "tinycloud.kv",
+      service: "tinycloud.vault",
       space: SECRETS_SPACE,
-      path: secretResourcePath("keys", name),
-      actions: [action],
-      skipPrefix: true,
-    },
-    {
-      service: "tinycloud.kv",
-      space: SECRETS_SPACE,
-      path: secretResourcePath("vault", name),
-      actions: [action],
+      path: `${SECRET_PREFIX}${name}`,
+      actions: [action === "put" ? "write" : "delete"],
       skipPrefix: true,
     },
   ];
+}
+
+function secretResourcePath(base: "keys" | "vault", name: string): string {
+  return `${base}/${SECRET_PREFIX}${name}`;
 }
 
 function isSecretsSpace(space: string): boolean {
@@ -156,7 +153,7 @@ export class WebSecretsService implements ISecretsService {
       if (!result.approved) {
         return secretsError(
           ErrorCodes.PERMISSION_DENIED,
-          `Permission request for ${actionUrn(action)} on ${name} was declined.`,
+          `Permission request for ${displayActionUrn(action)} on ${name} was declined.`,
         );
       }
       return this.restoreUnlockAfterEscalation();
@@ -165,7 +162,7 @@ export class WebSecretsService implements ISecretsService {
         ErrorCodes.PERMISSION_DENIED,
         error instanceof Error
           ? error.message
-          : `Permission request for ${actionUrn(action)} on ${name} failed.`,
+          : `Permission request for ${displayActionUrn(action)} on ${name} failed.`,
         error instanceof Error ? error : undefined,
       );
     }
@@ -187,7 +184,7 @@ export class WebSecretsService implements ISecretsService {
     }
 
     const manifests = Array.isArray(manifest) ? manifest : [manifest];
-    const requiredAction = actionUrn(action);
+    const requiredAction = kvActionUrn(action);
     return manifests.some((entry) => {
       const resolved = resolveManifest(entry);
       return (["keys", "vault"] as const).every((base) =>

--- a/packages/web-sdk/tests/WebSecretsService.test.ts
+++ b/packages/web-sdk/tests/WebSecretsService.test.ts
@@ -69,17 +69,10 @@ describe("WebSecretsService", () => {
     expect(requested).toEqual([
       [
         {
-          service: "tinycloud.kv",
+          service: "tinycloud.vault",
           space: "secrets",
-          path: "keys/secrets/ANTHROPIC_API_KEY",
-          actions: ["put"],
-          skipPrefix: true,
-        },
-        {
-          service: "tinycloud.kv",
-          space: "secrets",
-          path: "vault/secrets/ANTHROPIC_API_KEY",
-          actions: ["put"],
+          path: "secrets/ANTHROPIC_API_KEY",
+          actions: ["write"],
           skipPrefix: true,
         },
       ],
@@ -158,7 +151,7 @@ describe("WebSecretsService", () => {
         code: ErrorCodes.PERMISSION_DENIED,
         service: "secrets",
         message:
-          "Permission request for tinycloud.kv/del on ANTHROPIC_API_KEY was declined.",
+          "Permission request for tinycloud.vault/delete on ANTHROPIC_API_KEY was declined.",
       },
     });
     expect(base.delete).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Add `tinycloud.vault` as an SDK-only permission shorthand that expands to the backing KV resources used by encrypted vault operations.
- Reuse that expansion for manifest resolution, `delegateTo`, runtime permission grants, and runtime invocation matching.
- Update node/web secrets wrappers to request one vault permission for write/delete escalation while preserving manifest coverage checks against the concrete KV resources.
- Add a minor changeset for `@tinycloud/sdk-core`, `@tinycloud/node-sdk`, and `@tinycloud/web-sdk`.

## Verification
- `bun run --cwd packages/sdk-core build`
- `bun test packages/sdk-core/src/manifest.test.ts packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts packages/node-sdk/src/NodeSecretsService.test.ts packages/web-sdk/tests/WebSecretsService.test.ts packages/web-sdk/tests/requestPermissionsCore.test.ts`
- `bun run --cwd packages/node-sdk build`
- `bun run --cwd packages/web-sdk build` (passes with existing webpack bundle-size warnings)
- `git diff --check`