### PR TITLE
Route SQL PRAGMA through admin permission

### DIFF
--- a/.changeset/tall-rivers-pragma-admin.md
+++ b/.changeset/tall-rivers-pragma-admin.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/sdk-services": patch
+---
+
+Sign SQLite PRAGMA statements with the SQL admin capability so approved admin grants are used for PRAGMA requests.

--- a/packages/sdk-services/src/sql/SQLService.test.ts
+++ b/packages/sdk-services/src/sql/SQLService.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  FetchRequestInit,
+  FetchResponse,
+  IServiceContext,
+} from "../types";
+import { SQLService } from "./SQLService";
+import { SQLAction } from "./types";
+
+function response(
+  ok: boolean,
+  status: number,
+  body: unknown,
+  statusText = ok ? "OK" : "Error",
+): FetchResponse {
+  return {
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: () => null,
+    },
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    arrayBuffer: async () =>
+      new TextEncoder().encode(
+        typeof body === "string" ? body : JSON.stringify(body),
+      ).buffer as ArrayBuffer,
+    blob: async () =>
+      new Blob([typeof body === "string" ? body : JSON.stringify(body)]),
+  };
+}
+
+function createContext(
+  fetchImpl: IServiceContext["fetch"],
+  invokeCalls: Array<{ service: string; path: string; action: string }>,
+): IServiceContext {
+  return {
+    session: {
+      delegationHeader: { Authorization: "Bearer test" },
+      delegationCid: "bafybeitest",
+      spaceId: "tinycloud:pkh:eip155:1:0xabc:default",
+      verificationMethod: "did:key:test",
+      jwk: {},
+    },
+    isAuthenticated: true,
+    invoke: (_session, service, path, action) => {
+      invokeCalls.push({ service, path, action });
+      return {
+        Authorization: "Bearer signed-invocation",
+      };
+    },
+    fetch: fetchImpl,
+    hosts: ["https://node.tinycloud.xyz"],
+    getService: () => undefined,
+    emit: () => undefined,
+    on: () => () => undefined,
+    abortSignal: new AbortController().signal,
+    retryPolicy: {
+      maxAttempts: 3,
+      backoff: "exponential",
+      baseDelayMs: 1000,
+      maxDelayMs: 10000,
+      retryableErrors: [],
+    },
+  };
+}
+
+describe("SQLService permissions", () => {
+  test("query signs SELECT statements with read permission", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    let requestInit: FetchRequestInit | undefined;
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, {
+          columns: ["value"],
+          rows: [[1]],
+          rowCount: 1,
+        });
+      }, invokeCalls),
+    );
+
+    const result = await service.query("SELECT 1 AS value");
+
+    expect(result.ok).toBe(true);
+    expect(invokeCalls).toEqual([
+      { service: "sql", path: "default", action: SQLAction.READ },
+    ]);
+    expect(JSON.parse(requestInit?.body as string)).toEqual({
+      action: "query",
+      sql: "SELECT 1 AS value",
+      params: [],
+    });
+  });
+
+  test("query recognizes PRAGMA after leading comments", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async () => response(true, 200, {
+        columns: ["name"],
+        rows: [],
+        rowCount: 0,
+      }), invokeCalls),
+    );
+
+    const result = await service.query(`
+      -- schema introspection
+      /* migration probe */
+      pragma table_info(secret_records)
+    `);
+
+    expect(result.ok).toBe(true);
+    expect(invokeCalls).toEqual([
+      { service: "sql", path: "default", action: SQLAction.ADMIN },
+    ]);
+  });
+
+  test("execute and batch sign PRAGMA statements with admin permission", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async () => response(true, 200, {
+        changes: 0,
+        lastInsertRowId: null,
+      }), invokeCalls),
+    );
+
+    const executeResult = await service.execute("pragma user_version = 1");
+    const batchResult = await service.batch([
+      { sql: "INSERT INTO notes (body) VALUES (?)", params: ["hello"] },
+      { sql: "PRAGMA user_version" },
+    ]);
+
+    expect(executeResult.ok).toBe(true);
+    expect(batchResult.ok).toBe(true);
+    expect(invokeCalls).toEqual([
+      { service: "sql", path: "default", action: SQLAction.ADMIN },
+      { service: "sql", path: "default", action: SQLAction.ADMIN },
+    ]);
+  });
+});

--- a/packages/sdk-services/src/sql/SQLService.ts
+++ b/packages/sdk-services/src/sql/SQLService.ts
@@ -108,7 +108,7 @@ export class SQLService extends BaseService implements ISQLService {
       try {
         const response = await this.invokeSQL(
           dbName,
-          SQLAction.READ,
+          this.actionForSql(sql, SQLAction.READ),
           { action: "query", sql, params: params ?? [] },
           options?.signal
         );
@@ -148,7 +148,7 @@ export class SQLService extends BaseService implements ISQLService {
 
         const response = await this.invokeSQL(
           dbName,
-          SQLAction.WRITE,
+          this.actionForSql(sql, SQLAction.WRITE),
           body,
           options?.signal
         );
@@ -178,7 +178,7 @@ export class SQLService extends BaseService implements ISQLService {
       try {
         const response = await this.invokeSQL(
           dbName,
-          SQLAction.WRITE,
+          this.actionForSqlBatch(statements),
           { action: "batch", statements },
           options?.signal
         );
@@ -287,6 +287,18 @@ export class SQLService extends BaseService implements ISQLService {
     });
   }
 
+  private actionForSql(sql: string, fallback: string): string {
+    return firstSqlToken(sql) === "pragma" ? SQLAction.ADMIN : fallback;
+  }
+
+  private actionForSqlBatch(statements: SqlStatement[]): string {
+    return statements.some(
+      (statement) => this.actionForSql(statement.sql, SQLAction.WRITE) === SQLAction.ADMIN,
+    )
+      ? SQLAction.ADMIN
+      : SQLAction.WRITE;
+  }
+
   private async handleErrorResponse(
     response: FetchResponse,
     operation: string
@@ -345,4 +357,37 @@ export class SQLService extends BaseService implements ISQLService {
         return ErrorCodes.NETWORK_ERROR;
     }
   }
+}
+
+function firstSqlToken(sql: string): string | undefined {
+  let index = 0;
+
+  while (index < sql.length) {
+    while (index < sql.length && /\s/.test(sql[index])) {
+      index++;
+    }
+
+    if (sql.startsWith("--", index)) {
+      const newline = sql.indexOf("\n", index + 2);
+      if (newline === -1) {
+        return undefined;
+      }
+      index = newline + 1;
+      continue;
+    }
+
+    if (sql.startsWith("/*", index)) {
+      const end = sql.indexOf("*/", index + 2);
+      if (end === -1) {
+        return undefined;
+      }
+      index = end + 2;
+      continue;
+    }
+
+    break;
+  }
+
+  const match = /^[A-Za-z_]+/.exec(sql.slice(index));
+  return match?.[0].toLowerCase();
 }


### PR DESCRIPTION
## Summary
- Sign SQLite PRAGMA statements with `tinycloud.sql/admin` in SQL service invocations
- Apply the same action selection to query, execute, and batch calls
- Add focused tests for SELECT/read and PRAGMA/admin action selection

## Verification
- `bun test src/sql/SQLService.test.ts`
- `bun run build`

Note: tinycloud-node PR #77 owns the authoritative server-side PRAGMA permission error. This PR only makes the SDK choose the admin capability so existing admin runtime grants can be used.