### PR TITLE
feat(cli): per-profile default space (--space becomes optional)

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,11 +15,20 @@ export function registerInitCommand(program: Command): void {
     .option("--host <url>", "TinyCloud node URL")
     .option("--paste", "Use manual paste mode for authentication")
     .option("--no-popup", "Print the OpenKey URL without opening a browser")
+    .option("--default-space <name>", "Default space used when --space is omitted (e.g. applications)")
     .action(async (options, cmd) => {
       try {
         const globalOpts = cmd.optsWithGlobals();
         const profileName: string = options.name;
         const host: string = options.host ?? globalOpts.host ?? DEFAULT_HOST;
+        const defaultSpace: string | undefined = options.defaultSpace;
+        if (defaultSpace !== undefined && !/^[A-Za-z0-9_-]+$/.test(defaultSpace)) {
+          throw new CLIError(
+            "INVALID_SPACE",
+            `Invalid --default-space "${defaultSpace}". Use a short name ([A-Za-z0-9_-]).`,
+            ExitCode.USAGE_ERROR,
+          );
+        }
 
         // Check if profile already exists
         if (await ProfileManager.profileExists(profileName)) {
@@ -47,6 +56,7 @@ export function registerInitCommand(program: Command): void {
           spaceName: "default",
           did,
           createdAt: new Date().toISOString(),
+          ...(defaultSpace ? { defaultSpace } : {}),
         };
 
         await ProfileManager.setProfile(profileName, profileConfig);

--- a/packages/cli/src/commands/profile.test.ts
+++ b/packages/cli/src/commands/profile.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Command } from "commander";
+
+type SetProfileCall = { name: string; data: Record<string, unknown> };
+
+const recorded = {
+  outputs: [] as unknown[],
+  errors: [] as unknown[],
+  setProfiles: [] as SetProfileCall[],
+};
+
+function resetState(): void {
+  recorded.outputs = [];
+  recorded.errors = [];
+  recorded.setProfiles = [];
+}
+
+// Existing on-disk profile the manager hands back before mutation.
+const existingProfile = {
+  name: "cli-test",
+  host: "https://host",
+  chainId: 1,
+  spaceName: "default",
+  did: "did:key:zabc",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+mock.module("../config/profiles.js", () => ({
+  ProfileManager: {
+    resolveContext: async (opts: { profile?: string }) => ({
+      profile: opts.profile ?? "cli-test",
+      host: "https://host",
+    }),
+    getProfile: async () => ({ ...existingProfile }),
+    setProfile: async (name: string, data: Record<string, unknown>) => {
+      recorded.setProfiles.push({ name, data });
+    },
+  },
+}));
+
+mock.module("../output/formatter.js", () => ({
+  outputJson: (payload: unknown) => {
+    recorded.outputs.push(payload);
+  },
+  isInteractive: () => false,
+  shouldOutputJson: () => true,
+  formatField: () => "",
+}));
+
+mock.module("../output/theme.js", () => ({
+  theme: {
+    muted: (v: string) => v,
+    success: (v: string) => v,
+    brand: (v: string) => v,
+    heading: (v: string) => v,
+  },
+}));
+
+class MockCLIError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public exitCode: number,
+  ) {
+    super(message);
+  }
+}
+
+// Export the full errors.js surface so a real import in any sibling test file
+// resolving against this global mock never hits a missing-export error.
+mock.module("../output/errors.js", () => ({
+  CLIError: MockCLIError,
+  handleError: (error: unknown) => {
+    recorded.errors.push(error);
+  },
+  wrapError: (error: unknown) => error,
+  setActiveProfileName: () => {},
+}));
+
+// Full local-key.js surface (only generateKey is exercised here).
+mock.module("../auth/local-key.js", () => ({
+  generateKey: () => ({ jwk: {}, did: "did:key:zgen" }),
+  keyToDID: () => "did:key:zgen",
+  generateEthereumPrivateKey: () => "0x0",
+  deriveAddress: async () => "0x0",
+  addressToDID: () => "did:pkh:eip155:1:0x0",
+  generateLocalIdentity: async () => ({ jwk: {}, did: "did:key:zgen", privateKey: "0x0", address: "0x0" }),
+  localKeySignIn: async () => ({}),
+}));
+
+const { registerProfileCommand } = await import("./profile.js");
+
+async function runProfile(args: string[]): Promise<void> {
+  const program = new Command();
+  registerProfileCommand(program);
+  await program.parseAsync(["node", "tc", "profile", ...args], { from: "node" });
+}
+
+describe("tc profile set-default-space", () => {
+  beforeEach(resetState);
+
+  test("persists the default space to the profile json", async () => {
+    await runProfile(["set-default-space", "applications"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.setProfiles).toHaveLength(1);
+    expect(recorded.setProfiles[0]!.name).toBe("cli-test");
+    expect(recorded.setProfiles[0]!.data.defaultSpace).toBe("applications");
+    // Existing fields are preserved.
+    expect(recorded.setProfiles[0]!.data.did).toBe("did:key:zabc");
+    expect(recorded.outputs).toEqual([
+      { profile: "cli-test", defaultSpace: "applications", updated: true },
+    ]);
+  });
+
+  test("--unset clears the default space", async () => {
+    await runProfile(["set-default-space", "--unset"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.setProfiles[0]!.data.defaultSpace).toBeUndefined();
+    expect(recorded.outputs).toEqual([
+      { profile: "cli-test", defaultSpace: null, updated: true },
+    ]);
+  });
+
+  test("rejects an invalid space name", async () => {
+    await runProfile(["set-default-space", "bad/name"]);
+
+    expect(recorded.setProfiles).toEqual([]);
+    expect(recorded.errors).toHaveLength(1);
+    expect((recorded.errors[0] as { code: string }).code).toBe("INVALID_SPACE");
+  });
+
+  test("errors when neither a name nor --unset is given", async () => {
+    await runProfile(["set-default-space"]);
+
+    expect(recorded.setProfiles).toEqual([]);
+    expect(recorded.errors).toHaveLength(1);
+    expect((recorded.errors[0] as { code: string }).code).toBe("USAGE_ERROR");
+  });
+});

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -151,6 +151,7 @@ export function registerProfileCommand(program: Command): void {
           process.stdout.write(formatField("Posture", posture) + "\n");
           process.stdout.write(formatField("Operator", operatorType) + "\n");
           process.stdout.write(formatField("Space", p.spaceId || null) + "\n");
+          process.stdout.write(formatField("Default Space", p.defaultSpace || null) + "\n");
           process.stdout.write(formatField("Key", hasKey) + "\n");
           process.stdout.write(formatField("Session", hasSession) + "\n");
           process.stdout.write(formatField("Created", p.createdAt) + "\n");
@@ -173,6 +174,56 @@ export function registerProfileCommand(program: Command): void {
         await ProfileManager.setConfig({ ...config, defaultProfile: name });
 
         outputJson({ defaultProfile: name, switched: true });
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  profile
+    .command("set-default-space [name]")
+    .description("Set (or clear) the default space used when --space is omitted")
+    .option("--profile <name>", "Profile to modify (defaults to the active profile)")
+    .option("--unset", "Clear the default space so commands fall back to the primary space")
+    .addHelpText("after", `
+
+The default space is a short space NAME (e.g. "applications"), resolved per
+profile at command time. Precedence for every kv/sql command:
+  explicit --space flag  >  profile defaultSpace  >  primary space.
+
+Examples:
+  $ tc profile set-default-space applications
+  $ tc profile set-default-space applications --profile cli-test
+  $ tc profile set-default-space --unset
+`)
+    .action(async (name: string | undefined, options, cmd) => {
+      try {
+        const globalOpts = cmd.optsWithGlobals();
+        const ctx = await ProfileManager.resolveContext({
+          ...globalOpts,
+          profile: options.profile ?? globalOpts.profile,
+        });
+        const profileName = ctx.profile;
+
+        if (!options.unset && (name === undefined || name === "")) {
+          throw new CLIError(
+            "USAGE_ERROR",
+            "Provide a space name (e.g. `tc profile set-default-space applications`) or pass --unset.",
+            ExitCode.USAGE_ERROR,
+          );
+        }
+        if (!options.unset && !/^[A-Za-z0-9_-]+$/.test(name as string)) {
+          throw new CLIError(
+            "INVALID_SPACE",
+            `Invalid space name "${name}". Use a short name ([A-Za-z0-9_-]).`,
+            ExitCode.USAGE_ERROR,
+          );
+        }
+
+        const p = await ProfileManager.getProfile(profileName);
+        const defaultSpace = options.unset ? undefined : (name as string);
+        await ProfileManager.setProfile(profileName, { ...p, defaultSpace });
+
+        outputJson({ profile: profileName, defaultSpace: defaultSpace ?? null, updated: true });
       } catch (error) {
         handleError(error);
       }

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -50,6 +50,12 @@ export interface ProfileConfig {
   sessionDid?: string;
   ownerDid?: string;
   spaceId?: string;
+  /**
+   * Default space NAME (e.g. "applications") applied when a kv/sql command
+   * omits `--space`. Resolved per-profile at command time to a full URI.
+   * Precedence: explicit `--space` flag > profile `defaultSpace` > primary space.
+   */
+  defaultSpace?: string;
   createdAt: string;
   posture?: CLIProfilePosture;
   operatorType?: CLIOperatorType;

--- a/packages/cli/src/lib/space.test.ts
+++ b/packages/cli/src/lib/space.test.ts
@@ -93,6 +93,16 @@ describe("resolveSpaceUri default-space precedence", () => {
     expect(recorded.pkhCalls.map((c) => c.name)).toEqual(["applications"]);
   });
 
+  test("explicit --space matching the default resolves identically to omitting it", async () => {
+    // Locks the invariant: with defaultSpace="applications", passing
+    // "applications" explicitly must equal omitting --space entirely.
+    profile = { name: "p", address: ADDR, chainId: 1, defaultSpace: "applications" };
+    const explicit = await resolveSpaceUri("applications", "p");
+    const omitted = await resolveSpaceUri(undefined, "p");
+    expect(explicit).toBe(omitted);
+    expect(explicit).toBe(`tinycloud:pkh:eip155:1:${ADDR}:applications`);
+  });
+
   test("falls back to the primary space (undefined) when no default and no flag", async () => {
     profile = { name: "p", address: ADDR, chainId: 1 };
     const uri = await resolveSpaceUri(undefined, "p");

--- a/packages/cli/src/lib/space.test.ts
+++ b/packages/cli/src/lib/space.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Records the (address, chainId, name) that makePkhSpaceId is called with so we
+// can assert which NAME the resolver ultimately resolved.
+const recorded = {
+  pkhCalls: [] as Array<{ address: string; chainId: number; name: string }>,
+};
+
+function resetState(): void {
+  recorded.pkhCalls = [];
+}
+
+// Mutable profile the mocked ProfileManager returns. Each test sets defaultSpace.
+let profile: Record<string, unknown> = {};
+
+mock.module("../config/profiles.js", () => ({
+  ProfileManager: {
+    getProfile: async () => profile,
+    getSession: async () => null,
+  },
+}));
+
+// bun's mock.module is global, so this mock can be the active @tinycloud/node-sdk
+// while a sibling test file resolves its own source imports. Include stubs for
+// every node-sdk *value* the CLI source imports (status.ts → NodeWasmBindings,
+// secrets.ts → resolveSecret*, permissions.ts → expand/subset/resolveManifest)
+// so no sibling import hits a missing export. The helpers space.ts uses carry
+// real test behavior below.
+mock.module("@tinycloud/node-sdk", () => ({
+  canonicalizeAddress: (a: string) => a.toLowerCase(),
+  makePkhSpaceId: (address: string, chainId: number, name: string) => {
+    recorded.pkhCalls.push({ address, chainId, name });
+    return `tinycloud:pkh:eip155:${chainId}:${address}:${name}`;
+  },
+  parsePkhDid: () => null,
+  parseSpaceUri: (uri: string) => {
+    // tinycloud:pkh:eip155:<chain>:<addr>:<name>
+    const name = uri.slice(uri.lastIndexOf(":") + 1);
+    const owner = uri.slice(0, uri.lastIndexOf(":"));
+    return { owner, name };
+  },
+  buildSpaceUri: (owner: string, name: string) => `${owner}:${name}`,
+  // Stubs so sibling test files don't break on this global mock:
+  NodeWasmBindings: class NodeWasmBindings {},
+  resolveSecretPath: () => ({}),
+  resolveSecretListPrefix: () => "",
+  expandActionShortNames: (_s: string, a: string[]) => a,
+  isCapabilitySubset: () => ({ missing: [] }),
+  resolveManifest: () => ({ resources: [] }),
+  PrivateKeySigner: class PrivateKeySigner {},
+  pkhDid: () => "",
+  principalDidEquals: () => false,
+  TinyCloudNode: class TinyCloudNode {},
+}));
+
+// Export the full errors.js surface so a real import in any sibling test file
+// resolving against this global mock never hits a missing-export error.
+mock.module("../output/errors.js", () => ({
+  CLIError: class CLIError extends Error {
+    constructor(
+      public code: string,
+      message: string,
+      public exitCode: number,
+    ) {
+      super(message);
+    }
+  },
+  handleError: (error: unknown) => {
+    throw error;
+  },
+  wrapError: (error: unknown) => error,
+  setActiveProfileName: () => {},
+}));
+
+const { resolveSpaceUri } = await import("./space.js");
+
+const ADDR = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+describe("resolveSpaceUri default-space precedence", () => {
+  beforeEach(resetState);
+
+  test("explicit --space overrides the profile default", async () => {
+    profile = { name: "p", address: ADDR, chainId: 1, defaultSpace: "applications" };
+    const uri = await resolveSpaceUri("other", "p");
+    expect(uri).toBe(`tinycloud:pkh:eip155:1:${ADDR}:other`);
+    expect(recorded.pkhCalls.map((c) => c.name)).toEqual(["other"]);
+  });
+
+  test("uses the profile default when --space is omitted", async () => {
+    profile = { name: "p", address: ADDR, chainId: 1, defaultSpace: "applications" };
+    const uri = await resolveSpaceUri(undefined, "p");
+    expect(uri).toBe(`tinycloud:pkh:eip155:1:${ADDR}:applications`);
+    expect(recorded.pkhCalls.map((c) => c.name)).toEqual(["applications"]);
+  });
+
+  test("falls back to the primary space (undefined) when no default and no flag", async () => {
+    profile = { name: "p", address: ADDR, chainId: 1 };
+    const uri = await resolveSpaceUri(undefined, "p");
+    expect(uri).toBeUndefined();
+    expect(recorded.pkhCalls).toEqual([]);
+  });
+
+  test("a full URI flag is returned verbatim, ignoring the default", async () => {
+    profile = { name: "p", address: ADDR, chainId: 1, defaultSpace: "applications" };
+    const uri = await resolveSpaceUri(
+      `tinycloud:pkh:eip155:1:${ADDR}:explicit`,
+      "p",
+    );
+    expect(uri).toBe(`tinycloud:pkh:eip155:1:${ADDR}:explicit`);
+    // URI path doesn't go through makePkhSpaceId.
+    expect(recorded.pkhCalls).toEqual([]);
+  });
+});

--- a/packages/cli/src/lib/space.ts
+++ b/packages/cli/src/lib/space.ts
@@ -46,7 +46,11 @@ function resolveChainId(profile: ProfileConfig, session: Record<string, unknown>
 /**
  * Resolve a --space CLI argument into a full TinyCloud space URI.
  *
- *  - undefined          → undefined (caller falls back to node.spaceId)
+ * Precedence: explicit `input` > profile `defaultSpace` > primary space.
+ *
+ *  - input given        → resolved (URI verbatim, or bare name → owner space)
+ *  - input omitted, but profile has a defaultSpace → that name, resolved
+ *  - input omitted, no defaultSpace → undefined (caller falls back to node.spaceId)
  *  - "tinycloud:..."    → returned verbatim
  *  - bare name          → tinycloud:pkh:eip155:<chain>:<address>:<name>
  */
@@ -54,31 +58,36 @@ export async function resolveSpaceUri(
   input: string | undefined,
   profileName: string,
 ): Promise<string | undefined> {
-  if (!input) return undefined;
-  if (input.startsWith("tinycloud:")) {
-    const parsed = parseSpaceUri(input);
+  const profile = await ProfileManager.getProfile(profileName);
+
+  // Explicit --space overrides; otherwise fall back to the profile default.
+  // When neither is set, return undefined so the caller routes to the primary space.
+  const effective = input || profile.defaultSpace;
+  if (!effective) return undefined;
+
+  if (effective.startsWith("tinycloud:")) {
+    const parsed = parseSpaceUri(effective);
     if (!parsed) {
       throw new CLIError(
         "INVALID_SPACE",
-        `Invalid --space "${input}". Use a short name ([A-Za-z0-9_-]) or a full tinycloud:... URI.`,
+        `Invalid space "${effective}". Use a short name ([A-Za-z0-9_-]) or a full tinycloud:... URI.`,
         ExitCode.USAGE_ERROR,
       );
     }
     return buildSpaceUri(parsed.owner, parsed.name);
   }
 
-  if (!/^[A-Za-z0-9_-]+$/.test(input)) {
+  if (!/^[A-Za-z0-9_-]+$/.test(effective)) {
     throw new CLIError(
       "INVALID_SPACE",
-      `Invalid --space "${input}". Use a short name ([A-Za-z0-9_-]) or a full tinycloud:... URI.`,
+      `Invalid space "${effective}". Use a short name ([A-Za-z0-9_-]) or a full tinycloud:... URI.`,
       ExitCode.USAGE_ERROR,
     );
   }
 
-  const profile = await ProfileManager.getProfile(profileName);
   const session = (await ProfileManager.getSession(profileName)) as Record<string, unknown> | null;
 
   const address = resolveAddress(profile, session);
   const chainId = resolveChainId(profile, session);
-  return makePkhSpaceId(address, chainId, input);
+  return makePkhSpaceId(address, chainId, effective);
 }


### PR DESCRIPTION
## What

Give the `tc` CLI a per-profile **default space** so `--space` becomes optional. Commands that operate almost entirely in one space (e.g. our artifact pipeline in `applications`) no longer need `--space applications` on every `kv`/`sql` invocation.

**Precedence (uniform across all kv + sql commands):**
`explicit --space flag  >  profile defaultSpace  >  primary space`

## How

- **`config/types.ts`** — add `defaultSpace?: string` to `ProfileConfig` (stores a space NAME like `applications`, resolved per-profile at command time).
- **`lib/space.ts`** — the single resolution seam. `resolveSpaceUri(input, profile)` is already called by `kvHandle` (kv.ts), `dbHandle` (sql.ts), and `sql copy`. It now falls back to `profile.defaultSpace` when `input` is omitted, then resolves the name to a full URI the same way an explicit `--space <name>` would. No per-command special-casing.
- **`commands/profile.ts`** — `tc profile set-default-space <name>` (and `--unset`) persists it; `tc profile show` displays "Default Space".
- **`commands/init.ts`** — `tc init --default-space <name>` sets it at profile creation.

### Set mechanism (chosen)
`tc profile set-default-space <name>` is the primary surface — it mirrors the existing `tc profile switch` verb-noun pattern, is discoverable under `tc profile`, and round-trips to the same `profile.json` store. `tc init --default-space` is a secondary convenience for first-run. (Considered but rejected: a generic `tc profile set <key> <value>` — broader surface than asked, no precedent in the CLI.)

### Manifest-driven default-space — DEFERRED (with exact seam)
The assignment asked whether ingesting a manifest/capabilityRequest sign-in should set the profile's `defaultSpace`. There is **no manifest "apply/sign-in" command** in the CLI today — `tc manifest resolve` is read-only and `tc auth request --manifest` only requests caps. The point where a manifest's target space is known is `loadManifestPermissions` in `lib/permissions.ts` (`String(manifest.space ?? "applications")`), but that function returns *permissions*, not the space, and a single `auth request --manifest` may span multiple spaces. Wiring a default-space update there means threading the space back up through `auth request` and deciding multi-space semantics — a meaningful change beyond this PR's scope. Implemented the core feature now; manifest-driven update is a clean follow-up at that seam.

## Behavior note for review
`resolveSpaceUri` now also feeds `sql copy`'s `--from-space`/`--to-space` defaults, so a `defaultSpace`-carrying profile will route omitted copy endpoints to the default rather than primary. This is consistent with the "default applies when omitted" semantics, but flagging it as the one place the default reaches beyond plain `kv`/`sql get/put`.

## Testing
- `lib/space.test.ts`: explicit override wins; default used when omitted; primary (`undefined`) when neither; full-URI flag returned verbatim.
- `commands/profile.test.ts`: `set-default-space` persists to profile json; `--unset` clears; invalid name and missing-arg rejected.
- Full CLI suite green: **33 pass / 0 fail**.
- End-to-end via the `tc` alias (overlaid onto the artifactory checkout, then reverted): `set-default-space` persisted to `profile.json`; live `resolveSpaceUri` against the real `cli-test` profile resolved omitted→`...:applications` with a default set, omitted→`undefined` without, explicit→override.

> Base = **artifactory** (not master). REVIEW CHECKPOINT — do not merge; awaiting Codex + lead/user review of the broader CLI approach.