### PR TITLE
chore: beta version packages

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -28,6 +28,7 @@
     "manifest-permission-descriptions",
     "manifest-v1-composition",
     "runtime-permission-delegations",
+    "scoped-secrets",
     "secrets-wrapper",
     "tinycloud-vfs-initial-release",
     "vault-permission-shorthand"

--- a/apps/node-demo/CHANGELOG.md
+++ b/apps/node-demo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @tinycloudlabs/node-demo
 
+## 0.0.17-beta.11
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/sdk-core@2.2.0-beta.10
+  - @tinycloud/node-sdk@2.2.0-beta.10
+  - @tinycloud/vfs@0.1.0-beta.11
+
 ## 0.0.17-beta.10
 
 ### Patch Changes

--- a/apps/node-demo/package.json
+++ b/apps/node-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/node-demo",
-  "version": "0.0.17-beta.10",
+  "version": "0.0.17-beta.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/openkey-example/CHANGELOG.md
+++ b/apps/openkey-example/CHANGELOG.md
@@ -1,5 +1,12 @@
 # tinycloud-openkey-example-app
 
+## 0.0.15-beta.10
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/web-sdk@2.2.0-beta.10
+
 ## 0.0.15-beta.9
 
 ### Patch Changes

--- a/apps/openkey-example/package.json
+++ b/apps/openkey-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinycloud-openkey-example-app",
-  "version": "0.0.15-beta.9",
+  "version": "0.0.15-beta.10",
   "private": true,
   "repository": {
     "url": "ssh://git@github.com:TinyCloudLabs/web-sdk.git"

--- a/apps/openkey-vite/CHANGELOG.md
+++ b/apps/openkey-vite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openkey-vite
 
+## 0.0.13-beta.10
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/web-sdk@2.2.0-beta.10
+
 ## 0.0.13-beta.9
 
 ### Patch Changes

--- a/apps/openkey-vite/package.json
+++ b/apps/openkey-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openkey-vite",
   "private": true,
-  "version": "0.0.13-beta.9",
+  "version": "0.0.13-beta.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinycloud/cli
 
+## 0.4.8-beta.10
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/node-sdk@2.2.0-beta.10
+
 ## 0.4.8-beta.9
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/cli",
-  "version": "0.4.8-beta.9",
+  "version": "0.4.8-beta.10",
   "description": "TinyCloud CLI - manage data, delegations, and nodes from the terminal",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -23,7 +23,7 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "@tinycloud/node-sdk": "2.2.0-beta.9",
+    "@tinycloud/node-sdk": "2.2.0-beta.10",
     "@tinycloud/node-sdk-wasm": "1.7.3-beta.1",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",

--- a/packages/node-sdk/CHANGELOG.md
+++ b/packages/node-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tinycloudlabs/node-sdk
 
+## 2.2.0-beta.10
+
+### Minor Changes
+
+- 35212bb: Add canonical scoped secret support. Manifest `secrets` entries now accept object specs with `scope` and optional `name`, and `tc.secrets` supports scoped `get`, `put`, `delete`, and `list` calls using the canonical `secrets/scoped/<scope>/<NAME>` vault layout.
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/sdk-core@2.2.0-beta.10
+
 ## 2.2.0-beta.9
 
 ### Minor Changes

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/node-sdk",
-  "version": "2.2.0-beta.9",
+  "version": "2.2.0-beta.10",
   "description": "TinyCloud SDK for Node.js with configurable authorization strategies",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -33,7 +33,7 @@
     "test:integration": "echo 'Integration tests live in tests/node-sdk workspace'"
   },
   "dependencies": {
-    "@tinycloud/sdk-core": "2.2.0-beta.9",
+    "@tinycloud/sdk-core": "2.2.0-beta.10",
     "@tinycloud/node-sdk-wasm": "1.7.3-beta.1",
     "siwe": "^3.0.0"
   },

--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tinycloudlabs/sdk-core
 
+## 2.2.0-beta.10
+
+### Minor Changes
+
+- 35212bb: Add canonical scoped secret support. Manifest `secrets` entries now accept object specs with `scope` and optional `name`, and `tc.secrets` supports scoped `get`, `put`, `delete`, and `list` calls using the canonical `secrets/scoped/<scope>/<NAME>` vault layout.
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/sdk-services@2.2.0-beta.10
+
 ## 2.2.0-beta.9
 
 ### Minor Changes

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/sdk-core",
-  "version": "2.2.0-beta.9",
+  "version": "2.2.0-beta.10",
   "description": "Core TinyCloud SDK - shared interfaces and TinyCloud class",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -28,7 +28,7 @@
     "@multiformats/multiaddr-to-uri": "^12.0.0",
     "@multiformats/uri-to-multiaddr": "^10.0.0",
     "@noble/curves": "^1.9.7",
-    "@tinycloud/sdk-services": "2.2.0-beta.7",
+    "@tinycloud/sdk-services": "2.2.0-beta.10",
     "multiformats": "^13.4.1",
     "ms": "^2.1.3",
     "siwe": "^3.0.0",

--- a/packages/sdk-services/CHANGELOG.md
+++ b/packages/sdk-services/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinycloudlabs/sdk-services
 
+## 2.2.0-beta.10
+
+### Minor Changes
+
+- 35212bb: Add canonical scoped secret support. Manifest `secrets` entries now accept object specs with `scope` and optional `name`, and `tc.secrets` supports scoped `get`, `put`, `delete`, and `list` calls using the canonical `secrets/scoped/<scope>/<NAME>` vault layout.
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/sdk-services/package.json
+++ b/packages/sdk-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/sdk-services",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.10",
   "description": "TinyCloud SDK Services - Platform-agnostic service implementations",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",

--- a/packages/vfs/CHANGELOG.md
+++ b/packages/vfs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinycloud/vfs
 
+## 0.1.0-beta.11
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/node-sdk@2.2.0-beta.10
+
 ## 0.1.0-beta.10
 
 ### Patch Changes

--- a/packages/vfs/package.json
+++ b/packages/vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/vfs",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "description": "TinyCloud Virtual File System for Node.js",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@platformatic/vfs": "^0.4.0",
-    "@tinycloud/node-sdk": "2.2.0-beta.9"
+    "@tinycloud/node-sdk": "2.2.0-beta.10"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/web-sdk/CHANGELOG.md
+++ b/packages/web-sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tinycloudlabs/web-sdk
 
+## 2.2.0-beta.10
+
+### Minor Changes
+
+- 35212bb: Add canonical scoped secret support. Manifest `secrets` entries now accept object specs with `scope` and optional `name`, and `tc.secrets` supports scoped `get`, `put`, `delete`, and `list` calls using the canonical `secrets/scoped/<scope>/<NAME>` vault layout.
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/sdk-core@2.2.0-beta.10
+  - @tinycloud/node-sdk@2.2.0-beta.10
+
 ## 2.2.0-beta.9
 
 ### Minor Changes

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/web-sdk",
-  "version": "2.2.0-beta.9",
+  "version": "2.2.0-beta.10",
   "description": "A set of tools and utilities to help you build your app with TinyCloud.",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
@@ -38,8 +38,8 @@
     "@metamask/detect-provider": "^1.2.0",
     "@multiformats/multiaddr": "^13.0.1",
     "@multiformats/multiaddr-to-uri": "^12.0.0",
-    "@tinycloud/node-sdk": "2.2.0-beta.9",
-    "@tinycloud/sdk-core": "2.2.0-beta.9",
+    "@tinycloud/node-sdk": "2.2.0-beta.10",
+    "@tinycloud/sdk-core": "2.2.0-beta.10",
     "@tinycloud/web-sdk-wasm": "1.7.3-beta.1",
     "axios": "^1.7.9",
     "ethers": "^5.7.2",

--- a/tests/sdk-services/CHANGELOG.md
+++ b/tests/sdk-services/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinycloudlabs/sdk-services-test
 
+## 8.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [35212bb]
+  - @tinycloud/sdk-services@2.2.0-beta.10
+
 ## 8.0.0-beta.0
 
 ### Patch Changes

--- a/tests/sdk-services/package.json
+++ b/tests/sdk-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/sdk-services-test",
-  "version": "8.0.0-beta.0",
+  "version": "8.0.0-beta.1",
   "description": "Testing utilities for TinyCloud SDK Services",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",


### PR DESCRIPTION
## Summary
- apply the merged scoped-secrets changeset in prerelease mode
- advance scoped-secret SDK packages to 2.2.0-beta.10
- update dependent prerelease package metadata/changelogs

## Validation
- bun install --frozen-lockfile
- bun run --cwd packages/sdk-services build
- bun run --cwd packages/sdk-core build
- bun test packages/sdk-services/src/secrets/SecretsService.test.ts packages/sdk-core/src/manifest.test.ts packages/node-sdk/src/NodeSecretsService.test.ts packages/web-sdk/tests/WebSecretsService.test.ts