### PR TITLE
Add kvForSpace + tc kv --space for non-primary space reads

### DIFF
--- a/.changeset/kv-for-space.md
+++ b/.changeset/kv-for-space.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/cli": patch
+---
+
+Add `TinyCloudNode.kvForSpace(spaceId)` and a `--space` option on `tc kv get/list/head`, mirroring the existing `sqlForSpace` / `tc sql --space`. This lets KV reads target a non-primary space — e.g. reading a manifest app's data kept under the owner's `applications` space (such as Listen's transcripts at `applications/kv/<app-id>/transcript/<id>`) when the session already holds a covering delegation.

--- a/packages/cli/src/commands/kv.ts
+++ b/packages/cli/src/commands/kv.ts
@@ -6,7 +6,9 @@ import { outputJson, withSpinner, shouldOutputJson, formatTable, formatBytes, fo
 import { handleError, CLIError } from "../output/errors.js";
 import { ExitCode } from "../config/constants.js";
 import { ensureAuthenticated } from "../lib/sdk.js";
+import { resolveSpaceUri } from "../lib/space.js";
 import { theme } from "../output/theme.js";
+import type { TinyCloudNode } from "@tinycloud/node-sdk";
 
 /**
  * Read all data from stdin.
@@ -19,6 +21,24 @@ async function readStdin(): Promise<Buffer> {
   return Buffer.concat(chunks);
 }
 
+/**
+ * Pick a KV service for the requested space.
+ *
+ * `--space` is optional; when omitted, ops route through the node's primary
+ * space (preserves prior behavior). When present, we use
+ * TinyCloudNode.kvForSpace, which clones the active service context with a
+ * session whose spaceId points at the target space — e.g. to read a manifest
+ * app's data kept under the owner's `applications` space.
+ */
+async function kvHandle(
+  node: TinyCloudNode,
+  spaceInput: string | undefined,
+  profileName: string,
+) {
+  const spaceUri = await resolveSpaceUri(spaceInput, profileName);
+  return spaceUri ? node.kvForSpace(spaceUri) : node.kv;
+}
+
 export function registerKvCommand(program: Command): void {
   const kv = program.command("kv").description("Key-value store operations");
 
@@ -28,13 +48,15 @@ export function registerKvCommand(program: Command): void {
     .description("Get a value by key")
     .option("--raw", "Output raw value (no JSON wrapping)")
     .option("-o, --output <file>", "Write value to file")
+    .option("--space <name|uri>", "Target a non-primary space (short name or full URI)")
     .action(async (key: string, options, cmd) => {
       try {
         const globalOpts = cmd.optsWithGlobals();
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
-        const result = await withSpinner(`Getting ${key}...`, () => node.kv.get(key)) as any;
+        const kv = await kvHandle(node, options.space, ctx.profile);
+        const result = await withSpinner(`Getting ${key}...`, () => kv.get(key)) as any;
 
         if (!result.ok) {
           if (result.error.code === "KV_NOT_FOUND" || result.error.code === "NOT_FOUND") {
@@ -153,14 +175,16 @@ export function registerKvCommand(program: Command): void {
     .command("list")
     .description("List keys")
     .option("--prefix <prefix>", "Filter by key prefix")
+    .option("--space <name|uri>", "Target a non-primary space (short name or full URI)")
     .action(async (options, cmd) => {
       try {
         const globalOpts = cmd.optsWithGlobals();
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
+        const kv = await kvHandle(node, options.space, ctx.profile);
         const listOptions = options.prefix ? { prefix: options.prefix } : undefined;
-        const result = await withSpinner("Listing keys...", () => node.kv.list(listOptions)) as any;
+        const result = await withSpinner("Listing keys...", () => kv.list(listOptions)) as any;
 
         if (!result.ok) {
           throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR);
@@ -196,13 +220,15 @@ export function registerKvCommand(program: Command): void {
   kv
     .command("head <key>")
     .description("Get metadata for a key (no body)")
-    .action(async (key: string, _options, cmd) => {
+    .option("--space <name|uri>", "Target a non-primary space (short name or full URI)")
+    .action(async (key: string, options, cmd) => {
       try {
         const globalOpts = cmd.optsWithGlobals();
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
-        const result = await withSpinner(`Checking ${key}...`, () => node.kv.head(key)) as any;
+        const kv = await kvHandle(node, options.space, ctx.profile);
+        const result = await withSpinner(`Checking ${key}...`, () => kv.head(key)) as any;
 
         if (!result.ok) {
           if (result.error.code === "KV_NOT_FOUND" || result.error.code === "NOT_FOUND") {

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -1854,6 +1854,36 @@ export class TinyCloudNode {
   }
 
   /**
+   * Get a KV service scoped to a specific space.
+   *
+   * The KV counterpart to {@link sqlForSpace}: clones the active service
+   * context and overrides its session's spaceId so that subsequent
+   * `kv/<action>` invocations route to that space. Useful for reading data
+   * that a manifest app stores outside the primary space (e.g. transcripts a
+   * `defaults: true` app keeps under the owner's `applications` space), when
+   * the caller already holds a delegation covering the target space.
+   *
+   * Does NOT auto-create the space.
+   *
+   * @param spaceId - Full space URI (`tinycloud:pkh:eip155:<chain>:<addr>:<name>`).
+   */
+  kvForSpace(spaceId: string): IKVService {
+    if (!this._serviceContext || !this._serviceContext.session) {
+      throw new Error("Not signed in. Call signIn() first.");
+    }
+
+    const kv = new KVService({});
+    const spaceScopedContext = new ServiceContext({
+      invoke: this._serviceContext.invoke,
+      fetch: this._serviceContext.fetch,
+      hosts: this._serviceContext.hosts,
+    });
+    spaceScopedContext.setSession({ ...this._serviceContext.session, spaceId });
+    kv.initialize(spaceScopedContext);
+    return kv;
+  }
+
+  /**
    * DuckDB database operations on this user's space.
    */
   get duckdb(): IDuckDbService {


### PR DESCRIPTION
## What

Adds the KV counterpart to the existing `sqlForSpace` / `tc sql --space`:

- **`TinyCloudNode.kvForSpace(spaceId)`** (node-sdk) — clones the active service context with a session scoped to `spaceId`, mirroring `sqlForSpace` exactly.
- **`tc kv get/list/head --space <name|uri>`** (cli) — routes KV reads through `kvForSpace` via the same `resolveSpaceUri` helper `tc sql` uses.

## Why

TinyCloud manifest apps with `defaults: true` store their canonical data in the owner's **`applications`** space, not the primary `default` space. `tc sql --space applications` could already read those tables, but **KV had no equivalent** — `tc kv` only ever hit the primary space and the SDK exposed `sqlForSpace` but no `kvForSpace`.

Concrete case: the **Listen** app keeps transcripts as KV blobs at `applications/kv/xyz.tinycloud.listen/transcript/<id>`. They were unreachable from the CLI until this change. With it (and a covering delegation):

```sh
tc kv get "xyz.tinycloud.listen/transcript/<id>" --space applications --raw
```

## Scope / notes

- Source-only change; mirrors `sqlForSpace` and the `dbHandle` pattern in `sql.ts`.
- `--space` added to the read commands (`get`, `list`, `head`); `put`/`delete` left as-is.
- Changeset included (`patch` for `@tinycloud/node-sdk` + `@tinycloud/cli`).
- Unrelated: the repo's `tsup` DTS build currently fails on a pre-existing `@tinycloud/sdk-core` type-export skew; not touched here.