### PR TITLE
feat: add scoped secrets

### DIFF
--- a/.changeset/scoped-secrets.md
+++ b/.changeset/scoped-secrets.md
@@ -1,0 +1,8 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/sdk-services": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+---
+
+Add canonical scoped secret support. Manifest `secrets` entries now accept object specs with `scope` and optional `name`, and `tc.secrets` supports scoped `get`, `put`, `delete`, and `list` calls using the canonical `secrets/scoped/<scope>/<NAME>` vault layout.

--- a/packages/node-sdk/src/NodeSecretsService.test.ts
+++ b/packages/node-sdk/src/NodeSecretsService.test.ts
@@ -74,6 +74,39 @@ describe("NodeSecretsService", () => {
     expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
   });
 
+  it("grants scoped write permission before putting a scoped secret", async () => {
+    const base = makeBaseSecrets();
+    const grantPermissions = mock(async () => {});
+    const secrets = new NodeSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      grantPermissions,
+      canEscalate: () => true,
+    });
+
+    const result = await secrets.put(
+      "ANTHROPIC_API_KEY",
+      "secret",
+      { scope: "Food Tracker" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(grantPermissions).toHaveBeenCalledWith([
+      {
+        service: "tinycloud.vault",
+        space: "secrets",
+        path: "secrets/scoped/food-tracker/ANTHROPIC_API_KEY",
+        actions: ["write"],
+        skipPrefix: true,
+      },
+    ] satisfies PermissionEntry[]);
+    expect(base.put).toHaveBeenCalledWith(
+      "ANTHROPIC_API_KEY",
+      "secret",
+      { scope: "Food Tracker" },
+    );
+  });
+
   it("skips autosign when the manifest already includes the mutation action", async () => {
     const base = makeBaseSecrets();
     const grantPermissions = mock(async () => {});
@@ -94,6 +127,38 @@ describe("NodeSecretsService", () => {
     expect(result.ok).toBe(true);
     expect(grantPermissions).not.toHaveBeenCalled();
     expect(base.delete).toHaveBeenCalledWith("ANTHROPIC_API_KEY");
+  });
+
+  it("skips autosign when the manifest includes the scoped mutation action", async () => {
+    const base = makeBaseSecrets();
+    const grantPermissions = mock(async () => {});
+    const secrets = new NodeSecretsService({
+      getService: () => base,
+      getManifest: () => ({
+        ...readOnlyManifest(),
+        secrets: {
+          FOOD_TRACKER_ANTHROPIC_API_KEY: {
+            scope: "food-tracker",
+            name: "ANTHROPIC_API_KEY",
+            actions: ["read", "delete"],
+          },
+        },
+      }),
+      grantPermissions,
+      canEscalate: () => true,
+    });
+
+    const result = await secrets.delete(
+      "ANTHROPIC_API_KEY",
+      { scope: "food-tracker" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(grantPermissions).not.toHaveBeenCalled();
+    expect(base.delete).toHaveBeenCalledWith(
+      "ANTHROPIC_API_KEY",
+      { scope: "food-tracker" },
+    );
   });
 
   it("re-unlocks after autosign when already unlocked", async () => {

--- a/packages/node-sdk/src/NodeSecretsService.ts
+++ b/packages/node-sdk/src/NodeSecretsService.ts
@@ -1,17 +1,17 @@
 import {
   ErrorCodes,
+  resolveSecretPath,
   resolveManifest,
   type IDataVaultService,
   type ISecretsService,
   type Manifest,
   type PermissionEntry,
   type Result,
+  type SecretScopeOptions,
   type ServiceError,
   type VaultError,
 } from "@tinycloud/sdk-core";
 
-const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
-const SECRET_PREFIX = "secrets/";
 const SECRETS_SPACE = "secrets";
 
 function ok(): Result<void, ServiceError> {
@@ -42,23 +42,25 @@ function kvActionUrn(action: "put" | "del"): string {
   return `tinycloud.kv/${action}`;
 }
 
+function vaultMutationAction(action: "put" | "del"): "write" | "delete" {
+  return action === "put" ? "write" : "delete";
+}
+
 function secretPermissionEntries(
   name: string,
+  options: SecretScopeOptions | undefined,
   action: "put" | "del",
 ): PermissionEntry[] {
+  const secretPath = resolveSecretPath(name, options);
   return [
     {
       service: "tinycloud.vault",
       space: SECRETS_SPACE,
-      path: `${SECRET_PREFIX}${name}`,
-      actions: [action === "put" ? "write" : "delete"],
+      path: secretPath.vaultKey,
+      actions: [vaultMutationAction(action)],
       skipPrefix: true,
     },
   ];
-}
-
-function secretResourcePath(base: "keys" | "vault", name: string): string {
-  return `${base}/${SECRET_PREFIX}${name}`;
 }
 
 function isSecretsSpace(space: string): boolean {
@@ -104,24 +106,39 @@ export class NodeSecretsService implements ISecretsService {
     this.service.lock();
   }
 
-  get(name: string): ReturnType<ISecretsService["get"]> {
-    return this.service.get(name);
+  get(name: string, options?: SecretScopeOptions): ReturnType<ISecretsService["get"]> {
+    return options === undefined
+      ? this.service.get(name)
+      : this.service.get(name, options);
   }
 
-  async put(name: string, value: string): ReturnType<ISecretsService["put"]> {
-    const permission = await this.ensureMutationPermission(name, "put");
+  async put(
+    name: string,
+    value: string,
+    options?: SecretScopeOptions,
+  ): ReturnType<ISecretsService["put"]> {
+    const permission = await this.ensureMutationPermission(name, options, "put");
     if (!permission.ok) return permission;
-    return this.service.put(name, value);
+    return options === undefined
+      ? this.service.put(name, value)
+      : this.service.put(name, value, options);
   }
 
-  async delete(name: string): ReturnType<ISecretsService["delete"]> {
-    const permission = await this.ensureMutationPermission(name, "del");
+  async delete(
+    name: string,
+    options?: SecretScopeOptions,
+  ): ReturnType<ISecretsService["delete"]> {
+    const permission = await this.ensureMutationPermission(name, options, "del");
     if (!permission.ok) return permission;
-    return this.service.delete(name);
+    return options === undefined
+      ? this.service.delete(name)
+      : this.service.delete(name, options);
   }
 
-  list(): ReturnType<ISecretsService["list"]> {
-    return this.service.list();
+  list(options?: SecretScopeOptions): ReturnType<ISecretsService["list"]> {
+    return options === undefined
+      ? this.service.list()
+      : this.service.list(options);
   }
 
   private get service(): ISecretsService {
@@ -130,16 +147,21 @@ export class NodeSecretsService implements ISecretsService {
 
   private async ensureMutationPermission(
     name: string,
+    options: SecretScopeOptions | undefined,
     action: "put" | "del",
   ): Promise<Result<void, ServiceError | VaultError>> {
-    if (!SECRET_NAME_RE.test(name)) {
+    let permissionEntries: PermissionEntry[];
+    try {
+      permissionEntries = secretPermissionEntries(name, options, action);
+    } catch (error) {
       return secretsError(
         ErrorCodes.INVALID_INPUT,
-        `Invalid secret name ${JSON.stringify(name)}. Secret names must match ${SECRET_NAME_RE.source}.`,
+        error instanceof Error ? error.message : String(error),
+        error instanceof Error ? error : undefined,
       );
     }
 
-    if (this.hasMutationPermission(name, action)) {
+    if (this.hasMutationPermission(name, options, action)) {
       return ok();
     }
 
@@ -151,7 +173,7 @@ export class NodeSecretsService implements ISecretsService {
     }
 
     try {
-      await this.config.grantPermissions(secretPermissionEntries(name, action));
+      await this.config.grantPermissions(permissionEntries);
       return this.restoreUnlockAfterEscalation();
     } catch (error) {
       return secretsError(
@@ -173,7 +195,11 @@ export class NodeSecretsService implements ISecretsService {
     return this.service.unlock(this.unlockSigner);
   }
 
-  private hasMutationPermission(name: string, action: "put" | "del"): boolean {
+  private hasMutationPermission(
+    name: string,
+    options: SecretScopeOptions | undefined,
+    action: "put" | "del",
+  ): boolean {
     const manifest = this.config.getManifest();
     if (manifest === undefined) {
       return false;
@@ -181,6 +207,7 @@ export class NodeSecretsService implements ISecretsService {
 
     const manifests = Array.isArray(manifest) ? manifest : [manifest];
     const requiredAction = kvActionUrn(action);
+    const secretPath = resolveSecretPath(name, options);
     return manifests.some((entry) => {
       const resolved = resolveManifest(entry);
       return (["keys", "vault"] as const).every((base) =>
@@ -188,7 +215,7 @@ export class NodeSecretsService implements ISecretsService {
           (resource) =>
             resource.service === "tinycloud.kv" &&
             isSecretsSpace(resource.space) &&
-            resource.path === secretResourcePath(base, name) &&
+            resource.path === secretPath.permissionPaths[base] &&
             resource.actions.includes(requiredAction),
         ),
       );

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -175,7 +175,16 @@ export type {
 } from "@tinycloud/sdk-core";
 
 // Re-export Vault and Secrets service values
-export { DataVaultService, VaultHeaders, VaultPublicSpaceKVActions, createVaultCrypto, SecretsService } from "@tinycloud/sdk-core";
+export {
+  DataVaultService,
+  VaultHeaders,
+  VaultPublicSpaceKVActions,
+  createVaultCrypto,
+  SecretsService,
+  SECRET_NAME_RE,
+  canonicalizeSecretScope,
+  resolveSecretPath,
+} from "@tinycloud/sdk-core";
 
 // Re-export Vault and Secrets service types
 export type {
@@ -192,6 +201,8 @@ export type {
   ISecretsService,
   SecretPayload,
   SecretsError,
+  ResolvedSecretPath,
+  SecretScopeOptions,
 } from "@tinycloud/sdk-core";
 
 // Re-export v2 Delegation service values

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -213,6 +213,9 @@ export {
   VaultPublicSpaceKVActions,
   createVaultCrypto,
   SecretsService,
+  SECRET_NAME_RE,
+  canonicalizeSecretScope,
+  resolveSecretPath,
 } from "@tinycloud/sdk-core";
 
 // Re-export Vault and Secrets service types
@@ -230,6 +233,8 @@ export type {
   ISecretsService,
   SecretPayload,
   SecretsError,
+  ResolvedSecretPath,
+  SecretScopeOptions,
 } from "@tinycloud/sdk-core";
 
 // Re-export Hooks service values

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -171,9 +171,14 @@ export {
   type VaultError,
   // Secrets Service
   SecretsService,
+  SECRET_NAME_RE,
+  canonicalizeSecretScope,
+  resolveSecretPath,
   type ISecretsService,
   type SecretPayload,
   type SecretsError,
+  type ResolvedSecretPath,
+  type SecretScopeOptions,
 } from "@tinycloud/sdk-services";
 
 // Space utilities

--- a/packages/sdk-core/src/manifest.test.ts
+++ b/packages/sdk-core/src/manifest.test.ts
@@ -480,6 +480,77 @@ describe("resolveManifest — secrets shorthand", () => {
     expect(secretResource?.description).toBe("Call Anthropic.");
   });
 
+  it("supports scoped object form and defaults name to the manifest key", () => {
+    const resolved = resolveManifest({
+      app_id: "com.listen.app",
+      name: "Listen",
+      defaults: false,
+      secrets: {
+        ANTHROPIC_API_KEY: {
+          scope: "Food Tracker",
+        },
+      },
+    });
+
+    expect(resolved.resources).toEqual(
+      expect.arrayContaining([
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "keys/secrets/scoped/food-tracker/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/get"],
+        },
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "vault/secrets/scoped/food-tracker/ANTHROPIC_API_KEY",
+          actions: ["tinycloud.kv/get"],
+        },
+      ]),
+    );
+  });
+
+  it("supports scoped aliases with an explicit vault secret name", () => {
+    const resolved = resolveManifest({
+      app_id: "com.listen.app",
+      name: "Listen",
+      defaults: false,
+      secrets: {
+        FOOD_TRACKER_ANTHROPIC_API_KEY: {
+          scope: "food-tracker",
+          name: "ANTHROPIC_API_KEY",
+          actions: ["read", "write"],
+        },
+      },
+    });
+
+    expect(resourceCapabilitiesToSpaceAbilitiesMap(resolved.resources).secrets.kv).toEqual({
+      "keys/secrets/scoped/food-tracker/ANTHROPIC_API_KEY": [
+        "tinycloud.kv/get",
+        "tinycloud.kv/put",
+      ],
+      "vault/secrets/scoped/food-tracker/ANTHROPIC_API_KEY": [
+        "tinycloud.kv/get",
+        "tinycloud.kv/put",
+      ],
+    });
+  });
+
+  it("rejects reserved explicit secret scopes", () => {
+    expect(() =>
+      resolveManifest({
+        app_id: "com.listen.app",
+        name: "Listen",
+        defaults: false,
+        secrets: {
+          ANTHROPIC_API_KEY: {
+            scope: "global",
+          },
+        },
+      }),
+    ).toThrow(/reserved/);
+  });
+
   it("groups secret capabilities into the secrets space abilities map", () => {
     const resolved = resolveManifest({
       app_id: "com.listen.app",

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -16,6 +16,7 @@
  */
 
 import ms from "ms";
+import { resolveSecretPath, SECRET_NAME_RE } from "@tinycloud/sdk-services";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -62,6 +63,10 @@ export type ManifestSecretActions =
   | string
   | string[]
   | {
+      /** Actual vault secret name. Defaults to the manifest object key. */
+      name?: string;
+      /** Optional scoped secret namespace. Omit for global secrets. */
+      scope?: string;
       actions?: string | string[];
       expiry?: string;
       description?: string;
@@ -250,7 +255,6 @@ export const ACCOUNT_REGISTRY_SPACE = "account";
 export const ACCOUNT_REGISTRY_PATH = "applications/";
 
 const SECRETS_SPACE = "secrets";
-const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
 
 /** SDK-only permission service for encrypted vault resources. */
 export const VAULT_PERMISSION_SERVICE = "tinycloud.vault";
@@ -565,6 +569,16 @@ function validateManifestSecrets(secrets: unknown): void {
         `manifest.secrets.${name} must match ${SECRET_NAME_RE.source}`,
       );
     }
+    try {
+      resolveSecretPath(
+        secretNameFromSpec(name, spec as ManifestSecretActions),
+        { scope: secretScopeFromSpec(spec as ManifestSecretActions) },
+      );
+    } catch (error) {
+      throw new ManifestValidationError(
+        `manifest.secrets.${name}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     const actions = secretActionsFromSpec(name, spec as ManifestSecretActions);
     if (actions.length === 0) {
       throw new ManifestValidationError(
@@ -792,6 +806,25 @@ function normalizeSecretActions(actions: readonly string[]): string[] {
   return out;
 }
 
+function secretNameFromSpec(
+  fallbackName: string,
+  spec: ManifestSecretActions,
+): string {
+  if (spec !== null && typeof spec === "object" && !Array.isArray(spec)) {
+    return spec.name ?? fallbackName;
+  }
+  return fallbackName;
+}
+
+function secretScopeFromSpec(
+  spec: ManifestSecretActions,
+): string | undefined {
+  if (spec !== null && typeof spec === "object" && !Array.isArray(spec)) {
+    return spec.scope;
+  }
+  return undefined;
+}
+
 function secretActionsFromSpec(
   name: string,
   spec: ManifestSecretActions,
@@ -834,23 +867,25 @@ function secretEntriesForManifest(
   const entries: PermissionEntry[] = [];
   for (const [name, spec] of Object.entries(secrets)) {
     const actions = secretActionsFromSpec(name, spec);
+    const secretPath = resolveSecretPath(
+      secretNameFromSpec(name, spec),
+      { scope: secretScopeFromSpec(spec) },
+    );
     const extra: { expiry?: string; description?: string } =
       spec !== true && typeof spec === "object" && !Array.isArray(spec)
         ? spec
         : {};
-    for (const base of ["keys", "vault"]) {
-      entries.push({
-        service: "tinycloud.kv",
-        space: SECRETS_SPACE,
-        path: `${base}/secrets/${name}`,
-        actions: normalizeSecretActions(actions),
-        skipPrefix: true,
-        ...(extra.expiry !== undefined ? { expiry: extra.expiry } : {}),
-        ...(extra.description !== undefined
-          ? { description: extra.description }
-          : {}),
-      });
-    }
+    entries.push({
+      service: VAULT_PERMISSION_SERVICE,
+      space: SECRETS_SPACE,
+      path: secretPath.vaultKey,
+      actions: normalizeSecretActions(actions),
+      skipPrefix: true,
+      ...(extra.expiry !== undefined ? { expiry: extra.expiry } : {}),
+      ...(extra.description !== undefined
+        ? { description: extra.description }
+        : {}),
+    });
   }
   return entries;
 }

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -238,9 +238,16 @@ export type {
   VaultError,
 } from "./vault";
 
-export { SecretsService } from "./secrets";
+export {
+  SecretsService,
+  SECRET_NAME_RE,
+  canonicalizeSecretScope,
+  resolveSecretPath,
+} from "./secrets";
 export type {
   ISecretsService,
   SecretPayload,
   SecretsError,
+  ResolvedSecretPath,
+  SecretScopeOptions,
 } from "./secrets";

--- a/packages/sdk-services/src/secrets/ISecretsService.ts
+++ b/packages/sdk-services/src/secrets/ISecretsService.ts
@@ -1,6 +1,7 @@
 import type { IDataVaultService } from "../vault/IDataVaultService";
 import type { VaultError } from "../vault/types";
 import type { Result, ServiceError } from "../types";
+import type { SecretScopeOptions } from "./paths";
 
 export interface SecretPayload {
   value: string;
@@ -15,8 +16,8 @@ export interface ISecretsService {
   unlock(signer?: unknown): Promise<Result<void, VaultError>>;
   lock(): void;
   readonly isUnlocked: boolean;
-  get(name: string): Promise<Result<string, SecretsError>>;
-  put(name: string, value: string): Promise<Result<void, SecretsError>>;
-  delete(name: string): Promise<Result<void, SecretsError>>;
-  list(): Promise<Result<string[], SecretsError>>;
+  get(name: string, options?: SecretScopeOptions): Promise<Result<string, SecretsError>>;
+  put(name: string, value: string, options?: SecretScopeOptions): Promise<Result<void, SecretsError>>;
+  delete(name: string, options?: SecretScopeOptions): Promise<Result<void, SecretsError>>;
+  list(options?: SecretScopeOptions): Promise<Result<string[], SecretsError>>;
 }

--- a/packages/sdk-services/src/secrets/SecretsService.test.ts
+++ b/packages/sdk-services/src/secrets/SecretsService.test.ts
@@ -116,6 +116,31 @@ describe("SecretsService", () => {
     expect(vault.delete).toHaveBeenCalledWith("secrets/ANTHROPIC_API_KEY");
   });
 
+  it("maps scoped operations to canonical scoped vault keys", async () => {
+    const vault = new MockVault();
+    const secrets = new SecretsService(vault);
+
+    const options = { scope: "Food Tracker" };
+    const putResult = await secrets.put("ANTHROPIC_API_KEY", "secret", options);
+    expect(putResult.ok).toBe(true);
+    expect(vault.put).toHaveBeenCalledWith(
+      "secrets/scoped/food-tracker/ANTHROPIC_API_KEY",
+      expect.objectContaining({ value: "secret" }),
+    );
+
+    const getResult = await secrets.get("ANTHROPIC_API_KEY", options);
+    expect(getResult).toEqual({ ok: true, data: "stored-value" });
+    expect(vault.get).toHaveBeenCalledWith(
+      "secrets/scoped/food-tracker/ANTHROPIC_API_KEY",
+    );
+
+    const deleteResult = await secrets.delete("ANTHROPIC_API_KEY", options);
+    expect(deleteResult.ok).toBe(true);
+    expect(vault.delete).toHaveBeenCalledWith(
+      "secrets/scoped/food-tracker/ANTHROPIC_API_KEY",
+    );
+  });
+
   it("validates env-style names before calling the vault", async () => {
     const vault = new MockVault();
     const secrets = new SecretsService(vault);
@@ -137,6 +162,29 @@ describe("SecretsService", () => {
       prefix: "secrets/",
       removePrefix: true,
     });
+  });
+
+  it("lists only valid secret names under a scoped prefix", async () => {
+    const vault = new MockVault();
+    const secrets = new SecretsService(vault);
+
+    const result = await secrets.list({ scope: "Food Tracker" });
+
+    expect(result).toEqual({ ok: true, data: ["ANTHROPIC_API_KEY"] });
+    expect(vault.list).toHaveBeenCalledWith({
+      prefix: "secrets/scoped/food-tracker/",
+      removePrefix: true,
+    });
+  });
+
+  it("rejects reserved explicit scopes", async () => {
+    const vault = new MockVault();
+    const secrets = new SecretsService(vault);
+
+    const result = await secrets.get("ANTHROPIC_API_KEY", { scope: "default" });
+
+    expect(result.ok).toBe(false);
+    expect(vault.get).not.toHaveBeenCalled();
   });
 
   it("forwards lock state to the backing vault", async () => {

--- a/packages/sdk-services/src/secrets/SecretsService.ts
+++ b/packages/sdk-services/src/secrets/SecretsService.ts
@@ -11,21 +11,31 @@ import type {
   SecretPayload,
   SecretsError,
 } from "./ISecretsService";
+import {
+  canonicalizeSecretScope,
+  resolveSecretPath,
+  SECRET_NAME_RE,
+  type ResolvedSecretPath,
+  type SecretScopeOptions,
+} from "./paths";
 
-const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
-const SECRET_PREFIX = "secrets/";
-
-function invalidSecretName(name: string): Result<never, ServiceError> {
+function invalidSecretInput(message: string): Result<never, ServiceError> {
   return err({
     code: ErrorCodes.INVALID_INPUT,
     service: "secrets",
-    message:
-      `Invalid secret name ${JSON.stringify(name)}. Secret names must match ${SECRET_NAME_RE.source}.`,
+    message,
   });
 }
 
-function secretKey(name: string): string {
-  return `${SECRET_PREFIX}${name}`;
+function resolveSecretPathResult(
+  name: string,
+  options?: SecretScopeOptions,
+): ResolvedSecretPath | Result<never, ServiceError> {
+  try {
+    return resolveSecretPath(name, options);
+  } catch (error) {
+    return invalidSecretInput(error instanceof Error ? error.message : String(error));
+  }
 }
 
 export class SecretsService implements ISecretsService {
@@ -51,42 +61,57 @@ export class SecretsService implements ISecretsService {
     this.vault.lock();
   }
 
-  async get(name: string): Promise<Result<string, SecretsError>> {
-    if (!SECRET_NAME_RE.test(name)) {
-      return invalidSecretName(name);
-    }
+  async get(
+    name: string,
+    options?: SecretScopeOptions,
+  ): Promise<Result<string, SecretsError>> {
+    const secretPath = resolveSecretPathResult(name, options);
+    if ("ok" in secretPath) return secretPath;
 
-    const result = await this.vault.get<SecretPayload>(secretKey(name));
+    const result = await this.vault.get<SecretPayload>(secretPath.vaultKey);
     if (!result.ok) {
       return result;
     }
     return { ok: true, data: result.data.value.value };
   }
 
-  async put(name: string, value: string): Promise<Result<void, SecretsError>> {
-    if (!SECRET_NAME_RE.test(name)) {
-      return invalidSecretName(name);
-    }
+  async put(
+    name: string,
+    value: string,
+    options?: SecretScopeOptions,
+  ): Promise<Result<void, SecretsError>> {
+    const secretPath = resolveSecretPathResult(name, options);
+    if ("ok" in secretPath) return secretPath;
 
     const now = new Date().toISOString();
-    return this.vault.put(secretKey(name), {
+    return this.vault.put(secretPath.vaultKey, {
       value,
       createdAt: now,
       updatedAt: now,
     } satisfies SecretPayload);
   }
 
-  async delete(name: string): Promise<Result<void, SecretsError>> {
-    if (!SECRET_NAME_RE.test(name)) {
-      return invalidSecretName(name);
-    }
+  async delete(
+    name: string,
+    options?: SecretScopeOptions,
+  ): Promise<Result<void, SecretsError>> {
+    const secretPath = resolveSecretPathResult(name, options);
+    if ("ok" in secretPath) return secretPath;
 
-    return this.vault.delete(secretKey(name));
+    return this.vault.delete(secretPath.vaultKey);
   }
 
-  async list(): Promise<Result<string[], SecretsError>> {
+  async list(options?: SecretScopeOptions): Promise<Result<string[], SecretsError>> {
+    let prefix: string;
+    try {
+      const scope = canonicalizeSecretScope(options?.scope);
+      prefix = scope === undefined ? "secrets/" : `secrets/scoped/${scope}/`;
+    } catch (error) {
+      return invalidSecretInput(error instanceof Error ? error.message : String(error));
+    }
+
     const result = await this.vault.list({
-      prefix: SECRET_PREFIX,
+      prefix,
       removePrefix: true,
     });
     if (!result.ok) {

--- a/packages/sdk-services/src/secrets/index.ts
+++ b/packages/sdk-services/src/secrets/index.ts
@@ -1,6 +1,15 @@
 export { SecretsService } from "./SecretsService";
+export {
+  SECRET_NAME_RE,
+  canonicalizeSecretScope,
+  resolveSecretPath,
+} from "./paths";
 export type {
   ISecretsService,
   SecretPayload,
   SecretsError,
 } from "./ISecretsService";
+export type {
+  ResolvedSecretPath,
+  SecretScopeOptions,
+} from "./paths";

--- a/packages/sdk-services/src/secrets/paths.ts
+++ b/packages/sdk-services/src/secrets/paths.ts
@@ -1,0 +1,79 @@
+export const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
+
+const SECRET_PREFIX = "secrets/";
+const SCOPED_SECRET_PREFIX = "secrets/scoped/";
+const RESERVED_SECRET_SCOPES = new Set(["default", "global"]);
+
+export interface SecretScopeOptions {
+  /** Optional logical scope. Omit for the global secret namespace. */
+  scope?: string;
+}
+
+export interface ResolvedSecretPath {
+  /** Canonical env-style secret name. */
+  name: string;
+  /** Canonical scope. Undefined means global. */
+  scope?: string;
+  /** Key passed to the data vault service. */
+  vaultKey: string;
+  /** KV permission paths that back the encrypted vault entry. */
+  permissionPaths: {
+    keys: string;
+    vault: string;
+  };
+}
+
+export function canonicalizeSecretScope(scope: string | undefined): string | undefined {
+  if (scope === undefined) {
+    return undefined;
+  }
+
+  const trimmed = scope.trim();
+  if (trimmed === "") {
+    throw new Error("Secret scope must be non-empty; omit scope for global secrets.");
+  }
+
+  const canonical = trimmed
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  if (canonical === "") {
+    throw new Error("Secret scope must contain at least one letter or number.");
+  }
+  if (RESERVED_SECRET_SCOPES.has(canonical)) {
+    throw new Error(
+      `Secret scope ${JSON.stringify(scope)} is reserved; omit scope for global secrets.`,
+    );
+  }
+
+  return canonical;
+}
+
+export function resolveSecretPath(
+  name: string,
+  options: SecretScopeOptions = {},
+): ResolvedSecretPath {
+  const normalizedName = name.trim();
+  if (!SECRET_NAME_RE.test(normalizedName)) {
+    throw new Error(
+      `Invalid secret name ${JSON.stringify(name)}. Secret names must match ${SECRET_NAME_RE.source}.`,
+    );
+  }
+
+  const scope = canonicalizeSecretScope(options.scope);
+  const vaultKey = scope === undefined
+    ? `${SECRET_PREFIX}${normalizedName}`
+    : `${SCOPED_SECRET_PREFIX}${scope}/${normalizedName}`;
+
+  return {
+    name: normalizedName,
+    ...(scope !== undefined ? { scope } : {}),
+    vaultKey,
+    permissionPaths: {
+      keys: `keys/${vaultKey}`,
+      vault: `vault/${vaultKey}`,
+    },
+  };
+}

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -165,6 +165,9 @@ export {
   VaultPublicSpaceKVActions,
   createVaultCrypto,
   SecretsService,
+  SECRET_NAME_RE,
+  canonicalizeSecretScope,
+  resolveSecretPath,
   type WasmVaultFunctions,
   type VaultHeaders,
   type IDataVaultService,
@@ -179,6 +182,8 @@ export {
   type ISecretsService,
   type SecretPayload,
   type SecretsError,
+  type ResolvedSecretPath,
+  type SecretScopeOptions,
 } from '@tinycloud/sdk-core';
 
 // Adapter for web-sdk

--- a/packages/web-sdk/src/modules/WebSecretsService.ts
+++ b/packages/web-sdk/src/modules/WebSecretsService.ts
@@ -1,11 +1,13 @@
 import {
   ErrorCodes,
+  resolveSecretPath,
   resolveManifest,
   type IDataVaultService,
   type ISecretsService,
   type Manifest,
   type PermissionEntry,
   type Result,
+  type SecretScopeOptions,
   type ServiceError,
 } from "@tinycloud/sdk-core";
 import type { VaultError } from "@tinycloud/sdk-core";
@@ -14,8 +16,6 @@ type RequestPermissions = (
   additional: PermissionEntry[],
 ) => Promise<{ approved: boolean; delegations?: readonly unknown[] }>;
 
-const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
-const SECRET_PREFIX = "secrets/";
 const SECRETS_SPACE = "secrets";
 
 function ok(): Result<void, ServiceError> {
@@ -46,23 +46,25 @@ function kvActionUrn(action: "put" | "del"): string {
   return `tinycloud.kv/${action}`;
 }
 
+function vaultMutationAction(action: "put" | "del"): "write" | "delete" {
+  return action === "put" ? "write" : "delete";
+}
+
 function secretPermissionEntries(
   name: string,
+  options: SecretScopeOptions | undefined,
   action: "put" | "del",
 ): PermissionEntry[] {
+  const secretPath = resolveSecretPath(name, options);
   return [
     {
       service: "tinycloud.vault",
       space: SECRETS_SPACE,
-      path: `${SECRET_PREFIX}${name}`,
-      actions: [action === "put" ? "write" : "delete"],
+      path: secretPath.vaultKey,
+      actions: [vaultMutationAction(action)],
       skipPrefix: true,
     },
   ];
-}
-
-function secretResourcePath(base: "keys" | "vault", name: string): string {
-  return `${base}/${SECRET_PREFIX}${name}`;
 }
 
 function isSecretsSpace(space: string): boolean {
@@ -107,24 +109,39 @@ export class WebSecretsService implements ISecretsService {
     this.service.lock();
   }
 
-  get(name: string): ReturnType<ISecretsService["get"]> {
-    return this.service.get(name);
+  get(name: string, options?: SecretScopeOptions): ReturnType<ISecretsService["get"]> {
+    return options === undefined
+      ? this.service.get(name)
+      : this.service.get(name, options);
   }
 
-  async put(name: string, value: string): ReturnType<ISecretsService["put"]> {
-    const permission = await this.ensureMutationPermission(name, "put");
+  async put(
+    name: string,
+    value: string,
+    options?: SecretScopeOptions,
+  ): ReturnType<ISecretsService["put"]> {
+    const permission = await this.ensureMutationPermission(name, options, "put");
     if (!permission.ok) return permission;
-    return this.service.put(name, value);
+    return options === undefined
+      ? this.service.put(name, value)
+      : this.service.put(name, value, options);
   }
 
-  async delete(name: string): ReturnType<ISecretsService["delete"]> {
-    const permission = await this.ensureMutationPermission(name, "del");
+  async delete(
+    name: string,
+    options?: SecretScopeOptions,
+  ): ReturnType<ISecretsService["delete"]> {
+    const permission = await this.ensureMutationPermission(name, options, "del");
     if (!permission.ok) return permission;
-    return this.service.delete(name);
+    return options === undefined
+      ? this.service.delete(name)
+      : this.service.delete(name, options);
   }
 
-  list(): ReturnType<ISecretsService["list"]> {
-    return this.service.list();
+  list(options?: SecretScopeOptions): ReturnType<ISecretsService["list"]> {
+    return options === undefined
+      ? this.service.list()
+      : this.service.list(options);
   }
 
   private get service(): ISecretsService {
@@ -133,22 +150,27 @@ export class WebSecretsService implements ISecretsService {
 
   private async ensureMutationPermission(
     name: string,
+    options: SecretScopeOptions | undefined,
     action: "put" | "del",
   ): Promise<Result<void, ServiceError | VaultError>> {
-    if (!SECRET_NAME_RE.test(name)) {
+    let permissionEntries: PermissionEntry[];
+    try {
+      permissionEntries = secretPermissionEntries(name, options, action);
+    } catch (error) {
       return secretsError(
         ErrorCodes.INVALID_INPUT,
-        `Invalid secret name ${JSON.stringify(name)}. Secret names must match ${SECRET_NAME_RE.source}.`,
+        error instanceof Error ? error.message : String(error),
+        error instanceof Error ? error : undefined,
       );
     }
 
-    if (this.hasMutationPermission(name, action)) {
+    if (this.hasMutationPermission(name, options, action)) {
       return ok();
     }
 
     try {
       const result = await this.config.requestPermissions(
-        secretPermissionEntries(name, action),
+        permissionEntries,
       );
       if (!result.approved) {
         return secretsError(
@@ -177,7 +199,11 @@ export class WebSecretsService implements ISecretsService {
     return this.service.unlock(this.unlockSigner);
   }
 
-  private hasMutationPermission(name: string, action: "put" | "del"): boolean {
+  private hasMutationPermission(
+    name: string,
+    options: SecretScopeOptions | undefined,
+    action: "put" | "del",
+  ): boolean {
     const manifest = this.config.getManifest();
     if (manifest === undefined) {
       return false;
@@ -185,6 +211,7 @@ export class WebSecretsService implements ISecretsService {
 
     const manifests = Array.isArray(manifest) ? manifest : [manifest];
     const requiredAction = kvActionUrn(action);
+    const secretPath = resolveSecretPath(name, options);
     return manifests.some((entry) => {
       const resolved = resolveManifest(entry);
       return (["keys", "vault"] as const).every((base) =>
@@ -192,7 +219,7 @@ export class WebSecretsService implements ISecretsService {
           (resource) =>
             resource.service === "tinycloud.kv" &&
             isSecretsSpace(resource.space) &&
-            resource.path === secretResourcePath(base, name) &&
+            resource.path === secretPath.permissionPaths[base] &&
             resource.actions.includes(requiredAction),
         ),
       );

--- a/packages/web-sdk/tests/WebSecretsService.test.ts
+++ b/packages/web-sdk/tests/WebSecretsService.test.ts
@@ -80,6 +80,43 @@ describe("WebSecretsService", () => {
     expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
   });
 
+  it("requests scoped write permission before putting a scoped secret", async () => {
+    const base = makeBaseSecrets();
+    const requested: PermissionEntry[][] = [];
+    const secrets = new WebSecretsService({
+      getService: () => base,
+      getManifest: readOnlyManifest,
+      requestPermissions: async (additional) => {
+        requested.push(additional);
+        return { approved: true };
+      },
+    });
+
+    const result = await secrets.put(
+      "ANTHROPIC_API_KEY",
+      "secret",
+      { scope: "Food Tracker" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(requested).toEqual([
+      [
+        {
+          service: "tinycloud.vault",
+          space: "secrets",
+          path: "secrets/scoped/food-tracker/ANTHROPIC_API_KEY",
+          actions: ["write"],
+          skipPrefix: true,
+        },
+      ],
+    ]);
+    expect(base.put).toHaveBeenCalledWith(
+      "ANTHROPIC_API_KEY",
+      "secret",
+      { scope: "Food Tracker" },
+    );
+  });
+
   it("skips escalation when the manifest already includes the mutation action", async () => {
     const base = makeBaseSecrets();
     const requestPermissions = mock(async () => ({ approved: true }));
@@ -99,6 +136,39 @@ describe("WebSecretsService", () => {
     expect(result.ok).toBe(true);
     expect(requestPermissions).not.toHaveBeenCalled();
     expect(base.put).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "secret");
+  });
+
+  it("skips escalation when the manifest includes the scoped mutation action", async () => {
+    const base = makeBaseSecrets();
+    const requestPermissions = mock(async () => ({ approved: true }));
+    const secrets = new WebSecretsService({
+      getService: () => base,
+      getManifest: () => ({
+        ...readOnlyManifest(),
+        secrets: {
+          FOOD_TRACKER_ANTHROPIC_API_KEY: {
+            scope: "food-tracker",
+            name: "ANTHROPIC_API_KEY",
+            actions: ["read", "write"],
+          },
+        },
+      }),
+      requestPermissions,
+    });
+
+    const result = await secrets.put(
+      "ANTHROPIC_API_KEY",
+      "secret",
+      { scope: "food-tracker" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(requestPermissions).not.toHaveBeenCalled();
+    expect(base.put).toHaveBeenCalledWith(
+      "ANTHROPIC_API_KEY",
+      "secret",
+      { scope: "food-tracker" },
+    );
   });
 
   it("re-unlocks after approved escalation when already unlocked", async () => {


### PR DESCRIPTION
## Summary
- add shared scoped-secret path resolution with canonical scope handling
- extend manifest secrets object entries with optional scope and alias name
- add scoped options to tc.secrets get/put/delete/list in services plus node/web wrappers
- align runtime write/delete escalation with the rebased tinycloud.vault permission shorthand

## Validation
- bun test packages/sdk-services/src/secrets/SecretsService.test.ts packages/sdk-core/src/manifest.test.ts packages/node-sdk/src/NodeSecretsService.test.ts packages/web-sdk/tests/WebSecretsService.test.ts packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts packages/web-sdk/tests/requestPermissionsCore.test.ts
- bun test packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
- bun run --cwd packages/sdk-services build
- bun run --cwd packages/sdk-core build
- bun run --cwd packages/sdk-rs build:all
- bun run --cwd packages/node-sdk build
- bun run --cwd packages/web-sdk build