### PR TITLE
fix: harden encryption network SDK flows

### DIFF
--- a/.changeset/bright-clouds-decrypt.md
+++ b/.changeset/bright-clouds-decrypt.md
@@ -1,0 +1,8 @@
+---
+"@tinycloud/cli": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-services": patch
+"@tinycloud/web-sdk-wasm": patch
+---
+
+Harden encryption-network decrypt flows, add CLI secrets coverage, and fix web WASM initialization.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ TinyCloud SDK is a comprehensive toolkit for building decentralized applications
 - **KV Storage** - Content-addressed key-value store scoped to user spaces
 - **Delegation System** - Cryptographic capability chains for fine-grained access control
 - **Sharing** - Portable delegation bundles for cross-user data sharing
+- **Encryption Networks** - Network-scoped inline envelopes for secrets and vault data with `tinycloud.encryption/decrypt`
 - **Protocol Version Check** - Automatic SDK-node compatibility verification during sign-in
 - **Wallet Integration** - Seamless connection with popular Ethereum wallets (browser SDK)
 - **Server Support** - Node.js SDK for server-side delegation chains and automation

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,6 +24,11 @@ tc kv put greeting "Hello, world"
 tc kv get greeting
 tc kv list
 
+# Manage network-encrypted secrets on the default network
+tc secrets network init
+tc secrets put ANTHROPIC_API_KEY "sk-..."
+tc secrets get ANTHROPIC_API_KEY
+
 # Manage spaces
 tc space list
 tc space create
@@ -55,11 +60,20 @@ tc delegation create --to did:pkh:eip155:1:0x...
 | `tc profile list` | List profiles |
 | `tc profile show` | Show profile details |
 | `tc profile create` | Create a new profile |
-| `tc vault` | Manage encrypted vaults |
-| `tc secrets` | Manage secrets |
+| `tc vault` | Manage encrypted KV vaults |
+| `tc secrets` | Manage network-encrypted secrets |
+| `tc secrets network show` | Show a secrets decryption network |
+| `tc secrets network init` | Create or fetch the default secrets network |
+| `tc secrets network grant` | Grant `tinycloud.encryption/decrypt` on a secrets network |
 | `tc vars` | Manage environment variables |
 | `tc doctor` | Run diagnostic checks |
 | `tc completion` | Generate shell completions |
+
+Secret names are env-style uppercase identifiers such as `FIREFLIES_API_KEY`.
+`tc secrets network show` accepts either a short network name or a full
+`urn:tinycloud:encryption:<principal>:<network>` identifier. `tc secrets
+network grant` takes the short name, resolves the network, and grants
+`tinycloud.encryption/decrypt`.
 
 ## Global Options
 

--- a/packages/cli/skills/tc-cli/REFERENCE.md
+++ b/packages/cli/skills/tc-cli/REFERENCE.md
@@ -52,6 +52,28 @@ tc profile delete old-profile
 
 Per-command override: `tc kv get mykey --profile staging`
 
+## Secrets
+
+Secrets are stored as network-encrypted inline envelopes and read through
+`tinycloud.encryption/decrypt`. Secret names are env-style uppercase
+identifiers such as `FIREFLIES_API_KEY`. `tc secrets network show` accepts
+either a short network name or a full
+`urn:tinycloud:encryption:<principal>:<network>` identifier, and `tc secrets
+network grant` takes the short name, resolves the network, and issues
+`tinycloud.encryption/decrypt` on that network. Share the decrypt grant
+separately from any KV or SQL reads the app also needs.
+
+```bash
+tc secrets network init
+tc secrets network show
+tc secrets network grant did:pkh:eip155:1:0xRecipient...
+
+tc secrets put ANTHROPIC_API_KEY "sk-..."
+tc secrets get ANTHROPIC_API_KEY
+tc secrets list
+tc secrets delete ANTHROPIC_API_KEY
+```
+
 ## Node Health
 
 ```bash

--- a/packages/cli/src/commands/secrets.test.ts
+++ b/packages/cli/src/commands/secrets.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Command } from "commander";
+
+const DEFAULT_NETWORK_ID =
+  "urn:tinycloud:encryption:did:key:z6MkPrincipal:default";
+const DEFAULT_NODE_DID = "did:key:z6MkPrincipal";
+
+type CLIErrorLike = {
+  code: string;
+  message: string;
+  exitCode: number;
+};
+
+type NetworkDescriptorLike = {
+  networkId: string;
+  principal: string;
+  name: string;
+  members: Array<{ nodeId: string; role: "primary" | "share" }>;
+  threshold: { n: number; t: number };
+  state: "pending" | "generating" | "active" | "rotating" | "revoked" | "failed";
+  publicEncryptionKey: string;
+  alg: string;
+  keyVersion: number;
+  keyBackend: "local-one-of-one";
+  createdAt: string;
+  updatedAt: string;
+};
+
+type FakeNode = {
+  did: string;
+  getDefaultEncryptionNetworkId(name?: string): string;
+  secrets: {
+    list(options?: { scope?: string }): Promise<{ ok: true; data: string[] } | { ok: false; error: { code: string; message: string; service?: string } }>;
+    get(name: string, options?: { scope?: string }): Promise<{ ok: true; data: string } | { ok: false; error: { code: string; message: string; service?: string } }>;
+    put(name: string, value: string, options?: { scope?: string }): Promise<{ ok: true; data: undefined } | { ok: false; error: { code: string; message: string; service?: string } }>;
+    delete(name: string, options?: { scope?: string }): Promise<{ ok: true; data: undefined } | { ok: false; error: { code: string; message: string; service?: string } }>;
+  };
+  getEncryptionNetwork(nameOrNetworkId: string): Promise<NetworkDescriptorLike | null>;
+  ensureEncryptionNetwork(name: string): Promise<NetworkDescriptorLike>;
+  delegateTo(
+    recipientDid: string,
+    permissions: Array<{
+      service: string;
+      path: string;
+      actions: string[];
+    }>,
+  ): Promise<{
+    delegation: {
+      cid: string;
+      path: string;
+      actions: string[];
+    };
+    prompted: boolean;
+  }>;
+};
+
+const recorded = {
+  outputs: [] as unknown[],
+  spinners: [] as string[],
+  errors: [] as unknown[],
+  resolveContexts: [] as unknown[],
+  ensureAuthenticated: [] as unknown[],
+  listCalls: [] as Array<{ scope?: string } | undefined>,
+  getCalls: [] as Array<{ name: string; options?: { scope?: string } }>,
+  putCalls: [] as Array<{ name: string; value: string; options?: { scope?: string } }>,
+  deleteCalls: [] as Array<{ name: string; options?: { scope?: string } }>,
+  networkShowCalls: [] as string[],
+  networkInitCalls: [] as string[],
+  delegateCalls: [] as Array<{
+    recipientDid: string;
+    permissions: Array<{
+      service: string;
+      path: string;
+      actions: string[];
+    }>;
+  }>,
+};
+
+let currentNode: FakeNode;
+
+function resetRecorded(): void {
+  recorded.outputs.length = 0;
+  recorded.spinners.length = 0;
+  recorded.errors.length = 0;
+  recorded.resolveContexts.length = 0;
+  recorded.ensureAuthenticated.length = 0;
+  recorded.listCalls.length = 0;
+  recorded.getCalls.length = 0;
+  recorded.putCalls.length = 0;
+  recorded.deleteCalls.length = 0;
+  recorded.networkShowCalls.length = 0;
+  recorded.networkInitCalls.length = 0;
+  recorded.delegateCalls.length = 0;
+}
+
+function makeDescriptor(
+  networkId: string = DEFAULT_NETWORK_ID,
+): NetworkDescriptorLike {
+  return {
+    networkId,
+    principal: DEFAULT_NODE_DID,
+    name: "default",
+    members: [{ nodeId: DEFAULT_NODE_DID, role: "primary" }],
+    threshold: { n: 1, t: 1 },
+    state: "active",
+    publicEncryptionKey: "AQID",
+    alg: "x25519-aes256gcm/v1",
+    keyVersion: 1,
+    keyBackend: "local-one-of-one",
+    createdAt: "2026-06-02T00:00:00.000Z",
+    updatedAt: "2026-06-02T00:00:00.000Z",
+  };
+}
+
+function makeFakeNode(overrides: {
+  getResult?: { ok: false; error: { code: string; message: string; service?: string } } | { ok: true; data: string };
+  listResult?: { ok: false; error: { code: string; message: string; service?: string } } | { ok: true; data: string[] };
+  putResult?: { ok: false; error: { code: string; message: string; service?: string } } | { ok: true; data: undefined };
+  deleteResult?: { ok: false; error: { code: string; message: string; service?: string } } | { ok: true; data: undefined };
+  networkShowResult?: NetworkDescriptorLike | null;
+  networkInitResult?: NetworkDescriptorLike;
+  delegateResult?: { delegation: { cid: string; path: string; actions: string[] }; prompted: boolean };
+} = {}): FakeNode {
+  const descriptor = overrides.networkInitResult ?? makeDescriptor();
+  return {
+    did: DEFAULT_NODE_DID,
+    getDefaultEncryptionNetworkId(name = "default") {
+      return `urn:tinycloud:encryption:${DEFAULT_NODE_DID}:${name}`;
+    },
+    secrets: {
+      async list(options?: { scope?: string }) {
+        recorded.listCalls.push(options);
+        return overrides.listResult ?? { ok: true as const, data: ["ANTHROPIC_API_KEY"] };
+      },
+      async get(name: string, options?: { scope?: string }) {
+        recorded.getCalls.push({ name, options });
+        return overrides.getResult ?? { ok: true as const, data: "stored-value" };
+      },
+      async put(name: string, value: string, options?: { scope?: string }) {
+        recorded.putCalls.push({ name, value, options });
+        return overrides.putResult ?? { ok: true as const, data: undefined };
+      },
+      async delete(name: string, options?: { scope?: string }) {
+        recorded.deleteCalls.push({ name, options });
+        return overrides.deleteResult ?? { ok: true as const, data: undefined };
+      },
+    },
+    async getEncryptionNetwork(nameOrNetworkId: string) {
+      recorded.networkShowCalls.push(nameOrNetworkId);
+      return overrides.networkShowResult ?? descriptor;
+    },
+    async ensureEncryptionNetwork(name: string) {
+      recorded.networkInitCalls.push(name);
+      return overrides.networkInitResult ?? descriptor;
+    },
+    async delegateTo(recipientDid: string, permissions) {
+      recorded.delegateCalls.push({ recipientDid, permissions });
+      return (
+        overrides.delegateResult ?? {
+          delegation: {
+            cid: "bafy-delegation",
+            path: permissions[0]?.path ?? "",
+            actions: permissions[0]?.actions ?? [],
+          },
+          prompted: false,
+        }
+      );
+    },
+  };
+}
+
+mock.module("../config/profiles.js", () => ({
+  ProfileManager: {
+    resolveContext: async (globalOpts: unknown) => {
+      recorded.resolveContexts.push(globalOpts);
+      return {
+        profile: "default",
+        host: "https://tinycloud.test",
+      };
+    },
+  },
+}));
+
+mock.module("../lib/sdk.js", () => ({
+  ensureAuthenticated: async (ctx: unknown, options: unknown) => {
+    recorded.ensureAuthenticated.push({ ctx, options });
+    return currentNode;
+  },
+}));
+
+mock.module("../output/formatter.js", () => ({
+  outputJson: (payload: unknown) => {
+    recorded.outputs.push(payload);
+  },
+  withSpinner: async (_message: string, fn: () => unknown) => {
+    recorded.spinners.push(_message);
+    return await fn();
+  },
+}));
+
+mock.module("../output/errors.js", () => ({
+  CLIError: class CLIError extends Error implements CLIErrorLike {
+    constructor(
+      public code: string,
+      message: string,
+      public exitCode: number,
+    ) {
+      super(message);
+      this.name = "CLIError";
+    }
+  },
+  handleError: (error: unknown) => {
+    recorded.errors.push(error);
+  },
+}));
+
+const { registerSecretsCommand } = await import("./secrets.js");
+
+async function runSecretsCommand(args: string[]): Promise<void> {
+  const program = new Command();
+  registerSecretsCommand(program);
+  await program.parseAsync(["node", "tc", ...args], { from: "node" });
+}
+
+beforeEach(() => {
+  resetRecorded();
+  currentNode = makeFakeNode();
+});
+
+describe("CLI secrets commands", () => {
+  test("routes put/get/list/delete through node.secrets", async () => {
+    await runSecretsCommand(["secrets", "list", "--scope", "Food Tracker"]);
+    await runSecretsCommand(["secrets", "get", "ANTHROPIC_API_KEY"]);
+    await runSecretsCommand(["secrets", "put", "ANTHROPIC_API_KEY", "super-secret"]);
+    await runSecretsCommand(["secrets", "delete", "ANTHROPIC_API_KEY"]);
+
+    expect(recorded.listCalls).toEqual([{ scope: "Food Tracker" }]);
+    expect(recorded.getCalls).toEqual([
+      { name: "ANTHROPIC_API_KEY", options: undefined },
+    ]);
+    expect(recorded.putCalls).toEqual([
+      {
+        name: "ANTHROPIC_API_KEY",
+        value: "super-secret",
+        options: undefined,
+      },
+    ]);
+    expect(recorded.deleteCalls).toEqual([
+      { name: "ANTHROPIC_API_KEY", options: undefined },
+    ]);
+    expect(recorded.outputs).toEqual([
+      { secrets: ["ANTHROPIC_API_KEY"], count: 1, scope: "Food Tracker" },
+      { name: "ANTHROPIC_API_KEY", value: "stored-value" },
+      { name: "ANTHROPIC_API_KEY", written: true },
+      { name: "ANTHROPIC_API_KEY", deleted: true },
+    ]);
+    expect(recorded.spinners).toEqual([
+      "Listing secrets...",
+      "Getting secret ANTHROPIC_API_KEY...",
+      "Storing secret ANTHROPIC_API_KEY...",
+      "Deleting secret ANTHROPIC_API_KEY...",
+    ]);
+  });
+
+  test("queries the authoritative encryption network before reporting it", async () => {
+    const descriptor = makeDescriptor();
+    currentNode = makeFakeNode({ networkShowResult: descriptor });
+
+    await runSecretsCommand(["secrets", "network", "show", "default"]);
+
+    expect(recorded.networkShowCalls).toEqual(["default"]);
+    expect(recorded.outputs).toEqual([
+      {
+        networkId: descriptor.networkId,
+        exists: true,
+        descriptor,
+      },
+    ]);
+  });
+
+  test("ensures a decryption network and grants tinycloud.encryption/decrypt", async () => {
+    const descriptor = makeDescriptor("urn:tinycloud:encryption:did:key:z6MkPrincipal:shared");
+    currentNode = makeFakeNode({ networkInitResult: descriptor });
+
+    await runSecretsCommand([
+      "secrets",
+      "network",
+      "grant",
+      "did:key:z6MkRecipient",
+      "shared",
+    ]);
+
+    expect(recorded.networkInitCalls).toEqual(["shared"]);
+    expect(recorded.delegateCalls).toEqual([
+      {
+        recipientDid: "did:key:z6MkRecipient",
+        permissions: [
+          {
+            service: "tinycloud.encryption",
+            path: descriptor.networkId,
+            actions: ["decrypt"],
+          },
+        ],
+      },
+    ]);
+    expect(recorded.outputs).toEqual([
+      {
+        networkId: descriptor.networkId,
+        recipientDid: "did:key:z6MkRecipient",
+        cid: "bafy-delegation",
+        prompted: false,
+        path: descriptor.networkId,
+        actions: ["decrypt"],
+      },
+    ]);
+  });
+
+  test("surfaces permission errors without exposing secret values", async () => {
+    currentNode = makeFakeNode({
+      getResult: {
+        ok: false,
+        error: {
+          code: "PERMISSION_DENIED",
+          service: "secrets",
+          message: "Permission denied while reading secret",
+        },
+      },
+    });
+
+    await runSecretsCommand(["secrets", "get", "ANTHROPIC_API_KEY"]);
+
+    expect(recorded.errors).toHaveLength(1);
+    const error = recorded.errors[0] as CLIErrorLike;
+    expect(error.code).toBe("PERMISSION_DENIED");
+    expect(error.message).toBe("Permission denied while reading secret");
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,6 +97,7 @@ ${theme.heading("Examples:")}
   ${theme.command("tc auth login")}                        ${theme.muted("Authenticate via browser")}
   ${theme.command('tc kv put greeting "Hello"')}           ${theme.muted("Store a value")}
   ${theme.command("tc kv list")}                           ${theme.muted("List all keys")}
+  ${theme.command("tc secrets network init")}              ${theme.muted("Create the default secrets network")}
   ${theme.command("tc delegation create --to did:pkh:...")}  ${theme.muted("Grant access to another user")}
   ${theme.command("tc space list")}                        ${theme.muted("Show your spaces")}
 

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import {
+  canonicalHashHex,
+  hexEncode,
+  encryptionBase64Decode,
+  encryptionBase64Encode,
+  encryptionUtf8Encode,
+  type DecryptRequestBody,
+  type DecryptResponseBody,
+  type EncryptionCrypto,
   type ISessionManager,
   type IWasmBindings,
+  type NetworkDescriptor,
   type PermissionEntry,
 } from "@tinycloud/sdk-core";
 
@@ -74,6 +83,81 @@ function makeFakeWasmBindings(
     vault_random_bytes: mock(() => new Uint8Array()),
     vault_sha256: mock(() => new Uint8Array()),
     createSessionManager: makeFakeSessionManager,
+  };
+}
+
+function xor(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const out = new Uint8Array(right.length);
+  for (let i = 0; i < right.length; i++) {
+    out[i] = left[i % left.length] ^ right[i % right.length];
+  }
+  return out;
+}
+
+function deterministicSha256(bytes: Uint8Array): Uint8Array {
+  const out = new Uint8Array(32);
+  let h0 = 0x6a09e667;
+  let h1 = 0xbb67ae85;
+  for (let i = 0; i < bytes.length; i++) {
+    h0 = ((h0 + bytes[i] * 31) ^ ((h0 << 5) | (h0 >>> 27))) >>> 0;
+    h1 = ((h1 ^ (bytes[i] + 17)) + ((h1 << 7) | (h1 >>> 25))) >>> 0;
+  }
+  for (let i = 0; i < 16; i++) {
+    out[i] = (h0 >>> ((i % 4) * 8)) & 0xff;
+    out[i + 16] = (h1 >>> ((i % 4) * 8)) & 0xff;
+    h0 = (h0 * 1103515245 + 12345) >>> 0;
+    h1 = (h1 * 1664525 + 1013904223) >>> 0;
+  }
+  return out;
+}
+
+function makeEncryptionCrypto(): EncryptionCrypto {
+  let seed = 0xdeadbeef;
+  const randomBytes = (length: number): Uint8Array => {
+    const out = new Uint8Array(length);
+    for (let i = 0; i < length; i++) {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      out[i] = seed & 0xff;
+    }
+    return out;
+  };
+
+  return {
+    sha256: deterministicSha256,
+    randomBytes,
+    x25519FromSeed: (seedBytes) => ({
+      publicKey: seedBytes,
+      privateKey: seedBytes,
+    }),
+    x25519Dh: (priv, pub) => deterministicSha256(xor(priv, pub)),
+    authEncrypt: (key, plaintext, aad) => {
+      const mixedKey = aad === undefined ? key : deterministicSha256(xor(key, aad));
+      return xor(mixedKey, plaintext);
+    },
+    authDecrypt: (key, ciphertext, aad) => {
+      const mixedKey = aad === undefined ? key : deterministicSha256(xor(key, aad));
+      return xor(mixedKey, ciphertext);
+    },
+    sealToNetworkKey: (networkPublicKey, symmetricKey) => xor(networkPublicKey, symmetricKey),
+    openWithReceiverKey: (receiverPrivateKey, wrappedKey) => xor(receiverPrivateKey, wrappedKey),
+    verifyNodeSignature: () => true,
+  };
+}
+
+function makeEncryptionDescriptor(networkId: string, nodeDid: string): NetworkDescriptor {
+  return {
+    networkId,
+    principal: nodeDid,
+    name: "default",
+    members: [{ nodeId: nodeDid, role: "primary" }],
+    threshold: { n: 1, t: 1 },
+    state: "active",
+    publicEncryptionKey: encryptionBase64Encode(new Uint8Array(32).fill(11)),
+    alg: "x25519-aes256gcm/v1",
+    keyVersion: 1,
+    keyBackend: "local-one-of-one",
+    createdAt: "2026-06-02T00:00:00.000Z",
+    updatedAt: "2026-06-02T00:00:00.000Z",
   };
 }
 
@@ -605,5 +689,189 @@ describe("TinyCloudNode runtime permission delegations", () => {
     expect(invokeAny.mock.calls[0][0].delegationHeader.Authorization).toBe(
       "runtime-token",
     );
+  });
+
+  test("encryption discovery falls back to the well-known cache record", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    (node as any)._address = address;
+    (node as any)._chainId = 1;
+    (node as any).getEncryptionNetwork = mock(async () => null);
+
+    const networkId = node.getDefaultEncryptionNetworkId();
+    const descriptor = {
+      networkId,
+      principal: node.did,
+      name: "default",
+      members: [{ nodeId: "did:key:cache-node", role: "primary" as const }],
+      threshold: { n: 1, t: 1 },
+      state: "active" as const,
+      publicEncryptionKey: "AQID",
+      alg: "x25519-aes256gcm/v1",
+      keyVersion: 1,
+      keyBackend: "local-one-of-one" as const,
+      createdAt: "2026-06-02T00:00:00.000Z",
+      updatedAt: "2026-06-02T00:00:00.000Z",
+    };
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = mock(async () =>
+      new Response(JSON.stringify(descriptor), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      const encryption = (node as any).createEncryptionService();
+      const result = await encryption.discoverNetwork("default", node.did);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.networkId).toBe(networkId);
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("encryption service round-trips through the node encrypt/decrypt path", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const networkId = node.getDefaultEncryptionNetworkId();
+    const descriptor = makeEncryptionDescriptor(networkId, node.did);
+    const crypto = makeEncryptionCrypto();
+
+    (node as any).createEncryptionCrypto = () => crypto;
+
+    const signRawNetworkAuthorization = mock(
+      async ({ targetNode, networkId: signedNetworkId, action, facts }: any) => {
+        expect(targetNode).toBe(node.did);
+        expect(signedNetworkId).toBe(networkId);
+        expect(action).toBe("tinycloud.encryption/decrypt");
+        expect(facts.targetNode).toBe(node.did);
+        expect(facts.networkId).toBe(networkId);
+        return {
+          authorization: "Invocation node-encryption",
+          invocationCid: "bafy-node-encryption",
+        };
+      },
+    );
+    (node as any).signRawNetworkAuthorization = signRawNetworkAuthorization;
+
+    const fetchCalls: Array<{ method: string; url: string; body?: string }> = [];
+    const originalFetch = globalThis.fetch;
+    const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      const body =
+        typeof init?.body === "string"
+          ? init.body
+          : init?.body instanceof Uint8Array
+            ? new TextDecoder().decode(init.body)
+            : undefined;
+      fetchCalls.push({ method, url, body });
+
+      const getUrl =
+        `https://tinycloud.test/encryption/networks/${encodeURIComponent(networkId)}`;
+      const decryptUrl = `${getUrl}/decrypt`;
+
+      if (method === "GET" && url === getUrl) {
+        return new Response(JSON.stringify({ descriptor }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (method === "POST" && url === decryptUrl) {
+        if (!body) {
+          throw new Error("expected canonical decrypt body");
+        }
+        const request = JSON.parse(body) as DecryptRequestBody;
+        const wrappedSymmetricKey = encryptionBase64Decode(
+          request.encryptedSymmetricKey,
+        );
+        const networkPublicKey = encryptionBase64Decode(
+          descriptor.publicEncryptionKey,
+        );
+        const symmetricKey = xor(networkPublicKey, wrappedSymmetricKey);
+        const receiverPublicKey = encryptionBase64Decode(
+          request.receiverPublicKey,
+        );
+        const wrappedKey = xor(receiverPublicKey, symmetricKey);
+        const invocationCid = "bafy-node-encryption";
+        const requestBodyHash = canonicalHashHex(crypto.sha256, request as any);
+        const response: DecryptResponseBody = {
+          type: "tinycloud.encryption.decrypt-result/v1",
+          targetNode: request.targetNode,
+          networkId: request.networkId,
+          invocationCid,
+          encryptedSymmetricKeyHash: request.encryptedSymmetricKeyHash,
+          receiverPublicKeyHash: request.receiverPublicKeyHash,
+          wrappedKey: encryptionBase64Encode(wrappedKey),
+          alg: request.alg,
+          keyVersion: request.keyVersion,
+          requestHash: hexEncode(
+            crypto.sha256(
+              encryptionUtf8Encode(`${invocationCid}${requestBodyHash}`),
+            ),
+          ),
+          nodeId: node.did,
+          nodeSignature: encryptionBase64Encode(new Uint8Array(64).fill(9)),
+        };
+        return new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      throw new Error(`unexpected fetch ${method} ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      const encryption = (node as any).createEncryptionService();
+      const plaintext = encryptionUtf8Encode("hello tinycloud encryption");
+
+      const encryptResult = await encryption.encryptToNetwork(networkId, plaintext);
+      expect(encryptResult.ok).toBe(true);
+      if (!encryptResult.ok) return;
+
+      const decryptResult = await encryption.decryptEnvelope(encryptResult.data, {
+        proofs: ["bafyDelegationFromPrincipal"],
+      });
+      expect(decryptResult.ok).toBe(true);
+      if (!decryptResult.ok) return;
+
+      expect(new TextDecoder().decode(decryptResult.data)).toBe(
+        "hello tinycloud encryption",
+      );
+      expect(fetchCalls.map((call) => call.method)).toEqual(["GET", "GET", "POST"]);
+      expect(signRawNetworkAuthorization).toHaveBeenCalledTimes(1);
+
+      const postCall = fetchCalls[2];
+      expect(postCall.url).toBe(
+        `https://tinycloud.test/encryption/networks/${encodeURIComponent(networkId)}/decrypt`,
+      );
+      const request = JSON.parse(postCall.body ?? "{}") as DecryptRequestBody;
+      expect(request.targetNode).toBe(node.did);
+      expect(request.networkId).toBe(networkId);
+      expect(request.alg).toBe(descriptor.alg);
+      expect(request.keyVersion).toBe(descriptor.keyVersion);
+      expect(request.encryptedSymmetricKeyHash).toBe(
+        encryptResult.data.encryptedSymmetricKeyHash,
+      );
+      expect(request.receiverPublicKeyHash).toBe(
+        canonicalHashHex(crypto.sha256, request.receiverPublicKey),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -376,7 +376,6 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
           "": ["tinycloud.capabilities/read"],
         },
         kv: {
-          "keys/secrets/ANTHROPIC_API_KEY": ["tinycloud.kv/get"],
           "vault/secrets/ANTHROPIC_API_KEY": ["tinycloud.kv/get"],
         },
       },

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -1357,6 +1357,29 @@ export class TinyCloudNode {
       node: {
         fetchByNetworkId: (networkId) => this.getEncryptionNetwork(networkId),
       },
+      wellKnown: {
+        fetchWellKnown: async (principal, discoveryKey) => {
+          if (!this._address || principal !== this.did) {
+            return null;
+          }
+          if (!this.config.host) {
+            return null;
+          }
+          const publicSpaceId = makePublicSpaceId(this._address, this._chainId);
+          const result = await TinyCloud.readPublicSpace<
+            NetworkDescriptor | { descriptor?: NetworkDescriptor }
+          >(this.config.host, publicSpaceId, discoveryKey);
+          if (!result.ok) {
+            return null;
+          }
+          const body = result.data as
+            | NetworkDescriptor
+            | { descriptor?: NetworkDescriptor };
+          return "descriptor" in body && body.descriptor
+            ? body.descriptor
+            : (body as NetworkDescriptor);
+        },
+      },
     });
   }
 

--- a/packages/node-sdk/src/delegateToHelpers.test.ts
+++ b/packages/node-sdk/src/delegateToHelpers.test.ts
@@ -72,8 +72,8 @@ describe("legacyParamsToPermissionEntries", () => {
 });
 
 describe("resolveExpiryMs", () => {
-  test("undefined → 1 hour default", () => {
-    expect(resolveExpiryMs(undefined)).toBe(60 * 60 * 1000);
+  test("undefined → 7 day default", () => {
+    expect(resolveExpiryMs(undefined)).toBe(7 * 24 * 60 * 60 * 1000);
   });
 
   test("positive number passes through unchanged", () => {

--- a/packages/sdk-rs/packages/web/src/index.ts
+++ b/packages/sdk-rs/packages/web/src/index.ts
@@ -4,7 +4,7 @@ import wasm from "../../../web-sdk-wasm/tinycloud_web_sdk_rs_bg.wasm";
 
 import * as lib from "../../../web-sdk-wasm/tinycloud_web_sdk_rs.js";
 
-export const initialized: Promise<void> = init(wasm()).then(() =>
+export const initialized: Promise<void> = init({ module_or_path: wasm() }).then(() =>
   lib.initPanicHook()
 );
 

--- a/packages/sdk-services/src/encryption/EncryptionService.ts
+++ b/packages/sdk-services/src/encryption/EncryptionService.ts
@@ -175,6 +175,17 @@ export class EncryptionService
     try {
       const validated = validateEnvelope(this.crypto, envelope);
       if (!validated.ok) return validated;
+      if (
+        options?.aad !== undefined &&
+        validated.data.aad !== base64Encode(options.aad)
+      ) {
+        return encErr(
+          encryptionError({
+            code: "INVALID_INPUT",
+            message: "decryptEnvelope aad does not match the envelope",
+          }),
+        );
+      }
 
       let descriptor: NetworkDescriptor;
       if (options?.descriptor !== undefined) {

--- a/packages/sdk-services/src/encryption/encryption.test.ts
+++ b/packages/sdk-services/src/encryption/encryption.test.ts
@@ -668,6 +668,32 @@ describe("decrypt response verification", () => {
     }
   });
 
+  it("rejects a response whose nodeId does not match the target node", () => {
+    const crypto = makeCrypto();
+    const request = fullRequest(crypto);
+    const { response, requestBodyHash } = makeResponse(crypto, request, "bafyINV");
+    const facts = buildDecryptFacts({
+      crypto,
+      body: request,
+      encryptedSymmetricKeyHash: request.encryptedSymmetricKeyHash,
+      receiverPublicKey: new Uint8Array([4, 5, 6]),
+    });
+    response.nodeId = "did:key:z6MkOtherNode";
+    const result = verifyDecryptResponse({
+      crypto,
+      request,
+      facts,
+      invocationCid: "bafyINV",
+      requestBodyHash,
+      response,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("RESPONSE_BINDING_MISMATCH");
+      expect(result.error.field).toBe("nodeId");
+    }
+  });
+
   it("canonicalSignedResponse excludes the signature field", () => {
     const crypto = makeCrypto();
     const request = fullRequest(crypto);

--- a/packages/sdk-services/src/encryption/response.ts
+++ b/packages/sdk-services/src/encryption/response.ts
@@ -93,6 +93,15 @@ export function verifyDecryptResponse(
       }),
     };
   }
+  if (response.nodeId !== request.targetNode) {
+    return {
+      ok: false,
+      error: encryptionError({
+        code: "RESPONSE_BINDING_MISMATCH",
+        field: "nodeId",
+      }),
+    };
+  }
   if (response.alg !== request.alg) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary
- Adds SDK/node runtime permission and decrypt response binding coverage.
- Adds CLI secrets command tests/docs and exports command surface.
- Binds decrypt responses to the target node and validates optional AAD.

## Release
- Includes `.changeset/bright-clouds-decrypt.md` with patch entries for `@tinycloud/cli`, `@tinycloud/node-sdk`, `@tinycloud/sdk-services`, and `@tinycloud/web-sdk-wasm`.
- Changesets status also reports patch bumps for linked/internal dependent packages according to the repo config.

## Validation
- `bun test packages/sdk-services/src/encryption/encryption.test.ts packages/sdk-services/src/vault/DataVaultService.test.ts packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts packages/node-sdk/src/NodeSecretsService.test.ts packages/node-sdk/src/delegateToHelpers.test.ts`
- `bun test packages/cli/src/commands/secrets.test.ts packages/node-sdk/src/NodeSecretsService.test.ts packages/sdk-services/src/secrets/SecretsService.test.ts`
- `bunx @changesets/cli status --since origin/master`

## Notes
The full web-sdk suite and CLI typecheck still have pre-existing unrelated failures, so this PR was validated with the targeted suites above.
