### PR TITLE
TC-1365 Persist browser sessions in web SDK

### DIFF
--- a/.changeset/tc-1365-browser-session-restore.md
+++ b/.changeset/tc-1365-browser-session-restore.md
@@ -1,0 +1,10 @@
+---
+"@tinycloud/web-sdk": minor
+---
+
+TC-1365: add browser session persistence/restoration for `TinyCloudWeb`.
+
+The web SDK now uses `BrowserSessionStorage` by default, validates persisted
+session data before writing it, reports restore status, rejects expired or
+corrupt stored sessions, and attempts to restore a valid session in
+`signIn()` before falling back to wallet login.

--- a/packages/web-sdk/src/adapters/BrowserSessionStorage.ts
+++ b/packages/web-sdk/src/adapters/BrowserSessionStorage.ts
@@ -1,44 +1,150 @@
-import { ISessionStorage, PersistedSessionData, validatePersistedSessionData } from "@tinycloud/sdk-core";
+import {
+  ISessionStorage,
+  PersistedSessionData,
+  validatePersistedSessionData,
+} from "@tinycloud/sdk-core";
 
 const STORAGE_PREFIX = "tinycloud:session:";
 
+export type BrowserSessionLoadStatus =
+  | "loaded"
+  | "missing"
+  | "expired"
+  | "corrupt"
+  | "storage-unavailable";
+
+export type BrowserSessionLoadResult =
+  | { status: "loaded"; data: PersistedSessionData }
+  | { status: Exclude<BrowserSessionLoadStatus, "loaded">; data: null };
+
+export interface BrowserSessionStorageOptions {
+  /** Storage backend. Defaults to globalThis.localStorage when available. */
+  storage?: Storage;
+  /** Prefix used to isolate sessions by app/origin/environment. */
+  keyPrefix?: string;
+}
+
 export class BrowserSessionStorage implements ISessionStorage {
+  private readonly storage?: Storage;
+  private readonly keyPrefix: string;
+
+  constructor(options: BrowserSessionStorageOptions = {}) {
+    this.storage = options.storage ?? this.defaultStorage();
+    this.keyPrefix = options.keyPrefix ?? STORAGE_PREFIX;
+  }
+
+  private defaultStorage(): Storage | undefined {
+    return typeof globalThis.localStorage !== "undefined"
+      ? globalThis.localStorage
+      : undefined;
+  }
+
+  private key(address: string): string {
+    return this.keyPrefix + address.toLowerCase();
+  }
+
+  private assertPersistable(data: PersistedSessionData): void {
+    const result = validatePersistedSessionData(data);
+    if (!result.ok) {
+      throw new Error("Invalid session data.");
+    }
+    if (!result.data.tinycloudSession?.spaceId) {
+      throw new Error("Session data is missing TinyCloud delegation data.");
+    }
+    try {
+      const jwk = JSON.parse(result.data.sessionKey);
+      if (jwk === null || typeof jwk !== "object") {
+        throw new Error("not an object");
+      }
+    } catch {
+      throw new Error("Session data has an invalid session key.");
+    }
+    if (new Date(result.data.expiresAt).getTime() <= Date.now()) {
+      throw new Error("Session data is expired.");
+    }
+  }
+
   save(address: string, data: PersistedSessionData): Promise<void> {
-    localStorage.setItem(STORAGE_PREFIX + address.toLowerCase(), JSON.stringify(data));
+    if (!this.storage) return Promise.resolve();
+    this.assertPersistable(data);
+    this.storage.setItem(this.key(address), JSON.stringify(data));
     return Promise.resolve();
   }
 
   load(address: string): Promise<PersistedSessionData | null> {
-    const raw = localStorage.getItem(STORAGE_PREFIX + address.toLowerCase());
-    if (!raw) return Promise.resolve(null);
+    return this.loadWithStatus(address).then((result) =>
+      result.status === "loaded" ? result.data : null,
+    );
+  }
+
+  async loadWithStatus(address: string): Promise<BrowserSessionLoadResult> {
+    if (!this.storage) return { status: "storage-unavailable", data: null };
+
+    const key = this.key(address);
+    const raw = this.storage.getItem(key);
+    if (!raw) return { status: "missing", data: null };
+
     try {
       const parsed = JSON.parse(raw);
       const result = validatePersistedSessionData(parsed);
-      if (!result.ok) return Promise.resolve(null);
-      // Check for stale sessions (orbitId/namespaceId migration)
-      if (!result.data.tinycloudSession?.spaceId) {
-        this.clear(address);
-        return Promise.resolve(null);
+      if (!result.ok) {
+        this.storage.removeItem(key);
+        return { status: "corrupt", data: null };
       }
-      return Promise.resolve(result.data);
+
+      if (!result.data.tinycloudSession?.spaceId) {
+        this.storage.removeItem(key);
+        return { status: "corrupt", data: null };
+      }
+
+      try {
+        const jwk = JSON.parse(result.data.sessionKey);
+        if (jwk === null || typeof jwk !== "object") {
+          throw new Error("not an object");
+        }
+      } catch {
+        this.storage.removeItem(key);
+        return { status: "corrupt", data: null };
+      }
+
+      const expiresAt = new Date(result.data.expiresAt);
+      if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= Date.now()) {
+        this.storage.removeItem(key);
+        return { status: "expired", data: null };
+      }
+
+      return { status: "loaded", data: result.data };
     } catch {
-      return Promise.resolve(null);
+      this.storage.removeItem(key);
+      return { status: "corrupt", data: null };
     }
   }
 
   clear(address: string): Promise<void> {
-    localStorage.removeItem(STORAGE_PREFIX + address.toLowerCase());
+    this.storage?.removeItem(this.key(address));
     return Promise.resolve();
   }
 
   exists(address: string): boolean {
-    return localStorage.getItem(STORAGE_PREFIX + address.toLowerCase()) !== null;
+    if (!this.storage) return false;
+    const raw = this.storage.getItem(this.key(address));
+    if (!raw) return false;
+
+    try {
+      const parsed = JSON.parse(raw);
+      const result = validatePersistedSessionData(parsed);
+      if (!result.ok) return false;
+      return new Date(result.data.expiresAt).getTime() > Date.now();
+    } catch {
+      return false;
+    }
   }
 
   isAvailable(): boolean {
+    if (!this.storage) return false;
     try {
-      localStorage.setItem('__tc_test', '1');
-      localStorage.removeItem('__tc_test');
+      this.storage.setItem('__tc_test', '1');
+      this.storage.removeItem('__tc_test');
       return true;
     } catch {
       return false;

--- a/packages/web-sdk/src/adapters/BrowserWalletSigner.ts
+++ b/packages/web-sdk/src/adapters/BrowserWalletSigner.ts
@@ -31,6 +31,18 @@ export class BrowserWalletSigner implements ISigner {
     return this.cachedAddress;
   }
 
+  async getConnectedAddress(): Promise<string | undefined> {
+    if (this.cachedAddress) return this.cachedAddress;
+
+    const accounts = await this.provider.send("eth_accounts", []);
+    const address = Array.isArray(accounts) ? accounts[0] : undefined;
+    if (typeof address === "string" && address.length > 0) {
+      this.cachedAddress = address;
+      return address;
+    }
+    return undefined;
+  }
+
   async getChainId(): Promise<number> {
     if (!this.cachedChainId) {
       this.cachedChainId = await this.signer.getChainId();

--- a/packages/web-sdk/src/adapters/index.ts
+++ b/packages/web-sdk/src/adapters/index.ts
@@ -1,5 +1,10 @@
 export { BrowserWalletSigner } from "./BrowserWalletSigner";
 export { BrowserSessionStorage } from "./BrowserSessionStorage";
+export type {
+  BrowserSessionLoadResult,
+  BrowserSessionLoadStatus,
+  BrowserSessionStorageOptions,
+} from "./BrowserSessionStorage";
 export { BrowserENSResolver } from "./BrowserENSResolver";
 export { BrowserNotificationHandler } from "./BrowserNotificationHandler";
 export { BrowserWasmBindings } from "./BrowserWasmBindings";

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -1,5 +1,11 @@
 // Main class and config
-export { TinyCloudWeb, Config, ShareReceiveResult } from './modules/tcw';
+export {
+  TinyCloudWeb,
+  Config,
+  ShareReceiveResult,
+  SessionRestoreResult,
+  SessionRestoreStatus,
+} from './modules/tcw';
 
 // Browser Adapters
 export {
@@ -8,6 +14,11 @@ export {
   BrowserENSResolver,
   BrowserNotificationHandler,
   BrowserWasmBindings,
+} from './adapters';
+export type {
+  BrowserSessionLoadResult,
+  BrowserSessionLoadStatus,
+  BrowserSessionStorageOptions,
 } from './adapters';
 
 // Auth module (browser-specific strategies)

--- a/packages/web-sdk/src/modules/browserSessionPersistence.ts
+++ b/packages/web-sdk/src/modules/browserSessionPersistence.ts
@@ -1,0 +1,57 @@
+import type { ClientSession, PersistedSessionData } from "@tinycloud/sdk-core";
+
+export interface RestorableSessionData {
+  delegationHeader: { Authorization: string };
+  delegationCid: string;
+  spaceId: string;
+  jwk: object;
+  verificationMethod: string;
+  address: string;
+  chainId: number;
+  siwe: string;
+  signature: string;
+}
+
+export function clientSessionFromPersisted(
+  data: PersistedSessionData,
+): ClientSession {
+  return {
+    address: data.address,
+    walletAddress: data.address,
+    chainId: data.chainId,
+    sessionKey: data.sessionKey,
+    siwe: data.siwe,
+    signature: data.signature,
+  };
+}
+
+export function restoreDataFromPersisted(
+  data: PersistedSessionData,
+): RestorableSessionData {
+  if (!data.tinycloudSession) {
+    throw new Error("Persisted session is missing TinyCloud delegation data.");
+  }
+
+  let jwk: object;
+  try {
+    jwk = JSON.parse(data.sessionKey) as object;
+  } catch {
+    throw new Error("Persisted session has an invalid session key.");
+  }
+
+  if (jwk === null || typeof jwk !== "object") {
+    throw new Error("Persisted session has an invalid session key.");
+  }
+
+  return {
+    delegationHeader: data.tinycloudSession.delegationHeader,
+    delegationCid: data.tinycloudSession.delegationCid,
+    spaceId: data.tinycloudSession.spaceId,
+    jwk,
+    verificationMethod: data.tinycloudSession.verificationMethod,
+    address: data.address,
+    chainId: data.chainId,
+    siwe: data.siwe,
+    signature: data.signature,
+  };
+}

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -15,6 +15,8 @@ import {
   TinyCloudNodeConfig,
   type DelegateToOptions,
   type DelegateToResult,
+  type ISessionStorage,
+  type PersistedSessionData,
 } from "@tinycloud/node-sdk/core";
 import {
   IKVService,
@@ -51,6 +53,10 @@ import {
   requestPermissionsCore,
   validateAdditionalPermissions,
 } from "./requestPermissionsCore";
+import {
+  clientSessionFromPersisted,
+  restoreDataFromPersisted,
+} from "./browserSessionPersistence";
 import { WebSecretsService } from "./WebSecretsService";
 import type { providers } from "ethers";
 
@@ -58,6 +64,10 @@ import { BrowserWalletSigner } from "../adapters/BrowserWalletSigner";
 import { BrowserNotificationHandler } from "../adapters/BrowserNotificationHandler";
 import { BrowserWasmBindings } from "../adapters/BrowserWasmBindings";
 import { BrowserENSResolver } from "../adapters/BrowserENSResolver";
+import {
+  BrowserSessionStorage,
+  type BrowserSessionLoadResult,
+} from "../adapters/BrowserSessionStorage";
 import { RPCProviders, ClientConfig, Extension as ExtensionType } from "../providers";
 import {
   ModalSpaceCreationHandler,
@@ -107,6 +117,13 @@ export interface Config extends ClientConfig {
   /** Session expiration time in milliseconds (default: 1 hour) */
   sessionExpirationMs?: number;
 
+  /** Persist browser sessions so signIn() can restore before prompting. Default true. */
+  persistSession?: boolean;
+  /** Custom session storage implementation. */
+  sessionStorage?: ISessionStorage;
+  /** Browser storage key prefix for isolating apps/environments. */
+  sessionStorageKeyPrefix?: string;
+
   /** SIWE domain (default: window.location.hostname in browser, app.tinycloud.xyz otherwise) */
   domain?: string;
 
@@ -142,6 +159,24 @@ export interface RequestPermissionsResult {
   approved: boolean;
   session?: ClientSession;
   delegations?: readonly PortableDelegation[];
+}
+
+export type SessionRestoreStatus =
+  | "idle"
+  | "disabled"
+  | "restoring"
+  | "restored"
+  | "missing"
+  | "expired"
+  | "corrupt"
+  | "storage-unavailable"
+  | "restore-failed"
+  | "logging-in";
+
+export interface SessionRestoreResult {
+  status: Exclude<SessionRestoreStatus, "idle" | "restoring" | "logging-in">;
+  session?: ClientSession;
+  error?: Error;
 }
 
 // Share Link Utilities (static, no auth required)
@@ -213,6 +248,8 @@ export class TinyCloudWeb {
 
   /** Browser wallet signer */
   private walletSigner?: BrowserWalletSigner;
+  private sessionStorage?: ISessionStorage;
+  private _sessionRestoreStatus: SessionRestoreStatus = "idle";
   private _secrets?: ISecretsService;
 
   /** Promise that resolves when WASM + node are ready */
@@ -264,6 +301,14 @@ export class TinyCloudWeb {
     // Create browser WASM bindings
     this.wasmBindings = new BrowserWasmBindings();
 
+    if (config.persistSession !== false) {
+      this.sessionStorage =
+        config.sessionStorage ??
+        new BrowserSessionStorage({
+          keyPrefix: config.sessionStorageKeyPrefix,
+        });
+    }
+
     // Set up browser wallet signer if provider given
     const providerDriver = config.provider ?? config.providers?.web3?.driver;
     if (providerDriver) {
@@ -290,6 +335,7 @@ export class TinyCloudWeb {
       prefix: this.config.spacePrefix,
       autoCreateSpace: this.config.autoCreateSpace ?? true,
       sessionExpirationMs: this.config.sessionExpirationMs,
+      sessionStorage: this.sessionStorage,
       notificationHandler: this.notificationHandler,
       wasmBindings: this.wasmBindings,
       nonce: this.config.nonce,
@@ -380,6 +426,7 @@ export class TinyCloudWeb {
   get capabilityRegistry(): ICapabilityKeyRegistry { return this.node.capabilityRegistry; }
   get spaceId(): string | undefined { return this._node?.spaceId; }
   get hosts(): string[] { return this.node.hosts; }
+  get sessionRestoreStatus(): SessionRestoreStatus { return this._sessionRestoreStatus; }
 
   space(nameOrUri: string): ISpace { return this.spaces.get(nameOrUri); }
   get kvPrefix(): string { return this.config.kvPrefix || ""; }
@@ -388,7 +435,78 @@ export class TinyCloudWeb {
   // Auth Methods (delegate to TinyCloudNode)
   // ===========================================================================
 
+  private async resolveRestoreAddress(address?: string): Promise<string | undefined> {
+    if (address) return address;
+    if (this._node?.address) return this._node.address;
+    return this.walletSigner?.getConnectedAddress();
+  }
+
+  private async loadPersistedSession(
+    address: string,
+  ): Promise<BrowserSessionLoadResult> {
+    if (!this.sessionStorage) return { status: "storage-unavailable", data: null };
+    if ("loadWithStatus" in this.sessionStorage) {
+      return (this.sessionStorage as BrowserSessionStorage).loadWithStatus(address);
+    }
+
+    const data = await this.sessionStorage.load(address);
+    return data
+      ? { status: "loaded", data }
+      : { status: "missing", data: null };
+  }
+
+  async restoreSession(address?: string): Promise<SessionRestoreResult> {
+    if (!this.sessionStorage) {
+      this._sessionRestoreStatus = "disabled";
+      return { status: "disabled" };
+    }
+
+    const restoreAddress = await this.resolveRestoreAddress(address);
+    if (!restoreAddress) {
+      this._sessionRestoreStatus = "missing";
+      return { status: "missing" };
+    }
+
+    this._sessionRestoreStatus = "restoring";
+    const loaded = await this.loadPersistedSession(restoreAddress);
+    if (loaded.status !== "loaded") {
+      this._sessionRestoreStatus = loaded.status;
+      return { status: loaded.status };
+    }
+
+    try {
+      const node = await this.ensureNode();
+      await node.restoreSession(restoreDataFromPersisted(loaded.data));
+      this._sessionRestoreStatus = "restored";
+      return {
+        status: "restored",
+        session: clientSessionFromPersisted(loaded.data),
+      };
+    } catch (err) {
+      await this.sessionStorage.clear(restoreAddress);
+      this._sessionRestoreStatus = "restore-failed";
+      return {
+        status: "restore-failed",
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
+    }
+  }
+
+  async clearPersistedSession(address?: string): Promise<void> {
+    if (!this.sessionStorage) return;
+    const restoreAddress = await this.resolveRestoreAddress(address);
+    if (restoreAddress) {
+      await this.sessionStorage.clear(restoreAddress);
+    }
+  }
+
   signIn = async (options?: SignInOptions): Promise<ClientSession> => {
+    const restored = await this.restoreSession();
+    if (restored.status === "restored" && restored.session) {
+      return restored.session;
+    }
+
+    this._sessionRestoreStatus = "logging-in";
     const node = await this.ensureNode();
     await node.signIn(options);
     const session = node.session;
@@ -404,6 +522,7 @@ export class TinyCloudWeb {
   };
 
   signOut = async (): Promise<void> => {
+    await this.clearPersistedSession();
     this.notificationHandler.cleanup?.();
   };
 

--- a/packages/web-sdk/tests/browser-session-storage.bun.ts
+++ b/packages/web-sdk/tests/browser-session-storage.bun.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import type { PersistedSessionData } from "@tinycloud/sdk-core";
+
+import { BrowserSessionStorage } from "../src/adapters/BrowserSessionStorage";
+import {
+  clientSessionFromPersisted,
+  restoreDataFromPersisted,
+} from "../src/modules/browserSessionPersistence";
+
+const ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length(): number {
+    return this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.items.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value);
+  }
+}
+
+function persistedSession(overrides: Partial<PersistedSessionData> = {}): PersistedSessionData {
+  const now = new Date();
+  return {
+    address: ADDRESS,
+    chainId: 1,
+    sessionKey: JSON.stringify({ kty: "OKP", crv: "Ed25519", d: "secret" }),
+    siwe: "example.com wants you to sign in\n\nExpiration Time: 2999-01-01T00:00:00.000Z",
+    signature: "0xsig",
+    tinycloudSession: {
+      delegationHeader: { Authorization: "Bearer delegation" },
+      delegationCid: "bafydelegation",
+      spaceId: "space://tinycloud/1/owner/default",
+      verificationMethod: "did:key:z6MkSession#z6MkSession",
+    },
+    expiresAt: new Date(now.getTime() + 60_000).toISOString(),
+    createdAt: now.toISOString(),
+    version: "1.0",
+    ...overrides,
+  };
+}
+
+describe("BrowserSessionStorage", () => {
+  it("loads a valid persisted session with status", async () => {
+    const storage = new BrowserSessionStorage({ storage: new MemoryStorage() });
+    const session = persistedSession();
+
+    await storage.save(ADDRESS, session);
+
+    await expect(storage.loadWithStatus(ADDRESS)).resolves.toEqual({
+      status: "loaded",
+      data: session,
+    });
+  });
+
+  it("rejects and removes expired sessions", async () => {
+    const backend = new MemoryStorage();
+    const storage = new BrowserSessionStorage({ storage: backend });
+    backend.setItem(
+      `tinycloud:session:${ADDRESS}`,
+      JSON.stringify(
+        persistedSession({ expiresAt: new Date(Date.now() - 1_000).toISOString() }),
+      ),
+    );
+
+    await expect(storage.loadWithStatus(ADDRESS)).resolves.toEqual({
+      status: "expired",
+      data: null,
+    });
+    expect(backend.length).toBe(0);
+  });
+
+  it("rejects and removes corrupted storage", async () => {
+    const backend = new MemoryStorage();
+    const storage = new BrowserSessionStorage({ storage: backend });
+    backend.setItem(`tinycloud:session:${ADDRESS}`, "{not-json");
+
+    await expect(storage.loadWithStatus(ADDRESS)).resolves.toEqual({
+      status: "corrupt",
+      data: null,
+    });
+    expect(backend.length).toBe(0);
+  });
+
+  it("does not save impossible session data", async () => {
+    const storage = new BrowserSessionStorage({ storage: new MemoryStorage() });
+
+    expect(() =>
+      storage.save(ADDRESS, persistedSession({ sessionKey: "not-json" })),
+    ).toThrow("invalid session key");
+  });
+
+  it("clears a persisted session", async () => {
+    const storage = new BrowserSessionStorage({ storage: new MemoryStorage() });
+
+    await storage.save(ADDRESS, persistedSession());
+    expect(storage.exists(ADDRESS)).toBe(true);
+
+    await storage.clear(ADDRESS);
+
+    expect(storage.exists(ADDRESS)).toBe(false);
+    await expect(storage.loadWithStatus(ADDRESS)).resolves.toEqual({
+      status: "missing",
+      data: null,
+    });
+  });
+
+  it("isolates sessions by storage key prefix", async () => {
+    const backend = new MemoryStorage();
+    const appA = new BrowserSessionStorage({ storage: backend, keyPrefix: "app-a:" });
+    const appB = new BrowserSessionStorage({ storage: backend, keyPrefix: "app-b:" });
+    const sessionA = persistedSession({ signature: "0xa" });
+    const sessionB = persistedSession({ signature: "0xb" });
+
+    await appA.save(ADDRESS, sessionA);
+    await appB.save(ADDRESS, sessionB);
+
+    await expect(appA.load(ADDRESS)).resolves.toEqual(sessionA);
+    await expect(appB.load(ADDRESS)).resolves.toEqual(sessionB);
+  });
+});
+
+describe("browser session restore data", () => {
+  it("converts a valid persisted session to restore data and client session", async () => {
+    const session = persistedSession();
+
+    expect(clientSessionFromPersisted(session)).toEqual({
+      address: session.address,
+      walletAddress: session.address,
+      chainId: session.chainId,
+      sessionKey: session.sessionKey,
+      siwe: session.siwe,
+      signature: session.signature,
+    });
+    expect(restoreDataFromPersisted(session)).toEqual({
+      delegationHeader: session.tinycloudSession?.delegationHeader,
+      delegationCid: session.tinycloudSession?.delegationCid,
+      spaceId: session.tinycloudSession?.spaceId,
+      jwk: JSON.parse(session.sessionKey),
+      verificationMethod: session.tinycloudSession?.verificationMethod,
+      address: session.address,
+      chainId: session.chainId,
+      siwe: session.siwe,
+      signature: session.signature,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds browser session persistence/restoration for `TinyCloudWeb.signIn()` so valid stored sessions restore before wallet login.
- Expands `BrowserSessionStorage` into an explicit browser persistence API with save/load/clear, load status reporting, expiry/corruption rejection, and storage-key isolation.
- Persists through the existing node-sdk session storage path and restores through `TinyCloudNode.restoreSession(...)` using the saved session key, SIWE, signature, and TinyCloud delegation data.

## TC-1365 approach/spec
- Storage shape: reuse the existing `PersistedSessionData` shape already produced by `NodeUserAuthorization`, including `sessionKey`, `siwe`, `signature`, and `tinycloudSession` delegation fields. This keeps browser persistence aligned with how the CLI stores a key plus delegation instead of introducing a second session format.
- Storage backend: `TinyCloudWeb` now uses `BrowserSessionStorage` by default unless `persistSession: false` is passed. Apps can provide `sessionStorage` or `sessionStorageKeyPrefix` for isolation across apps/environments.
- Restore flow: `TinyCloudWeb.signIn()` calls `restoreSession()` first. If a connected wallet address has a valid stored session, the SDK rehydrates `TinyCloudNode` with `restoreSession(...)` and returns the restored client session. If storage is missing, expired, corrupt, disabled, or restore fails, the SDK falls back to the normal login path.
- Status for UI: `sessionRestoreStatus` and `restoreSession()` results expose `restoring`, `missing`, `expired`, `corrupt`, `restored`, `restore-failed`, `storage-unavailable`, `disabled`, and `logging-in` states so Listen can show restoring/no-session/restored/logging-in UI later.
- Safety: writes validate the persisted session, require TinyCloud delegation data, require a parseable JWK session key, and reject expired sessions. Loads remove expired/corrupt entries instead of restoring them. Restore failures clear the bad entry and fall back to login.

## Tests
- `bun test ./packages/web-sdk/tests/browser-session-storage.bun.ts`

## Verification notes
- `bun --cwd packages/web-sdk build` is currently blocked by generated workspace artifacts, not this change: dependency builds require missing Rust WASM output (`packages/sdk-rs/node-sdk-wasm/tinycloud_web_sdk_rs.*`), and the web-sdk build sees stale/missing workspace dist exports until those artifacts are generated.
- `bun --cwd packages/web-sdk test -- --runTestsByPath tests/tcw-spaceId.test.js` is also blocked before tests run because `packages/web-sdk/dist/index.cjs` is absent.

## Follow-up
- Listen integration should happen after this SDK release: call `signIn()` as usual, read `sessionRestoreStatus`/`restoreSession()` for UI states, and choose a `sessionStorageKeyPrefix` if Listen needs environment-specific isolation.
