### PR TITLE
TC-1376 Fix js-sdk changeset prerelease failure

### DIFF
--- a/.changeset/dependabot-dependabot-cargo-rust-minor-patch-6abb98af4c.md
+++ b/.changeset/dependabot-dependabot-cargo-rust-minor-patch-6abb98af4c.md
@@ -1,5 +1,6 @@
 ---
-"tinycloud-web-sdk": patch
+"@tinycloud/node-sdk-wasm": patch
+"@tinycloud/web-sdk-wasm": patch
 ---
 
 build(deps): bump tokio from 1.52.1 to 1.52.2 in the rust-minor-patch group


### PR DESCRIPTION
## Summary
- Fix the dependabot cargo changeset that referenced the private repo-root package `tinycloud-web-sdk`
- Retarget the tokio dependency bump changeset to the published WASM packages built from the Rust workspace
- Preserve the dependency release intent while allowing prerelease changeset versioning to resolve workspace packages

## Error
`bun changeset version` failed in prerelease mode with:

```
Error: Found changeset dependabot-dependabot-cargo-rust-minor-patch-6abb98af4c for package tinycloud-web-sdk which is not in the workspace
```

## Cause
The changeset generated for the dependabot tokio update referenced `tinycloud-web-sdk`, the private root package name, instead of publishable workspace packages. Changesets does not treat that root/private package as a releaseable workspace package in prerelease mode.

## Fix
Changed `.changeset/dependabot-dependabot-cargo-rust-minor-patch-6abb98af4c.md` to patch `@tinycloud/node-sdk-wasm` and `@tinycloud/web-sdk-wasm`, matching the repo's existing cargo dependabot changeset pattern.

## Validation
- Copied the worktree to `/tmp/js-sdk-tc1376-validate.cEhEwA`
- Ran `bun install --frozen-lockfile`
- Ran `bun changeset version` successfully in prerelease mode in the disposable copy
- Ran `git diff --check`

TC-1376
