### PR TITLE
fix: add canonical network id helper

### DIFF
--- a/.changeset/canonical-network-id.md
+++ b/.changeset/canonical-network-id.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Add canonical encryption network ID helpers so apps can compare network-scoped capabilities across equivalent owner DID address casing.

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -34,6 +34,7 @@ export type {
   ISpaceCreationHandler,
   SpaceCreationContext,
   CanonicalAddress,
+  CanonicalParsedNetworkId,
   DidCacheKeyOptions,
   DidEqualsOptions,
   PkhDidParts,
@@ -49,6 +50,7 @@ export {
   canonicalizeAddress,
   canonicalizeDid,
   canonicalizeDidUrl,
+  canonicalizeNetworkId,
   didCacheKey,
   didEquals,
   isEvmAddress,
@@ -57,6 +59,7 @@ export {
   pkhDid,
   principalDid,
   principalDidEquals,
+  parseCanonicalNetworkId,
 } from "@tinycloud/sdk-core";
 
 // Storage implementations
@@ -131,10 +134,7 @@ export {
 
 // Delegation
 export { DelegatedAccess } from "./DelegatedAccess";
-export {
-  serializeDelegation,
-  deserializeDelegation,
-} from "./delegation";
+export { serializeDelegation, deserializeDelegation } from "./delegation";
 export type { PortableDelegation } from "./delegation";
 
 // Re-export KV service values
@@ -174,7 +174,11 @@ export type {
 } from "@tinycloud/sdk-core";
 
 // Re-export DuckDB service values
-export { DuckDbService, DuckDbDatabaseHandle, DuckDbAction } from "@tinycloud/sdk-core";
+export {
+  DuckDbService,
+  DuckDbDatabaseHandle,
+  DuckDbAction,
+} from "@tinycloud/sdk-core";
 
 // Re-export DuckDB service types
 export type {

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -58,6 +58,7 @@ export type {
   ISpaceCreationHandler,
   SpaceCreationContext,
   CanonicalAddress,
+  CanonicalParsedNetworkId,
   DidCacheKeyOptions,
   DidEqualsOptions,
   PkhDidParts,
@@ -73,6 +74,7 @@ export {
   canonicalizeAddress,
   canonicalizeDid,
   canonicalizeDidUrl,
+  canonicalizeNetworkId,
   didCacheKey,
   didEquals,
   isEvmAddress,
@@ -81,6 +83,7 @@ export {
   pkhDid,
   principalDid,
   principalDidEquals,
+  parseCanonicalNetworkId,
 } from "@tinycloud/sdk-core";
 
 // Signers

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -59,6 +59,13 @@ export {
   type PkhDidParts,
 } from "./identity";
 
+// Encryption network identity helpers
+export {
+  canonicalizeNetworkId,
+  parseCanonicalNetworkId,
+  type CanonicalParsedNetworkId,
+} from "./networkId";
+
 // Session storage interface and types
 export {
   // Interface

--- a/packages/sdk-core/src/networkId.test.ts
+++ b/packages/sdk-core/src/networkId.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+
+import { canonicalizeNetworkId, parseCanonicalNetworkId } from "./networkId";
+
+const LOWER_OWNER_DID =
+  "did:pkh:eip155:1:0xd559ccd9eb87c530a9a349262669386de93cf412";
+const CHECKSUM_OWNER_DID =
+  "did:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412";
+
+describe("canonicalizeNetworkId", () => {
+  it("canonicalizes did:pkh:eip155 owner address casing", () => {
+    expect(
+      canonicalizeNetworkId(
+        `urn:tinycloud:encryption:${LOWER_OWNER_DID}:default`,
+      ),
+    ).toBe(`urn:tinycloud:encryption:${CHECKSUM_OWNER_DID}:default`);
+  });
+
+  it("preserves non-PKH owner DIDs", () => {
+    const networkId =
+      "urn:tinycloud:encryption:did:key:z6MkfPN4DefaultPrincipalAaaaaaaaaaaaaaaaaaaaaaaaa:default";
+
+    expect(canonicalizeNetworkId(networkId)).toBe(networkId);
+  });
+
+  it("returns parsed canonical owner DID and name", () => {
+    expect(
+      parseCanonicalNetworkId(
+        `urn:tinycloud:encryption:${LOWER_OWNER_DID}:default`,
+      ),
+    ).toMatchObject({
+      networkId: `urn:tinycloud:encryption:${CHECKSUM_OWNER_DID}:default`,
+      ownerDid: CHECKSUM_OWNER_DID,
+      name: "default",
+    });
+  });
+});

--- a/packages/sdk-core/src/networkId.ts
+++ b/packages/sdk-core/src/networkId.ts
@@ -1,0 +1,32 @@
+import {
+  buildNetworkId,
+  parseNetworkId,
+  type ParsedNetworkId,
+} from "@tinycloud/sdk-services";
+
+import { canonicalizeDid } from "./identity";
+
+export interface CanonicalParsedNetworkId extends ParsedNetworkId {
+  /** Owner DID canonicalized with TinyCloud identity rules. */
+  ownerDid: string;
+}
+
+/**
+ * Canonicalize a TinyCloud encryption network id.
+ *
+ * Network ids embed an owner DID. For `did:pkh:eip155` owners, address casing
+ * can vary between SIWE/session tokens and delegated network resources. This
+ * helper parses the network id, canonicalizes the owner DID, and rebuilds the
+ * URN so comparisons can use one stable representation.
+ */
+export function canonicalizeNetworkId(networkId: string): string {
+  const parsed = parseNetworkId(networkId);
+  return buildNetworkId(canonicalizeDid(parsed.ownerDid), parsed.name);
+}
+
+export function parseCanonicalNetworkId(
+  networkId: string,
+): CanonicalParsedNetworkId {
+  const canonical = canonicalizeNetworkId(networkId);
+  return parseNetworkId(canonical) as CanonicalParsedNetworkId;
+}

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -199,7 +199,9 @@ export {
 // Re-export encryption service types and helpers from sdk-core
 export {
   EncryptionService,
+  canonicalizeNetworkId,
   parseNetworkId,
+  parseCanonicalNetworkId,
   buildNetworkId,
   isNetworkId,
   networkDiscoveryKey,


### PR DESCRIPTION
## Summary
- add sdk-core helpers to canonicalize encryption network IDs by canonicalizing the embedded owner DID
- re-export the helpers from node-sdk and web-sdk
- add regression coverage for lower-case vs checksummed did:pkh:eip155 network IDs

## Validation
- bunx prettier --write packages/sdk-core/src/networkId.ts packages/sdk-core/src/networkId.test.ts packages/sdk-core/src/index.ts packages/node-sdk/src/core.ts packages/node-sdk/src/index.ts packages/web-sdk/src/index.ts .changeset/canonical-network-id.md
- bun test packages/sdk-core/src/networkId.test.ts packages/sdk-core/src/identity.test.ts packages/sdk-services/src/encryption/encryption.test.ts
- bun run --cwd packages/sdk-core build
- bun run --cwd packages/node-sdk build
- git diff --check

Note: web-sdk build is not run in this worktree because the local @tinycloud/web-sdk-wasm package dependency is unavailable here.