### PR TITLE
TC-1392: Dedupe OpenKey signer prompts during vault unlock

### DIFF
--- a/.changeset/tc-1392-vault-unlock-dedupe.md
+++ b/.changeset/tc-1392-vault-unlock-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/sdk-services": patch
+---
+
+Deduplicate in-flight vault unlocks and reuse in-memory vault key material so repeated OpenKey-backed unlock paths do not trigger duplicate signer prompts.

--- a/packages/sdk-services/src/vault/DataVaultService.test.ts
+++ b/packages/sdk-services/src/vault/DataVaultService.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { DataVaultService, type VaultCrypto } from "./DataVaultService";
+import {
+  CURRENT_VAULT_VERSION,
+  VaultVersionConfig,
+} from "./types";
+
+const spaceId = "tinycloud:pkh:eip155:1:0xabc:default";
+const address = "0xabc";
+const chainId = 1;
+
+function bytes(input: string, length = 32): Uint8Array {
+  const encoded = new TextEncoder().encode(input);
+  const output = new Uint8Array(length);
+  output.set(encoded.slice(0, length));
+  return output;
+}
+
+function createVault(calls: string[]): DataVaultService {
+  const crypto: VaultCrypto = {
+    encrypt: (_key, plaintext) => plaintext,
+    decrypt: (_key, blob) => blob,
+    deriveKey: (signature, salt, info) =>
+      bytes(`${signature.length}:${salt.length}:${info.length}`),
+    x25519FromSeed: (seed) => ({
+      publicKey: seed.slice(0, 32),
+      privateKey: seed.slice(0, 32),
+    }),
+    x25519Dh: () => bytes("shared-secret"),
+    randomBytes: (length) => bytes("random", length),
+    sha256: (data) => bytes(`hash:${data.length}`),
+  };
+
+  return new DataVaultService({
+    spaceId,
+    crypto,
+    tc: {
+      kv: {},
+      ensurePublicSpace: async () => ({ ok: true, data: undefined }),
+      publicKV: {
+        put: async () => ({ ok: true, data: undefined }),
+      },
+      readPublicSpace: async () => ({
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          service: "kv",
+          message: "missing",
+        },
+      }),
+      makePublicSpaceId: (ownerAddress: string, ownerChainId: number) =>
+        `public:${ownerChainId}:${ownerAddress}`,
+      did: `did:pkh:eip155:${chainId}:${address}`,
+      address,
+      chainId,
+      hosts: ["https://tinycloud.test"],
+    },
+  } as any);
+}
+
+function createSigner(calls: string[]) {
+  return {
+    signMessage: async (message: string): Promise<string> => {
+      calls.push(message);
+      await Promise.resolve();
+      return `signature:${message}`;
+    },
+  };
+}
+
+describe("DataVaultService.unlock", () => {
+  test("dedupes concurrent unlock calls so the signer is prompted once per vault signature", async () => {
+    const calls: string[] = [];
+    const vault = createVault(calls);
+    const signer = createSigner(calls);
+
+    const results = await Promise.all([
+      vault.unlock(signer),
+      vault.unlock(signer),
+    ]);
+
+    expect(results.every((result) => result.ok)).toBe(true);
+    expect(calls).toEqual([
+      VaultVersionConfig[CURRENT_VAULT_VERSION].masterMessage(spaceId),
+      VaultVersionConfig[CURRENT_VAULT_VERSION].identityMessage,
+    ]);
+  });
+
+  test("does not prompt the signer again when unlock is repeated after key material is present", async () => {
+    const calls: string[] = [];
+    const vault = createVault(calls);
+    const signer = createSigner(calls);
+
+    const first = await vault.unlock(signer);
+    const second = await vault.unlock(signer);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(calls).toEqual([
+      VaultVersionConfig[CURRENT_VAULT_VERSION].masterMessage(spaceId),
+      VaultVersionConfig[CURRENT_VAULT_VERSION].identityMessage,
+    ]);
+  });
+});

--- a/packages/sdk-services/src/vault/DataVaultService.ts
+++ b/packages/sdk-services/src/vault/DataVaultService.ts
@@ -152,6 +152,16 @@ function base64Decode(str: string): Uint8Array {
   return bytes;
 }
 
+function isUnlockSigner(
+  signer: unknown
+): signer is { signMessage(message: string): Promise<string> } {
+  return (
+    typeof signer === "object" &&
+    signer !== null &&
+    typeof (signer as { signMessage?: unknown }).signMessage === "function"
+  );
+}
+
 function defaultVaultMessage(input: VaultErrorInput): string {
   switch (input.code) {
     case "DECRYPTION_FAILED": return input.message ?? "Decryption failed";
@@ -219,6 +229,7 @@ export class DataVaultService extends BaseService implements IDataVaultService {
   } | null = null;
   private _isUnlocked = false;
   private vaultConfig: DataVaultServiceConfig;
+  private unlockInFlight: Promise<Result<void, VaultError>> | null = null;
 
   /**
    * Create a new DataVaultService instance.
@@ -296,7 +307,20 @@ export class DataVaultService extends BaseService implements IDataVaultService {
   async unlock(
     signer?: { signMessage(message: string): Promise<string> } | unknown
   ): Promise<Result<void, VaultError>> {
-    return this.withTelemetry("unlock", undefined, async () => {
+    const unlockSigner = isUnlockSigner(signer) ? signer : undefined;
+    if (
+      this._isUnlocked &&
+      this.masterKey &&
+      (this.encryptionIdentity || !unlockSigner)
+    ) {
+      return { ok: true, data: undefined };
+    }
+
+    if (this.unlockInFlight) {
+      return this.unlockInFlight;
+    }
+
+    this.unlockInFlight = this.withTelemetry("unlock", undefined, async () => {
       const spaceId = this.vaultConfig.spaceId;
       const versionConfig = VaultVersionConfig[CURRENT_VAULT_VERSION];
       const masterCacheKey = `vault-master:${spaceId}`;
@@ -306,27 +330,30 @@ export class DataVaultService extends BaseService implements IDataVaultService {
         // -----------------------------------------------------------------
         // Step 1: Master signature → master key
         // -----------------------------------------------------------------
-        let masterSigBytes = await loadCachedSignature(masterCacheKey);
+        if (!this.masterKey) {
+          let masterSigBytes = await loadCachedSignature(masterCacheKey);
 
-        if (!masterSigBytes) {
-          if (!signer) {
-            return vaultError({
-              code: "VAULT_LOCKED",
-              message: "Signer is required when no cached master signature exists",
-            });
+          if (!masterSigBytes) {
+            if (!unlockSigner) {
+              return vaultError({
+                code: "VAULT_LOCKED",
+                message: "Signer is required when no cached master signature exists",
+              });
+            }
+            const sig = await unlockSigner.signMessage(
+              versionConfig.masterMessage(spaceId)
+            );
+            masterSigBytes = toBytes(sig);
+            await cacheSignature(masterCacheKey, masterSigBytes);
           }
-          const s = signer as { signMessage(message: string): Promise<string> };
-          const sig = await s.signMessage(versionConfig.masterMessage(spaceId));
-          masterSigBytes = toBytes(sig);
-          await cacheSignature(masterCacheKey, masterSigBytes);
-        }
 
-        // Derive master key: deriveKey(sigBytes, sha256(spaceId), "vault-master")
-        this.masterKey = this.crypto.deriveKey(
-          masterSigBytes,
-          this.crypto.sha256(toBytes(spaceId)),
-          toBytes("vault-master")
-        );
+          // Derive master key: deriveKey(sigBytes, sha256(spaceId), "vault-master")
+          this.masterKey = this.crypto.deriveKey(
+            masterSigBytes,
+            this.crypto.sha256(toBytes(spaceId)),
+            toBytes("vault-master")
+          );
+        }
 
         // -----------------------------------------------------------------
         // Step 2: Identity — check public space first, then sign if needed
@@ -357,15 +384,16 @@ export class DataVaultService extends BaseService implements IDataVaultService {
           let identitySigBytes = await loadCachedSignature(identityCacheKey);
 
           if (!identitySigBytes) {
-            if (!signer) {
+            if (!unlockSigner) {
               // No signer available — skip identity derivation.
               // Vault still works for get/put (only needs master key).
               this.encryptionIdentity = null;
               this._isUnlocked = true;
               return ok(undefined);
             }
-            const s = signer as { signMessage(message: string): Promise<string> };
-            const sig = await s.signMessage(versionConfig.identityMessage);
+            const sig = await unlockSigner.signMessage(
+              versionConfig.identityMessage
+            );
             identitySigBytes = toBytes(sig);
             await cacheSignature(identityCacheKey, identitySigBytes);
           }
@@ -403,6 +431,12 @@ export class DataVaultService extends BaseService implements IDataVaultService {
         });
       }
     }) as Promise<Result<void, VaultError>>;
+
+    try {
+      return await this.unlockInFlight;
+    } finally {
+      this.unlockInFlight = null;
+    }
   }
 
   /**


### PR DESCRIPTION
Linear: TC-1392

Summary:
- Make DataVaultService.unlock idempotent once vault key material is present.
- Dedupe concurrent unlock calls through a shared in-flight promise.
- Add regression coverage for concurrent and repeated unlock calls.

Verification:
- bun test packages/sdk-services/src/vault/DataVaultService.test.ts
- bun run build in packages/sdk-services