### PR TITLE
fix: accept canonical secrets network principals

### DIFF
--- a/.changeset/secrets-descriptor-principal.md
+++ b/.changeset/secrets-descriptor-principal.md
@@ -1,0 +1,9 @@
+---
+"@tinycloud/sdk-services": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/cli": patch
+"@tinycloud/node-sdk-wasm": patch
+"@tinycloud/web-sdk-wasm": patch
+---
+
+Accept equivalent `did:pkh:eip155` owner DID address casing when validating encryption network descriptors, including legacy `principal` descriptors, so `tc secrets` can read existing network metadata. Pin the Rust WASM source to the released `tinycloud-node` `v1.4.2` tag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "cacaos"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
 dependencies = [
  "async-trait",
  "hex",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
 dependencies = [
  "hex",
  "http 1.4.0",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "siwe-recap"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
 dependencies = [
  "base64 0.22.1",
  "ipld-core",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-auth"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4928,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-rs"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
 dependencies = [
  "async-trait",
  "hex",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-wasm"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?rev=b483946a0ed2737237daa38f6ee456a4a398b51e#b483946a0ed2737237daa38f6ee456a4a398b51e"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
 dependencies = [
  "aes-gcm",
  "chrono",

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -22,9 +22,9 @@ console_error_panic_hook = "0.1"
 hex = "0.4.3"
 iri-string = "0.7.12"
 js-sys = "0.3.59"
-# Includes TinyCloudLabs/tinycloud-node#71.
-tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "b483946a0ed2737237daa38f6ee456a4a398b51e" }
-tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", rev = "b483946a0ed2737237daa38f6ee456a4a398b51e" }
+# Includes TinyCloudLabs/tinycloud-node#71 via the v1.4.2 release.
+tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", tag = "v1.4.2" }
+tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", tag = "v1.4.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.150"
 serde-wasm-bindgen = "0.6.5"

--- a/packages/sdk-services/src/encryption/discovery.ts
+++ b/packages/sdk-services/src/encryption/discovery.ts
@@ -17,6 +17,7 @@
 import {
   NetworkIdError,
   networkDiscoveryKey,
+  ownerDidMatches,
   parseNetworkId,
 } from "./networkId";
 import {
@@ -159,7 +160,25 @@ function validateDescriptor(
 ):
   | { ok: true; data: NetworkDescriptor }
   | { ok: false; error: EncryptionError } {
-  if (descriptor.networkId !== networkId) {
+  let descriptorNetwork;
+  try {
+    descriptorNetwork = parseNetworkId(descriptor.networkId);
+  } catch (err) {
+    return {
+      ok: false,
+      error: encryptionError({
+        code: "INVALID_NETWORK_ID",
+        message: `descriptor networkId is malformed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      }),
+    };
+  }
+
+  if (
+    descriptorNetwork.name !== name ||
+    !ownerDidMatches(descriptorNetwork.ownerDid, ownerDid)
+  ) {
     return {
       ok: false,
       error: encryptionError({
@@ -168,7 +187,13 @@ function validateDescriptor(
       }),
     };
   }
-  if (descriptor.ownerDid !== ownerDid) {
+
+  const descriptorOwnerDid = descriptorOwner(descriptor);
+  if (
+    descriptorOwnerDid === undefined ||
+    !ownerDidMatches(descriptorOwnerDid, ownerDid) ||
+    !ownerDidMatches(descriptorOwnerDid, descriptorNetwork.ownerDid)
+  ) {
     return {
       ok: false,
       error: encryptionError({
@@ -198,7 +223,27 @@ function validateDescriptor(
       }),
     };
   }
-  return { ok: true, data: descriptor };
+  return {
+    ok: true,
+    data: {
+      ...descriptor,
+      ownerDid: descriptorOwnerDid,
+    },
+  };
+}
+
+function descriptorOwner(descriptor: NetworkDescriptor): string | undefined {
+  if (typeof descriptor.ownerDid === "string" && descriptor.ownerDid.length > 0) {
+    return descriptor.ownerDid;
+  }
+
+  const legacyDescriptor = descriptor as NetworkDescriptor & {
+    principal?: unknown;
+  };
+  return typeof legacyDescriptor.principal === "string" &&
+    legacyDescriptor.principal.length > 0
+    ? legacyDescriptor.principal
+    : undefined;
 }
 
 /**

--- a/packages/sdk-services/src/encryption/encryption.test.ts
+++ b/packages/sdk-services/src/encryption/encryption.test.ts
@@ -70,6 +70,10 @@ const OWNER_DID = "did:key:z6MkfPN4DefaultPrincipalAaaaaaaaaaaaaaaaaaaaaaaaa";
 const NETWORK_NAME = "default";
 const NETWORK_ID = `${ENCRYPTION_NETWORK_URN_PREFIX}${OWNER_DID}:${NETWORK_NAME}`;
 const TARGET_NODE = "did:key:z6MkrfTargetNodeBbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PKH_OWNER_DID =
+  "did:pkh:eip155:1:0x7bEF1A1238Bf1e2C0615602DDD589aD7F385fE8B";
+const LOWERCASE_PKH_OWNER_DID = PKH_OWNER_DID.toLowerCase();
+const PKH_NETWORK_ID = `${ENCRYPTION_NETWORK_URN_PREFIX}${PKH_OWNER_DID}:${NETWORK_NAME}`;
 
 // ---------------------------------------------------------------------------
 // In-memory crypto used across all tests.
@@ -747,6 +751,16 @@ describe("discoverNetwork", () => {
     };
   }
 
+  function makePkhDescriptor(
+    ownerDid = LOWERCASE_PKH_OWNER_DID,
+  ): NetworkDescriptor {
+    return {
+      ...makeDescriptor(),
+      networkId: `${ENCRYPTION_NETWORK_URN_PREFIX}${ownerDid}:${NETWORK_NAME}`,
+      ownerDid,
+    };
+  }
+
   it("prefers the node-authoritative descriptor", async () => {
     const node: NodeDescriptorFetcher = {
       fetchByNetworkId: async () => makeDescriptor(),
@@ -783,6 +797,41 @@ describe("discoverNetwork", () => {
     if (result.ok) {
       expect(result.data.source).toBe("well-known");
     }
+  });
+
+  it("accepts PKH descriptor principals that differ only by address casing", async () => {
+    const node: NodeDescriptorFetcher = {
+      fetchByNetworkId: async () => makePkhDescriptor(),
+    };
+    const result = await discoverNetwork({ identifier: PKH_NETWORK_ID, node });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts legacy principal descriptors when the PKH principal matches", async () => {
+    const { ownerDid: _ownerDid, ...descriptor } = makePkhDescriptor();
+    const node: NodeDescriptorFetcher = {
+      fetchByNetworkId: async () =>
+        ({
+          ...descriptor,
+          principal: LOWERCASE_PKH_OWNER_DID,
+        }) as unknown as NetworkDescriptor,
+    };
+    const result = await discoverNetwork({ identifier: PKH_NETWORK_ID, node });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.descriptor.ownerDid).toBe(LOWERCASE_PKH_OWNER_DID);
+    }
+  });
+
+  it("rejects PKH descriptors whose principal address really drifts", async () => {
+    const node: NodeDescriptorFetcher = {
+      fetchByNetworkId: async () =>
+        makePkhDescriptor(
+          "did:pkh:eip155:1:0x0000000000000000000000000000000000000001",
+        ),
+    };
+    const result = await discoverNetwork({ identifier: PKH_NETWORK_ID, node });
+    expect(result.ok).toBe(false);
   });
 
   it("rejects descriptors whose embedded ids drift from the URN", async () => {

--- a/packages/sdk-services/src/encryption/networkId.ts
+++ b/packages/sdk-services/src/encryption/networkId.ts
@@ -12,6 +12,7 @@
 
 const URN_PREFIX = "urn:tinycloud:encryption:";
 const NETWORK_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+const PKH_EIP155_DID_RE = /^did:pkh:eip155:(\d+):(0x[a-fA-F0-9]{40})$/;
 
 export interface ParsedNetworkId {
   /** The full URN string. */
@@ -112,6 +113,31 @@ export function isNetworkId(networkId: unknown): networkId is string {
   } catch {
     return false;
   }
+}
+
+function parsePkhOwnerDid(ownerDid: string):
+  | { chainId: string; address: string }
+  | null {
+  const match = ownerDid.match(PKH_EIP155_DID_RE);
+  if (!match) return null;
+  return {
+    chainId: match[1],
+    address: match[2].toLowerCase(),
+  };
+}
+
+/**
+ * Compare owner DIDs as network principals. For `did:pkh:eip155`, EVM
+ * address casing is not part of principal identity; other DID methods
+ * remain exact string matches.
+ */
+export function ownerDidMatches(a: string, b: string): boolean {
+  const aPkh = parsePkhOwnerDid(a);
+  const bPkh = parsePkhOwnerDid(b);
+  if (aPkh && bPkh) {
+    return aPkh.chainId === bPkh.chainId && aPkh.address === bPkh.address;
+  }
+  return a === b;
 }
 
 /**


### PR DESCRIPTION
## Context

`tc secrets` can fail while reading network-encrypted secrets with a descriptor/network principal mismatch when the descriptor was written with a different `did:pkh:eip155` address casing, or when an older node descriptor still exposes the owner as `principal` instead of `ownerDid`.

The principals are equivalent, but the SDK descriptor validator was comparing raw strings.

## Summary

- Compare encryption descriptor owner DIDs as network principals, treating `did:pkh:eip155` address casing as equivalent.
- Accept legacy descriptor `principal` fields and normalize them to `ownerDid` after validation.
- Keep rejecting real network name or owner address drift.
- Pin the Rust WASM source to the released `tinycloud-node` `v1.4.2` tag instead of the temporary post-fix git rev.
- Add a changeset for the CLI/secrets path and wasm packages.

## Tests

- `bun test packages/sdk-services/src/encryption/encryption.test.ts`
- `bun test packages/cli/src/commands/secrets.test.ts packages/sdk-services/src/secrets/SecretsService.test.ts packages/sdk-services/src/vault/DataVaultService.test.ts`
- `bun run --cwd packages/sdk-services build`
- `bun run --cwd packages/sdk-core build`
- `bun run --cwd packages/node-sdk build`
- `bun run --cwd packages/cli build`
- `cargo update -p tinycloud-sdk-rs -p tinycloud-sdk-wasm`
- `bun run --cwd packages/sdk-rs build:wasm:node`
- `bun run --cwd packages/sdk-rs/packages/node build`
- `bun run --cwd packages/sdk-rs build:wasm:web`
- `bun run --cwd packages/sdk-rs/packages/web build`
- `bun changeset status`

Internal reference: TC-1371.