### PR TITLE
fix(tests): add batchPut to mock kv service

### DIFF
--- a/.changeset/mock-kv-batch-put.md
+++ b/.changeset/mock-kv-batch-put.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/sdk-services-test": patch
+---
+
+Add `batchPut` to `MockKVService` so the test utility package matches the current KV service interface.

--- a/tests/sdk-services/src/MockKVService.ts
+++ b/tests/sdk-services/src/MockKVService.ts
@@ -13,6 +13,9 @@ import type {
   KVServiceConfig,
   KVGetOptions,
   KVPutOptions,
+  KVBatchPutItem,
+  KVBatchPutOptions,
+  KVBatchPutResponse,
   KVListOptions,
   KVDeleteOptions,
   KVHeadOptions,
@@ -35,7 +38,14 @@ import {
  * Recorded operation for assertions.
  */
 export interface RecordedOperation {
-  type: "get" | "put" | "list" | "delete" | "head" | "createSignedReadUrl";
+  type:
+    | "get"
+    | "put"
+    | "batchPut"
+    | "list"
+    | "delete"
+    | "head"
+    | "createSignedReadUrl";
   key?: string;
   value?: unknown;
   options?: unknown;
@@ -213,6 +223,60 @@ export class MockKVService implements IKVService {
       data: undefined as void,
       headers: this.createHeaders(stored),
     });
+  }
+
+  async batchPut(
+    items: KVBatchPutItem[],
+    options?: KVBatchPutOptions
+  ): Promise<Result<KVBatchPutResponse>> {
+    this.recordOperation("batchPut", undefined, items, options);
+
+    if (items.length === 0) {
+      return ok({ written: [], count: 0 });
+    }
+
+    const entries = items.map((item) => ({
+      item,
+      fullKey: this.getFullKey(item.key, options?.prefix),
+    }));
+    const seen = new Set<string>();
+
+    for (const { fullKey } of entries) {
+      if (seen.has(fullKey)) {
+        return err(
+          serviceError(
+            ErrorCodes.INVALID_INPUT,
+            `KV batchPut received duplicate key after prefix resolution: ${fullKey}`,
+            "kv"
+          )
+        );
+      }
+      seen.add(fullKey);
+    }
+
+    for (const { fullKey } of entries) {
+      const injectedError = this.checkErrorInjection(fullKey, "batchPut");
+      if (injectedError) {
+        return err(injectedError);
+      }
+    }
+
+    await this.simulateLatency();
+
+    // Check abort
+    if (options?.signal?.aborted) {
+      return err(serviceError(ErrorCodes.ABORTED, "Request aborted", "kv"));
+    }
+
+    for (const { item, fullKey } of entries) {
+      this._store.set(
+        fullKey,
+        this.createStoredValue(item.value, item.contentType)
+      );
+    }
+
+    const written = entries.map(({ fullKey }) => fullKey);
+    return ok({ written, count: written.length });
   }
 
   async list(options?: KVListOptions): Promise<Result<KVListResponse>> {


### PR DESCRIPTION
## Summary
- add `batchPut` to `MockKVService` so it implements the current `IKVService` contract
- preserve mock behavior for prefixing, duplicate-key validation, aborts, latency, error injection, and operation recording

## Validation
- `bun run build` in `packages/sdk-services`
- `bun run build` in `tests/sdk-services`
- `bunx turbo build --filter=@tinycloud/sdk-services-test...`
- `git diff --check`

Fixes the beta release blocker from https://github.com/TinyCloudLabs/js-sdk/actions/runs/27357395743.