### PR TITLE
fix(kv): add --space to kv put/delete and fix binary KV round-trips

### DIFF
--- a/.changeset/kv-space-and-binary-roundtrip.md
+++ b/.changeset/kv-space-and-binary-roundtrip.md
@@ -1,0 +1,18 @@
+---
+"@tinycloud/sdk-services": patch
+"@tinycloud/cli": patch
+---
+
+Fix `tc kv put`/`kv delete --space` and binary KV round-trips.
+
+- `tc kv put` and `tc kv delete` now accept `--space <name|uri>`, routing through
+  the space-scoped KV (`kvForSpace`) like `get`/`list`/`head` already did. KV
+  writes to a non-primary space (e.g. an `applications` space) are now possible
+  from the CLI.
+- Binary KV values now round-trip byte-identically. `KVService.put` sends
+  Blob/ArrayBuffer/typed-array/Buffer values as raw bytes
+  (`application/octet-stream`, honoring an explicit `contentType`) instead of
+  JSON-stringifying them into `{"type":"Buffer","data":[...]}`. A new
+  `KVGetOptions.binary` returns the raw response bytes as a `Uint8Array`, and the
+  CLI's `kv get -o <file>` / `--raw` use it so images and other binaries are
+  written out unchanged.

--- a/packages/cli/src/commands/kv.test.ts
+++ b/packages/cli/src/commands/kv.test.ts
@@ -1,16 +1,24 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Command } from "commander";
 
 type PutCall = { handle: string; key: string; value: unknown };
 type DeleteCall = { handle: string; key: string };
+type GetCall = { handle: string; key: string; options: unknown };
+
+// Bytes the fake KV handle returns from get(). Includes a non-UTF-8 byte (0xff)
+// to prove raw bytes pass through unchanged, not a lossy text round-trip.
+const GET_BYTES = new Uint8Array([137, 80, 78, 71, 0, 255, 1]);
 
 const recorded = {
   outputs: [] as unknown[],
   errors: [] as unknown[],
   puts: [] as PutCall[],
   deletes: [] as DeleteCall[],
+  gets: [] as GetCall[],
   resolveSpace: [] as Array<{ input: string | undefined; profile: string }>,
   kvForSpace: [] as string[],
+  stdoutWrites: [] as Uint8Array[],
+  fileWrites: [] as Array<{ path: string; data: Uint8Array }>,
 };
 
 function resetState(): void {
@@ -18,8 +26,16 @@ function resetState(): void {
   recorded.errors = [];
   recorded.puts = [];
   recorded.deletes = [];
+  recorded.gets = [];
   recorded.resolveSpace = [];
   recorded.kvForSpace = [];
+  recorded.stdoutWrites = [];
+  recorded.fileWrites = [];
+}
+
+function toBytes(chunk: unknown): Uint8Array {
+  if (chunk instanceof Uint8Array) return chunk;
+  return new TextEncoder().encode(String(chunk));
 }
 
 // A KV handle whose name records which space ("primary" vs the resolved uri)
@@ -33,6 +49,11 @@ function makeKv(handle: string) {
     delete: async (key: string) => {
       recorded.deletes.push({ handle, key });
       return { ok: true, data: undefined };
+    },
+    get: async (key: string, options: unknown) => {
+      recorded.gets.push({ handle, key, options });
+      // Mirror the SDK: when { binary: true }, data is the raw bytes.
+      return { ok: true, data: { data: GET_BYTES, headers: {} } };
     },
   };
 }
@@ -78,6 +99,13 @@ mock.module("../output/formatter.js", () => ({
 
 mock.module("../output/theme.js", () => ({
   theme: { muted: (v: string) => v },
+}));
+
+mock.module("node:fs/promises", () => ({
+  writeFile: async (path: string, data: unknown) => {
+    recorded.fileWrites.push({ path, data: toBytes(data) });
+  },
+  readFile: async () => Buffer.from(""),
 }));
 
 mock.module("../output/errors.js", () => ({
@@ -156,6 +184,60 @@ describe("CLI kv delete --space", () => {
     ]);
     expect(recorded.deletes).toEqual([
       { handle: "tinycloud:pkh:eip155:1:0xabc:applications", key: "note" },
+    ]);
+  });
+});
+
+describe("CLI kv get binary output", () => {
+  const realStdoutWrite = process.stdout.write.bind(process.stdout);
+
+  beforeEach(() => {
+    resetState();
+    // Capture raw stdout writes without printing during the test run.
+    (process.stdout.write as unknown) = (chunk: unknown) => {
+      recorded.stdoutWrites.push(toBytes(chunk));
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    (process.stdout.write as unknown) = realStdoutWrite;
+  });
+
+  test("--raw requests binary mode and emits exact bytes to stdout", async () => {
+    await runKv(["get", "img.png", "--raw"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.gets).toEqual([
+      { handle: "primary", key: "img.png", options: { binary: true } },
+    ]);
+    // Exactly the bytes, nothing else (no trailing newline, no JSON wrapping).
+    expect(recorded.stdoutWrites).toEqual([GET_BYTES]);
+    expect(recorded.fileWrites).toEqual([]);
+  });
+
+  test("-o requests binary mode and writes exact bytes to the file", async () => {
+    await runKv(["get", "img.png", "-o", "out.png"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.gets).toEqual([
+      { handle: "primary", key: "img.png", options: { binary: true } },
+    ]);
+    expect(recorded.fileWrites).toEqual([
+      { path: "out.png", data: GET_BYTES },
+    ]);
+    // No raw bytes leaked to stdout on the -o path (only the JSON status line,
+    // which goes through outputJson, not process.stdout.write here).
+    expect(recorded.stdoutWrites).toEqual([]);
+  });
+
+  test("default get (no --raw/-o) does NOT request binary mode", async () => {
+    await runKv(["get", "img.png"]);
+
+    expect(recorded.errors).toEqual([]);
+    // wantBytes is false → get is called with `undefined` options.
+    expect(recorded.gets).toEqual([
+      { handle: "primary", key: "img.png", options: undefined },
     ]);
   });
 });

--- a/packages/cli/src/commands/kv.test.ts
+++ b/packages/cli/src/commands/kv.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Command } from "commander";
+
+type PutCall = { handle: string; key: string; value: unknown };
+type DeleteCall = { handle: string; key: string };
+
+const recorded = {
+  outputs: [] as unknown[],
+  errors: [] as unknown[],
+  puts: [] as PutCall[],
+  deletes: [] as DeleteCall[],
+  resolveSpace: [] as Array<{ input: string | undefined; profile: string }>,
+  kvForSpace: [] as string[],
+};
+
+function resetState(): void {
+  recorded.outputs = [];
+  recorded.errors = [];
+  recorded.puts = [];
+  recorded.deletes = [];
+  recorded.resolveSpace = [];
+  recorded.kvForSpace = [];
+}
+
+// A KV handle whose name records which space ("primary" vs the resolved uri)
+// each operation routed through.
+function makeKv(handle: string) {
+  return {
+    put: async (key: string, value: unknown) => {
+      recorded.puts.push({ handle, key, value });
+      return { ok: true, data: { data: undefined, headers: {} } };
+    },
+    delete: async (key: string) => {
+      recorded.deletes.push({ handle, key });
+      return { ok: true, data: undefined };
+    },
+  };
+}
+
+const node = {
+  kv: makeKv("primary"),
+  kvForSpace: (spaceUri: string) => {
+    recorded.kvForSpace.push(spaceUri);
+    return makeKv(spaceUri);
+  },
+};
+
+mock.module("../config/profiles.js", () => ({
+  ProfileManager: {
+    resolveContext: async () => ({ profile: "cli-test", host: "https://host" }),
+  },
+}));
+
+mock.module("../lib/sdk.js", () => ({
+  ensureAuthenticated: async () => node,
+}));
+
+mock.module("../lib/space.js", () => ({
+  // Mirrors the real helper contract: undefined input => undefined (primary
+  // space), otherwise a resolved full space URI.
+  resolveSpaceUri: async (input: string | undefined, profile: string) => {
+    recorded.resolveSpace.push({ input, profile });
+    if (!input) return undefined;
+    return `tinycloud:pkh:eip155:1:0xabc:${input}`;
+  },
+}));
+
+mock.module("../output/formatter.js", () => ({
+  outputJson: (payload: unknown) => {
+    recorded.outputs.push(payload);
+  },
+  withSpinner: async (_message: string, fn: () => unknown) => await fn(),
+  shouldOutputJson: () => true,
+  formatTable: () => "",
+  formatBytes: () => "",
+  formatTimeAgo: () => "",
+}));
+
+mock.module("../output/theme.js", () => ({
+  theme: { muted: (v: string) => v },
+}));
+
+mock.module("../output/errors.js", () => ({
+  CLIError: class CLIError extends Error {
+    constructor(
+      public code: string,
+      message: string,
+      public exitCode: number,
+    ) {
+      super(message);
+    }
+  },
+  handleError: (error: unknown) => {
+    recorded.errors.push(error);
+  },
+}));
+
+const { registerKvCommand } = await import("./kv.js");
+
+async function runKv(args: string[]): Promise<void> {
+  const program = new Command();
+  registerKvCommand(program);
+  await program.parseAsync(["node", "tc", "kv", ...args], { from: "node" });
+}
+
+describe("CLI kv put --space", () => {
+  beforeEach(resetState);
+
+  test("writes to the primary space when --space is omitted", async () => {
+    await runKv(["put", "note", "hello"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.kvForSpace).toEqual([]);
+    expect(recorded.puts).toEqual([
+      { handle: "primary", key: "note", value: "hello" },
+    ]);
+  });
+
+  test("routes through kvForSpace when --space is provided", async () => {
+    await runKv(["put", "note", "hello", "--space", "applications"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.resolveSpace).toEqual([
+      { input: "applications", profile: "cli-test" },
+    ]);
+    expect(recorded.kvForSpace).toEqual([
+      "tinycloud:pkh:eip155:1:0xabc:applications",
+    ]);
+    expect(recorded.puts).toEqual([
+      {
+        handle: "tinycloud:pkh:eip155:1:0xabc:applications",
+        key: "note",
+        value: "hello",
+      },
+    ]);
+  });
+});
+
+describe("CLI kv delete --space", () => {
+  beforeEach(resetState);
+
+  test("deletes from the primary space when --space is omitted", async () => {
+    await runKv(["delete", "note"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.kvForSpace).toEqual([]);
+    expect(recorded.deletes).toEqual([{ handle: "primary", key: "note" }]);
+  });
+
+  test("routes through kvForSpace when --space is provided", async () => {
+    await runKv(["delete", "note", "--space", "applications"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.kvForSpace).toEqual([
+      "tinycloud:pkh:eip155:1:0xabc:applications",
+    ]);
+    expect(recorded.deletes).toEqual([
+      { handle: "tinycloud:pkh:eip155:1:0xabc:applications", key: "note" },
+    ]);
+  });
+});

--- a/packages/cli/src/commands/kv.ts
+++ b/packages/cli/src/commands/kv.ts
@@ -56,7 +56,14 @@ export function registerKvCommand(program: Command): void {
         const node = await ensureAuthenticated(ctx);
 
         const kv = await kvHandle(node, options.space, ctx.profile);
-        const result = await withSpinner(`Getting ${key}...`, () => kv.get(key)) as any;
+        // For raw / file output, read the value as raw bytes so binary values
+        // (e.g. images) round-trip byte-identically. The default (parsed/JSON)
+        // path is unchanged.
+        const wantBytes = !!options.output || !!options.raw;
+        const result = await withSpinner(
+          `Getting ${key}...`,
+          () => kv.get(key, wantBytes ? { binary: true } : undefined),
+        ) as any;
 
         if (!result.ok) {
           if (result.error.code === "KV_NOT_FOUND" || result.error.code === "NOT_FOUND") {
@@ -69,17 +76,15 @@ export function registerKvCommand(program: Command): void {
         const metadata = result.data.headers ?? {};
 
         if (options.output) {
-          // Write to file
-          const content = typeof data === "string" ? data : JSON.stringify(data);
-          await writeFile(options.output, content);
+          // Write raw bytes to file (data is a Uint8Array when wantBytes).
+          await writeFile(options.output, data as Uint8Array);
           outputJson({ key, written: options.output });
           return;
         }
 
         if (options.raw) {
-          // Raw output - write directly to stdout
-          const content = typeof data === "string" ? data : JSON.stringify(data);
-          process.stdout.write(content);
+          // Raw output - write bytes directly to stdout.
+          process.stdout.write(data as Uint8Array);
           return;
         }
 
@@ -106,6 +111,7 @@ export function registerKvCommand(program: Command): void {
     .description("Set a value")
     .option("--file <path>", "Read value from file")
     .option("--stdin", "Read value from stdin")
+    .option("--space <name|uri>", "Target a non-primary space (short name or full URI)")
     .action(async (key: string, value: string | undefined, options, cmd) => {
       try {
         const globalOpts = cmd.optsWithGlobals();
@@ -136,7 +142,8 @@ export function registerKvCommand(program: Command): void {
           }
         }
 
-        const result = await withSpinner(`Writing ${key}...`, () => node.kv.put(key, putValue)) as any;
+        const kv = await kvHandle(node, options.space, ctx.profile);
+        const result = await withSpinner(`Writing ${key}...`, () => kv.put(key, putValue)) as any;
 
         if (!result.ok) {
           throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR);
@@ -152,13 +159,15 @@ export function registerKvCommand(program: Command): void {
   kv
     .command("delete <key>")
     .description("Delete a key")
-    .action(async (key: string, _options, cmd) => {
+    .option("--space <name|uri>", "Target a non-primary space (short name or full URI)")
+    .action(async (key: string, options, cmd) => {
       try {
         const globalOpts = cmd.optsWithGlobals();
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
-        const result = await withSpinner(`Deleting ${key}...`, () => node.kv.delete(key)) as any;
+        const kv = await kvHandle(node, options.space, ctx.profile);
+        const result = await withSpinner(`Deleting ${key}...`, () => kv.delete(key)) as any;
 
         if (!result.ok) {
           throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR);

--- a/packages/sdk-services/src/kv/KVService.test.ts
+++ b/packages/sdk-services/src/kv/KVService.test.ts
@@ -374,3 +374,136 @@ describe("KVService.createSignedReadUrl", () => {
     }
   });
 });
+
+describe("KVService.put serialization", () => {
+  test("sends a string value as-is (no JSON wrapping)", async () => {
+    let requestInit: FetchRequestInit | undefined;
+    const service = new KVService({});
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, "");
+      })
+    );
+
+    const result = await service.put("note", "hello-artifact");
+
+    expect(result.ok).toBe(true);
+    expect(requestInit?.body).toBe("hello-artifact");
+  });
+
+  test("JSON-encodes plain objects", async () => {
+    let requestInit: FetchRequestInit | undefined;
+    const service = new KVService({});
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, "");
+      })
+    );
+
+    const result = await service.put("settings", { theme: "dark" });
+
+    expect(result.ok).toBe(true);
+    expect(requestInit?.body).toBe(JSON.stringify({ theme: "dark" }));
+  });
+
+  test("sends binary (Uint8Array) values as raw bytes, not JSON", async () => {
+    let requestInit: FetchRequestInit | undefined;
+    const service = new KVService({});
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, "");
+      })
+    );
+
+    const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]); // PNG magic
+    const result = await service.put("img.png", bytes);
+
+    expect(result.ok).toBe(true);
+    expect(requestInit?.body).toBeInstanceOf(Blob);
+    const blob = requestInit?.body as Blob;
+    expect(blob.type).toBe("application/octet-stream");
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(bytes);
+  });
+
+  test("sends Buffer values as raw bytes (not {type:Buffer,data:[...]})", async () => {
+    let requestInit: FetchRequestInit | undefined;
+    const service = new KVService({});
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, "");
+      })
+    );
+
+    const buf = Buffer.from([0, 1, 2, 254, 255]);
+    const result = await service.put("blob.bin", buf);
+
+    expect(result.ok).toBe(true);
+    expect(requestInit?.body).toBeInstanceOf(Blob);
+    const blob = requestInit?.body as Blob;
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(
+      new Uint8Array([0, 1, 2, 254, 255])
+    );
+    // Guard against the regression: must NOT serialize as JSON Buffer wrapper.
+    const text = await blob.text();
+    expect(text).not.toContain('"type":"Buffer"');
+  });
+
+  test("honors an explicit contentType for binary values", async () => {
+    let requestInit: FetchRequestInit | undefined;
+    const service = new KVService({});
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, "");
+      })
+    );
+
+    const bytes = new Uint8Array([1, 2, 3]);
+    const result = await service.put("img.png", bytes, {
+      contentType: "image/png",
+    });
+
+    expect(result.ok).toBe(true);
+    expect((requestInit?.body as Blob).type).toBe("image/png");
+  });
+});
+
+describe("KVService.get binary", () => {
+  function binaryResponse(bytes: Uint8Array): FetchResponse {
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { get: () => null },
+      json: async () => {
+        throw new Error("not json");
+      },
+      text: async () => new TextDecoder().decode(bytes),
+      arrayBuffer: async () =>
+        bytes.buffer.slice(
+          bytes.byteOffset,
+          bytes.byteOffset + bytes.byteLength
+        ) as ArrayBuffer,
+      blob: async () => new Blob([bytes]),
+    };
+  }
+
+  test("returns raw bytes as a Uint8Array when binary: true", async () => {
+    // Bytes that are NOT valid UTF-8, to prove we don't go through text().
+    const bytes = new Uint8Array([137, 80, 78, 71, 0, 255, 254, 1]);
+    const service = new KVService({});
+    service.initialize(createContext(async () => binaryResponse(bytes)));
+
+    const result = await service.get("img.png", { binary: true });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.data).toBeInstanceOf(Uint8Array);
+      expect(result.data.data).toEqual(bytes);
+    }
+  });
+});

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -249,11 +249,11 @@ export class KVService extends BaseService implements IKVService {
     }
 
     if (ArrayBuffer.isView(value)) {
-      const bytes = new Uint8Array(value.byteLength);
-      bytes.set(
-        new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
-      );
-      return new Blob([bytes], {
+      // Pass a ranged view (honors byteOffset/byteLength so a Node Buffer backed
+      // by a shared pool isn't over-read); Blob snapshots the bytes at
+      // construction, so no defensive copy is needed.
+      const view = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+      return new Blob([view], {
         type: contentType ?? "application/octet-stream",
       });
     }

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -222,6 +222,49 @@ export class KVService extends BaseService implements IKVService {
     });
   }
 
+  /**
+   * Serialize a single put value into a fetch body.
+   *
+   * Binary values (Blob/ArrayBuffer/typed-array, incl. Node Buffer) are sent as
+   * raw bytes (as a Blob) so they round-trip byte-identically — without this a
+   * Buffer would be JSON.stringify'd into `{"type":"Buffer","data":[...]}`.
+   * Strings are returned unchanged (preserving prior behavior); other values are
+   * JSON-encoded. `contentType` overrides the inferred type for binary values.
+   */
+  private serializePutValue(
+    value: unknown,
+    contentType?: string
+  ): Blob | string {
+    if (value instanceof Blob) {
+      if (!contentType || value.type === contentType) {
+        return value;
+      }
+      return new Blob([value], { type: contentType });
+    }
+
+    if (value instanceof ArrayBuffer) {
+      return new Blob([value], {
+        type: contentType ?? "application/octet-stream",
+      });
+    }
+
+    if (ArrayBuffer.isView(value)) {
+      const bytes = new Uint8Array(value.byteLength);
+      bytes.set(
+        new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+      );
+      return new Blob([bytes], {
+        type: contentType ?? "application/octet-stream",
+      });
+    }
+
+    if (typeof value === "string") {
+      return contentType ? new Blob([value], { type: contentType }) : value;
+    }
+
+    return JSON.stringify(value);
+  }
+
   private serializeBatchPutValue(item: KVBatchPutItem): Blob {
     const contentType = item.contentType;
 
@@ -312,10 +355,15 @@ export class KVService extends BaseService implements IKVService {
    */
   private async parseResponse<T>(
     response: FetchResponse,
-    raw: boolean = false
+    raw: boolean = false,
+    binary: boolean = false
   ): Promise<T | undefined> {
     if (!response.ok) {
       return undefined;
+    }
+
+    if (binary) {
+      return new Uint8Array(await response.arrayBuffer()) as unknown as T;
     }
 
     if (raw) {
@@ -454,7 +502,11 @@ export class KVService extends BaseService implements IKVService {
           );
         }
 
-        const data = await this.parseResponse<T>(response, options?.raw);
+        const data = await this.parseResponse<T>(
+          response,
+          options?.raw,
+          options?.binary
+        );
         return ok({
           data: data as T,
           headers: this.createResponseHeaders(response.headers),
@@ -480,13 +532,10 @@ export class KVService extends BaseService implements IKVService {
 
       const path = this.getFullPath(key, options?.prefix);
 
-      // Serialize value to string
-      let body: string;
-      if (typeof value === "string") {
-        body = value;
-      } else {
-        body = JSON.stringify(value);
-      }
+      // Serialize the value. Binary values (Blob/ArrayBuffer/typed-array/Buffer)
+      // are sent as raw bytes so they round-trip byte-identically; strings are
+      // sent as-is; everything else is JSON. Mirrors serializeBatchPutValue.
+      const body = this.serializePutValue(value, options?.contentType);
 
       try {
         const response = await this.invokeOperation(

--- a/packages/sdk-services/src/kv/types.ts
+++ b/packages/sdk-services/src/kv/types.ts
@@ -46,6 +46,13 @@ export interface KVGetOptions {
   raw?: boolean;
 
   /**
+   * Return the raw response bytes as a Uint8Array instead of parsed/text data.
+   * Use this to read back binary values (e.g. images) byte-identically. Takes
+   * precedence over {@link raw}.
+   */
+  binary?: boolean;
+
+  /**
    * Custom timeout for this operation in milliseconds.
    */
   timeout?: number;


### PR DESCRIPTION
Fixes two verified `tc` CLI / KV bugs.

## Bug A — `tc kv put` / `tc kv delete` ignore `--space` (closes #253)
`get`/`list`/`head` already accept `--space` and route through `kvForSpace`, but `put`/`delete` called `node.kv.put`/`node.kv.delete` directly (primary space only). Now both accept `--space <name|uri>` and route through the existing `kvHandle()` helper — KV writes/deletes to a non-primary space (e.g. an `applications` space) are possible from the CLI.

## Bug B — binary KV values don't round-trip (closes #254)
`tc kv put --file <png>`/`--stdin` then `tc kv get` returned `{"type":"Buffer","data":[...]}` instead of raw bytes.
- **Write:** `KVService.put` now sends Blob/ArrayBuffer/typed-array/Buffer values as raw bytes (`application/octet-stream`, honoring `options.contentType`) via a new `serializePutValue` helper that mirrors the already-correct `serializeBatchPutValue`. Strings/objects unchanged.
- **Read:** new `KVGetOptions.binary` returns the raw response bytes as a `Uint8Array` (via `response.arrayBuffer()`).
- **CLI:** `kv get -o <file>` / `--raw` now request `{ binary: true }` and write raw bytes, so images round-trip byte-identically. The default (parsed/JSON) `get` path is unchanged.

No `node-sdk` changes needed — `node.kv` and `node.kvForSpace` both return `KVService` instances, so the fix reaches both primary and space-scoped KV.

## Tests
- `packages/sdk-services/src/kv/KVService.test.ts`: put serialization (string as-is, object→JSON, Uint8Array/Buffer→raw bytes incl. a guard against the `{type:Buffer}` regression, explicit `contentType`) and binary `get` returning a `Uint8Array` from non-UTF-8 bytes.
- `packages/cli/src/commands/kv.test.ts` (new): `put`/`delete` route to primary vs `kvForSpace` based on `--space`.
- Full suites green: sdk-services 144 pass, cli 22 pass.

## Manual verification (live CLI, local-key `cli-test` profile)
- PNG (incl. non-UTF-8 bytes) round-trips byte-identically via `kv put --file` + `kv get -o` and `--raw` (sha256 match).
- `kv put/get/delete --space` write/read/remove against a named space (routed through `kvForSpace`).
- String + JSON `get` unchanged. All test keys cleaned up afterward.

## Release
Adds a `patch` changeset for `@tinycloud/cli` and `@tinycloud/sdk-services`. The repo is in changesets pre/beta mode; on merge to `master`, the `Release` workflow (`.github/workflows/changesets.yml`) auto-runs `changeset version` + `changeset publish`, producing `@tinycloud/cli@0.6.1-beta.0` and `@tinycloud/sdk-services@2.3.1-beta.0` (linked sdk-core/node-sdk/web-sdk move together). Verified via a local `changeset version` dry run (reverted; CI owns the bump).

## Related, not addressed
- #257 — `readStdin()` reads empty bytes when stdin is a **redirected file** (`--stdin < file`) under bun. Pre-existing (reproduced on `master` before this PR) and affects all `--stdin` paths (kv/secrets/vars/vault/share) via the shared `readStdin` pattern. Out of scope here; this PR fixes the binary serialization once bytes are in hand (`--file` and pipe-`--stdin` round-trip byte-identically). Workaround: use `--file` or `cat file | tc … --stdin`.

## Review
Codex review: APPROVE-WITH-NITS (no blockers). Addressed both nits:
- KVService.ts binary branch now passes a ranged `Uint8Array` view to `Blob` instead of an extra full-size copy.
- Added mocked CLI `kv get` tests asserting `--raw`/`-o` request `{ binary: true }` and emit exact bytes (incl. a non-UTF-8 byte), plus that default `get` does not request binary mode.

Suites green after changes: sdk-services 144 pass, cli 25 pass.
