### PR TITLE
fix: target wasm packages in rust dependency changeset

### DIFF
--- a/.changeset/dependabot-dependabot-cargo-rust-minor-patch-fcf40cfdd5.md
+++ b/.changeset/dependabot-dependabot-cargo-rust-minor-patch-fcf40cfdd5.md
@@ -1,5 +1,6 @@
 ---
-"tinycloud-web-sdk": patch
+"@tinycloud/web-sdk-wasm": patch
+"@tinycloud/node-sdk-wasm": patch
 ---
 
 build(deps): bump the rust-minor-patch group across 1 directory with 2 updates


### PR DESCRIPTION
## Summary
- Fixes the dependabot rust dependency changeset so it targets releaseable workspace packages.
- Replaces the invalid private root package target `tinycloud-web-sdk` with `@tinycloud/web-sdk-wasm` and `@tinycloud/node-sdk-wasm`.

## Validation
- `bun install --frozen-lockfile`
- `bun changeset version`

## Notes
`bun changeset version` still prints the existing prerelease-mode warning, but it now completes successfully instead of failing on the invalid package target.
