### PR TITLE
Add SDK telemetry benchmarks

### DIFF
--- a/.changeset/telemetry-config.md
+++ b/.changeset/telemetry-config.md
@@ -1,0 +1,8 @@
+---
+"@tinycloud/sdk-services": patch
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Add default-off telemetry configuration and named span timing events for SDK operations.

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ packages/sdk-rs/.profile
 packages/sdk-rs/.zshenv
 packages/sdk-services/dist/
 tests/sdk-services/dist
+tests/node-sdk/benchmarks/results/
 packages/cli/dist

--- a/packages/node-sdk/src/DelegatedAccess.ts
+++ b/packages/node-sdk/src/DelegatedAccess.ts
@@ -10,6 +10,7 @@ import {
   IDuckDbService,
   ServiceSession,
   ServiceContext,
+  type TelemetryConfig,
 } from "@tinycloud/sdk-core";
 import type { InvokeFunction } from "@tinycloud/sdk-services";
 import { PortableDelegation } from "./delegation";
@@ -57,6 +58,7 @@ export class DelegatedAccess {
     delegation: PortableDelegation,
     host: string,
     invoke: InvokeFunction,
+    telemetry?: TelemetryConfig,
   ) {
     this.session = session;
     this._delegation = delegation;
@@ -67,6 +69,7 @@ export class DelegatedAccess {
       invoke,
       fetch: globalThis.fetch.bind(globalThis),
       hosts: [host],
+      telemetry,
     });
 
     // Create and initialize KV service with path prefix from delegation

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -229,6 +229,14 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     // legacy default table.
     expect(cfg.abilities.kv).toHaveProperty("");
     expect(cfg.abilities.kv[""]).toContain("tinycloud.kv/get");
+    expect(cfg.spaceAbilities[cfg.spaceId]).toEqual(cfg.abilities);
+    const secretsSpaceId = Object.keys(cfg.spaceAbilities).find((spaceId) =>
+      spaceId.endsWith(":secrets"),
+    );
+    expect(secretsSpaceId).toBeDefined();
+    expect(cfg.spaceAbilities[secretsSpaceId!].kv["vault/secrets/"]).toContain(
+      "tinycloud.kv/get",
+    );
   });
 
   test("manifest with app permissions → recap reflects manifest", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -52,6 +52,7 @@ import {
   createVaultCrypto,
   ServiceSession,
   ServiceContext,
+  type TelemetryConfig,
   ISessionStorage,
   ISigner,
   type InvokeAnyFunction,
@@ -215,6 +216,8 @@ export interface TinyCloudNodeConfig {
   capabilityRequest?: ComposedManifestRequest;
   /** Include implicit account registry permissions when composing `manifest`. Default true. */
   includeAccountRegistryPermissions?: boolean;
+  /** Default-off service telemetry. */
+  telemetry?: TelemetryConfig;
 }
 
 /**
@@ -574,6 +577,7 @@ export class TinyCloudNode {
           invoke: config.invoke,
           fetch: config.fetch ?? globalThis.fetch.bind(globalThis),
           hosts: config.hosts,
+          telemetry: this.config.telemetry,
         });
         kvContext.setSession(config.session);
         kvService.initialize(kvContext);
@@ -625,6 +629,7 @@ export class TinyCloudNode {
 
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
+      telemetry: config.telemetry,
     });
   }
 
@@ -932,6 +937,7 @@ export class TinyCloudNode {
       invokeAny: this.invokeAnyWithRuntimePermissions,
       fetch: globalThis.fetch.bind(globalThis),
       hosts: [this.config.host!],
+      telemetry: this.config.telemetry,
     });
 
     // Create and register KV service
@@ -1076,6 +1082,7 @@ export class TinyCloudNode {
     // Create TinyCloud instance
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
+      telemetry: this.config.telemetry,
     });
 
     // Update config with prefix
@@ -1127,6 +1134,7 @@ export class TinyCloudNode {
 
     this.tc = new TinyCloud(this.auth, {
       invokeAny: this.invokeAnyWithRuntimePermissions,
+      telemetry: this.config.telemetry,
     });
     this.config.prefix = prefix;
   }
@@ -1150,6 +1158,7 @@ export class TinyCloudNode {
       invokeAny: this.invokeAnyWithRuntimePermissions,
       fetch: globalThis.fetch.bind(globalThis),
       hosts: [this.config.host!],
+      telemetry: this.config.telemetry,
     });
 
     // Create and register KV service
@@ -1203,6 +1212,7 @@ export class TinyCloudNode {
         invoke: this._serviceContext.invoke,
         fetch: this._serviceContext.fetch,
         hosts: this._serviceContext.hosts,
+        telemetry: this.config.telemetry,
       });
       const session = this._serviceContext.session;
       if (session) {
@@ -1847,6 +1857,7 @@ export class TinyCloudNode {
       invoke: this._serviceContext.invoke,
       fetch: this._serviceContext.fetch,
       hosts: this._serviceContext.hosts,
+      telemetry: this.config.telemetry,
     });
     spaceScopedContext.setSession({ ...this._serviceContext.session, spaceId });
     sql.initialize(spaceScopedContext);
@@ -2506,6 +2517,7 @@ export class TinyCloudNode {
         invoke: this.invokeWithRuntimePermissions,
         fetch: this._serviceContext.fetch,
         hosts: this._serviceContext.hosts,
+        telemetry: this.config.telemetry,
       });
       publicContext.setSession({
         delegationHeader: delegationSession.delegationHeader,
@@ -3747,7 +3759,13 @@ export class TinyCloudNode {
         delegation.expiry,
       );
 
-      return new DelegatedAccess(session, delegation, targetHost, this.wasmBindings.invoke);
+      return new DelegatedAccess(
+        session,
+        delegation,
+        targetHost,
+        this.wasmBindings.invoke,
+        this.config.telemetry,
+      );
     }
 
     // Wallet mode: create a SIWE sub-delegation
@@ -3855,7 +3873,13 @@ export class TinyCloudNode {
       expirationTime,
     );
 
-    return new DelegatedAccess(session, delegation, targetHost, this.wasmBindings.invoke);
+    return new DelegatedAccess(
+      session,
+      delegation,
+      targetHost,
+      this.wasmBindings.invoke,
+      this.config.telemetry,
+    );
   }
 
   /**

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -406,11 +406,13 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const request = this.getCapabilityRequest();
     if (request === undefined) {
       const defaultNetworkId = this.defaultEncryptionNetworkId(address, chainId);
+      const primarySpaceId = makePkhSpaceId(address, chainId, this.spacePrefix);
       const secretsSpaceId = makePkhSpaceId(address, chainId, "secrets");
       return {
         abilities: this.defaultActions,
-        spaceId: makePkhSpaceId(address, chainId, this.spacePrefix),
+        spaceId: primarySpaceId,
         spaceAbilities: {
+          [primarySpaceId]: this.defaultActions,
           [secretsSpaceId]: {
             kv: {
               "vault/secrets/": [

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -325,6 +325,8 @@ export type {
   ServiceSession,
   InvokeFunction,
   FetchFunction,
+  TelemetryConfig,
+  TelemetryEventHandler,
 } from "@tinycloud/sdk-core";
 
 // Re-export KeyProvider interface from sdk-core

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -452,6 +452,8 @@ export type {
   ServiceSession,
   InvokeFunction,
   FetchFunction,
+  TelemetryConfig,
+  TelemetryEventHandler,
 } from "@tinycloud/sdk-core";
 
 // Re-export KeyProvider interface from sdk-core

--- a/packages/sdk-core/src/TinyCloud.ts
+++ b/packages/sdk-core/src/TinyCloud.ts
@@ -24,6 +24,7 @@ import {
   FetchFunction,
   RetryPolicy,
   defaultRetryPolicy,
+  TelemetryConfig,
   ServiceConstructor,
   Result,
   ok,
@@ -97,6 +98,11 @@ export interface TinyCloudConfig {
    * Retry policy for service operations.
    */
   retryPolicy?: Partial<RetryPolicy>;
+
+  /**
+   * Default-off telemetry for service operation timing.
+   */
+  telemetry?: TelemetryConfig;
 }
 
 /**
@@ -216,6 +222,7 @@ export class TinyCloud {
       fetch: fetchFn ?? this.config.fetch ?? globalThis.fetch.bind(globalThis),
       hosts: effectiveHosts,
       retryPolicy: this.config.retryPolicy,
+      telemetry: this.config.telemetry,
     });
 
     // Register default services (can be overridden via config.services)
@@ -680,6 +687,7 @@ export class TinyCloud {
       fetch: this._serviceContext.fetch,
       hosts: this._serviceContext.hosts,
       retryPolicy: this.config.retryPolicy,
+      telemetry: this.config.telemetry,
     });
     publicContext.setSession({
       ...session,

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -130,6 +130,8 @@ export {
   type InvokeAnyFunction,
   type InvokeAnyEntry,
   type FetchFunction,
+  type TelemetryConfig,
+  type TelemetryEventHandler,
   // Retry
   type RetryPolicy,
   defaultRetryPolicy,

--- a/packages/sdk-services/src/base/BaseService.ts
+++ b/packages/sdk-services/src/base/BaseService.ts
@@ -157,9 +157,11 @@ export abstract class BaseService implements IService {
    * @param key - Optional key/path being accessed
    */
   protected emitRequest(action: string, key?: string): void {
+    const service = this.getServiceName();
     this.emit(TelemetryEvents.SERVICE_REQUEST, {
-      service: this.getServiceName(),
+      service,
       action,
+      span: this.spanName(action),
       key,
       timestamp: Date.now(),
     });
@@ -179,11 +181,24 @@ export abstract class BaseService implements IService {
     startTime: number,
     status?: number
   ): void {
+    const service = this.getServiceName();
+    const durationMs = Date.now() - startTime;
+    const span = this.spanName(action);
     this.emit(TelemetryEvents.SERVICE_RESPONSE, {
-      service: this.getServiceName(),
+      service,
+      action,
+      span,
+      ok,
+      duration: durationMs,
+      durationMs,
+      status,
+    });
+    this.emit(TelemetryEvents.SPAN, {
+      span,
+      service,
       action,
       ok,
-      duration: Date.now() - startTime,
+      durationMs,
       status,
     });
   }
@@ -193,9 +208,11 @@ export abstract class BaseService implements IService {
    *
    * @param error - The service error
    */
-  protected emitError(error: ServiceError): void {
+  protected emitError(error: ServiceError, action?: string): void {
+    const span = action ? this.spanName(action) : undefined;
     this.emit(TelemetryEvents.SERVICE_ERROR, {
       service: this.getServiceName(),
+      ...(span ? { span } : {}),
       error,
     });
   }
@@ -206,6 +223,13 @@ export abstract class BaseService implements IService {
    */
   protected getServiceName(): string {
     return (this.constructor as typeof BaseService).serviceName;
+  }
+
+  /**
+   * Stable span name used by SDK telemetry sinks.
+   */
+  protected spanName(action: string): string {
+    return `sdk.${this.getServiceName()}.${action}`;
   }
 
   /**
@@ -254,14 +278,14 @@ export abstract class BaseService implements IService {
         this.emitResponse(action, true, startTime);
       } else {
         this.emitResponse(action, false, startTime);
-        this.emitError(result.error);
+        this.emitError(result.error, action);
       }
 
       return result;
     } catch (error) {
       const serviceError = wrapError(this.getServiceName(), error);
       this.emitResponse(action, false, startTime);
-      this.emitError(serviceError);
+      this.emitError(serviceError, action);
       return err(serviceError);
     }
   }

--- a/packages/sdk-services/src/context.test.ts
+++ b/packages/sdk-services/src/context.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { ServiceContext } from "./context";
+
+function createContext(telemetry?: ConstructorParameters<typeof ServiceContext>[0]["telemetry"]) {
+  return new ServiceContext({
+    invoke: () => ({}),
+    hosts: ["https://node.tinycloud.xyz"],
+    telemetry,
+  });
+}
+
+describe("ServiceContext telemetry", () => {
+  test("does not call telemetry callback by default", () => {
+    const events: Array<[string, unknown]> = [];
+    const context = createContext({ onEvent: (event, data) => events.push([event, data]) });
+
+    context.emit("service.response", { duration: 12 });
+
+    expect(events).toHaveLength(0);
+  });
+
+  test("calls telemetry callback when enabled", () => {
+    const events: Array<[string, unknown]> = [];
+    const context = createContext({
+      enabled: true,
+      onEvent: (event, data) => events.push([event, data]),
+    });
+
+    context.emit("service.response", { duration: 12 });
+
+    expect(events).toEqual([["service.response", { duration: 12 }]]);
+  });
+});

--- a/packages/sdk-services/src/context.ts
+++ b/packages/sdk-services/src/context.ts
@@ -12,12 +12,10 @@ import {
   InvokeAnyFunction,
   FetchFunction,
   defaultRetryPolicy,
+  EventHandler,
+  TelemetryEventHandler,
+  TelemetryConfig,
 } from "./types";
-
-/**
- * Event handler type for telemetry events.
- */
-type EventHandler = (data: unknown) => void;
 
 /**
  * Configuration options for ServiceContext.
@@ -35,6 +33,8 @@ export interface ServiceContextConfig {
   session?: ServiceSession | null;
   /** Retry policy configuration */
   retryPolicy?: Partial<RetryPolicy>;
+  /** Default-off telemetry event delivery. */
+  telemetry?: TelemetryConfig;
 }
 
 /**
@@ -68,6 +68,8 @@ export class ServiceContext implements IServiceContext {
   private readonly _fetch: FetchFunction;
   private readonly _hosts: string[];
   private readonly _retryPolicy: RetryPolicy;
+  private readonly _telemetryEnabled: boolean;
+  private readonly _telemetryHandler?: TelemetryEventHandler;
 
   constructor(config: ServiceContextConfig) {
     this._invoke = config.invoke;
@@ -79,6 +81,12 @@ export class ServiceContext implements IServiceContext {
       ...defaultRetryPolicy,
       ...config.retryPolicy,
     };
+    this._telemetryEnabled =
+      typeof config.telemetry === "boolean"
+        ? config.telemetry
+        : config.telemetry?.enabled === true;
+    this._telemetryHandler =
+      typeof config.telemetry === "object" ? config.telemetry.onEvent : undefined;
   }
 
   // ============================================================
@@ -190,6 +198,15 @@ export class ServiceContext implements IServiceContext {
    * @param data - Event data
    */
   emit(event: string, data: unknown): void {
+    if (this._telemetryEnabled && this._telemetryHandler) {
+      try {
+        this._telemetryHandler(event, data);
+      } catch (error) {
+        // Don't let telemetry handlers break SDK operations.
+        console.error(`Error in telemetry handler for "${event}":`, error);
+      }
+    }
+
     const handlers = this._eventHandlers.get(event);
     if (handlers) {
       for (const handler of handlers) {

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -54,10 +54,13 @@ export type {
   FetchResponse,
   ServiceHeaders,
   EventHandler,
+  TelemetryConfig,
+  TelemetryEventHandler,
   ServiceRequestEvent,
   ServiceResponseEvent,
   ServiceErrorEvent,
   ServiceRetryEvent,
+  TelemetrySpanEvent,
 } from "./types";
 
 export {
@@ -79,6 +82,7 @@ export {
   ServiceResponseEventSchema,
   ServiceErrorEventSchema,
   ServiceRetryEventSchema,
+  TelemetrySpanEventSchema,
   RetryPolicySchema,
   ServiceSessionSchema,
   GenericResultSchema,
@@ -95,6 +99,7 @@ export {
   validateRetryPolicy,
   validateServiceRequestEvent,
   validateServiceResponseEvent,
+  validateTelemetrySpanEvent,
 } from "./types.schema";
 
 export type {
@@ -109,6 +114,7 @@ export type {
   ServiceResponseEventType,
   ServiceErrorEventType,
   ServiceRetryEventType,
+  TelemetrySpanEventType,
   RetryPolicyType,
   ServiceSessionType,
 } from "./types.schema";

--- a/packages/sdk-services/src/types.schema.test.ts
+++ b/packages/sdk-services/src/types.schema.test.ts
@@ -11,6 +11,7 @@ import {
   ServiceResponseEventSchema,
   ServiceErrorEventSchema,
   ServiceRetryEventSchema,
+  TelemetrySpanEventSchema,
   RetryPolicySchema,
   ServiceSessionSchema,
   GenericResultSchema,
@@ -23,6 +24,7 @@ import {
   validateRetryPolicy,
   validateServiceRequestEvent,
   validateServiceResponseEvent,
+  validateTelemetrySpanEvent,
 } from "./types.schema";
 import { z } from "zod";
 
@@ -55,6 +57,7 @@ const validKVListResponse = {
 const validServiceRequestEvent = {
   service: "kv",
   action: "tinycloud.kv/get",
+  span: "sdk.kv.get",
   key: "test-key",
   timestamp: 1706832000000,
 };
@@ -62,9 +65,19 @@ const validServiceRequestEvent = {
 const validServiceResponseEvent = {
   service: "kv",
   action: "tinycloud.kv/get",
+  span: "sdk.kv.get",
   ok: true,
   duration: 150,
+  durationMs: 150,
   status: 200,
+};
+
+const validTelemetrySpanEvent = {
+  span: "sdk.kv.get",
+  service: "kv",
+  action: "get",
+  ok: true,
+  durationMs: 150,
 };
 
 const validRetryPolicy = {
@@ -442,6 +455,23 @@ describe("ServiceResponseEventSchema", () => {
 });
 
 // =============================================================================
+// TelemetrySpanEventSchema Tests
+// =============================================================================
+
+describe("TelemetrySpanEventSchema", () => {
+  it("accepts valid named span event", () => {
+    const result = TelemetrySpanEventSchema.safeParse(validTelemetrySpanEvent);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing span", () => {
+    const { span, ...withoutSpan } = validTelemetrySpanEvent;
+    const result = TelemetrySpanEventSchema.safeParse(withoutSpan);
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
 // ServiceErrorEventSchema Tests
 // =============================================================================
 
@@ -789,5 +819,18 @@ describe("validateServiceResponseEvent", () => {
     if (!result.ok) {
       expect(result.error.service).toBe("telemetry");
     }
+  });
+});
+
+describe("validateTelemetrySpanEvent", () => {
+  it("returns ok result for valid data", () => {
+    const result = validateTelemetrySpanEvent(validTelemetrySpanEvent);
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns error result for missing durationMs", () => {
+    const { durationMs, ...withoutDuration } = validTelemetrySpanEvent;
+    const result = validateTelemetrySpanEvent(withoutDuration);
+    expect(result.ok).toBe(false);
   });
 });

--- a/packages/sdk-services/src/types.schema.ts
+++ b/packages/sdk-services/src/types.schema.ts
@@ -166,6 +166,7 @@ export type KVListResultType = z.infer<typeof KVListResultSchema>;
 export const ServiceRequestEventSchema = z.object({
   service: z.string(),
   action: z.string(),
+  span: z.string().optional(),
   key: z.string().optional(),
   timestamp: z.number(),
 });
@@ -178,8 +179,10 @@ export type ServiceRequestEventType = z.infer<typeof ServiceRequestEventSchema>;
 export const ServiceResponseEventSchema = z.object({
   service: z.string(),
   action: z.string(),
+  span: z.string().optional(),
   ok: z.boolean(),
   duration: z.number(),
+  durationMs: z.number().optional(),
   status: z.number().optional(),
 });
 
@@ -190,6 +193,7 @@ export type ServiceResponseEventType = z.infer<typeof ServiceResponseEventSchema
  */
 export const ServiceErrorEventSchema = z.object({
   service: z.string(),
+  span: z.string().optional(),
   error: ServiceErrorSchema,
 });
 
@@ -206,6 +210,21 @@ export const ServiceRetryEventSchema = z.object({
 });
 
 export type ServiceRetryEventType = z.infer<typeof ServiceRetryEventSchema>;
+
+/**
+ * Schema for generic named span event.
+ */
+export const TelemetrySpanEventSchema = z.object({
+  span: z.string(),
+  ok: z.boolean(),
+  durationMs: z.number(),
+  service: z.string().optional(),
+  action: z.string().optional(),
+  status: z.number().optional(),
+  error: ServiceErrorSchema.optional(),
+});
+
+export type TelemetrySpanEventType = z.infer<typeof TelemetrySpanEventSchema>;
 
 // =============================================================================
 // Retry Policy Schema
@@ -411,6 +430,30 @@ export function validateServiceResponseEvent(
   data: unknown
 ): { ok: true; data: ServiceResponseEventType } | { ok: false; error: ValidationError } {
   const result = ServiceResponseEventSchema.safeParse(data);
+  if (!result.success) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: result.error.message,
+        service: "telemetry",
+        meta: { issues: result.error.issues },
+      },
+    };
+  }
+  return { ok: true, data: result.data };
+}
+
+/**
+ * Validate named telemetry span event against the schema.
+ *
+ * @param data - Unknown data to validate
+ * @returns Result with validated data or validation error
+ */
+export function validateTelemetrySpanEvent(
+  data: unknown
+): { ok: true; data: TelemetrySpanEventType } | { ok: false; error: ValidationError } {
+  const result = TelemetrySpanEventSchema.safeParse(data);
   if (!result.success) {
     return {
       ok: false,

--- a/packages/sdk-services/src/types.ts
+++ b/packages/sdk-services/src/types.ts
@@ -267,6 +267,21 @@ export const defaultRetryPolicy: RetryPolicy = {
 export type EventHandler = (data: unknown) => void;
 
 /**
+ * SDK telemetry event handler.
+ */
+export type TelemetryEventHandler = (event: string, data: unknown) => void;
+
+/**
+ * Default-off telemetry configuration.
+ */
+export type TelemetryConfig =
+  | boolean
+  | {
+      enabled?: boolean;
+      onEvent?: TelemetryEventHandler;
+    };
+
+/**
  * Service interface - base contract for all services.
  */
 export interface IService {
@@ -333,6 +348,7 @@ export interface IServiceContext {
 export interface ServiceRequestEvent {
   service: string;
   action: string;
+  span?: string;
   key?: string;
   timestamp: number;
 }
@@ -343,8 +359,10 @@ export interface ServiceRequestEvent {
 export interface ServiceResponseEvent {
   service: string;
   action: string;
+  span?: string;
   ok: boolean;
   duration: number;
+  durationMs?: number;
   status?: number;
 }
 
@@ -353,6 +371,7 @@ export interface ServiceResponseEvent {
  */
 export interface ServiceErrorEvent {
   service: string;
+  span?: string;
   error: ServiceError;
 }
 
@@ -367,9 +386,23 @@ export interface ServiceRetryEvent {
 }
 
 /**
+ * Generic named span event for aggregating operation timings.
+ */
+export interface TelemetrySpanEvent {
+  span: string;
+  ok: boolean;
+  durationMs: number;
+  service?: string;
+  action?: string;
+  status?: number;
+  error?: ServiceError;
+}
+
+/**
  * Telemetry event names.
  */
 export const TelemetryEvents = {
+  SPAN: "telemetry.span",
   SERVICE_REQUEST: "service.request",
   SERVICE_RESPONSE: "service.response",
   SERVICE_ERROR: "service.error",

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -42,6 +42,7 @@ import {
   KVService,
   ServiceContext,
   ServiceSession,
+  type TelemetryConfig,
   ISpaceCreationHandler,
   type Manifest,
   type ComposedManifestRequest,
@@ -150,6 +151,8 @@ export interface Config extends ClientConfig {
   capabilityRequest?: ComposedManifestRequest;
   /** Include implicit account registry permissions when composing `manifest`. Default true. */
   includeAccountRegistryPermissions?: boolean;
+  /** Default-off service telemetry. */
+  telemetry?: TelemetryConfig;
 }
 
 /**
@@ -351,6 +354,7 @@ export class TinyCloudWeb {
       capabilityRequest: this._capabilityRequest,
       includeAccountRegistryPermissions:
         this.config.includeAccountRegistryPermissions,
+      telemetry: this.config.telemetry,
     };
 
     // Wire up signer if available

--- a/tests/node-sdk/benchmarks/README.md
+++ b/tests/node-sdk/benchmarks/README.md
@@ -1,0 +1,38 @@
+# Node SDK Benchmarks
+
+Run repeatable TinyCloud Node SDK benchmarks and save plot-friendly records.
+
+Start a local node first:
+
+```bash
+cd ../tinycloud-node
+ROCKET_PORT=9000 TINYCLOUD_TELEMETRY__ENABLED=true cargo run
+```
+
+Then run the benchmark from the `js-sdk` repo:
+
+```bash
+cd tests/node-sdk
+bun run bench:prepare
+bun run bench
+```
+
+Environment:
+
+- `TC_TEST_SERVER`: node URL, default `http://localhost:9000`
+- `TC_BENCH_ITERATIONS`: measured iterations, default `10`
+- `TC_BENCH_WARMUP`: warmup iterations excluded from summaries, default `2`
+- `TC_BENCH_OUTPUT_DIR`: output directory, default `benchmarks/results`
+- `TC_BENCH_RUN_ID`: run id, default timestamp
+- `TC_BENCH_DUCKDB=true`: force DuckDB benchmarks if the node does not advertise
+  features
+
+Outputs:
+
+- `<runId>.jsonl`: raw manual and SDK telemetry span samples
+- `<runId>.summary.json`: per-run aggregate summary
+- `summary.csv`: cumulative per-run span summaries for plotting over time
+
+The CSV has one row per `(runId, span, source)` with `meanMs`, `p50Ms`, `p95Ms`,
+`p99Ms`, and `maxMs`. Use `source=manual` for end-to-end benchmark timings and
+`source=telemetry` for spans emitted by SDK internals.

--- a/tests/node-sdk/benchmarks/node-sdk.bench.ts
+++ b/tests/node-sdk/benchmarks/node-sdk.bench.ts
@@ -1,0 +1,392 @@
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { TinyCloudNode, type TelemetrySpanEvent } from "@tinycloud/node-sdk";
+import { checkServerHealth, SERVER_URL, TEST_KEY } from "../setup";
+
+type BenchmarkSource = "manual" | "telemetry";
+
+interface BenchmarkRecord {
+  runId: string;
+  timestamp: string;
+  server: string;
+  benchmark: string;
+  span: string;
+  source: BenchmarkSource;
+  iteration: number;
+  ok: boolean;
+  durationMs: number;
+  meta?: Record<string, unknown>;
+}
+
+interface SpanSummary {
+  runId: string;
+  timestamp: string;
+  server: string;
+  span: string;
+  source: BenchmarkSource;
+  count: number;
+  okCount: number;
+  errorCount: number;
+  minMs: number;
+  meanMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  maxMs: number;
+}
+
+const iterations = positiveInt(process.env.TC_BENCH_ITERATIONS, 10);
+const warmupIterations = positiveInt(process.env.TC_BENCH_WARMUP, 2);
+const outputDir = process.env.TC_BENCH_OUTPUT_DIR ?? join("benchmarks", "results");
+const runId = process.env.TC_BENCH_RUN_ID ?? new Date().toISOString().replace(/[:.]/g, "-");
+const timestamp = new Date().toISOString();
+const forceDuckDb = process.env.TC_BENCH_DUCKDB === "true";
+const records: BenchmarkRecord[] = [];
+
+let currentBenchmark = "setup";
+let currentIteration = -1;
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function nowMs(): number {
+  return performance.now();
+}
+
+function record(record: Omit<BenchmarkRecord, "runId" | "timestamp" | "server">): void {
+  records.push({
+    runId,
+    timestamp,
+    server: SERVER_URL,
+    ...record,
+  });
+}
+
+function recordTelemetrySpan(data: unknown): void {
+  const span = data as Partial<TelemetrySpanEvent>;
+  if (typeof span.span !== "string" || typeof span.durationMs !== "number") {
+    return;
+  }
+  record({
+    benchmark: currentBenchmark,
+    span: span.span,
+    source: "telemetry",
+    iteration: currentIteration,
+    ok: span.ok !== false,
+    durationMs: span.durationMs,
+    meta: {
+      service: span.service,
+      action: span.action,
+      status: span.status,
+    },
+  });
+}
+
+async function measure<T>(
+  span: string,
+  iteration: number,
+  operation: () => Promise<T>,
+  meta?: Record<string, unknown>,
+): Promise<T> {
+  currentBenchmark = span;
+  currentIteration = iteration;
+  const start = nowMs();
+  try {
+    const value = await operation();
+    record({
+      benchmark: span,
+      span,
+      source: "manual",
+      iteration,
+      ok: true,
+      durationMs: nowMs() - start,
+      meta,
+    });
+    return value;
+  } catch (error) {
+    record({
+      benchmark: span,
+      span,
+      source: "manual",
+      iteration,
+      ok: false,
+      durationMs: nowMs() - start,
+      meta: {
+        ...meta,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    throw error;
+  }
+}
+
+function assertOk<T>(result: { ok: true; data: T } | { ok: false; error: { message: string } }): T {
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+  return result.data;
+}
+
+async function serverFeatures(): Promise<string[]> {
+  const response = await fetch(`${SERVER_URL}/info`);
+  if (!response.ok) {
+    return [];
+  }
+  const info = (await response.json()) as { features?: unknown };
+  return Array.isArray(info.features)
+    ? info.features.filter((feature): feature is string => typeof feature === "string")
+    : [];
+}
+
+async function main(): Promise<void> {
+  await checkServerHealth();
+  const features = await serverFeatures();
+  const includeDuckDb = forceDuckDb || features.includes("duckdb");
+
+  const client = new TinyCloudNode({
+    privateKey: TEST_KEY,
+    host: SERVER_URL,
+    prefix: `sdk-bench-${runId}`,
+    autoCreateSpace: true,
+    telemetry: {
+      enabled: true,
+      onEvent(event, data) {
+        if (event === "telemetry.span") {
+          recordTelemetrySpan(data);
+        }
+      },
+    },
+  });
+
+  await measure("sdk.signIn", 0, () => client.signIn());
+
+  const sqlTable = `sdk_bench_sql_${Date.now()}`;
+  const duckTable = `sdk_bench_duck_${Date.now()}`;
+
+  await measure("sdk.sql.setup", 0, async () => {
+    assertOk(
+      await client.sql.execute(
+        `CREATE TABLE IF NOT EXISTS ${sqlTable} (id INTEGER PRIMARY KEY, value TEXT)`,
+      ),
+    );
+  });
+
+  if (includeDuckDb) {
+    await measure("sdk.duckdb.setup", 0, async () => {
+      assertOk(
+        await client.duckdb.execute(
+          `CREATE TABLE IF NOT EXISTS ${duckTable} (id INTEGER, value VARCHAR)`,
+        ),
+      );
+    });
+  }
+
+  for (let i = -warmupIterations; i < iterations; i += 1) {
+    const isWarmup = i < 0;
+    const iteration = isWarmup ? i : i + 1;
+    const key = `${isWarmup ? "warmup" : "item"}-${iteration}`;
+    const value = { iteration, runId, payload: "x".repeat(256) };
+
+    await measure("sdk.kv.put", iteration, async () => {
+      assertOk(await client.kv.put(key, value));
+    }, { warmup: isWarmup });
+
+    await measure("sdk.kv.get", iteration, async () => {
+      assertOk(await client.kv.get(key));
+    }, { warmup: isWarmup });
+
+    await measure("sdk.kv.list", iteration, async () => {
+      assertOk(await client.kv.list({ prefix: isWarmup ? "warmup" : "item" }));
+    }, { warmup: isWarmup });
+
+    await measure("sdk.sql.execute", iteration, async () => {
+      assertOk(
+        await client.sql.execute(`INSERT OR REPLACE INTO ${sqlTable} (id, value) VALUES (?, ?)`, [
+          iteration,
+          `value-${iteration}`,
+        ]),
+      );
+    }, { warmup: isWarmup });
+
+    await measure("sdk.sql.query", iteration, async () => {
+      assertOk(await client.sql.query(`SELECT * FROM ${sqlTable} WHERE id = ?`, [iteration]));
+    }, { warmup: isWarmup });
+
+    if (includeDuckDb) {
+      await measure("sdk.duckdb.execute", iteration, async () => {
+        assertOk(
+          await client.duckdb.execute(`INSERT INTO ${duckTable} VALUES (?, ?)`, [
+            iteration,
+            `value-${iteration}`,
+          ]),
+        );
+      }, { warmup: isWarmup });
+
+      await measure("sdk.duckdb.query", iteration, async () => {
+        assertOk(await client.duckdb.query(`SELECT * FROM ${duckTable} WHERE id = ?`, [iteration]));
+      }, { warmup: isWarmup });
+    }
+  }
+
+  await measure("sdk.sql.cleanup", 0, async () => {
+    assertOk(await client.sql.execute(`DROP TABLE IF EXISTS ${sqlTable}`));
+  });
+  if (includeDuckDb) {
+    await measure("sdk.duckdb.cleanup", 0, async () => {
+      assertOk(await client.duckdb.execute(`DROP TABLE IF EXISTS ${duckTable}`));
+    });
+  }
+
+  await writeResults();
+}
+
+function summarize(records: BenchmarkRecord[]): SpanSummary[] {
+  const measuredRecords = records.filter((record) => record.iteration > 0);
+  const groups = new Map<string, BenchmarkRecord[]>();
+  for (const record of measuredRecords) {
+    const key = `${record.source}\u0000${record.span}`;
+    const group = groups.get(key);
+    if (group) {
+      group.push(record);
+    } else {
+      groups.set(key, [record]);
+    }
+  }
+
+  return [...groups.values()]
+    .map((group) => {
+      const durations = group.map((record) => record.durationMs).sort((a, b) => a - b);
+      const okCount = group.filter((record) => record.ok).length;
+      return {
+        runId,
+        timestamp,
+        server: SERVER_URL,
+        span: group[0].span,
+        source: group[0].source,
+        count: group.length,
+        okCount,
+        errorCount: group.length - okCount,
+        minMs: durations[0],
+        meanMs: durations.reduce((sum, value) => sum + value, 0) / durations.length,
+        p50Ms: percentile(durations, 0.5),
+        p95Ms: percentile(durations, 0.95),
+        p99Ms: percentile(durations, 0.99),
+        maxMs: durations[durations.length - 1],
+      };
+    })
+    .sort((a, b) => a.span.localeCompare(b.span) || a.source.localeCompare(b.source));
+}
+
+function percentile(sortedValues: number[], p: number): number {
+  if (sortedValues.length === 0) return 0;
+  const index = Math.ceil(sortedValues.length * p) - 1;
+  return sortedValues[Math.max(0, Math.min(index, sortedValues.length - 1))];
+}
+
+async function writeResults(): Promise<void> {
+  await mkdir(outputDir, { recursive: true });
+
+  const rawPath = join(outputDir, `${runId}.jsonl`);
+  const summaryPath = join(outputDir, `${runId}.summary.json`);
+  const summaryCsvPath = join(outputDir, "summary.csv");
+  const summaries = summarize(records);
+
+  await writeFile(rawPath, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+  await writeFile(
+    summaryPath,
+    JSON.stringify(
+      {
+        runId,
+        timestamp,
+        server: SERVER_URL,
+        iterations,
+        warmupIterations,
+        records: records.length,
+        summaries,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  await appendCsv(summaryCsvPath, summaries);
+
+  console.log(`[Bench] Wrote raw samples: ${rawPath}`);
+  console.log(`[Bench] Wrote run summary: ${summaryPath}`);
+  console.log(`[Bench] Appended plot index: ${summaryCsvPath}`);
+  console.table(
+    summaries
+      .filter((summary) => summary.source === "manual")
+      .map((summary) => ({
+        span: summary.span,
+        count: summary.count,
+        meanMs: summary.meanMs.toFixed(2),
+        p95Ms: summary.p95Ms.toFixed(2),
+        maxMs: summary.maxMs.toFixed(2),
+      })),
+  );
+}
+
+async function appendCsv(path: string, summaries: SpanSummary[]): Promise<void> {
+  const header = [
+    "timestamp",
+    "runId",
+    "server",
+    "span",
+    "source",
+    "count",
+    "okCount",
+    "errorCount",
+    "minMs",
+    "meanMs",
+    "p50Ms",
+    "p95Ms",
+    "p99Ms",
+    "maxMs",
+  ];
+  const rows = summaries.map((summary) =>
+    [
+      summary.timestamp,
+      summary.runId,
+      summary.server,
+      summary.span,
+      summary.source,
+      summary.count,
+      summary.okCount,
+      summary.errorCount,
+      summary.minMs,
+      summary.meanMs,
+      summary.p50Ms,
+      summary.p95Ms,
+      summary.p99Ms,
+      summary.maxMs,
+    ]
+      .map(csvCell)
+      .join(","),
+  );
+
+  let needsHeader = false;
+  try {
+    const file = Bun.file(path);
+    needsHeader = !(await file.exists()) || file.size === 0;
+  } catch {
+    needsHeader = true;
+  }
+
+  await appendFile(path, `${needsHeader ? `${header.join(",")}\n` : ""}${rows.join("\n")}\n`);
+}
+
+function csvCell(value: unknown): string {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value.toFixed(3) : "";
+  }
+  const text = String(value);
+  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+main().catch((error) => {
+  console.error("[Bench] Failed:", error);
+  process.exit(1);
+});

--- a/tests/node-sdk/package.json
+++ b/tests/node-sdk/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "bench:prepare": "bun run --cwd ../../packages/sdk-rs build:wasm:node && bun run --cwd ../../packages/sdk-rs/packages/node build && bun run --cwd ../../packages/sdk-services build && bun run --cwd ../../packages/sdk-core build && bun run --cwd ../../packages/node-sdk build",
+    "bench": "bun benchmarks/node-sdk.bench.ts",
     "test": "bun test",
     "test:sql": "bun test sql/",
     "test:duckdb": "bun test duckdb/"


### PR DESCRIPTION
## Summary
- add default-off SDK telemetry span events and config plumbing across sdk-services, sdk-core, node-sdk, and web-sdk
- fix default node-sdk sign-in capabilities so the primary owned space is delegated alongside the secrets space
- add a Node SDK benchmark harness that records raw JSONL samples and cumulative CSV summaries for plotting over time

## Verification
- bun test packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts packages/sdk-services/src/context.test.ts packages/sdk-services/src/types.schema.test.ts packages/sdk-services/src/kv/KVService.test.ts
- bun run bench:prepare
- end-to-end benchmark smoke against local tinycloud-node wrote JSONL, summary JSON, and summary.csv
- git diff --check