### PR TITLE
chore: bump tinycloud-node wasm rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "cacaos"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=01176a8ceb01a1192d688436376d122843b72efa#01176a8ceb01a1192d688436376d122843b72efa"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
 dependencies = [
  "async-trait",
  "hex",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=01176a8ceb01a1192d688436376d122843b72efa#01176a8ceb01a1192d688436376d122843b72efa"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
 dependencies = [
  "hex",
  "http 1.4.0",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "siwe-recap"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=01176a8ceb01a1192d688436376d122843b72efa#01176a8ceb01a1192d688436376d122843b72efa"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
 dependencies = [
  "base64 0.22.1",
  "ipld-core",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-auth"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=01176a8ceb01a1192d688436376d122843b72efa#01176a8ceb01a1192d688436376d122843b72efa"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4928,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-rs"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=01176a8ceb01a1192d688436376d122843b72efa#01176a8ceb01a1192d688436376d122843b72efa"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
 dependencies = [
  "async-trait",
  "hex",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-wasm"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=01176a8ceb01a1192d688436376d122843b72efa#01176a8ceb01a1192d688436376d122843b72efa"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
 dependencies = [
  "aes-gcm",
  "chrono",

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -22,9 +22,9 @@ console_error_panic_hook = "0.1"
 hex = "0.4.3"
 iri-string = "0.7.12"
 js-sys = "0.3.59"
-# Depends on TinyCloudLabs/tinycloud-node#66.
-tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "01176a8ceb01a1192d688436376d122843b72efa" }
-tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "01176a8ceb01a1192d688436376d122843b72efa" }
+# Includes TinyCloudLabs/tinycloud-node#71.
+tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "b483946a0ed2737237daa38f6ee456a4a398b51e" }
+tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "b483946a0ed2737237daa38f6ee456a4a398b51e" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.150"
 serde-wasm-bindgen = "0.6.5"


### PR DESCRIPTION
## Context

The TypeScript DID/address canonicalization merged in js-sdk, but the Rust-backed wasm package still pinned `tinycloud-sdk-rs` and `tinycloud-sdk-wasm` to an older `tinycloud-node` git revision. That means generated wasm builds would not include the merged tinycloud-node canonicalization changes.

## Summary

- Bump `packages/sdk-rs` tinycloud-node git dependencies to `b483946a0ed2737237daa38f6ee456a4a398b51e`.
- Update `Cargo.lock` for the tinycloud-node git crates.

## Tests

- `cargo update -p tinycloud-sdk-rs -p tinycloud-sdk-wasm`
- `bun run --cwd packages/sdk-rs build:wasm:node`

Related public PR: TinyCloudLabs/tinycloud-node#71.