### PR TITLE
feat(cli): delegated secret reads (tc secrets get --delegation) + cross-user auth import

### DIFF
--- a/.changeset/cli-cross-user-auth-import.md
+++ b/.changeset/cli-cross-user-auth-import.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/cli": patch
+---
+
+Fix `tc auth import` rejecting cross-user delegations. Import unconditionally called `node.useRuntimeDelegation(...)`, which requires the delegation to target the active session key and so threw `Runtime delegation targets did:pkh:... but this session key is did:key:...` for a delegation received from another user (audience = your stable identity DID). Import now routes by audience: a delegation that targets the active session key is still installed as a runtime grant, while a cross-user delegation is persisted to `additional-delegations.json` and later activated at read time via `node.useDelegation(...)`. The `imported` output now includes an `activated` flag indicating whether a runtime grant was installed.

--- a/.changeset/cli-delegated-secret-reads.md
+++ b/.changeset/cli-delegated-secret-reads.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/cli": minor
+---
+
+Add `tc secrets get <NAME> --delegation <file-or-imported-profile>` for reading a secret you were delegated access to. The `--delegation` source can be a delegation JSON file or the name of a profile that imported the delegation (resolved from `additional-delegations.json`). The read path validates that the delegation covers both the secret's `tinycloud.kv/get` path and the envelope's `tinycloud.encryption/decrypt` network, then activates the delegation in wallet mode via `node.useDelegation(...)` to fetch and decrypt the value. Adds a `smoke:delegated-secrets` script that exercises the full owner-delegate flow against a live node.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf dist",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "smoke:delegated-secrets": "bun scripts/live-delegated-secrets-smoke.ts"
   },
   "dependencies": {
     "@tinycloud/node-sdk": "2.3.0",

--- a/packages/cli/scripts/live-delegated-secrets-smoke.ts
+++ b/packages/cli/scripts/live-delegated-secrets-smoke.ts
@@ -1,0 +1,267 @@
+#!/usr/bin/env bun
+
+import { randomBytes } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const SMOKE_HOST = process.env.TC_LIVE_SMOKE_HOST ?? "https://node.tinycloud.xyz";
+const ENABLED = process.env.TC_LIVE_SMOKE === "1";
+
+type RunResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+  command: string;
+};
+
+type JsonResult = {
+  [key: string]: unknown;
+};
+
+function isDefaultNodeHost(host: string): boolean {
+  try {
+    return new URL(host).hostname === "node.tinycloud.xyz";
+  } catch {
+    return false;
+  }
+}
+
+if (!ENABLED) {
+  process.stderr.write("[skip] Set TC_LIVE_SMOKE=1 to run the delegated secrets smoke test.\n");
+  process.exit(0);
+}
+
+function buildCommand(args: string[]): string {
+  return ["bun", ...args].join(" ");
+}
+
+async function run(
+  cliEntry: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<RunResult> {
+  return await new Promise<RunResult>((resolvePromise, rejectPromise) => {
+    const child = spawn(process.execPath, ["run", cliEntry, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", rejectPromise);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        rejectPromise(new Error(`Command ${buildCommand(["run", cliEntry, ...args])} exited via signal ${signal}.`));
+        return;
+      }
+      resolvePromise({
+        code: code ?? 0,
+        stdout,
+        stderr,
+        command: buildCommand(["run", cliEntry, ...args]),
+      });
+    });
+  });
+}
+
+function parseJson<T extends JsonResult>(result: RunResult, label: string): T {
+  const text = result.stdout.trim();
+  if (text === "") {
+    throw new Error(`${label} produced no JSON output.\n${result.stderr.trim()}`);
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    throw new Error(
+      `${label} did not produce valid JSON.\nCommand: ${result.command}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}\n${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function expectSuccess(result: RunResult, label: string): void {
+  if (result.code === 0) {
+    return;
+  }
+
+  const caveat = label === "delegated secret read" && isDefaultNodeHost(SMOKE_HOST)
+    ? "\nKnown caveat: node.tinycloud.xyz has not been verified to expose the encryption-networks service. If this looks like a decrypt failure, retry against https://tee.node.tinycloud.xyz."
+    : "";
+
+  throw new Error(
+    `${label} failed.\nCommand: ${result.command}\nExit code: ${result.code}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}${caveat}`,
+  );
+}
+
+function expectSecretValue(result: RunResult, expected: string): void {
+  const parsed = parseJson<{ name: string; value: string }>(result, "delegated secret read");
+  if (parsed.value !== expected) {
+    throw new Error(
+      `Delegated secret read returned the wrong value.\nExpected: ${expected}\nReceived: ${parsed.value}\nCommand: ${result.command}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const { TinyCloudNode } = await import("../../node-sdk/src/index.ts");
+  const { generateLocalIdentity } = await import("../src/auth/local-key.ts");
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const cliRoot = resolve(scriptDir, "..");
+  const cliEntry = resolve(cliRoot, "src/index.ts");
+  const tempHome = await mkdtemp(join(tmpdir(), "tc-cli-live-smoke-"));
+  const profile = `delegated-smoke-${Date.now().toString(36)}`;
+  const secretName = `SMOKE_${Date.now().toString(36).toUpperCase()}_${randomBytes(3).toString("hex").toUpperCase()}`;
+  const secretValue = `secret-${randomBytes(12).toString("hex")}`;
+  const env = {
+    ...process.env,
+    HOME: tempHome,
+    USERPROFILE: tempHome,
+    TC_HOME: tempHome,
+  };
+
+  try {
+    const ownerIdentity = await generateLocalIdentity();
+    const ownerNode = new TinyCloudNode({
+      privateKey: ownerIdentity.privateKey,
+      host: SMOKE_HOST,
+      autoCreateSpace: true,
+    });
+    await ownerNode.signIn();
+
+    const agentInit = await run(cliEntry, [
+      "--quiet",
+      "--json",
+      "--profile",
+      profile,
+      "--host",
+      SMOKE_HOST,
+      "init",
+      "--name",
+      profile,
+      "--key-only",
+    ], {
+      cwd: cliRoot,
+      env,
+    });
+    expectSuccess(agentInit, "agent init");
+    parseJson<{ did: string }>(agentInit, "agent init");
+
+    const login = await run(cliEntry, [
+      "--quiet",
+      "--json",
+      "--profile",
+      profile,
+      "--host",
+      SMOKE_HOST,
+      "auth",
+      "login",
+      "--method",
+      "local",
+    ], {
+      cwd: cliRoot,
+      env,
+    });
+    expectSuccess(login, "agent login");
+    const loginJson = parseJson<{ sessionDid: string; did: string }>(login, "agent login");
+    if (typeof loginJson.did !== "string" || loginJson.did.length === 0) {
+      throw new Error(`Agent login did not return a DID.\nSTDOUT:\n${login.stdout}\nSTDERR:\n${login.stderr}`);
+    }
+    // The delegation audience must be the agent's STABLE identity DID (did:pkh),
+    // not its ephemeral session-key DID. When the agent later runs
+    // `tc secrets get --delegation`, it authenticates in wallet mode and
+    // `useDelegation` mints the activation sub-delegation with the agent's
+    // did:pkh as the delegator. The node validates that the parent
+    // delegation's delegatee equals that delegator, so delegating to the
+    // session DID (did:key) makes activation fail with
+    // "Cannot find parent delegation".
+    const agentAudienceDid = loginJson.did;
+
+    const networkDescriptor = await ownerNode.ensureEncryptionNetwork("default");
+    const putResult = await ownerNode.secrets.put(secretName, secretValue);
+    if (!putResult.ok) {
+      throw new Error(`Owner secret write failed: ${putResult.error.code} ${putResult.error.message}`);
+    }
+
+    const delegationResult = await ownerNode.delegateTo(agentAudienceDid, [
+      {
+        service: "tinycloud.kv",
+        space: "secrets",
+        path: `vault/secrets/${secretName}`,
+        actions: ["tinycloud.kv/get"],
+      },
+      {
+        service: "tinycloud.encryption",
+        path: networkDescriptor.networkId,
+        actions: ["tinycloud.encryption/decrypt"],
+      },
+    ]);
+
+    const delegationFile = join(tempHome, "delegation.json");
+    await writeFile(
+      delegationFile,
+      `${JSON.stringify(delegationResult.delegation, null, 2)}\n`,
+      "utf8",
+    );
+
+    const imported = await run(cliEntry, [
+      "--quiet",
+      "--json",
+      "--profile",
+      profile,
+      "--host",
+      SMOKE_HOST,
+      "auth",
+      "import",
+      delegationFile,
+    ], {
+      cwd: cliRoot,
+      env,
+    });
+    expectSuccess(imported, "delegation import");
+
+    const delegatedRead = await run(cliEntry, [
+      "--quiet",
+      "--json",
+      "--profile",
+      profile,
+      "--host",
+      SMOKE_HOST,
+      "secrets",
+      "get",
+      secretName,
+      "--delegation",
+      profile,
+    ], {
+      cwd: cliRoot,
+      env,
+    });
+    expectSuccess(delegatedRead, "delegated secret read");
+    expectSecretValue(delegatedRead, secretValue);
+
+    process.stdout.write(
+      JSON.stringify({
+        ok: true,
+        host: SMOKE_HOST,
+        profile,
+        secretName,
+      }) + "\n",
+    );
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/packages/cli/src/auth/local-key.ts
+++ b/packages/cli/src/auth/local-key.ts
@@ -1,5 +1,5 @@
 import { TCWSessionManager, importKey, initPanicHook } from "@tinycloud/node-sdk-wasm";
-import { PrivateKeySigner, pkhDid } from "@tinycloud/node-sdk";
+import { PrivateKeySigner } from "@tinycloud/node-sdk";
 import { randomBytes } from "node:crypto";
 
 let wasmInitialized = false;
@@ -58,7 +58,7 @@ export async function deriveAddress(privateKey: string): Promise<string> {
  * Uses EIP-155 chain ID 1 (mainnet).
  */
 export function addressToDID(address: string, chainId: number = 1): string {
-  return pkhDid(address, chainId);
+  return `did:pkh:eip155:${chainId}:${address}`;
 }
 
 /**

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -1,5 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Command } from "commander";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 type ProfileLike = {
   name: string;
@@ -197,15 +200,32 @@ mock.module("../auth/local-key.js", () => ({
   keyToDID: (jwk: { did?: string }) => jwk.did ?? "did:key:from-key",
 }));
 
+let importSessionDid = "did:key:z6MkSession#z6MkSession";
+const importRecorded = {
+  useRuntimeDelegation: [] as Array<{ cid: string }>,
+  appendedDelegations: [] as Array<{ delegation: { cid: string }; permissions: unknown[] }>,
+};
+
 mock.module("../lib/sdk.js", () => ({
   ensureAuthenticated: async () => ({
     hasRuntimePermissions: () => true,
     getRuntimePermissionDelegations: () => [],
+    get sessionDid() {
+      return importSessionDid;
+    },
+    useRuntimeDelegation: async (delegation: { cid: string }) => {
+      importRecorded.useRuntimeDelegation.push({ cid: delegation.cid });
+    },
   }),
 }));
 
 mock.module("../lib/permissions.js", () => ({
-  appendAdditionalDelegation: async () => {},
+  appendAdditionalDelegation: async (
+    _profile: string,
+    entry: { delegation: { cid: string }; permissions: unknown[] },
+  ) => {
+    importRecorded.appendedDelegations.push(entry);
+  },
   appendPermissionRequestArtifact: async () => {},
   createPermissionRequestArtifact: () => ({}),
   getLastPermissionRequestArtifact: async () => null,
@@ -521,5 +541,79 @@ describe("CLI auth rotate command", () => {
         }),
       ],
     }));
+  });
+});
+
+function makePortableDelegation(overrides: { delegateDID: string; cid?: string }): Record<string, unknown> {
+  return {
+    cid: overrides.cid ?? "bafy-import-delegation",
+    spaceId: "tinycloud:pkh:eip155:1:0xOwner:secrets",
+    path: "vault/secrets/ANTHROPIC_API_KEY",
+    actions: ["tinycloud.kv/get"],
+    delegateDID: overrides.delegateDID,
+    ownerAddress: "0xOwner",
+    chainId: 1,
+    delegationHeader: { Authorization: "Bearer import-delegation" },
+    expiry: "2099-01-01T00:00:00.000Z",
+  };
+}
+
+describe("CLI auth import command", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    resetState();
+    importRecorded.useRuntimeDelegation.length = 0;
+    importRecorded.appendedDelegations.length = 0;
+    importSessionDid = "did:key:z6MkSession#z6MkSession";
+    tempDir = await mkdtemp(join(tmpdir(), "tc-auth-import-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("persists a cross-user delegation without installing it as a runtime grant", async () => {
+    // Audience is the importer's stable identity DID (did:pkh), not the session
+    // key. The node would reject this via useRuntimeDelegation, so import must
+    // persist it for later activation through useDelegation.
+    const delegation = makePortableDelegation({
+      delegateDID: "did:pkh:eip155:1:0xAgent",
+      cid: "bafy-cross-user",
+    });
+    const source = join(tempDir, "cross-user.json");
+    await writeFile(source, JSON.stringify(delegation), "utf8");
+
+    await runAuthCommand(["auth", "import", source]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(importRecorded.appendedDelegations).toHaveLength(1);
+    expect(importRecorded.appendedDelegations[0].delegation.cid).toBe("bafy-cross-user");
+    expect(importRecorded.useRuntimeDelegation).toEqual([]);
+    expect(recorded.outputs[0]).toMatchObject({
+      imported: true,
+      activated: false,
+      delegationCid: "bafy-cross-user",
+    });
+  });
+
+  test("installs a delegation that targets the active session key as a runtime grant", async () => {
+    const delegation = makePortableDelegation({
+      delegateDID: "did:key:z6MkSession",
+      cid: "bafy-self-session",
+    });
+    const source = join(tempDir, "self-session.json");
+    await writeFile(source, JSON.stringify(delegation), "utf8");
+
+    await runAuthCommand(["auth", "import", source]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(importRecorded.appendedDelegations).toHaveLength(1);
+    expect(importRecorded.useRuntimeDelegation).toEqual([{ cid: "bafy-self-session" }]);
+    expect(recorded.outputs[0]).toMatchObject({
+      imported: true,
+      activated: true,
+      delegationCid: "bafy-self-session",
+    });
   });
 });

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -6,7 +6,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { createInterface } from "node:readline";
 import type { IncomingMessage } from "node:http";
-import type { PermissionEntry, PortableDelegation } from "@tinycloud/node-sdk";
+import { principalDidEquals, type PermissionEntry, type PortableDelegation } from "@tinycloud/node-sdk";
 import { ProfileManager } from "../config/profiles.js";
 import { outputJson, shouldOutputJson, formatField, formatTable, isInteractive, withSpinner } from "../output/formatter.js";
 import { handleError, CLIError } from "../output/errors.js";
@@ -403,7 +403,21 @@ export function registerAuthCommand(program: Command): void {
           imported.delegation,
           imported.permissions,
         ));
-        await node.useRuntimeDelegation(imported.delegation);
+
+        // A delegation whose audience is this profile's own session key can be
+        // installed as a runtime grant (useRuntimeDelegation activates it for
+        // matching service calls). A cross-user delegation — audience is this
+        // profile's stable identity DID or another principal — cannot: the node
+        // rejects runtime delegations that don't target the session key. Persist
+        // it and let the read path activate it via useDelegation in wallet mode.
+        const targetsSessionKey =
+          typeof imported.delegation.delegateDID === "string" &&
+          principalDidEquals(imported.delegation.delegateDID, node.sessionDid);
+        let activated = false;
+        if (targetsSessionKey) {
+          await node.useRuntimeDelegation(imported.delegation);
+          activated = true;
+        }
         await appendGrantHistory(ctx.profile, {
           addedCaps: imported.permissions,
           source: "cli",
@@ -413,6 +427,7 @@ export function registerAuthCommand(program: Command): void {
 
         outputJson({
           imported: true,
+          activated,
           kind: "tinycloud.auth.delegation",
           requestId: imported.requestId ?? null,
           delegationCid: imported.delegation.cid,

--- a/packages/cli/src/commands/delegation.ts
+++ b/packages/cli/src/commands/delegation.ts
@@ -5,12 +5,17 @@ import { handleError, CLIError } from "../output/errors.js";
 import { ExitCode } from "../config/constants.js";
 import { ensureAuthenticated } from "../lib/sdk.js";
 import { parseExpiry } from "../lib/duration.js";
-import { principalDidEquals } from "@tinycloud/node-sdk";
+
+function normalizeDid(input: string): string {
+  const normalized = input.trim();
+  const fragmentIndex = normalized.indexOf("#");
+  return (fragmentIndex === -1 ? normalized : normalized.slice(0, fragmentIndex)).toLowerCase();
+}
 
 function didMatches(actual: string | undefined, expected: string): boolean {
   if (!actual) return false;
   try {
-    return principalDidEquals(actual, expected);
+    return normalizeDid(actual) === normalizeDid(expected);
   } catch {
     return actual === expected;
   }

--- a/packages/cli/src/commands/secrets.test.ts
+++ b/packages/cli/src/commands/secrets.test.ts
@@ -233,6 +233,41 @@ mock.module("@tinycloud/node-sdk", () => ({
         : `vault/secrets/${name}`,
     },
   }),
+  principalDidEquals: (a: string, b: string) =>
+    a.split("#")[0].toLowerCase() === b.split("#")[0].toLowerCase(),
+}));
+
+mock.module("../lib/permissions.js", () => ({
+  loadAdditionalDelegations: async () => [],
+  permissionsFromDelegation: (delegation: {
+    spaceId: string;
+    path: string;
+    actions: string[];
+    resources?: Array<{
+      service: string;
+      space?: string;
+      path: string;
+      actions: string[];
+    }>;
+  }) => {
+    if (Array.isArray(delegation.resources) && delegation.resources.length > 0) {
+      return delegation.resources.map((resource) => ({
+        service: resource.service.startsWith("tinycloud.")
+          ? resource.service
+          : `tinycloud.${resource.service}`,
+        space: resource.space ?? delegation.spaceId,
+        path: resource.path,
+        actions: [...resource.actions],
+      }));
+    }
+
+    return [{
+      service: "tinycloud.kv",
+      space: delegation.spaceId,
+      path: delegation.path,
+      actions: [...delegation.actions],
+    }];
+  },
 }));
 
 mock.module("../config/profiles.js", () => ({

--- a/packages/cli/src/commands/secrets.ts
+++ b/packages/cli/src/commands/secrets.ts
@@ -1,11 +1,11 @@
 import { Command } from "commander";
 import { readFile } from "node:fs/promises";
 import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import {
-  resolveSecretListPrefix,
-  resolveSecretPath,
   type PermissionEntry,
-  type SecretScopeOptions,
+  type PortableDelegation,
   type TinyCloudNode,
 } from "@tinycloud/node-sdk";
 import { ProfileManager } from "../config/profiles.js";
@@ -33,6 +33,19 @@ type SecretResult<T> =
   | { ok: true; data: T }
   | { ok: false; error: { code: string; message: string; service?: string } };
 
+interface SecretScopeOptions {
+  scope?: string;
+}
+
+interface DelegationCandidate {
+  delegation: PortableDelegation;
+  permissions: PermissionEntry[];
+}
+
+interface ResolvedDelegatedSecretSource extends DelegationCandidate {
+  source: string;
+}
+
 /**
  * Read all data from stdin.
  */
@@ -52,6 +65,86 @@ function authOptions(options: { privateKey?: string }): { privateKey?: string } 
 function resolveSecretScope(options: { scope?: string; space?: string }): { scope?: string } | undefined {
   const scope = options.scope ?? options.space;
   return scope ? { scope } : undefined;
+}
+
+const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
+const RESERVED_SECRET_SCOPES = new Set(["default", "global"]);
+
+function canonicalizeSecretScope(scope: string | undefined): string | undefined {
+  if (scope === undefined) return undefined;
+
+  const trimmed = scope.trim();
+  if (trimmed === "") {
+    throw new CLIError(
+      "INVALID_SECRET_SCOPE",
+      "Secret scope must be non-empty; omit scope for global secrets.",
+      ExitCode.USAGE_ERROR,
+    );
+  }
+
+  const canonical = trimmed
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  if (canonical === "") {
+    throw new CLIError(
+      "INVALID_SECRET_SCOPE",
+      "Secret scope must contain at least one letter or number.",
+      ExitCode.USAGE_ERROR,
+    );
+  }
+
+  if (RESERVED_SECRET_SCOPES.has(canonical)) {
+    throw new CLIError(
+      "INVALID_SECRET_SCOPE",
+      `Secret scope ${JSON.stringify(scope)} is reserved; omit scope for global secrets.`,
+      ExitCode.USAGE_ERROR,
+    );
+  }
+
+  return canonical;
+}
+
+function resolveSecretPath(
+  name: string,
+  options: SecretScopeOptions = {},
+): { name: string; scope?: string; vaultKey: string; permissionPaths: { vault: string } } {
+  const normalizedName = name.trim();
+  if (!SECRET_NAME_RE.test(normalizedName)) {
+    throw new CLIError(
+      "INVALID_SECRET_NAME",
+      `Invalid secret name ${JSON.stringify(name)}. Secret names must match ${SECRET_NAME_RE.source}.`,
+      ExitCode.USAGE_ERROR,
+    );
+  }
+
+  const scope = canonicalizeSecretScope(options.scope);
+  const vaultKey = scope === undefined
+    ? `secrets/${normalizedName}`
+    : `secrets/scoped/${scope}/${normalizedName}`;
+
+  return {
+    name: normalizedName,
+    ...(scope !== undefined ? { scope } : {}),
+    vaultKey,
+    permissionPaths: {
+      vault: `vault/${vaultKey}`,
+    },
+  };
+}
+
+function resolveSecretListPrefix(options: SecretScopeOptions = {}): string {
+  const scope = canonicalizeSecretScope(options.scope);
+  return scope === undefined
+    ? "vault/secrets/"
+    : `vault/secrets/scoped/${scope}/`;
+}
+
+function resolveProfilesDir(): string {
+  const home = process.env.TC_HOME ?? process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+  return join(home, ".tinycloud", "profiles");
 }
 
 async function ensureSecretsNode(
@@ -155,6 +248,411 @@ function thrownPermissionError<T>(error: unknown): SecretResult<T> | null {
       message,
     },
   };
+}
+
+function isMissingFileError(error: unknown): boolean {
+  const typed = error as NodeJS.ErrnoException | null;
+  return typed?.code === "ENOENT";
+}
+
+function hasPermissionAction(actions: string[], action: string): boolean {
+  return actions.some(
+    (entry) =>
+      entry === action ||
+      entry.endsWith(`/${action.split("/").at(-1)}`) ||
+      entry === action.split("/").at(-1),
+  );
+}
+
+function delegationCoversPath(
+  permissions: PermissionEntry[],
+  path: string,
+): boolean {
+  return permissions.some((permission) => {
+    if (permission.service !== "tinycloud.kv") return false;
+    if (!permissionTargetsSecretsSpace(permission)) return false;
+    if (!hasPermissionAction(permission.actions, "tinycloud.kv/get")) return false;
+    return permission.path === path || (permission.path.endsWith("/") && path.startsWith(permission.path));
+  });
+}
+
+function permissionTargetsSecretsSpace(permission: PermissionEntry): boolean {
+  if (permission.service !== "tinycloud.kv") return false;
+  if (typeof permission.space !== "string") return false;
+  const space = permission.space.trim().toLowerCase();
+  if (space === "") return false;
+  return space === SECRETS_SPACE || space.endsWith(`:${SECRETS_SPACE}`);
+}
+
+function delegationCoversDecrypt(
+  permissions: PermissionEntry[],
+  networkId: string,
+): boolean {
+  return permissions.some((permission) => {
+    if (permission.service !== "tinycloud.encryption") return false;
+    if (!hasPermissionAction(permission.actions, "tinycloud.encryption/decrypt")) return false;
+    return permission.path === networkId;
+  });
+}
+
+function parseDelegationExpiry(expiry: unknown): Date {
+  const parsed =
+    expiry instanceof Date
+      ? expiry
+      : typeof expiry === "number"
+        ? new Date(expiry)
+        : new Date(String(expiry));
+  if (Number.isNaN(parsed.getTime())) {
+    throw new CLIError(
+      "INVALID_DELEGATION_SOURCE",
+      "Delegation must include a valid expiry.",
+      ExitCode.USAGE_ERROR,
+    );
+  }
+  return parsed;
+}
+
+function normalizePortableDelegation(value: unknown): PortableDelegation {
+  if (value === null || typeof value !== "object") {
+    throw new CLIError(
+      "INVALID_DELEGATION_SOURCE",
+      "Delegation source must contain a PortableDelegation object.",
+      ExitCode.USAGE_ERROR,
+    );
+  }
+
+  const candidate = value as Partial<PortableDelegation> & {
+    expiry?: unknown;
+    delegationHeader?: unknown;
+  };
+  const authorization = candidate.delegationHeader as { Authorization?: unknown } | undefined;
+  if (
+    typeof candidate.cid !== "string" ||
+    typeof candidate.spaceId !== "string" ||
+    typeof candidate.path !== "string" ||
+    !Array.isArray(candidate.actions) ||
+    typeof candidate.delegateDID !== "string" ||
+    typeof candidate.ownerAddress !== "string" ||
+    typeof candidate.chainId !== "number" ||
+    typeof authorization !== "object" ||
+    authorization === null ||
+    typeof authorization.Authorization !== "string"
+  ) {
+    throw new CLIError(
+      "INVALID_DELEGATION_SOURCE",
+      "Delegation source must contain a PortableDelegation object.",
+      ExitCode.USAGE_ERROR,
+    );
+  }
+
+  return {
+    ...candidate,
+    actions: [...candidate.actions],
+    expiry: parseDelegationExpiry(candidate.expiry),
+    delegationHeader: { Authorization: authorization.Authorization },
+  } as PortableDelegation;
+}
+
+function normalizeDelegationCandidates(
+  value: unknown,
+  source: string,
+): DelegationCandidate[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizeDelegationCandidates(entry, source));
+  }
+
+  if (value === null || typeof value !== "object") {
+    throw new CLIError(
+      "INVALID_DELEGATION_SOURCE",
+      `Delegation source "${source}" must be a delegation file or imported profile reference.`,
+      ExitCode.USAGE_ERROR,
+    );
+  }
+
+  const candidate = value as Record<string, unknown> & {
+    delegation?: unknown;
+    permissions?: PermissionEntry[];
+  };
+
+  if (candidate.delegation !== undefined) {
+    const delegation = normalizePortableDelegation(candidate.delegation);
+    return [{
+      delegation,
+      permissions: Array.isArray(candidate.permissions) && candidate.permissions.length > 0
+        ? candidate.permissions
+        : permissionsFromDelegation(delegation),
+    }];
+  }
+
+  const delegation = normalizePortableDelegation(candidate);
+  return [{
+    delegation,
+    permissions: permissionsFromDelegation(delegation),
+  }];
+}
+
+function permissionsFromDelegation(delegation: PortableDelegation): PermissionEntry[] {
+  if (delegation.resources?.length) {
+    return delegation.resources.map((resource) => ({
+      service: resource.service.startsWith("tinycloud.")
+        ? resource.service
+        : `tinycloud.${resource.service}`,
+      space: resource.space,
+      path: resource.path,
+      actions: [...resource.actions],
+    }));
+  }
+
+  const service = delegation.actions[0]?.includes("/")
+    ? delegation.actions[0].slice(0, delegation.actions[0].indexOf("/"))
+    : "tinycloud.unknown";
+
+  return [{
+    service,
+    space: delegation.spaceId,
+    path: delegation.path,
+    actions: [...delegation.actions],
+  }];
+}
+
+async function loadDelegationCandidates(source: string): Promise<DelegationCandidate[]> {
+  try {
+    const raw = JSON.parse(await readFile(source, "utf8")) as unknown;
+    return normalizeDelegationCandidates(raw, source);
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      if (error instanceof SyntaxError) {
+        throw new CLIError(
+          "INVALID_DELEGATION_SOURCE",
+          `Delegation source "${source}" must be valid JSON.`,
+          ExitCode.USAGE_ERROR,
+        );
+      }
+      throw new CLIError(
+        "INVALID_DELEGATION_SOURCE",
+        `Delegation source "${source}" could not be read.`,
+        ExitCode.USAGE_ERROR,
+      );
+    }
+  }
+
+  try {
+    const importedPath = join(resolveProfilesDir(), source, "additional-delegations.json");
+    const raw = JSON.parse(await readFile(importedPath, "utf8")) as unknown;
+    return normalizeDelegationCandidates(raw, source);
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return [];
+    }
+    if (error instanceof SyntaxError) {
+      throw new CLIError(
+        "INVALID_DELEGATION_SOURCE",
+        `Delegation source "${source}" must be valid JSON.`,
+        ExitCode.USAGE_ERROR,
+      );
+    }
+    throw new CLIError(
+      "INVALID_DELEGATION_SOURCE",
+      `Delegation source "${source}" could not be read.`,
+      ExitCode.USAGE_ERROR,
+    );
+  }
+}
+
+function selectDelegationCandidate(
+  candidates: DelegationCandidate[],
+  source: string,
+  secretPath: string,
+): DelegationCandidate {
+  const liveCandidates = candidates.filter((candidate) => candidate.delegation.expiry.getTime() > Date.now());
+  if (liveCandidates.length === 0) {
+    throw new CLIError(
+      "DELEGATION_EXPIRED",
+      `Delegation source "${source}" has no live delegations.`,
+      ExitCode.PERMISSION_DENIED,
+    );
+  }
+
+  const secretsSpaceCandidates = liveCandidates.filter((candidate) =>
+    candidate.permissions.some(permissionTargetsSecretsSpace)
+  );
+  if (secretsSpaceCandidates.length === 0) {
+    throw new CLIError(
+      "PERMISSION_DENIED",
+      `Delegation source "${source}" does not target the secrets space.`,
+      ExitCode.PERMISSION_DENIED,
+    );
+  }
+
+  const exact = secretsSpaceCandidates.find((candidate) => delegationCoversPath(candidate.permissions, secretPath));
+  if (exact) {
+    return exact;
+  }
+
+  throw new CLIError(
+    "PERMISSION_DENIED",
+    `Delegation source "${source}" does not cover secret "${secretPath}".`,
+    ExitCode.PERMISSION_DENIED,
+  );
+}
+
+async function resolveDelegatedSecretSource(
+  source: string,
+  secretPath: string,
+): Promise<ResolvedDelegatedSecretSource> {
+  const candidates = await loadDelegationCandidates(source);
+  if (candidates.length === 0) {
+    throw new CLIError(
+      "DELEGATION_NOT_FOUND",
+      `Delegation source "${source}" did not resolve to any imported delegations.`,
+      ExitCode.PERMISSION_DENIED,
+    );
+  }
+
+  const selected = selectDelegationCandidate(candidates, source, secretPath);
+  return { ...selected, source };
+}
+
+function mapEncryptionResultError(error: { code: string; message: string }): CLIError {
+  const code = error.code || "DECRYPTION_FAILED";
+  const exitCode =
+    code === "PERMISSION_DENIED" ? ExitCode.PERMISSION_DENIED :
+    code === "NOT_FOUND" ? ExitCode.NOT_FOUND :
+    code === "NETWORK_ERROR" || code === "TRANSPORT_ERROR" ? ExitCode.NETWORK_ERROR :
+    ExitCode.ERROR;
+
+  return new CLIError(code, error.message, exitCode);
+}
+
+function parseDecryptedSecretPayload(
+  data: Uint8Array,
+  secretPath: string,
+): string {
+  const text = new TextDecoder().decode(data);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new CLIError(
+      "INVALID_SECRET_PAYLOAD",
+      `Delegated secret "${secretPath}" did not decrypt to valid JSON.`,
+      ExitCode.ERROR,
+    );
+  }
+
+  if (parsed === null || typeof parsed !== "object" || typeof (parsed as { value?: unknown }).value !== "string") {
+    throw new CLIError(
+      "INVALID_SECRET_PAYLOAD",
+      `Delegated secret "${secretPath}" did not decrypt to { value: string }.`,
+      ExitCode.ERROR,
+    );
+  }
+
+  return (parsed as { value: string }).value;
+}
+
+async function readDelegatedSecretValue(params: {
+  node: TinyCloudNode;
+  delegation: PortableDelegation;
+  delegationCid: string;
+  permissions: PermissionEntry[];
+  secretPath: string;
+  name: string;
+}): Promise<string> {
+  if (!delegationCoversPath(params.permissions, params.secretPath)) {
+    throw new CLIError(
+      "PERMISSION_DENIED",
+      `Delegation "${params.delegationCid}" does not cover secret "${params.secretPath}".`,
+      ExitCode.PERMISSION_DENIED,
+    );
+  }
+
+  const access = await params.node.useDelegation(params.delegation);
+  if (typeof access?.kv?.get !== "function") {
+    throw new CLIError(
+      "DELEGATION_INVALID",
+      `Delegation "${params.delegationCid}" did not resolve delegated KV access.`,
+      ExitCode.ERROR,
+    );
+  }
+
+  const envelopeResult = await access.kv.get<unknown>(params.secretPath, {
+    raw: true,
+    prefix: "",
+  });
+
+  if (!envelopeResult.ok) {
+    if (
+      envelopeResult.error.code === "NOT_FOUND" ||
+      envelopeResult.error.code === "KEY_NOT_FOUND" ||
+      envelopeResult.error.code === "KV_NOT_FOUND"
+    ) {
+      throw new CLIError(
+        "NOT_FOUND",
+        `Secret "${params.name}" not found`,
+        ExitCode.NOT_FOUND,
+      );
+    }
+    if (envelopeResult.error.code === "PERMISSION_DENIED") {
+      throw new CLIError(
+        "PERMISSION_DENIED",
+        `Delegation "${params.delegationCid}" does not cover secret "${params.secretPath}".`,
+        ExitCode.PERMISSION_DENIED,
+      );
+    }
+    throw new CLIError(
+      envelopeResult.error.code,
+      envelopeResult.error.message,
+      ExitCode.ERROR,
+    );
+  }
+
+  const rawEnvelope = envelopeResult.data.data;
+  if (typeof rawEnvelope !== "string") {
+    throw new CLIError(
+      "INVALID_ENVELOPE",
+      `Secret "${params.secretPath}" did not contain an encrypted envelope.`,
+      ExitCode.ERROR,
+    );
+  }
+
+  let envelope: Record<string, unknown>;
+  try {
+    envelope = JSON.parse(rawEnvelope) as Record<string, unknown>;
+  } catch {
+    throw new CLIError(
+      "INVALID_ENVELOPE",
+      `Secret "${params.secretPath}" did not contain an encrypted envelope.`,
+      ExitCode.ERROR,
+    );
+  }
+
+  const networkId = envelope.networkId;
+  if (typeof networkId !== "string") {
+    throw new CLIError(
+      "INVALID_ENVELOPE",
+      `Secret "${params.secretPath}" did not contain an encrypted envelope.`,
+      ExitCode.ERROR,
+    );
+  }
+
+  if (!delegationCoversDecrypt(params.permissions, networkId)) {
+    throw new CLIError(
+      "PERMISSION_DENIED",
+      `Delegation "${params.delegationCid}" does not include tinycloud.encryption/decrypt for ${networkId}.`,
+      ExitCode.PERMISSION_DENIED,
+    );
+  }
+
+  const decrypted = await params.node.encryption.decryptEnvelope(
+    envelope as never,
+    { proofs: [params.delegationCid] },
+  );
+  if (!decrypted.ok) {
+    throw mapEncryptionResultError(decrypted.error);
+  }
+
+  return parseDecryptedSecretPayload(decrypted.data, params.secretPath);
 }
 
 function isStoredSessionExpired(session: object): boolean {
@@ -314,13 +812,48 @@ export function registerSecretsCommand(program: Command): void {
     .option("--raw", "Output raw value (no JSON wrapping)")
     .option("--value-only", "Output only the secret value (alias for --raw)")
     .option("-o, --output <file>", "Write value to file")
+    .option("--delegation <source>", "Delegation file path or imported profile name")
     .option("--private-key <hex>", "Ethereum private key (or set TC_PRIVATE_KEY)")
     .action(async (name: string, options, cmd) => {
       try {
         const globalOpts = cmd.optsWithGlobals();
         const ctx = await ProfileManager.resolveContext(globalOpts);
-        const node = await ensureSecretsNode(ctx, options);
         const scopeOptions = resolveSecretScope(options);
+        const secretPath = resolveSecretPath(name, scopeOptions).permissionPaths.vault;
+
+        if (options.delegation) {
+          const delegated = await resolveDelegatedSecretSource(options.delegation, secretPath);
+          const effectiveHost = globalOpts.host ?? delegated.delegation.host ?? ctx.host;
+          const delegatedCtx = { ...ctx, host: effectiveHost };
+          const node = await ensureSecretsNode(delegatedCtx, options);
+          const value = await withSpinner(
+            `Getting secret ${name}...`,
+            () => readDelegatedSecretValue({
+              node,
+              delegation: delegated.delegation,
+              delegationCid: delegated.delegation.cid,
+              permissions: delegated.permissions,
+              secretPath,
+              name,
+            }),
+          );
+
+          if (options.output) {
+            await writeFile(options.output, value);
+            outputJson({ name, written: options.output });
+            return;
+          }
+
+          if (options.raw) {
+            process.stdout.write(value);
+            return;
+          }
+
+          outputJson({ name, value });
+          return;
+        }
+
+        const node = await ensureSecretsNode(ctx, options);
         const result = await runSecretOperation({
           ctx,
           node,

--- a/packages/cli/src/lib/permissions.ts
+++ b/packages/cli/src/lib/permissions.ts
@@ -3,8 +3,10 @@ import { appendFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   expandActionShortNames,
-  isCapabilitySubset,
   resolveManifest,
+} from "../../../sdk-core/src/manifest.js";
+import { isCapabilitySubset } from "../../../sdk-core/src/capabilities.js";
+import {
   type PermissionEntry,
   type PortableDelegation,
   type TinyCloudNode,

--- a/packages/cli/src/lib/space.ts
+++ b/packages/cli/src/lib/space.ts
@@ -2,13 +2,47 @@ import { CLIError } from "../output/errors.js";
 import { ExitCode } from "../config/constants.js";
 import { ProfileManager } from "../config/profiles.js";
 import type { ProfileConfig } from "../config/types.js";
-import {
-  buildSpaceUri,
-  canonicalizeAddress,
-  makePkhSpaceId,
-  parsePkhDid,
-  parseSpaceUri,
-} from "@tinycloud/node-sdk";
+
+interface ParsedPkhDid {
+  address: string;
+  chainId: number;
+}
+
+function canonicalizeAddress(address: string): string {
+  const trimmed = address.trim();
+  return trimmed.startsWith("0x")
+    ? `0x${trimmed.slice(2).toLowerCase()}`
+    : trimmed.toLowerCase();
+}
+
+function parsePkhDid(did: string): ParsedPkhDid | null {
+  const match = did.match(/^did:pkh:eip155:(\d+):(0x[a-fA-F0-9]{40})$/);
+  if (!match) return null;
+  return {
+    chainId: Number(match[1]),
+    address: canonicalizeAddress(match[2]),
+  };
+}
+
+function makePkhSpaceId(address: string, chainId: number, name: string): string {
+  return `tinycloud:pkh:eip155:${chainId}:${canonicalizeAddress(address)}:${name}`;
+}
+
+function parseSpaceUri(input: string): { owner: string; name: string } | null {
+  if (!input.startsWith("tinycloud:")) return null;
+  const parts = input.split(":");
+  if (parts.length < 3) return null;
+  const name = parts.at(-1);
+  if (!name) return null;
+  return {
+    owner: parts.slice(1, -1).join(":"),
+    name,
+  };
+}
+
+function buildSpaceUri(owner: string, name: string): string {
+  return `tinycloud:${owner}:${name}`;
+}
 
 /**
  * Resolve the active profile's Ethereum address. Source priority matches

--- a/tests/cli/secrets/secrets.test.ts
+++ b/tests/cli/secrets/secrets.test.ts
@@ -1,5 +1,8 @@
 import { Command } from "commander";
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { PermissionEntry } from "@tinycloud/sdk-core";
 
 type FakeNode = {
@@ -7,6 +10,10 @@ type FakeNode = {
   getEncryptionNetwork: ReturnType<typeof mock>;
   ensureEncryptionNetwork: ReturnType<typeof mock>;
   delegateTo: ReturnType<typeof mock>;
+  useDelegation: ReturnType<typeof mock>;
+  encryption: {
+    decryptEnvelope: ReturnType<typeof mock>;
+  };
   secrets: {
     get: ReturnType<typeof mock>;
     put: ReturnType<typeof mock>;
@@ -26,6 +33,35 @@ const context = {
 const outputs: unknown[] = [];
 const errors: unknown[] = [];
 let currentNode: FakeNode;
+let currentSession: object | null = { expiresAt: "2099-01-01T00:00:00.000Z" };
+let currentProfile = {
+  name: "cli-test",
+  host: "https://profile-host.test",
+  chainId: 1,
+  spaceName: "default",
+  did: "did:key:z6MkProfile",
+  createdAt: "2026-06-01T00:00:00.000Z",
+  authMethod: "openkey" as const,
+  posture: "delegate-session" as const,
+  operatorType: "agent" as const,
+};
+const ensureAuthenticatedCalls: Array<{ ctx: unknown; options: unknown }> = [];
+const delegatedCalls = {
+  useDelegation: [] as Array<{
+    cid: string;
+    path: string;
+    actions: string[];
+    host?: string;
+  }>,
+  kvGet: [] as Array<{
+    key: string;
+    options?: { raw?: boolean; prefix?: string };
+  }>,
+  decrypt: [] as Array<{
+    networkId: string;
+    proofs: string[];
+  }>,
+};
 
 const resolveContext = mock(async (globalOptions: Record<string, unknown>) => {
   return {
@@ -57,33 +93,35 @@ const handleError = mock((error: unknown) => {
   errors.push(error);
 });
 
-const ensureAuthenticated = mock(async () => currentNode);
+const ensureAuthenticated = mock(async (ctx: unknown, options: unknown) => {
+  ensureAuthenticatedCalls.push({ ctx, options });
+  return currentNode;
+});
+
+mock.module("@tinycloud/node-sdk", () => ({
+  resolveSecretListPrefix: (options?: { scope?: string }) =>
+    options?.scope ? `vault/secrets/scoped/${options.scope.toLowerCase().replaceAll(/\s+/g, "-")}/` : "vault/secrets/",
+  resolveSecretPath: (name: string, options?: { scope?: string }) => ({
+    permissionPaths: {
+      vault: options?.scope
+        ? `vault/secrets/scoped/${options.scope.toLowerCase().replaceAll(/\s+/g, "-")}/${name}`
+        : `vault/secrets/${name}`,
+    },
+  }),
+  principalDidEquals: (a: string, b: string) =>
+    a.split("#")[0].toLowerCase() === b.split("#")[0].toLowerCase(),
+}));
 
 mock.module(new URL("../../../packages/cli/src/config/profiles.ts", import.meta.url).pathname, () => ({
   ProfileManager: {
     resolveContext,
-    getProfile: async () => ({
-      name: context.profile,
-      host: context.host,
-      chainId: 1,
-      spaceName: "default",
-      did: "did:key:z6MkSession",
-      createdAt: "2026-06-01T00:00:00.000Z",
-      authMethod: "openkey",
-      posture: "delegate-session",
-      operatorType: "agent",
-    }),
-    getSession: async () => null,
+    getProfile: async () => currentProfile,
+    getSession: async () => currentSession,
   },
 }));
 
 mock.module(new URL("../../../packages/cli/src/output/formatter.ts", import.meta.url).pathname, () => ({
-  formatField: (label: string, value: unknown) => `${label}: ${String(value)}`,
-  formatTable: (_headers: string[], rows: string[][]) =>
-    rows.map((row) => row.join("  ")).join("\n"),
-  isInteractive: () => false,
   outputJson,
-  shouldOutputJson: () => true,
   withSpinner,
 }));
 
@@ -96,33 +134,9 @@ mock.module(new URL("../../../packages/cli/src/lib/sdk.ts", import.meta.url).pat
   ensureAuthenticated,
 }));
 
-mock.module("@tinycloud/node-sdk", () => ({
-  buildSpaceUri: (owner: string, name: string) => `${owner}:${name}`,
-  canonicalizeAddress: (address: string) => address,
-  makePkhSpaceId: (address: string, chainId = 1, name = "default") =>
-    `tinycloud:pkh:eip155:${chainId}:${address}:${name}`,
-  parsePkhDid: (did: string) => {
-    const match = did.match(/^did:pkh:eip155:(\d+):(.+)$/);
-    return match ? { chainId: Number(match[1]), address: match[2] } : null;
-  },
-  parseSpaceUri: (space: string) => {
-    const match = space.match(/^(tinycloud:pkh:eip155:\d+:[^:]+):([^:]+)$/);
-    return match ? { owner: match[1], name: match[2] } : null;
-  },
-  expandActionShortNames: (permission: { actions: string[] }) => permission.actions,
-  isCapabilitySubset: () => false,
-  PrivateKeySigner: class PrivateKeySigner {},
-  pkhDid: (address: string, chainId = 1) => `did:pkh:eip155:${chainId}:${address}`,
-  resolveManifest: () => ({ permissions: [] }),
-  resolveSecretListPrefix: (options?: { scope?: string }) =>
-    options?.scope ? `vault/secrets/scoped/${options.scope.toLowerCase().replaceAll(/\s+/g, "-")}/` : "vault/secrets/",
-  resolveSecretPath: (name: string, options?: { scope?: string }) => ({
-    permissionPaths: {
-      vault: options?.scope
-        ? `vault/secrets/scoped/${options.scope.toLowerCase().replaceAll(/\s+/g, "-")}/${name}`
-        : `vault/secrets/${name}`,
-    },
-  }),
+mock.module(new URL("../../../packages/cli/src/commands/auth.ts", import.meta.url).pathname, () => ({
+  ensureDelegationAuthority: async () => undefined,
+  refreshOpenKeySession: async () => undefined,
 }));
 
 const { registerSecretsCommand } = await import("../../../packages/cli/src/commands/secrets.ts");
@@ -150,7 +164,12 @@ function makeNetworkDescriptor(name = "default") {
   };
 }
 
-function makeNode(): FakeNode {
+const DEFAULT_NETWORK_ID = makeNetworkDescriptor().networkId;
+
+function makeNode(overrides: {
+  delegatedGetResult?: { ok: true; data: { data: string } } | { ok: false; error: { code: string; message: string } };
+  decryptResult?: { ok: true; data: Uint8Array } | { ok: false; error: { code: string; message: string } };
+} = {}): FakeNode {
   return {
     getDefaultEncryptionNetworkId: mock((name = "default") => makeNetworkDescriptor(name).networkId),
     getEncryptionNetwork: mock(async (nameOrNetworkId: string) => {
@@ -174,6 +193,43 @@ function makeNode(): FakeNode {
         ),
       },
     })),
+    useDelegation: mock(async (delegation: {
+      cid: string;
+      path: string;
+      actions: string[];
+      host?: string;
+    }) => {
+      delegatedCalls.useDelegation.push(delegation);
+      return {
+        kv: {
+          get: mock(async (key: string, options?: { raw?: boolean; prefix?: string }) => {
+            delegatedCalls.kvGet.push({ key, options });
+            return overrides.delegatedGetResult ?? {
+              ok: true,
+              data: {
+                data: JSON.stringify({
+                  v: 1,
+                  networkId: DEFAULT_NETWORK_ID,
+                  alg: "x25519-aes256gcm/v1",
+                  encryptedSymmetricKey: "enc-key",
+                  ciphertext: "ciphertext",
+                  keyVersion: 1,
+                }),
+              },
+            };
+          }),
+        },
+      };
+    }),
+    encryption: {
+      decryptEnvelope: mock(async (envelope: { networkId: string }, proof: { proofs: string[] }) => {
+        delegatedCalls.decrypt.push({ networkId: envelope.networkId, proofs: proof.proofs });
+        return overrides.decryptResult ?? {
+          ok: true,
+          data: new TextEncoder().encode(JSON.stringify({ value: "delegated-value" })),
+        };
+      }),
+    },
     secrets: {
       get: mock(async (name: string, options?: { scope?: string }) => ({
         ok: true,
@@ -189,7 +245,69 @@ function makeNode(): FakeNode {
   };
 }
 
-async function runCommand(args: string[]): Promise<void> {
+function makeDelegatedSecretEnvelope(networkId = DEFAULT_NETWORK_ID) {
+  return {
+    v: 1,
+    networkId,
+    alg: "x25519-aes256gcm/v1",
+    encryptedSymmetricKey: "enc-key",
+    ciphertext: "ciphertext",
+    keyVersion: 1,
+  };
+}
+
+function makeDelegationArtifact(params: {
+  cid: string;
+  host: string;
+  secretPath: string;
+  networkId: string;
+  secretSpace?: string;
+}): {
+  cid: string;
+  delegationHeader: { Authorization: string };
+  spaceId: string;
+  path: string;
+  actions: string[];
+  resources: Array<{
+    service: string;
+    space?: string;
+    path: string;
+    actions: string[];
+  }>;
+  expiry: string;
+  delegateDID: string;
+  ownerAddress: string;
+  chainId: number;
+  host: string;
+} {
+  return {
+    cid: params.cid,
+    delegationHeader: { Authorization: "owner-token" },
+    spaceId: "tinycloud:pkh:eip155:1:0xowner:secrets",
+    path: params.secretPath,
+    actions: ["tinycloud.kv/get"],
+    resources: [
+      {
+        service: "kv",
+        space: params.secretSpace ?? "secrets",
+        path: params.secretPath,
+        actions: ["tinycloud.kv/get"],
+      },
+      {
+        service: "encryption",
+        path: params.networkId,
+        actions: ["tinycloud.encryption/decrypt"],
+      },
+    ],
+    expiry: "2026-06-30T00:00:00.000Z",
+    delegateDID: "did:key:z6MkRecipient",
+    ownerAddress: "0xowner",
+    chainId: 1,
+    host: params.host,
+  };
+}
+
+async function runCommand(args: string[], options: { host?: string | null } = {}): Promise<void> {
   outputs.length = 0;
   errors.length = 0;
   const program = new Command();
@@ -201,10 +319,38 @@ async function runCommand(args: string[]): Promise<void> {
     .option("-q, --quiet", "Suppress non-essential output")
     .option("--json", "Force JSON output");
   registerSecretsCommand(program);
-  await program.parseAsync(["--profile", "cli-test", "--host", "http://localhost:8000", "--json", "--quiet", ...args], {
+  const parsedArgs = ["--profile", "cli-test"];
+  if (options.host !== null) {
+    parsedArgs.push("--host", options.host ?? "http://localhost:8000");
+  }
+  parsedArgs.push("--json", "--quiet", ...args);
+  await program.parseAsync(parsedArgs, {
     from: "user",
   });
 }
+
+beforeEach(() => {
+  outputs.length = 0;
+  errors.length = 0;
+  ensureAuthenticatedCalls.length = 0;
+  delegatedCalls.useDelegation.length = 0;
+  delegatedCalls.kvGet.length = 0;
+  delegatedCalls.decrypt.length = 0;
+  context.host = "http://localhost:8000";
+  currentSession = { expiresAt: "2099-01-01T00:00:00.000Z" };
+  currentProfile = {
+    name: "cli-test",
+    host: "https://profile-host.test",
+    chainId: 1,
+    spaceName: "default",
+    did: "did:key:z6MkProfile",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    authMethod: "openkey",
+    posture: "delegate-session",
+    operatorType: "agent",
+  };
+  currentNode = makeNode();
+});
 
 describe("secrets CLI", () => {
   test("stores, reads, lists, and deletes network-encrypted secrets", async () => {
@@ -241,6 +387,275 @@ describe("secrets CLI", () => {
     await runCommand(["secrets", "delete", "ANTHROPIC_API_KEY"]);
     expect(outputs).toEqual([{ name: "ANTHROPIC_API_KEY", deleted: true }]);
     expect(currentNode.secrets.delete).toHaveBeenCalledWith("ANTHROPIC_API_KEY", undefined);
+  });
+
+  test("reads a delegated secret from a file path and uses the delegation host", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "tc-cli-delegation-file-"));
+    const secretName = "ANTHROPIC_API_KEY";
+    const secretPath = `vault/secrets/${secretName}`;
+    const delegationHost = "https://delegation-host.test";
+    const delegation = makeDelegationArtifact({
+      cid: "bafy-file-delegation",
+      host: delegationHost,
+      secretPath,
+      networkId: DEFAULT_NETWORK_ID,
+    });
+    const delegationPath = join(tempDir, "delegation.json");
+
+    context.host = "https://profile-host.test";
+    await writeFile(delegationPath, `${JSON.stringify(delegation, null, 2)}\n`, "utf8");
+
+    try {
+      currentNode = makeNode();
+
+      await runCommand(["secrets", "get", secretName, "--delegation", delegationPath], { host: null });
+
+      expect(ensureAuthenticatedCalls).toHaveLength(1);
+      expect((ensureAuthenticatedCalls[0].ctx as { host?: string }).host).toBe(delegationHost);
+      expect(delegatedCalls.useDelegation).toHaveLength(1);
+      expect(delegatedCalls.useDelegation[0]).toMatchObject({
+        cid: "bafy-file-delegation",
+        path: secretPath,
+        actions: ["tinycloud.kv/get"],
+        host: delegationHost,
+      });
+      expect(delegatedCalls.kvGet).toEqual([
+        { key: secretPath, options: { raw: true, prefix: "" } },
+      ]);
+      expect(delegatedCalls.decrypt).toEqual([
+        { networkId: DEFAULT_NETWORK_ID, proofs: ["bafy-file-delegation"] },
+      ]);
+      expect(outputs).toEqual([
+        { name: secretName, value: "delegated-value" },
+      ]);
+      expect(currentNode.secrets.get).not.toHaveBeenCalled();
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("reads a delegated secret from an imported owner profile", async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), "tc-cli-home-"));
+    const secretName = "OPENAI_API_KEY";
+    const secretPath = `vault/secrets/${secretName}`;
+    const delegationHost = "https://delegation-owner.test";
+    const delegation = makeDelegationArtifact({
+      cid: "bafy-imported-delegation",
+      host: delegationHost,
+      secretPath,
+      networkId: DEFAULT_NETWORK_ID,
+    });
+
+    const previousHome = process.env.HOME;
+    const profileDir = join(tempHome, ".tinycloud", "profiles", "owner-profile");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      join(profileDir, "additional-delegations.json"),
+      `${JSON.stringify([{ delegation }], null, 2)}\n`,
+      "utf8",
+    );
+
+    try {
+      process.env.HOME = tempHome;
+      context.host = "https://profile-host.test";
+      currentNode = makeNode();
+
+      await runCommand(["secrets", "get", secretName, "--delegation", "owner-profile"], { host: null });
+
+      expect(ensureAuthenticatedCalls).toHaveLength(1);
+      expect((ensureAuthenticatedCalls[0].ctx as { host?: string }).host).toBe(delegationHost);
+      expect(delegatedCalls.useDelegation).toHaveLength(1);
+      expect(delegatedCalls.useDelegation[0]).toMatchObject({
+        cid: "bafy-imported-delegation",
+        path: secretPath,
+        actions: ["tinycloud.kv/get"],
+        host: delegationHost,
+      });
+      expect(delegatedCalls.kvGet).toEqual([
+        { key: secretPath, options: { raw: true, prefix: "" } },
+      ]);
+      expect(delegatedCalls.decrypt).toEqual([
+        { networkId: DEFAULT_NETWORK_ID, proofs: ["bafy-imported-delegation"] },
+      ]);
+      expect(outputs).toEqual([
+        { name: secretName, value: "delegated-value" },
+      ]);
+      expect(currentNode.secrets.get).not.toHaveBeenCalled();
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("reports a delegated secret path mismatch explicitly", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "tc-cli-delegation-mismatch-"));
+    const secretName = "ANTHROPIC_API_KEY";
+    const secretPath = `vault/secrets/${secretName}`;
+    const delegation = makeDelegationArtifact({
+      cid: "bafy-wrong-path",
+      host: "https://delegation-owner.test",
+      secretPath: "vault/secrets/OTHER_SECRET",
+      networkId: DEFAULT_NETWORK_ID,
+    });
+    const delegationPath = join(tempDir, "delegation.json");
+
+    await writeFile(delegationPath, `${JSON.stringify(delegation, null, 2)}\n`, "utf8");
+
+    try {
+      currentNode = makeNode();
+      await runCommand(["secrets", "get", secretName, "--delegation", delegationPath], { host: null });
+
+      expect(outputs).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(MockCLIError);
+      expect((errors[0] as MockCLIError).code).toBe("PERMISSION_DENIED");
+      expect((errors[0] as MockCLIError).message).toContain(secretPath);
+      expect(delegatedCalls.useDelegation).toHaveLength(0);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports a delegated secret wrong-space mismatch explicitly", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "tc-cli-delegation-wrong-space-"));
+    const secretName = "ANTHROPIC_API_KEY";
+    const secretPath = `vault/secrets/${secretName}`;
+    const delegation = makeDelegationArtifact({
+      cid: "bafy-wrong-space",
+      host: "https://delegation-owner.test",
+      secretPath,
+      networkId: DEFAULT_NETWORK_ID,
+      secretSpace: "other-space",
+    });
+    const delegationPath = join(tempDir, "delegation.json");
+
+    await writeFile(delegationPath, `${JSON.stringify(delegation, null, 2)}\n`, "utf8");
+
+    try {
+      currentNode = makeNode();
+
+      await runCommand(["secrets", "get", secretName, "--delegation", delegationPath], { host: null });
+
+      expect(outputs).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(MockCLIError);
+      expect((errors[0] as MockCLIError).code).toBe("PERMISSION_DENIED");
+      expect((errors[0] as MockCLIError).message).toContain("secrets space");
+      expect(delegatedCalls.useDelegation).toHaveLength(0);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports a missing decrypt capability explicitly", async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), "tc-cli-home-"));
+    const secretName = "ANTHROPIC_API_KEY";
+    const secretPath = `vault/secrets/${secretName}`;
+    const delegation = makeDelegationArtifact({
+      cid: "bafy-no-decrypt",
+      host: "https://delegation-owner.test",
+      secretPath,
+      networkId: "urn:tinycloud:encryption:did:pkh:eip155:1:0xowner:alternate",
+    });
+
+    const previousHome = process.env.HOME;
+    const profileDir = join(tempHome, ".tinycloud", "profiles", "owner-profile");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      join(profileDir, "additional-delegations.json"),
+      `${JSON.stringify([{ delegation }], null, 2)}\n`,
+      "utf8",
+    );
+
+    try {
+      process.env.HOME = tempHome;
+      currentNode = makeNode();
+
+      await runCommand(["secrets", "get", secretName, "--delegation", "owner-profile"], { host: null });
+
+      expect(delegatedCalls.useDelegation).toHaveLength(1);
+      expect(delegatedCalls.kvGet).toEqual([
+        { key: secretPath, options: { raw: true, prefix: "" } },
+      ]);
+      expect(delegatedCalls.decrypt).toHaveLength(0);
+      expect(outputs).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(MockCLIError);
+      expect((errors[0] as MockCLIError).code).toBe("PERMISSION_DENIED");
+      expect((errors[0] as MockCLIError).message).toContain("tinycloud.encryption/decrypt");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("reports a missing delegated secret as not found", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "tc-cli-delegation-missing-"));
+    const secretName = "ANTHROPIC_API_KEY";
+    const secretPath = `vault/secrets/${secretName}`;
+    const delegation = makeDelegationArtifact({
+      cid: "bafy-missing-secret",
+      host: "https://delegation-owner.test",
+      secretPath,
+      networkId: DEFAULT_NETWORK_ID,
+    });
+    const delegationPath = join(tempDir, "delegation.json");
+
+    await writeFile(delegationPath, `${JSON.stringify(delegation, null, 2)}\n`, "utf8");
+
+    try {
+      currentNode = makeNode({
+        delegatedGetResult: {
+          ok: false,
+          error: {
+            code: "KV_NOT_FOUND",
+            message: "missing",
+          },
+        },
+      });
+
+      await runCommand(["secrets", "get", secretName, "--delegation", delegationPath], { host: null });
+
+      expect(outputs).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(MockCLIError);
+      expect((errors[0] as MockCLIError).code).toBe("NOT_FOUND");
+      expect((errors[0] as MockCLIError).message).toBe(`Secret "${secretName}" not found`);
+      expect(delegatedCalls.decrypt).toHaveLength(0);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a malformed delegation source explicitly", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "tc-cli-delegation-invalid-"));
+    const secretName = "ANTHROPIC_API_KEY";
+    const badPath = join(tempDir, "delegation.json");
+
+    await writeFile(badPath, "{ not valid json }\n", "utf8");
+
+    try {
+      currentNode = makeNode();
+
+      await runCommand(["secrets", "get", secretName, "--delegation", badPath], { host: null });
+
+      expect(outputs).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(MockCLIError);
+      expect((errors[0] as MockCLIError).code).toBe("INVALID_DELEGATION_SOURCE");
+      expect((errors[0] as MockCLIError).message).toContain("must be valid JSON");
+      expect(delegatedCalls.useDelegation).toHaveLength(0);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("grants decrypt permission for the default encryption network", async () => {


### PR DESCRIPTION
## Summary

Two stacked CLI changes for git-haiku phase-1 delegated secret reads.

### Feature: `tc secrets get <NAME> --delegation <file-or-imported-profile>`
Read a secret you were delegated access to. The `--delegation` source may be a delegation JSON file **or** the name of a profile that imported the delegation (resolved from `additional-delegations.json`). The read path:
- validates the delegation covers the secret's `tinycloud.kv/get` path and the envelope's `tinycloud.encryption/decrypt` network,
- activates the delegation in wallet mode via `node.useDelegation(...)`,
- fetches the encrypted envelope and decrypts it.

Adds a `smoke:delegated-secrets` script (`packages/cli/scripts/live-delegated-secrets-smoke.ts`) exercising the full owner→delegate flow against a live node.

### Bug fix #2: `tc auth import` rejected cross-user delegations
Import unconditionally called `node.useRuntimeDelegation(...)`, which requires the delegation to target the **active session key** and so threw `Runtime delegation targets did:pkh:... but this session key is did:key:...` for a delegation received from another user (audience = your stable identity DID).

**Fix** (`packages/cli/src/commands/auth.ts`): route by audience.
- Delegation targeting the active session key → installed as a runtime grant (unchanged behavior).
- Cross-user delegation (audience = stable identity DID / another principal) → persisted to `additional-delegations.json` and activated later at read time via `node.useDelegation(...)`.

Audience is compared with `principalDidEquals(delegation.delegateDID, node.sessionDid)`. Output now includes an `activated` flag.

## Dependency on #258
This PR is **stacked on #258** (`fix/usedelegation-resources`), which fixes wallet-mode `useDelegation` to activate the full `delegation.resources[]` (multi-resource) and exports the type-only node-sdk barrel names. The delegated read path depends on that fix. **Base should be retargeted to `master` after #258 merges.**

## Verification (real, local node — not mocked)
- Build: `bunx turbo build --filter=@tinycloud/cli` green.
- Stood up a local tinycloud-node (`/version` reports features `kv`, `delegation`, `encryption`) and ran the smoke GREEN end-to-end through the real CLI:
  ```
  TC_LIVE_SMOKE=1 TC_LIVE_SMOKE_HOST=http://localhost:8012 bun packages/cli/scripts/live-delegated-secrets-smoke.ts
  {"ok":true,"host":"http://localhost:8012","profile":"delegated-smoke-...","secretName":"SMOKE_..."}
  ```
  This exercises: owner `secrets.put` → `delegateTo(agent pkh, multi-resource)` → `tc auth import` (bug #2 fix, cross-user) → `tc secrets get --delegation` (read via `useDelegation`, needs #258). The smoke asserts the decrypted value matches.
- Unit tests: `packages/cli/src` 20 pass / 0 fail; `tests/cli` (unit, non-e2e) 18 pass / 0 fail. Added two tests for the #2 routing (cross-user delegation persists rather than rejects; session-key delegation still runtime-activates).

## Changesets
- minor `@tinycloud/cli` — new `--delegation` feature.
- patch `@tinycloud/cli` — cross-user auth import fix.