### PR TITLE
fix(node-sdk): activate all delegation.resources[] in wallet-mode useDelegation

### DIFF
--- a/.changeset/usedelegation-multiresource.md
+++ b/.changeset/usedelegation-multiresource.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/node-sdk": patch
+---
+
+Fix wallet-mode `useDelegation` dropping every resource except the top-level one. A multi-resource delegation (e.g. `[{tinycloud.kv get vault/secrets/X}, {tinycloud.encryption decrypt <networkId>}]`) carries each grant in `delegation.resources[]`, but the flat top-level `path`/`actions` mirror only the first resource. `useDelegation` built the activation sub-delegation's abilities from those flat fields alone, so for multi-resource delegations every other resource was silently dropped — the activated session held only the encryption cap and a subsequent `access.kv.get(...)` failed with `Unauthorized Action: .../tinycloud.kv/get`. Wallet-mode `useDelegation` now builds the activated abilities from the full `resources[]` set (kv/sql/duckdb scoped to the delegation space, encryption network URNs as raw abilities), so one `useDelegation` call grants every resource's capabilities.
+
+Also export the type-only barrel names `WasmKeyProviderConfig` and `NodeUserAuthorizationConfig` as `export type`, so importing node-sdk as raw TypeScript (e.g. via bun) no longer throws `SyntaxError: export 'X' not found`.

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -734,6 +734,103 @@ describe("TinyCloudNode runtime permission delegations", () => {
     );
   });
 
+  test("useDelegation activates every resource of a multi-resource delegation", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const secretsSpaceId = `tinycloud:pkh:eip155:1:${address}:secrets`;
+    const networkId = node.getDefaultEncryptionNetworkId();
+    const secretPath = "vault/secrets/ANTHROPIC_API_KEY";
+
+    // A delegation covering BOTH a kv secret and an encryption network.
+    // The flat top-level path/actions mirror only the encryption resource
+    // (sorted first by service); the full set lives in `resources[]`.
+    const delegation = {
+      cid: "owner-multi-cid",
+      delegationHeader: { Authorization: "owner-multi-token" },
+      spaceId: secretsSpaceId,
+      path: networkId,
+      actions: ["tinycloud.encryption/decrypt"],
+      resources: [
+        {
+          service: "encryption",
+          space: "encryption",
+          path: networkId,
+          actions: ["tinycloud.encryption/decrypt"],
+        },
+        {
+          service: "kv",
+          space: secretsSpaceId,
+          path: secretPath,
+          actions: ["tinycloud.kv/get"],
+        },
+      ],
+      disableSubDelegation: false,
+      expiry: new Date(Date.now() + 3600_000),
+      delegateDID: "did:key:default",
+      ownerAddress: address,
+      chainId: 1,
+      host: "https://tinycloud.test",
+    };
+
+    await withActivatedDelegations(async () => {
+      await node.useDelegation(delegation as any);
+    });
+
+    const prepareSession = (node as any).wasmBindings.prepareSession;
+    const call = prepareSession.mock.calls[0][0];
+
+    // The kv capability must NOT be dropped from the activation.
+    expect(call.abilities).toEqual({
+      kv: { [secretPath]: ["tinycloud.kv/get"] },
+    });
+    // The encryption capability must also be present, as a raw network grant.
+    expect(call.rawAbilities).toEqual({
+      [networkId]: ["tinycloud.encryption/decrypt"],
+    });
+
+    // Both resources are tracked as runtime grants so subsequent
+    // invocations route to the activated sub-delegation session.
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: secretsSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      secretPath,
+      "tinycloud.kv/get",
+    );
+    expect(
+      invoke.mock.calls[invoke.mock.calls.length - 1][0].delegationHeader
+        .Authorization,
+    ).toBe("runtime-token");
+
+    (node as any).invokeAnyWithRuntimePermissions(
+      fallback,
+      [
+        {
+          resource: networkId,
+          service: "encryption",
+          path: networkId,
+          action: "tinycloud.encryption/decrypt",
+        },
+      ],
+      [{}],
+    );
+    const invokeAny = (node as any).wasmBindings.invokeAny;
+    expect(
+      invokeAny.mock.calls[invokeAny.mock.calls.length - 1][0].delegationHeader
+        .Authorization,
+    ).toBe("runtime-token");
+  });
+
   test("encryption discovery falls back to the well-known cache record", async () => {
     const invoke = mock((session: any) => ({
       Authorization: session.delegationHeader.Authorization,

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -3317,6 +3317,73 @@ export class TinyCloudNode {
     }));
   }
 
+  /**
+   * Build the abilities/rawAbilities maps for a wallet-mode activation
+   * sub-delegation from the FULL resource set of a received delegation.
+   *
+   * Each entry in `delegation.resources[]` is one `(service, space, path,
+   * actions)` grant; the flat top-level `path`/`actions` mirror only the
+   * first resource. We must reconstruct every grant so the activated
+   * session carries all of them (e.g. both `tinycloud.kv/get` and
+   * `tinycloud.encryption/decrypt`) — not just the primary one.
+   *
+   * Encryption resources are raw network URNs (space-independent) and go
+   * into `rawAbilities`. All other resources are space-scoped and go into
+   * `abilities` keyed by short service name. The activation `prepareSession`
+   * call uses a single `spaceId` (`delegation.spaceId`), so every
+   * non-encryption resource must target that same space — which is exactly
+   * what the multi-resource issuance path enforces. A resource targeting a
+   * different space cannot be activated in one call, so we fail loudly
+   * rather than silently dropping it.
+   *
+   * @internal
+   */
+  private buildActivationAbilities(delegation: PortableDelegation): {
+    abilities: Record<string, Record<string, string[]>>;
+    rawAbilities: Record<string, string[]>;
+  } {
+    const resources =
+      delegation.resources !== undefined && delegation.resources.length > 0
+        ? delegation.resources
+        : this.flatDelegationResources(delegation);
+
+    const abilities: Record<string, Record<string, string[]>> = {};
+    const rawAbilities: Record<string, string[]> = {};
+
+    const addActions = (target: string[], actions: string[]): void => {
+      const seen = new Set(target);
+      for (const action of actions) {
+        if (!seen.has(action)) {
+          target.push(action);
+          seen.add(action);
+        }
+      }
+    };
+
+    for (const resource of resources) {
+      const service = this.invocationServiceName(resource.service);
+      if (this.isEncryptionNetworkOperation(service, resource.path)) {
+        rawAbilities[resource.path] ??= [];
+        addActions(rawAbilities[resource.path], resource.actions);
+        continue;
+      }
+
+      if (resource.space !== delegation.spaceId) {
+        throw new Error(
+          `useDelegation: resource targets space '${resource.space}' but the ` +
+            `delegation activates space '${delegation.spaceId}'. Multi-space ` +
+            `delegations cannot be activated in a single useDelegation call.`,
+        );
+      }
+
+      abilities[service] ??= {};
+      abilities[service][resource.path] ??= [];
+      addActions(abilities[service][resource.path], resource.actions);
+    }
+
+    return { abilities, rawAbilities };
+  }
+
   private selectInvocationSession(
     fallback: ServiceSession,
     service: string,
@@ -3808,30 +3875,13 @@ export class TinyCloudNode {
     // We must use the same key that the delegation was created for
     const jwk = mySession.jwk;
 
-    // Build abilities from the delegation
-    const abilities: Record<string, Record<string, string[]>> = {};
-    const kvActions = delegation.actions.filter(a => a.startsWith("tinycloud.kv/"));
-    const sqlActions = delegation.actions.filter(a => a.startsWith("tinycloud.sql/"));
-    const duckdbActions = delegation.actions.filter(a => a.startsWith("tinycloud.duckdb/"));
-    const encryptionActions = delegation.actions.filter(a =>
-      a.startsWith("tinycloud.encryption/"),
-    );
-    const rawAbilities: Record<string, string[]> = {};
-    if (kvActions.length > 0) {
-      abilities.kv = { [delegation.path]: kvActions };
-    }
-    if (sqlActions.length > 0) {
-      abilities.sql = { [delegation.path]: sqlActions };
-    }
-    if (duckdbActions.length > 0) {
-      abilities.duckdb = { [delegation.path]: duckdbActions };
-    }
-    if (
-      encryptionActions.length > 0 &&
-      delegation.path.startsWith("urn:tinycloud:encryption:")
-    ) {
-      rawAbilities[delegation.path] = encryptionActions;
-    }
+    // Build the activation abilities from the FULL resource set, not just
+    // the flat top-level path/actions. A multi-resource delegation (e.g.
+    // [{kv get vault/secrets/X}, {encryption decrypt <networkId>}]) carries
+    // every grant in `delegation.resources[]`; the flat `path`/`actions`
+    // mirror only the first resource. Building from the flat fields alone
+    // silently drops every other resource from the activated session.
+    const { abilities, rawAbilities } = this.buildActivationAbilities(delegation);
 
     const now = new Date();
     // Use delegation expiry or 1 hour, whichever is sooner

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -69,7 +69,7 @@ export { FileSessionStorage } from "./storage/FileSessionStorage";
 // Authorization
 export {
   NodeUserAuthorization,
-  NodeUserAuthorizationConfig,
+  type NodeUserAuthorizationConfig,
 } from "./authorization/NodeUserAuthorization";
 
 // Sign strategies — value exports
@@ -335,6 +335,6 @@ export type { KeyProvider } from "@tinycloud/sdk-core";
 // Key management for node-sdk
 export {
   WasmKeyProvider,
-  WasmKeyProviderConfig,
+  type WasmKeyProviderConfig,
   createWasmKeyProvider,
 } from "./keys/WasmKeyProvider";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -96,7 +96,7 @@ export { FileSessionStorage } from "./storage/FileSessionStorage";
 // Authorization
 export {
   NodeUserAuthorization,
-  NodeUserAuthorizationConfig,
+  type NodeUserAuthorizationConfig,
 } from "./authorization/NodeUserAuthorization";
 
 // Sign strategies — value exports
@@ -462,6 +462,6 @@ export type { KeyProvider } from "@tinycloud/sdk-core";
 // Key management for node-sdk
 export {
   WasmKeyProvider,
-  WasmKeyProviderConfig,
+  type WasmKeyProviderConfig,
   createWasmKeyProvider,
 } from "./keys/WasmKeyProvider";

--- a/packages/node-sdk/src/keys/index.ts
+++ b/packages/node-sdk/src/keys/index.ts
@@ -4,4 +4,5 @@
  * @packageDocumentation
  */
 
-export { WasmKeyProvider, WasmKeyProviderConfig, createWasmKeyProvider } from "./WasmKeyProvider";
+export { WasmKeyProvider, createWasmKeyProvider } from "./WasmKeyProvider";
+export type { WasmKeyProviderConfig } from "./WasmKeyProvider";


### PR DESCRIPTION
## Root cause

Wallet-mode `TinyCloudNode.useDelegation` built the activation sub-delegation's abilities only from the flat top-level `delegation.path` / `delegation.actions`. For a delegation issued via the multi-resource WASM path, those flat fields mirror **only the first resource** (sorted by `(service, path)`); the full grant set lives in `delegation.resources[]`. So every resource except the top-level one was silently dropped from the activated session.

Concretely, a secret delegation `[{tinycloud.kv get vault/secrets/NAME}, {tinycloud.encryption decrypt <networkId>}]` activated with **only** the encryption cap, and a subsequent `access.kv.get(...)` failed with:

```
Unauthorized Action: tinycloud:pkh:eip155:1:0x...:secrets/kv/vault/secrets/NAME / tinycloud.kv/get
```

## The fix

`useDelegation` (wallet mode) now builds the activated abilities from the **full** resource set via a new `buildActivationAbilities` helper:

- Uses `delegation.resources[]` when present; falls back to the existing `flatDelegationResources(delegation)` for legacy single-resource shapes.
- kv/sql/duckdb resources are scoped to the delegation space (`abilities`), encryption network URNs go into `rawAbilities` (space-independent), reusing the same `invocationServiceName` / `isEncryptionNetworkOperation` classification the rest of the runtime-grant code uses.
- Resources targeting a space other than `delegation.spaceId` throw a clear error rather than being silently dropped (a single `prepareSession` activation can only cover one space; the issuance path already enforces a single non-encryption space).

The single-resource path and session-only mode are unchanged.

### Bundle fix (raw-TS barrels)

`WasmKeyProviderConfig` and `NodeUserAuthorizationConfig` are type-only but were re-exported as **values** in `keys/index.ts`, `index.ts`, and `core.ts`, which throws `SyntaxError: export 'X' not found` when node-sdk is imported as raw TS (e.g. via bun). They are now `export type` (matching each file's existing style). These were the only type-as-value barrel mistakes in those three files.

## Verification

- `bunx turbo build --filter=@tinycloud/node-sdk` — green.
- node-sdk unit suite: **62 pass / 0 fail**. Added a unit test (`useDelegation activates every resource of a multi-resource delegation`) asserting the kv cap is **not** dropped (both `abilities.kv` and `rawAbilities[networkId]` are present in the activation `prepareSession` call) and that both resources install as runtime grants.
- End-to-end against a **local tinycloud-node** (owner signs in → `ensureEncryptionNetwork` → encrypt + write envelope to kv → `delegateTo(agentPkhDid, [kv get, encryption decrypt])` → agent `useDelegation` → `access.kv.get` + `decryptEnvelope`):
  - **Before (master behavior):** `access.kv.get` → `AUTH_UNAUTHORIZED: Unauthorized Action: .../tinycloud.kv/get`. FAIL.
  - **After (fix):** `access.kv.get` succeeds and `decryptEnvelope` returns the original plaintext from a single `useDelegation` call. PASS.

Raw-TS import of the keys barrel via bun now succeeds (`WasmKeyProviderConfig` is correctly absent from runtime exports).

A changeset (patch bump for `@tinycloud/node-sdk`) is included.