### PR TITLE
feat(cli,node-sdk): host-request verb, identity-aware SPACE_NOT_HOSTED, SDK grant fn

### DIFF
--- a/.changeset/auth-dx-host-request.md
+++ b/.changeset/auth-dx-host-request.md
@@ -1,12 +1,13 @@
 ---
 "@tinycloud/node-sdk": minor
 "@tinycloud/cli": minor
+"@tinycloud/sdk-services": patch
 ---
 
 Auth/hosting developer experience for the delegate-asks-owner-to-host model.
 
 - **`tc space host-request <name> --emit <file>`** (delegate-only): emits a `tinycloud.host.request` artifact naming the space and its resolved owner DID so an agent can surface it to the owner, who then runs `tc space host <name>`. If the caller IS the root authority of the resolved space, it refuses (`ALREADY_ROOT_AUTHORITY`) and tells them to host directly — no request is emitted. The command is a pure local emit and never contacts the node.
 
-- **Identity-aware `SPACE_NOT_HOSTED`**: an unhosted-space write/read previously surfaced as an opaque `404 - Space not found`. The kv and sql commands now normalize **only** that exact condition (404 + "Space not found" body) to a `SPACE_NOT_HOSTED` error carrying an identity-aware `hint`. The branch key `is_root_authority(space, active session)` is computed locally from the profile address + space DID (no network): the owner is told to run `tc space host <name>`, a delegate is told they cannot host and to emit `tc space host-request <name> --emit`. A wrong db/table/path or permission error is left untouched.
+- **Identity-aware `SPACE_NOT_HOSTED`**: an unhosted-space write/read previously surfaced as an opaque `404 - Space not found`. The kv and sql commands now normalize **only** that exact condition (404 + "Space not found" body) to a `SPACE_NOT_HOSTED` error carrying an identity-aware `hint`. The branch key `is_root_authority(space, active session)` is computed locally from the profile address + space DID (no network): the owner is told to run `tc space host <name>`, a delegate is told they cannot host and to emit `tc space host-request <name> --emit`. A wrong db/table/path or permission error is left untouched. A `delegate-session` profile is never treated as the root authority even when its stored ownerDid is the space owner, so a delegate always gets the host-request hint. `KVService` get/head/delete now preserve the `Space not found` 404 body (previously collapsed to `KV_NOT_FOUND` before the body was read), so unhosted-space **reads** normalize too, while a genuine missing key still reports `KV_NOT_FOUND`.
 
 - **SDK `grantAuthRequest(authority, request, options?)`** (`@tinycloud/node-sdk`): takes a delegation request artifact and returns a grant artifact (`tinycloud.auth.delegation`) by signing through `delegateTo`, so the request→grant handshake is callable programmatically. `tc auth grant` is now a thin wrapper over it. Adds the `AuthRequestArtifact`, `AuthDelegationArtifact`, and `DelegationAuthority` types.

--- a/.changeset/auth-dx-host-request.md
+++ b/.changeset/auth-dx-host-request.md
@@ -1,0 +1,12 @@
+---
+"@tinycloud/node-sdk": minor
+"@tinycloud/cli": minor
+---
+
+Auth/hosting developer experience for the delegate-asks-owner-to-host model.
+
+- **`tc space host-request <name> --emit <file>`** (delegate-only): emits a `tinycloud.host.request` artifact naming the space and its resolved owner DID so an agent can surface it to the owner, who then runs `tc space host <name>`. If the caller IS the root authority of the resolved space, it refuses (`ALREADY_ROOT_AUTHORITY`) and tells them to host directly — no request is emitted. The command is a pure local emit and never contacts the node.
+
+- **Identity-aware `SPACE_NOT_HOSTED`**: an unhosted-space write/read previously surfaced as an opaque `404 - Space not found`. The kv and sql commands now normalize **only** that exact condition (404 + "Space not found" body) to a `SPACE_NOT_HOSTED` error carrying an identity-aware `hint`. The branch key `is_root_authority(space, active session)` is computed locally from the profile address + space DID (no network): the owner is told to run `tc space host <name>`, a delegate is told they cannot host and to emit `tc space host-request <name> --emit`. A wrong db/table/path or permission error is left untouched.
+
+- **SDK `grantAuthRequest(authority, request, options?)`** (`@tinycloud/node-sdk`): takes a delegation request artifact and returns a grant artifact (`tinycloud.auth.delegation`) by signing through `delegateTo`, so the request→grant handshake is callable programmatically. `tc auth grant` is now a thin wrapper over it. Adds the `AuthRequestArtifact`, `AuthDelegationArtifact`, and `DelegationAuthority` types.

--- a/.changeset/web-sdk-space-scoped-services.md
+++ b/.changeset/web-sdk-space-scoped-services.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/web-sdk": minor
+---
+
+Expose `sqlForSpace(spaceId)` and `kvForSpace(spaceId)` on `TinyCloudWeb`.
+
+These thin passthroughs forward to the underlying `TinyCloudNode.sqlForSpace`/`kvForSpace` (already used by the CLI), mirroring the existing `get sql()`/`get kv()` accessors. They let a browser/web-SDK app read or write a non-primary space — e.g. the pure-client viewer reading the artifact `feed` SQL and appending `interaction` rows under the owner's `applications` space.

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -6,7 +6,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { createInterface } from "node:readline";
 import type { IncomingMessage } from "node:http";
-import { principalDidEquals, type PermissionEntry, type PortableDelegation } from "@tinycloud/node-sdk";
+import { grantAuthRequest, principalDidEquals, type PermissionEntry, type PortableDelegation } from "@tinycloud/node-sdk";
 import { ProfileManager } from "../config/profiles.js";
 import { outputJson, shouldOutputJson, formatField, formatTable, isInteractive, withSpinner } from "../output/formatter.js";
 import { handleError, CLIError } from "../output/errors.js";
@@ -472,24 +472,12 @@ export function registerAuthCommand(program: Command): void {
           expiryOption: parsed.requestedExpiry,
           yes: options.yes === true,
         });
-        const result = await node.delegateTo(
-          parsed.sessionDid,
-          parsed.requested,
-          parsed.requestedExpiry !== undefined
-            ? { expiry: parsed.requestedExpiry }
-            : undefined,
-        );
 
-        outputJson({
-          kind: "tinycloud.auth.delegation",
-          version: 1,
-          requestId: parsed.requestId,
-          delegationCid: result.delegation.cid,
-          delegation: result.delegation,
-          permissions: parsed.requested,
-          expiry: result.delegation.expiry.toISOString(),
-          prompted: result.prompted,
-        });
+        // The grant logic lives in the SDK (grantAuthRequest) so it is callable
+        // programmatically; this command is a thin wrapper. The CLI request
+        // artifact is a structural superset of AuthRequestArtifact.
+        const grant = await grantAuthRequest(node, parsed);
+        outputJson(grant);
       } catch (error) {
         handleError(error);
       }

--- a/packages/cli/src/commands/kv.test.ts
+++ b/packages/cli/src/commands/kv.test.ts
@@ -123,6 +123,12 @@ mock.module("../output/errors.js", () => ({
   },
 }));
 
+mock.module("../lib/host.js", () => ({
+  // The unhosted-space normalizer is exercised in host.test.ts; here we keep it
+  // a no-op so kv command routing tests don't pull in its real dependency graph.
+  unhostedSpaceError: async () => null,
+}));
+
 const { registerKvCommand } = await import("./kv.js");
 
 async function runKv(args: string[]): Promise<void> {

--- a/packages/cli/src/commands/kv.test.ts
+++ b/packages/cli/src/commands/kv.test.ts
@@ -38,22 +38,39 @@ function toBytes(chunk: unknown): Uint8Array {
   return new TextEncoder().encode(String(chunk));
 }
 
+// Sentinel key prefixes let a test drive the error path of a KV op:
+//   UNHOSTED:* -> 404 + "Space not found" body (the unhosted-space signal)
+//   MISSING:*  -> plain KV_NOT_FOUND "Key not found"
+function errorFor(key: string) {
+  if (key.startsWith("UNHOSTED:")) {
+    return { ok: false, error: { code: "KV_NOT_FOUND", message: "KV 404 - Space not found", meta: { status: 404 } } };
+  }
+  if (key.startsWith("MISSING:")) {
+    return { ok: false, error: { code: "KV_NOT_FOUND", message: "Key not found: " + key } };
+  }
+  return null;
+}
+
 // A KV handle whose name records which space ("primary" vs the resolved uri)
 // each operation routed through.
 function makeKv(handle: string) {
   return {
     put: async (key: string, value: unknown) => {
       recorded.puts.push({ handle, key, value });
-      return { ok: true, data: { data: undefined, headers: {} } };
+      return errorFor(key) ?? { ok: true, data: { data: undefined, headers: {} } };
     },
     delete: async (key: string) => {
       recorded.deletes.push({ handle, key });
-      return { ok: true, data: undefined };
+      return errorFor(key) ?? { ok: true, data: undefined };
     },
     get: async (key: string, options: unknown) => {
       recorded.gets.push({ handle, key, options });
       // Mirror the SDK: when { binary: true }, data is the raw bytes.
-      return { ok: true, data: { data: GET_BYTES, headers: {} } };
+      return errorFor(key) ?? { ok: true, data: { data: GET_BYTES, headers: {} } };
+    },
+    head: async (key: string) => {
+      recorded.gets.push({ handle, key, options: "head" });
+      return errorFor(key) ?? { ok: true, data: { headers: {} } };
     },
   };
 }
@@ -124,9 +141,22 @@ mock.module("../output/errors.js", () => ({
 }));
 
 mock.module("../lib/host.js", () => ({
-  // The unhosted-space normalizer is exercised in host.test.ts; here we keep it
-  // a no-op so kv command routing tests don't pull in its real dependency graph.
-  unhostedSpaceError: async () => null,
+  // Mirror the real predicate (status 404 + "Space not found") so the kv
+  // command's error routing is genuinely exercised; the per-identity hint
+  // wording is covered in host.test.ts. Returns a CLIError-like on match.
+  unhostedSpaceError: async (
+    error: { message: string; meta?: { status?: number } },
+    spaceUri: string | undefined,
+  ) => {
+    if (!spaceUri) return null;
+    if (error.meta?.status === 404 && /space not found/i.test(error.message)) {
+      const e: any = new Error("SPACE_NOT_HOSTED");
+      e.code = "SPACE_NOT_HOSTED";
+      e.exitCode = 1;
+      return e;
+    }
+    return null;
+  },
 }));
 
 const { registerKvCommand } = await import("./kv.js");
@@ -245,5 +275,48 @@ describe("CLI kv get binary output", () => {
     expect(recorded.gets).toEqual([
       { handle: "primary", key: "img.png", options: undefined },
     ]);
+  });
+});
+
+describe("CLI kv SPACE_NOT_HOSTED routing for reads", () => {
+  beforeEach(resetState);
+
+  // get/head/delete must surface SPACE_NOT_HOSTED on an unhosted space (not a
+  // benign "key not found" / exists:false), while a genuine missing key still
+  // reports NOT_FOUND / exists:false.
+  test("get on an unhosted space surfaces SPACE_NOT_HOSTED, not NOT_FOUND", async () => {
+    await runKv(["get", "UNHOSTED:k", "--space", "applications"]);
+    expect(recorded.outputs).toEqual([]);
+    expect(recorded.errors).toHaveLength(1);
+    expect((recorded.errors[0] as { code: string }).code).toBe("SPACE_NOT_HOSTED");
+  });
+
+  test("get on a genuinely missing key reports NOT_FOUND", async () => {
+    await runKv(["get", "MISSING:k", "--space", "applications"]);
+    expect(recorded.outputs).toEqual([]);
+    expect(recorded.errors).toHaveLength(1);
+    expect((recorded.errors[0] as { code: string }).code).toBe("NOT_FOUND");
+  });
+
+  test("head on an unhosted space surfaces SPACE_NOT_HOSTED, not exists:false", async () => {
+    await runKv(["head", "UNHOSTED:k", "--space", "applications"]);
+    expect(recorded.outputs).toEqual([]);
+    expect(recorded.errors).toHaveLength(1);
+    expect((recorded.errors[0] as { code: string }).code).toBe("SPACE_NOT_HOSTED");
+  });
+
+  test("head on a genuinely missing key reports exists:false", async () => {
+    await runKv(["head", "MISSING:k", "--space", "applications"]);
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.outputs).toEqual([
+      { key: "MISSING:k", exists: false, metadata: {} },
+    ]);
+  });
+
+  test("delete on an unhosted space surfaces SPACE_NOT_HOSTED", async () => {
+    await runKv(["delete", "UNHOSTED:k", "--space", "applications"]);
+    expect(recorded.outputs).toEqual([]);
+    expect(recorded.errors).toHaveLength(1);
+    expect((recorded.errors[0] as { code: string }).code).toBe("SPACE_NOT_HOSTED");
   });
 });

--- a/packages/cli/src/commands/kv.ts
+++ b/packages/cli/src/commands/kv.ts
@@ -83,6 +83,10 @@ export function registerKvCommand(program: Command): void {
         ) as any;
 
         if (!result.ok) {
+          // SPACE_NOT_HOSTED (unhosted-space 404) takes precedence over the
+          // generic "key not found"; only a true missing key falls through.
+          const hosted = await unhostedSpaceError(result.error, spaceUri, ctx.profile);
+          if (hosted) throw hosted;
           if (result.error.code === "KV_NOT_FOUND" || result.error.code === "NOT_FOUND") {
             throw new CLIError("NOT_FOUND", `Key "${key}" not found`, ExitCode.NOT_FOUND);
           }
@@ -257,6 +261,9 @@ export function registerKvCommand(program: Command): void {
         const result = await withSpinner(`Checking ${key}...`, () => kv.head(key)) as any;
 
         if (!result.ok) {
+          // An unhosted space must not be reported as a benign "key absent".
+          const hosted = await unhostedSpaceError(result.error, spaceUri, ctx.profile);
+          if (hosted) throw hosted;
           if (result.error.code === "KV_NOT_FOUND" || result.error.code === "NOT_FOUND") {
             outputJson({ key, exists: false, metadata: {} });
             return;

--- a/packages/cli/src/commands/kv.ts
+++ b/packages/cli/src/commands/kv.ts
@@ -7,8 +7,24 @@ import { handleError, CLIError } from "../output/errors.js";
 import { ExitCode } from "../config/constants.js";
 import { ensureAuthenticated } from "../lib/sdk.js";
 import { resolveSpaceUri } from "../lib/space.js";
+import { unhostedSpaceError } from "../lib/host.js";
 import { theme } from "../output/theme.js";
 import type { TinyCloudNode } from "@tinycloud/node-sdk";
+
+/**
+ * Throw the kv/sql service error, normalized to SPACE_NOT_HOSTED with an
+ * identity-aware hint when (and only when) the failure is the exact
+ * unhosted-space condition. Keeps the single error path consistent across kv.
+ */
+async function throwKvError(
+  error: { code: string; message: string; meta?: { status?: number } },
+  spaceUri: string | undefined,
+  profileName: string,
+): Promise<never> {
+  const hosted = await unhostedSpaceError(error, spaceUri, profileName);
+  if (hosted) throw hosted;
+  throw new CLIError(error.code, error.message, ExitCode.ERROR);
+}
 
 /**
  * Read all data from stdin.
@@ -36,7 +52,8 @@ async function kvHandle(
   profileName: string,
 ) {
   const spaceUri = await resolveSpaceUri(spaceInput, profileName);
-  return spaceUri ? node.kvForSpace(spaceUri) : node.kv;
+  const kv = spaceUri ? node.kvForSpace(spaceUri) : node.kv;
+  return { kv, spaceUri };
 }
 
 export function registerKvCommand(program: Command): void {
@@ -55,7 +72,7 @@ export function registerKvCommand(program: Command): void {
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
-        const kv = await kvHandle(node, options.space, ctx.profile);
+        const { kv, spaceUri } = await kvHandle(node, options.space, ctx.profile);
         // For raw / file output, read the value as raw bytes so binary values
         // (e.g. images) round-trip byte-identically. The default (parsed/JSON)
         // path is unchanged.
@@ -69,7 +86,7 @@ export function registerKvCommand(program: Command): void {
           if (result.error.code === "KV_NOT_FOUND" || result.error.code === "NOT_FOUND") {
             throw new CLIError("NOT_FOUND", `Key "${key}" not found`, ExitCode.NOT_FOUND);
           }
-          throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR);
+          await throwKvError(result.error, spaceUri, ctx.profile);
         }
 
         const data = result.data.data;
@@ -142,11 +159,11 @@ export function registerKvCommand(program: Command): void {
           }
         }
 
-        const kv = await kvHandle(node, options.space, ctx.profile);
+        const { kv, spaceUri } = await kvHandle(node, options.space, ctx.profile);
         const result = await withSpinner(`Writing ${key}...`, () => kv.put(key, putValue)) as any;
 
         if (!result.ok) {
-          throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR);
+          await throwKvError(result.error, spaceUri, ctx.profile);
         }
 
         outputJson({ key, written: true });
@@ -166,11 +183,11 @@ export function registerKvCommand(program: Command): void {
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
-        const kv = await kvHandle(node, options.space, ctx.profile);
+        const { kv, spaceUri } = await kvHandle(node, options.space, ctx.profile);
         const result = await withSpinner(`Deleting ${key}...`, () => kv.delete(key)) as any;
 
         if (!result.ok) {
-          throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR);
+          await throwKvError(result.error, spaceUri, ctx.profile);
         }
 
         outputJson({ key, deleted: true });
@@ -191,12 +208,12 @@ export function registerKvCommand(program: Command): void {
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
-        const kv = await kvHandle(node, options.space, ctx.profile);
+        const { kv, spaceUri } = await kvHandle(node, options.space, ctx.profile);
         const listOptions = options.prefix ? { prefix: options.prefix } : undefined;
         const result = await withSpinner("Listing keys...", () => kv.list(listOptions)) as any;
 
         if (!result.ok) {
-          throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR);
+          await throwKvError(result.error, spaceUri, ctx.profile);
         }
 
         const rawData = result.data.data ?? result.data;
@@ -236,7 +253,7 @@ export function registerKvCommand(program: Command): void {
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
-        const kv = await kvHandle(node, options.space, ctx.profile);
+        const { kv, spaceUri } = await kvHandle(node, options.space, ctx.profile);
         const result = await withSpinner(`Checking ${key}...`, () => kv.head(key)) as any;
 
         if (!result.ok) {
@@ -244,7 +261,7 @@ export function registerKvCommand(program: Command): void {
             outputJson({ key, exists: false, metadata: {} });
             return;
           }
-          throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR);
+          await throwKvError(result.error, spaceUri, ctx.profile);
         }
 
         outputJson({

--- a/packages/cli/src/commands/space.test.ts
+++ b/packages/cli/src/commands/space.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Command } from "commander";
+
+const SELF_ADDR = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+const OTHER_ADDR = "0xd559ccd9eb87c530a9a349262669386de93cf412";
+
+type CLIErrorLike = { code: string; message: string; exitCode: number };
+
+const recorded = {
+  outputs: [] as unknown[],
+  errors: [] as unknown[],
+  fileWrites: [] as Array<{ path: string; data: string }>,
+};
+
+// Controls whether the resolved space is owned by the active profile.
+let owner = false;
+let profile: Record<string, unknown> = {};
+
+function resetState(): void {
+  recorded.outputs = [];
+  recorded.errors = [];
+  recorded.fileWrites = [];
+  owner = false;
+  profile = {
+    name: "agent-test",
+    chainId: 1,
+    sessionDid: "did:key:z6MkAgentSession#z6MkAgentSession",
+    did: "did:key:z6MkAgentSession",
+  };
+}
+
+mock.module("../config/profiles.js", () => ({
+  ProfileManager: {
+    resolveContext: async () => ({ profile: "agent-test", host: "https://node.tinycloud.xyz" }),
+    getProfile: async () => profile,
+  },
+}));
+
+mock.module("../lib/sdk.js", () => ({
+  // host-request must NOT contact the node; fail loudly if it tries.
+  ensureAuthenticated: async () => {
+    throw new Error("host-request must not authenticate");
+  },
+}));
+
+mock.module("../lib/host.js", () => ({
+  isRootAuthority: async () => owner,
+  resolveHostSpace: async (name: string) =>
+    name.startsWith("tinycloud:") ? name : `tinycloud:pkh:eip155:1:${OTHER_ADDR}:${name}`,
+  spaceNameFromUri: (uri: string) => uri.slice(uri.lastIndexOf(":") + 1),
+  ownerDidFromSpaceUri: (uri: string) => {
+    const m = uri.match(/^tinycloud:pkh:eip155:(\d+):(0x[a-fA-F0-9]{40}):/);
+    return m ? `did:pkh:eip155:${m[1]}:${m[2]}` : null;
+  },
+}));
+
+mock.module("../output/formatter.js", () => ({
+  outputJson: (payload: unknown) => recorded.outputs.push(payload),
+  shouldOutputJson: () => true,
+  formatTable: () => "",
+}));
+
+mock.module("../output/theme.js", () => ({
+  theme: { muted: (v: string) => v },
+}));
+
+mock.module("../output/errors.js", () => ({
+  CLIError: class CLIError extends Error implements CLIErrorLike {
+    constructor(
+      public code: string,
+      message: string,
+      public exitCode: number,
+      public metadata?: Record<string, unknown>,
+    ) {
+      super(message);
+    }
+  },
+  handleError: (error: unknown) => recorded.errors.push(error),
+}));
+
+mock.module("node:fs/promises", () => ({
+  mkdir: async () => {},
+  writeFile: async (path: string, data: string) => {
+    recorded.fileWrites.push({ path, data });
+  },
+}));
+
+const { registerSpaceCommand } = await import("./space.js");
+
+async function runSpace(args: string[]): Promise<void> {
+  const program = new Command();
+  registerSpaceCommand(program);
+  await program.parseAsync(["node", "tc", "space", ...args], { from: "node" });
+}
+
+describe("tc space host-request", () => {
+  beforeEach(resetState);
+
+  test("delegate emits a tinycloud.host.request artifact to the file", async () => {
+    owner = false;
+    await runSpace(["host-request", "applications", "--emit", "./host-request.json"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.fileWrites).toHaveLength(1);
+    expect(recorded.fileWrites[0].path).toBe("./host-request.json");
+
+    const artifact = JSON.parse(recorded.fileWrites[0].data);
+    expect(artifact).toMatchObject({
+      kind: "tinycloud.host.request",
+      version: 1,
+      spaceName: "applications",
+      spaceId: `tinycloud:pkh:eip155:1:${OTHER_ADDR}:applications`,
+      ownerDid: `did:pkh:eip155:1:${OTHER_ADDR}`,
+      requesterDid: "did:key:z6MkAgentSession",
+      host: "https://node.tinycloud.xyz",
+    });
+    expect(typeof artifact.requestId).toBe("string");
+    expect(artifact.requestId.startsWith("hostreq_")).toBe(true);
+
+    // Summary points back at the emitted file.
+    expect(recorded.outputs[0]).toMatchObject({
+      emitted: true,
+      path: "./host-request.json",
+      spaceName: "applications",
+    });
+  });
+
+  test("delegate prints the artifact to stdout when --emit has no path", async () => {
+    owner = false;
+    await runSpace(["host-request", "applications", "--emit"]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.fileWrites).toEqual([]);
+    expect(recorded.outputs[0]).toMatchObject({
+      kind: "tinycloud.host.request",
+      spaceName: "applications",
+    });
+  });
+
+  test("owner is refused and told to host directly", async () => {
+    owner = true;
+    await runSpace(["host-request", "applications", "--emit", "./host-request.json"]);
+
+    expect(recorded.fileWrites).toEqual([]);
+    expect(recorded.outputs).toEqual([]);
+    expect(recorded.errors).toHaveLength(1);
+    const error = recorded.errors[0] as CLIErrorLike;
+    expect(error.code).toBe("ALREADY_ROOT_AUTHORITY");
+    expect(error.message).toContain("tc space host applications");
+  });
+});

--- a/packages/cli/src/commands/space.ts
+++ b/packages/cli/src/commands/space.ts
@@ -1,10 +1,19 @@
 import { Command } from "commander";
+import { randomBytes } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { ProfileManager } from "../config/profiles.js";
 import { outputJson, shouldOutputJson, formatTable } from "../output/formatter.js";
 import { handleError, CLIError } from "../output/errors.js";
 import { ExitCode } from "../config/constants.js";
 import { ensureAuthenticated } from "../lib/sdk.js";
+import { isRootAuthority, ownerDidFromSpaceUri, resolveHostSpace, spaceNameFromUri, type HostRequestArtifact } from "../lib/host.js";
 import { theme } from "../output/theme.js";
+
+function didWithoutFragment(did: string): string {
+  const fragment = did.indexOf("#");
+  return fragment === -1 ? did : did.slice(0, fragment);
+}
 
 export function registerSpaceCommand(program: Command): void {
   const space = program.command("space").description("Space management");
@@ -60,6 +69,65 @@ export function registerSpaceCommand(program: Command): void {
     });
 
   space
+    .command("host-request <name>")
+    .description("Emit a request asking the space owner to host it (delegate-only)")
+    .option("--emit [file]", "Write the request artifact to file (or stdout when no path)")
+    .addHelpText("after", `
+
+A delegate cannot host a space — only its owner (root authority) can. This
+emits a tinycloud.host.request artifact naming the space and its owner so you
+can hand it to the owner; they run \`tc space host <name>\` and confirm.
+
+If you ARE the owner of the resolved space, this refuses and tells you to host
+it directly with \`tc space host <name>\` (no request needed).
+`)
+    .action(async (name: string, options, cmd) => {
+      try {
+        const globalOpts = cmd.optsWithGlobals();
+        const ctx = await ProfileManager.resolveContext(globalOpts);
+        const profile = await ProfileManager.getProfile(ctx.profile);
+
+        // Pure local emit — no node contact, mirroring `tc auth request --emit`.
+        const spaceId = await resolveHostSpace(name, ctx.profile);
+        const spaceName = spaceNameFromUri(spaceId);
+
+        if (await isRootAuthority(spaceId, ctx.profile)) {
+          throw new CLIError(
+            "ALREADY_ROOT_AUTHORITY",
+            `You are the owner of ${spaceId}. Host it directly: tc space host ${spaceName}`,
+            ExitCode.USAGE_ERROR,
+          );
+        }
+
+        const requesterDid = didWithoutFragment(profile.sessionDid ?? profile.did);
+        const ownerDid = ownerDidFromSpaceUri(spaceId);
+        if (!ownerDid) {
+          throw new CLIError(
+            "UNRESOLVABLE_OWNER",
+            `Cannot determine the owner of ${spaceId}; host-request needs a pkh space URI.`,
+            ExitCode.USAGE_ERROR,
+          );
+        }
+
+        const artifact: HostRequestArtifact = {
+          kind: "tinycloud.host.request",
+          version: 1,
+          requestId: `hostreq_${Date.now().toString(36)}_${randomBytes(4).toString("hex")}`,
+          createdAt: new Date().toISOString(),
+          spaceName,
+          spaceId,
+          ownerDid,
+          requesterDid,
+          host: ctx.host,
+        };
+
+        await emitHostRequestArtifact(artifact, options.emit);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  space
     .command("info [space-id]")
     .description("Get space info")
     .action(async (spaceId: string | undefined, _options, cmd) => {
@@ -101,4 +169,24 @@ export function registerSpaceCommand(program: Command): void {
         handleError(error);
       }
     });
+}
+
+async function emitHostRequestArtifact(
+  artifact: HostRequestArtifact,
+  emitOption: unknown,
+): Promise<void> {
+  if (typeof emitOption === "string" && emitOption.length > 0) {
+    await mkdir(dirname(emitOption), { recursive: true });
+    await writeFile(emitOption, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+    outputJson({
+      emitted: true,
+      path: emitOption,
+      requestId: artifact.requestId,
+      spaceName: artifact.spaceName,
+      spaceId: artifact.spaceId,
+      ownerDid: artifact.ownerDid,
+    });
+    return;
+  }
+  outputJson(artifact);
 }

--- a/packages/cli/src/commands/sql.ts
+++ b/packages/cli/src/commands/sql.ts
@@ -8,6 +8,7 @@ import { handleError, CLIError } from "../output/errors.js";
 import { ExitCode } from "../config/constants.js";
 import { ensureAuthenticated } from "../lib/sdk.js";
 import { resolveSpaceUri } from "../lib/space.js";
+import { unhostedSpaceError } from "../lib/host.js";
 import { theme } from "../output/theme.js";
 
 /**
@@ -17,16 +18,36 @@ import { theme } from "../output/theme.js";
  * primary-space SQL service (preserves prior behavior). When present,
  * we use TinyCloudNode.sqlForSpace, which clones the active service
  * context with a session whose spaceId points at the target space.
+ *
+ * Returns the resolved space URI alongside the handle so error handling can
+ * build the identity-aware SPACE_NOT_HOSTED hint.
  */
 async function dbHandle(
   node: TinyCloudNode,
   dbName: string,
   spaceInput: string | undefined,
   profileName: string,
-): Promise<IDatabaseHandle> {
+): Promise<{ handle: IDatabaseHandle; spaceUri: string | undefined }> {
   const spaceUri = await resolveSpaceUri(spaceInput, profileName);
   const sql = spaceUri ? node.sqlForSpace(spaceUri) : node.sql;
-  return sql.db(dbName);
+  return { handle: sql.db(dbName), spaceUri };
+}
+
+/**
+ * Throw the sql service error, normalized to SPACE_NOT_HOSTED with an
+ * identity-aware hint when (and only when) the failure is the exact
+ * unhosted-space condition. Keeps the single error path consistent across sql.
+ */
+async function throwSqlError(
+  error: { code: string; message: string; meta?: { status?: number } },
+  spaceUri: string | undefined,
+  profileName: string,
+  prefix?: string,
+): Promise<never> {
+  const hosted = await unhostedSpaceError(error, spaceUri, profileName);
+  if (hosted) throw hosted;
+  const message = prefix ? `${prefix}${error.message}` : error.message;
+  throw new CLIError(error.code, message, ExitCode.ERROR, error.meta);
 }
 
 export function registerSqlCommand(program: Command): void {
@@ -86,14 +107,14 @@ Output:
         const node = await ensureAuthenticated(ctx);
 
         const params = options.params ? JSON.parse(options.params) : undefined;
-        const handle = await dbHandle(node, options.db, options.space, ctx.profile);
+        const { handle, spaceUri } = await dbHandle(node, options.db, options.space, ctx.profile);
 
         const result = await withSpinner("Running query...", () =>
           handle.query(sqlStr, params)
         ) as any;
 
         if (!result.ok) {
-          throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR, result.error.meta);
+          await throwSqlError(result.error, spaceUri, ctx.profile);
         }
 
         const { columns, rows, rowCount } = result.data;
@@ -142,14 +163,14 @@ Output:
         const node = await ensureAuthenticated(ctx);
 
         const params = options.params ? JSON.parse(options.params) : undefined;
-        const handle = await dbHandle(node, options.db, options.space, ctx.profile);
+        const { handle, spaceUri } = await dbHandle(node, options.db, options.space, ctx.profile);
 
         const result = await withSpinner("Executing statement...", () =>
           handle.execute(sqlStr, params)
         ) as any;
 
         if (!result.ok) {
-          throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR, result.error.meta);
+          await throwSqlError(result.error, spaceUri, ctx.profile);
         }
 
         outputJson({
@@ -184,14 +205,14 @@ Output:
         const ctx = await ProfileManager.resolveContext(globalOpts);
         const node = await ensureAuthenticated(ctx);
 
-        const handle = await dbHandle(node, options.db, options.space, ctx.profile);
+        const { handle, spaceUri } = await dbHandle(node, options.db, options.space, ctx.profile);
 
         const result = await withSpinner("Exporting database...", () =>
           handle.export()
         ) as any;
 
         if (!result.ok) {
-          throw new CLIError(result.error.code, result.error.message, ExitCode.ERROR, result.error.meta);
+          await throwSqlError(result.error, spaceUri, ctx.profile);
         }
 
         const blob: Blob = result.data;
@@ -259,8 +280,8 @@ Notes:
           );
         }
 
-        const fromHandle = await dbHandle(node, options.fromDb, fromSpaceInput, ctx.profile);
-        const toHandle = await dbHandle(node, options.toDb, toSpaceInput, ctx.profile);
+        const { handle: fromHandle, spaceUri: fromSpaceUriResolved } = await dbHandle(node, options.fromDb, fromSpaceInput, ctx.profile);
+        const { handle: toHandle, spaceUri: toSpaceUriResolved } = await dbHandle(node, options.toDb, toSpaceInput, ctx.profile);
 
         // Resolve target tables: explicit list, or all user tables in source.
         let tables: string[];
@@ -271,7 +292,7 @@ Notes:
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
           ) as any;
           if (!listing.ok) {
-            throw new CLIError(listing.error.code, `Cannot list source tables: ${listing.error.message}`, ExitCode.ERROR, listing.error.meta);
+            await throwSqlError(listing.error, fromSpaceUriResolved, ctx.profile, "Cannot list source tables: ");
           }
           tables = (listing.data.rows as unknown[][]).map((r) => String(r[0]));
         }
@@ -290,12 +311,7 @@ Notes:
           const safe = quoteIdent(table);
           const countResult = await fromHandle.query(`SELECT count(*) AS n FROM ${safe}`) as any;
           if (!countResult.ok) {
-            throw new CLIError(
-              countResult.error.code,
-              `Cannot count rows in source table "${table}": ${countResult.error.message}`,
-              ExitCode.ERROR,
-              countResult.error.meta,
-            );
+            await throwSqlError(countResult.error, fromSpaceUriResolved, ctx.profile, `Cannot count rows in source table "${table}": `);
           }
           const rows = Number(countResult.data.rows[0]?.[0] ?? 0);
           plan.push({ table, rows, copied: 0, skipped: 0 });
@@ -315,7 +331,7 @@ Notes:
           const safe = quoteIdent(entry.table);
           const fetched = await fromHandle.query(`SELECT * FROM ${safe}`) as any;
           if (!fetched.ok) {
-            throw new CLIError(fetched.error.code, `Failed to read "${entry.table}": ${fetched.error.message}`, ExitCode.ERROR, fetched.error.meta);
+            await throwSqlError(fetched.error, fromSpaceUriResolved, ctx.profile, `Failed to read "${entry.table}": `);
           }
           const columns: string[] = fetched.data.columns;
           const rows: unknown[][] = fetched.data.rows;
@@ -329,12 +345,7 @@ Notes:
           for (const row of rows) {
             const writeResult = await toHandle.execute(insertSql, row as any) as any;
             if (!writeResult.ok) {
-              throw new CLIError(
-                writeResult.error.code,
-                `Insert into "${entry.table}" failed after ${entry.copied} row(s): ${writeResult.error.message}`,
-                ExitCode.ERROR,
-                writeResult.error.meta,
-              );
+              await throwSqlError(writeResult.error, toSpaceUriResolved, ctx.profile, `Insert into "${entry.table}" failed after ${entry.copied} row(s): `);
             }
             entry.copied += writeResult.data.changes ?? 1;
           }

--- a/packages/cli/src/lib/host.test.ts
+++ b/packages/cli/src/lib/host.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// The owner's own address (Hardhat #0). A bare `--space applications` resolves
+// against this; a full URI naming a DIFFERENT owner address makes the active
+// profile a delegate.
+const SELF_ADDR = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+const OTHER_ADDR = "0xd559ccd9eb87c530a9a349262669386de93cf412";
+
+let profile: Record<string, unknown> = {};
+let session: Record<string, unknown> | null = null;
+
+mock.module("../config/profiles.js", () => ({
+  ProfileManager: {
+    getProfile: async () => profile,
+    getSession: async () => session,
+  },
+}));
+
+// Mirror the real resolveSpaceUri contract enough for resolveHostSpace: a bare
+// name resolves against SELF_ADDR; a full URI passes through.
+mock.module("./space.js", () => ({
+  resolveSpaceUri: async (input: string | undefined) => {
+    if (!input) return undefined;
+    if (input.startsWith("tinycloud:")) return input;
+    return `tinycloud:pkh:eip155:1:${SELF_ADDR}:${input}`;
+  },
+}));
+
+const {
+  isRootAuthority,
+  ownerDidFromSpaceUri,
+  spaceNameFromUri,
+  resolveHostSpace,
+  unhostedSpaceError,
+} = await import("./host.js");
+
+beforeEach(() => {
+  profile = { name: "cli-test", address: SELF_ADDR, chainId: 1 };
+  session = null;
+});
+
+describe("isRootAuthority", () => {
+  test("true when the profile address owns the space DID", async () => {
+    const uri = `tinycloud:pkh:eip155:1:${SELF_ADDR}:applications`;
+    expect(await isRootAuthority(uri, "cli-test")).toBe(true);
+  });
+
+  test("false when the space DID names a different owner (delegate)", async () => {
+    const uri = `tinycloud:pkh:eip155:1:${OTHER_ADDR}:applications`;
+    expect(await isRootAuthority(uri, "cli-test")).toBe(false);
+  });
+
+  test("case-insensitive on the address comparison", async () => {
+    const uri = `tinycloud:pkh:eip155:1:${SELF_ADDR.toUpperCase().replace("0X", "0x")}:applications`;
+    expect(await isRootAuthority(uri, "cli-test")).toBe(true);
+  });
+
+  test("falls back to session.address then ownerDid", async () => {
+    profile = { name: "p", chainId: 1, ownerDid: `did:pkh:eip155:1:${SELF_ADDR}` };
+    const uri = `tinycloud:pkh:eip155:1:${SELF_ADDR}:applications`;
+    expect(await isRootAuthority(uri, "p")).toBe(true);
+  });
+});
+
+describe("ownerDidFromSpaceUri / spaceNameFromUri", () => {
+  test("extracts owner DID and space name", () => {
+    const uri = `tinycloud:pkh:eip155:1:${OTHER_ADDR}:applications`;
+    expect(ownerDidFromSpaceUri(uri)).toBe(`did:pkh:eip155:1:${OTHER_ADDR}`);
+    expect(spaceNameFromUri(uri)).toBe("applications");
+  });
+
+  test("returns null for a non-pkh URI", () => {
+    expect(ownerDidFromSpaceUri("tinycloud:weird:applications")).toBeNull();
+  });
+});
+
+describe("resolveHostSpace", () => {
+  test("resolves a bare name against the active profile", async () => {
+    expect(await resolveHostSpace("applications", "cli-test")).toBe(
+      `tinycloud:pkh:eip155:1:${SELF_ADDR}:applications`,
+    );
+  });
+});
+
+describe("unhostedSpaceError", () => {
+  const OWNED = `tinycloud:pkh:eip155:1:${SELF_ADDR}:applications`;
+  const DELEGATED = `tinycloud:pkh:eip155:1:${OTHER_ADDR}:applications`;
+
+  function err(message: string, status?: number) {
+    return { code: "SQL_DATABASE_NOT_FOUND", message, meta: { status } };
+  }
+
+  test("returns null when no space URI (primary space is always hosted)", async () => {
+    const out = await unhostedSpaceError(err("404 - Space not found", 404), undefined, "cli-test");
+    expect(out).toBeNull();
+  });
+
+  test("returns null for a 404 that is NOT a space-not-found body", async () => {
+    // A missing table/db inside a hosted space must NOT be relabeled.
+    const out = await unhostedSpaceError(
+      err("SQL execute failed: 404 - no such table: feed", 404),
+      DELEGATED,
+      "cli-test",
+    );
+    expect(out).toBeNull();
+  });
+
+  test("returns null for a permission error (different status)", async () => {
+    const out = await unhostedSpaceError(
+      { code: "SQL_PERMISSION_DENIED", message: "403 - forbidden", meta: { status: 403 } },
+      DELEGATED,
+      "cli-test",
+    );
+    expect(out).toBeNull();
+  });
+
+  test("owner hint tells them to host directly", async () => {
+    const out = await unhostedSpaceError(
+      err("SQL execute failed: 404 - Space not found", 404),
+      OWNED,
+      "cli-test",
+    );
+    expect(out).not.toBeNull();
+    expect(out!.code).toBe("SPACE_NOT_HOSTED");
+    const hint = out!.metadata?.hint as string;
+    expect(hint).toContain("You are the owner");
+    expect(hint).toContain("tc space host applications");
+    expect(hint).not.toContain("host-request");
+  });
+
+  test("delegate hint tells them they cannot host and to emit a host-request", async () => {
+    const out = await unhostedSpaceError(
+      err("SQL execute failed: 404 - Space not found", 404),
+      DELEGATED,
+      "cli-test",
+    );
+    expect(out).not.toBeNull();
+    expect(out!.code).toBe("SPACE_NOT_HOSTED");
+    const hint = out!.metadata?.hint as string;
+    expect(hint).toContain("CANNOT host");
+    expect(hint).toContain("tc space host-request applications --emit");
+    // Identity-aware message names the owner, not the delegate.
+    expect(out!.message).toContain(`did:pkh:eip155:1:${OTHER_ADDR}`);
+  });
+
+  test("matches the KV write unhosted shape too (status + message, any code)", async () => {
+    const out = await unhostedSpaceError(
+      { code: "KV_WRITE_FAILED", message: `Failed to put key "x": 404 - Space not found`, meta: { status: 404 } },
+      DELEGATED,
+      "cli-test",
+    );
+    expect(out).not.toBeNull();
+    expect(out!.code).toBe("SPACE_NOT_HOSTED");
+  });
+});

--- a/packages/cli/src/lib/host.test.ts
+++ b/packages/cli/src/lib/host.test.ts
@@ -60,6 +60,21 @@ describe("isRootAuthority", () => {
     const uri = `tinycloud:pkh:eip155:1:${SELF_ADDR}:applications`;
     expect(await isRootAuthority(uri, "p")).toBe(true);
   });
+
+  test("delegate-session is NEVER root authority, even when ownerDid == the space owner", async () => {
+    // A delegate legitimately knows the space owner's address (it's in ownerDid
+    // / session.address). Posture must win so the delegate gets the host-request
+    // hint, not the owner "tc space host" hint.
+    profile = {
+      name: "delegate",
+      chainId: 1,
+      posture: "delegate-session",
+      ownerDid: `did:pkh:eip155:1:${OTHER_ADDR}`,
+    };
+    session = { address: OTHER_ADDR };
+    const uri = `tinycloud:pkh:eip155:1:${OTHER_ADDR}:applications`;
+    expect(await isRootAuthority(uri, "delegate")).toBe(false);
+  });
 });
 
 describe("ownerDidFromSpaceUri / spaceNameFromUri", () => {

--- a/packages/cli/src/lib/host.ts
+++ b/packages/cli/src/lib/host.ts
@@ -1,6 +1,6 @@
 import { ProfileManager } from "../config/profiles.js";
 import { ExitCode } from "../config/constants.js";
-import type { ProfileConfig } from "../config/types.js";
+import { resolveProfilePosture, type ProfileConfig } from "../config/types.js";
 import { CLIError } from "../output/errors.js";
 import { resolveSpaceUri } from "./space.js";
 
@@ -89,12 +89,18 @@ export function ownerDidFromSpaceUri(spaceUri: string): string | null {
  * the owner address baked into the space DID. Only the root authority may host
  * a space — a delegate's key never matches, so this is the same branch key the
  * server enforces cryptographically, computed client-side for actionable hints.
+ *
+ * A `delegate-session` profile is NEVER the root authority, even when its stored
+ * ownerDid/session.address is the SPACE OWNER's address (a delegate legitimately
+ * knows whose space it accesses). Short-circuiting on posture prevents handing a
+ * delegate the owner hint ("run tc space host"), which only the owner can do.
  */
 export async function isRootAuthority(
   spaceUri: string,
   profileName: string,
 ): Promise<boolean> {
   const profile = await ProfileManager.getProfile(profileName);
+  if (resolveProfilePosture(profile) === "delegate-session") return false;
   const ownerAddr = ownerAddressFromSpaceUri(spaceUri);
   if (!ownerAddr) return false;
   const selfAddr = await resolveLocalAddress(profile, profileName);

--- a/packages/cli/src/lib/host.ts
+++ b/packages/cli/src/lib/host.ts
@@ -1,0 +1,171 @@
+import { ProfileManager } from "../config/profiles.js";
+import { ExitCode } from "../config/constants.js";
+import type { ProfileConfig } from "../config/types.js";
+import { CLIError } from "../output/errors.js";
+import { resolveSpaceUri } from "./space.js";
+
+/** Minimal shape of a kv/sql service error this module inspects. */
+interface ServiceErrorLike {
+  code: string;
+  message: string;
+  meta?: { status?: number } & Record<string, unknown>;
+}
+
+/**
+ * Host-request artifact: a delegate's ASK that the owner host a space.
+ *
+ * `tc space host-request --emit` writes this; the human relays it to the
+ * owner, who runs `tc space host <name>`. It is NOT a delegation and grants
+ * nothing — it only names the space (and its resolved owner DID) so the owner
+ * knows what to host.
+ */
+export interface HostRequestArtifact {
+  kind: "tinycloud.host.request";
+  version: 1;
+  requestId: string;
+  createdAt: string;
+  /** The space short name the owner should host (`tc space host <name>`). */
+  spaceName: string;
+  /** Fully-resolved owner space URI the host action targets. */
+  spaceId: string;
+  /** The owner principal expected to perform the host (root authority). */
+  ownerDid: string;
+  /** The delegate that is asking (audit / who to grant to afterwards). */
+  requesterDid: string;
+  /** TinyCloud node the space must be hosted on. */
+  host: string;
+}
+
+function canonicalizeAddress(address: string): string {
+  const trimmed = address.trim();
+  return trimmed.startsWith("0x")
+    ? `0x${trimmed.slice(2).toLowerCase()}`
+    : trimmed.toLowerCase();
+}
+
+/**
+ * Resolve the active profile's Ethereum address with no network call.
+ * Mirrors the source priority in lib/space.ts (session.address → profile.address
+ * → ownerDid pkh address); returns null when none can be determined.
+ */
+async function resolveLocalAddress(
+  profile: ProfileConfig,
+  profileName: string,
+): Promise<string | null> {
+  const session = (await ProfileManager.getSession(profileName)) as
+    | Record<string, unknown>
+    | null;
+  const sessAddr = session?.address;
+  if (typeof sessAddr === "string" && sessAddr.length > 0) {
+    return canonicalizeAddress(sessAddr);
+  }
+  if (profile.address) return canonicalizeAddress(profile.address);
+  if (profile.ownerDid) {
+    const match = profile.ownerDid.match(/^did:pkh:eip155:\d+:(0x[a-fA-F0-9]{40})$/);
+    if (match) return canonicalizeAddress(match[1]);
+  }
+  return null;
+}
+
+/** Extract the owner address segment from a `tinycloud:pkh:eip155:<chain>:<addr>:<name>` URI. */
+function ownerAddressFromSpaceUri(spaceUri: string): string | null {
+  const match = spaceUri.match(/^tinycloud:pkh:eip155:\d+:(0x[a-fA-F0-9]{40}):/);
+  return match ? canonicalizeAddress(match[1]) : null;
+}
+
+/**
+ * Owner principal of a `tinycloud:pkh:eip155:<chain>:<addr>:<name>` space URI,
+ * as a `did:pkh:eip155:<chain>:<addr>`. Returns null for non-pkh URIs.
+ */
+export function ownerDidFromSpaceUri(spaceUri: string): string | null {
+  const match = spaceUri.match(/^tinycloud:pkh:eip155:(\d+):(0x[a-fA-F0-9]{40}):/);
+  if (!match) return null;
+  return `did:pkh:eip155:${match[1]}:${canonicalizeAddress(match[2])}`;
+}
+
+/**
+ * Decide LOCALLY (no network) whether the active profile is the root authority
+ * (owner) of a resolved space URI. True iff the profile's own address equals
+ * the owner address baked into the space DID. Only the root authority may host
+ * a space — a delegate's key never matches, so this is the same branch key the
+ * server enforces cryptographically, computed client-side for actionable hints.
+ */
+export async function isRootAuthority(
+  spaceUri: string,
+  profileName: string,
+): Promise<boolean> {
+  const profile = await ProfileManager.getProfile(profileName);
+  const ownerAddr = ownerAddressFromSpaceUri(spaceUri);
+  if (!ownerAddr) return false;
+  const selfAddr = await resolveLocalAddress(profile, profileName);
+  return selfAddr !== null && selfAddr === ownerAddr;
+}
+
+/** Last `:`-delimited segment of a space URI is its short name. */
+export function spaceNameFromUri(spaceUri: string): string {
+  return spaceUri.slice(spaceUri.lastIndexOf(":") + 1);
+}
+
+/**
+ * Detect the EXACT unhosted-space condition and, only then, return an
+ * identity-aware SPACE_NOT_HOSTED CLIError. Returns null for every other
+ * failure (wrong db/table/path, permission, network) so the caller throws the
+ * original error untouched — we never mislabel a non-host problem as a host one.
+ *
+ * The unhosted condition is a 404 whose message says "Space not found" (the
+ * server's wording for an un-hosted space; a missing db/table inside a hosted
+ * space returns a different body). The hint branches on is_root_authority,
+ * computed locally from the profile address + space DID (no network).
+ */
+export async function unhostedSpaceError(
+  error: ServiceErrorLike,
+  spaceUri: string | undefined,
+  profileName: string,
+): Promise<CLIError | null> {
+  // Without a resolved space URI the op targeted the primary space, which is
+  // auto-hosted at sign-in — this branch can't be an unhosted-space problem.
+  if (!spaceUri) return null;
+
+  const status = error.meta?.status;
+  const isUnhosted = status === 404 && /space not found/i.test(error.message);
+  if (!isUnhosted) return null;
+
+  const spaceName = spaceNameFromUri(spaceUri);
+  const owner = await isRootAuthority(spaceUri, profileName);
+  const hint = owner
+    ? [
+        "You are the owner. Host it once:",
+        `  tc space host ${spaceName}`,
+        "Then retry.",
+      ].join("\n")
+    : [
+        "You are a delegate and CANNOT host this space — only its owner can.",
+        "Emit a host request:",
+        `  tc space host-request ${spaceName} --emit ./host-request.json`,
+        "Send it to the owner; they run `tc space host` and confirm. Then retry.",
+      ].join("\n");
+
+  const message = owner
+    ? `Space '${spaceName}' (${spaceUri}) is not hosted.`
+    : `Space '${spaceName}' (owner ${ownerDidFromSpaceUri(spaceUri) ?? spaceUri}) is not hosted.`;
+
+  return new CLIError("SPACE_NOT_HOSTED", message, ExitCode.ERROR, { hint });
+}
+
+/**
+ * Resolve a `--space`-style name/URI to its full owner space URI for hosting.
+ * Unlike the kv/sql path, hosting always needs a concrete space, so this never
+ * returns undefined — a bare name resolves against the active profile's address.
+ */
+export async function resolveHostSpace(
+  name: string,
+  profileName: string,
+): Promise<string> {
+  const resolved = await resolveSpaceUri(name, profileName);
+  if (!resolved) {
+    // Unreachable in practice: resolveSpaceUri only returns undefined when its
+    // input is empty AND no default space is set; host-request requires a name.
+    throw new Error(`Could not resolve a space for "${name}".`);
+  }
+  return resolved;
+}

--- a/packages/cli/src/output/errors.ts
+++ b/packages/cli/src/output/errors.ts
@@ -46,7 +46,12 @@ export function wrapError(error: unknown): CLIError {
 
 export function handleError(error: unknown): never {
   const cliError = wrapError(error);
-  const hint = buildAuthHint(cliError) ??
+  // A pre-built hint on the error (e.g. the identity-aware SPACE_NOT_HOSTED
+  // hint) takes precedence over the derived auth/network hints.
+  const prebuilt = typeof cliError.metadata?.hint === "string"
+    ? (cliError.metadata.hint as string)
+    : undefined;
+  const hint = prebuilt ?? buildAuthHint(cliError) ??
     (cliError.code === "NETWORK_ERROR" ? buildNetworkHint() : undefined);
   outputError(cliError.code, cliError.message, hint);
   process.exit(cliError.exitCode);

--- a/packages/node-sdk/src/delegation.test.ts
+++ b/packages/node-sdk/src/delegation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  grantAuthRequest,
+  type AuthRequestArtifact,
+  type DelegationAuthority,
+  type PortableDelegation,
+} from "./delegation";
+
+const REQUESTER_DID = "did:key:z6MkRequesterSessionKey";
+
+function makeRequest(overrides: Partial<AuthRequestArtifact> = {}): AuthRequestArtifact {
+  return {
+    kind: "tinycloud.auth.request",
+    version: 1,
+    requestId: "req_test_1",
+    sessionDid: REQUESTER_DID,
+    requested: [
+      {
+        service: "tinycloud.sql",
+        space: "tinycloud:pkh:eip155:1:0xowner:applications",
+        path: "xyz.tinycloud.artifacts/feed",
+        actions: ["tinycloud.sql/read", "tinycloud.sql/write"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makePortableDelegation(): PortableDelegation {
+  return {
+    cid: "bafy-granted",
+    delegationHeader: { Authorization: "Bearer granted" },
+    spaceId: "tinycloud:pkh:eip155:1:0xowner:applications",
+    path: "xyz.tinycloud.artifacts/feed",
+    actions: ["tinycloud.sql/read", "tinycloud.sql/write"],
+    expiry: new Date("2099-01-01T00:00:00.000Z"),
+    ownerAddress: "0xowner",
+    chainId: 1,
+  } as PortableDelegation;
+}
+
+/** Records what delegateTo received and returns a canned delegation. */
+function makeAuthority(): DelegationAuthority & {
+  calls: Array<{ did: string; permissions: unknown; options: unknown }>;
+} {
+  const calls: Array<{ did: string; permissions: unknown; options: unknown }> = [];
+  return {
+    calls,
+    async delegateTo(did, permissions, options) {
+      calls.push({ did, permissions, options });
+      return { delegation: makePortableDelegation(), prompted: false };
+    },
+  };
+}
+
+describe("grantAuthRequest", () => {
+  test("turns a request into a tinycloud.auth.delegation grant audienced to the requester", async () => {
+    const authority = makeAuthority();
+    const request = makeRequest();
+
+    const grant = await grantAuthRequest(authority, request);
+
+    // Delegation is issued to the requester's session DID, for exactly the
+    // requested caps.
+    expect(authority.calls).toHaveLength(1);
+    expect(authority.calls[0].did).toBe(REQUESTER_DID);
+    expect(authority.calls[0].permissions).toEqual(request.requested);
+
+    // Grant artifact has the shape `tc auth import` accepts.
+    expect(grant).toEqual({
+      kind: "tinycloud.auth.delegation",
+      version: 1,
+      requestId: "req_test_1",
+      delegationCid: "bafy-granted",
+      delegation: expect.objectContaining({ cid: "bafy-granted" }),
+      permissions: request.requested,
+      expiry: "2099-01-01T00:00:00.000Z",
+      prompted: false,
+    });
+  });
+
+  test("forwards the request's requestedExpiry to delegateTo", async () => {
+    const authority = makeAuthority();
+    await grantAuthRequest(authority, makeRequest({ requestedExpiry: "7d" }));
+    expect(authority.calls[0].options).toEqual({ expiry: "7d" });
+  });
+
+  test("an explicit expiry option overrides the request's requestedExpiry", async () => {
+    const authority = makeAuthority();
+    await grantAuthRequest(authority, makeRequest({ requestedExpiry: "7d" }), { expiry: "30m" });
+    expect(authority.calls[0].options).toEqual({ expiry: "30m" });
+  });
+
+  test("omits the options argument when no expiry is specified", async () => {
+    const authority = makeAuthority();
+    await grantAuthRequest(authority, makeRequest());
+    expect(authority.calls[0].options).toBeUndefined();
+  });
+
+  test("rejects a non-request artifact", async () => {
+    const authority = makeAuthority();
+    await expect(
+      grantAuthRequest(
+        authority,
+        { kind: "tinycloud.auth.delegation" } as unknown as AuthRequestArtifact,
+      ),
+    ).rejects.toThrow(/tinycloud.auth.request/);
+    expect(authority.calls).toHaveLength(0);
+  });
+
+  test("rejects a request with no requested capabilities", async () => {
+    const authority = makeAuthority();
+    await expect(
+      grantAuthRequest(authority, makeRequest({ requested: [] })),
+    ).rejects.toThrow(/no requested capabilities/);
+    expect(authority.calls).toHaveLength(0);
+  });
+});

--- a/packages/node-sdk/src/delegation.ts
+++ b/packages/node-sdk/src/delegation.ts
@@ -1,4 +1,4 @@
-import { Delegation, DelegatedResource } from "@tinycloud/sdk-core";
+import { Delegation, DelegatedResource, PermissionEntry } from "@tinycloud/sdk-core";
 
 /**
  * A portable delegation that can be transported between users.
@@ -44,6 +44,100 @@ export interface PortableDelegation extends Omit<Delegation, "isRevoked"> {
    * fields are authoritative (legacy single-resource shape).
    */
   resources?: DelegatedResource[];
+}
+
+/**
+ * The transport shape `tc auth request --emit` produces and that an owner
+ * grants to its requester. Only the fields the grant logic needs are declared;
+ * the CLI artifact carries more (posture, captured command, ...) and remains a
+ * structural superset of this interface.
+ */
+export interface AuthRequestArtifact {
+  kind: "tinycloud.auth.request";
+  version: 1;
+  requestId: string;
+  /** The requester's session DID — the audience the grant is issued to. */
+  sessionDid: string;
+  /** The capabilities the requester is asking the owner to delegate. */
+  requested: PermissionEntry[];
+  /** Optional lifetime override carried from the request. */
+  requestedExpiry?: string | number;
+}
+
+/**
+ * The transport shape returned by {@link grantAuthRequest} (and written by
+ * `tc auth grant`). `tc auth import` accepts this artifact directly.
+ */
+export interface AuthDelegationArtifact {
+  kind: "tinycloud.auth.delegation";
+  version: 1;
+  requestId: string;
+  delegationCid: string;
+  delegation: PortableDelegation;
+  permissions: PermissionEntry[];
+  expiry: string;
+  /** Whether issuing the delegation triggered a wallet prompt. */
+  prompted: boolean;
+}
+
+/**
+ * Minimal owner-side capability {@link grantAuthRequest} needs: the signed
+ * `delegateTo` primitive. `TinyCloudNode` satisfies this directly; web/SDK
+ * contexts can supply any object that exposes the same method.
+ */
+export interface DelegationAuthority {
+  delegateTo(
+    did: string,
+    permissions: PermissionEntry[],
+    options?: { expiry?: string | number; forceWalletSign?: boolean },
+  ): Promise<{ delegation: PortableDelegation; prompted: boolean }>;
+}
+
+/**
+ * Turn a delegation REQUEST into a signed GRANT.
+ *
+ * Lifts the body of `tc auth grant` into the SDK so the request→grant
+ * handshake is callable programmatically (future SDK/web owner tooling and the
+ * KV delegation inbox), with the CLI verb reduced to a thin wrapper. The owner
+ * `authority` (a `TinyCloudNode`) signs a delegation scoped to exactly the
+ * requested caps, audienced to the requester's `sessionDid`, honoring the
+ * request's expiry. The returned artifact round-trips through `tc auth import`.
+ *
+ * Authorization is enforced cryptographically by `delegateTo`: caps that are
+ * not derivable from the owner's own session capability chain are rejected
+ * (it throws), so this never widens authority the owner doesn't hold.
+ */
+export async function grantAuthRequest(
+  authority: DelegationAuthority,
+  request: AuthRequestArtifact,
+  options?: { expiry?: string | number },
+): Promise<AuthDelegationArtifact> {
+  if (request.kind !== "tinycloud.auth.request") {
+    throw new Error(
+      `grantAuthRequest expects a tinycloud.auth.request artifact, got "${request.kind}".`,
+    );
+  }
+  if (!Array.isArray(request.requested) || request.requested.length === 0) {
+    throw new Error("grantAuthRequest request has no requested capabilities.");
+  }
+
+  const expiry = options?.expiry ?? request.requestedExpiry;
+  const result = await authority.delegateTo(
+    request.sessionDid,
+    request.requested,
+    expiry !== undefined ? { expiry } : undefined,
+  );
+
+  return {
+    kind: "tinycloud.auth.delegation",
+    version: 1,
+    requestId: request.requestId,
+    delegationCid: result.delegation.cid,
+    delegation: result.delegation,
+    permissions: request.requested,
+    expiry: result.delegation.expiry.toISOString(),
+    prompted: result.prompted,
+  };
 }
 
 /**

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -162,8 +162,13 @@ export { NodeWasmBindings } from "./NodeWasmBindings";
 // Delegation
 export { DelegatedAccess } from "./DelegatedAccess";
 export type { RestorableSession } from "./DelegatedAccess";
-export { serializeDelegation, deserializeDelegation } from "./delegation";
-export type { PortableDelegation } from "./delegation";
+export { serializeDelegation, deserializeDelegation, grantAuthRequest } from "./delegation";
+export type {
+  PortableDelegation,
+  AuthRequestArtifact,
+  AuthDelegationArtifact,
+  DelegationAuthority,
+} from "./delegation";
 
 // Re-export KV service values
 export {

--- a/packages/sdk-services/src/kv/KVService.test.ts
+++ b/packages/sdk-services/src/kv/KVService.test.ts
@@ -507,3 +507,35 @@ describe("KVService.get binary", () => {
     }
   });
 });
+
+describe("KVService 404 classification (unhosted space vs missing key)", () => {
+  function service(body: string) {
+    const svc = new KVService({});
+    svc.initialize(createContext(async () => response(false, 404, body)));
+    return svc;
+  }
+
+  // An un-hosted space 404 must preserve status + the "Space not found" body so
+  // the CLI/SDK can normalize it to SPACE_NOT_HOSTED (matching put/list/sql).
+  for (const op of ["get", "head", "delete"] as const) {
+    test(`${op}: unhosted-space 404 keeps status 404 + "Space not found" body`, async () => {
+      const result = await service("404 - Space not found")[op]("k");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe(ErrorCodes.KV_NOT_FOUND);
+        expect(result.error.message).toMatch(/space not found/i);
+        expect((result.error.meta as { status?: number } | undefined)?.status).toBe(404);
+      }
+    });
+
+    test(`${op}: genuine missing key 404 is a plain KV_NOT_FOUND (no host signal)`, async () => {
+      const result = await service("key not found")[op]("k");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe(ErrorCodes.KV_NOT_FOUND);
+        expect(result.error.message).toBe("Key not found: k");
+        expect(result.error.message).not.toMatch(/space not found/i);
+      }
+    });
+  }
+});

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -162,6 +162,35 @@ export class KVService extends BaseService implements IKVService {
   }
 
   /**
+   * Classify a KV 404 by reading the response body once.
+   *
+   * The server returns 404 both for a genuinely missing key AND for an
+   * un-hosted space (body "Space not found"). Previously get/head/delete
+   * collapsed every 404 to KV_NOT_FOUND before reading the body, so an
+   * un-hosted-space read was indistinguishable from a missing key. We now
+   * preserve status + the "Space not found" body for the un-hosted case (so the
+   * CLI/SDK can normalize it to SPACE_NOT_HOSTED, matching put/list/sql), and
+   * fall through to KV_NOT_FOUND for a real missing key.
+   */
+  private async classifyNotFound(
+    response: FetchResponse,
+    key: string
+  ): Promise<Result<never>> {
+    const errorText = await response.text();
+    if (/space not found/i.test(errorText)) {
+      return err(
+        serviceError(
+          ErrorCodes.KV_NOT_FOUND,
+          `KV ${response.status} - ${errorText}`,
+          "kv",
+          { meta: { status: response.status, statusText: response.statusText } }
+        )
+      );
+    }
+    return err(serviceError(ErrorCodes.KV_NOT_FOUND, `Key not found: ${key}`, "kv"));
+  }
+
+  /**
    * Get the full path with optional prefix.
    *
    * @param key - The key
@@ -482,13 +511,7 @@ export class KVService extends BaseService implements IKVService {
           }
 
           if (response.status === 404) {
-            return err(
-              serviceError(
-                ErrorCodes.KV_NOT_FOUND,
-                `Key not found: ${key}`,
-                "kv"
-              )
-            );
+            return this.classifyNotFound(response, key);
           }
 
           const errorText = await response.text();
@@ -803,13 +826,7 @@ export class KVService extends BaseService implements IKVService {
           }
 
           if (response.status === 404) {
-            return err(
-              serviceError(
-                ErrorCodes.KV_NOT_FOUND,
-                `Key not found: ${key}`,
-                "kv"
-              )
-            );
+            return this.classifyNotFound(response, key);
           }
 
           const errorText = await response.text();
@@ -864,13 +881,7 @@ export class KVService extends BaseService implements IKVService {
           }
 
           if (response.status === 404) {
-            return err(
-              serviceError(
-                ErrorCodes.KV_NOT_FOUND,
-                `Key not found: ${key}`,
-                "kv"
-              )
-            );
+            return this.classifyNotFound(response, key);
           }
 
           const errorText = await response.text();

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -412,6 +412,11 @@ export class TinyCloudWeb {
 
   get kv(): IKVService { return this.node.kv; }
   get sql(): ISQLService { return this.node.sql; }
+
+  /** Space-scoped SQL service for a non-primary space (e.g. the owner's `applications` space). */
+  sqlForSpace(spaceId: string): ISQLService { return this.node.sqlForSpace(spaceId); }
+  /** Space-scoped KV service for a non-primary space (e.g. the owner's `applications` space). */
+  kvForSpace(spaceId: string): IKVService { return this.node.kvForSpace(spaceId); }
   get duckdb(): IDuckDbService { return this.node.duckdb; }
   get hooks(): IHooksService { return this.node.hooks; }
   get encryption(): IEncryptionService { return this.node.encryption; }

--- a/packages/web-sdk/tests/spaceScopedServices.test.ts
+++ b/packages/web-sdk/tests/spaceScopedServices.test.ts
@@ -1,0 +1,49 @@
+const { TextEncoder: TE, TextDecoder: TD } = require('util');
+
+global.TextEncoder = TE;
+global.TextDecoder = TD;
+
+const { TinyCloudWeb } = require('../src');
+
+// sqlForSpace/kvForSpace are thin passthroughs to the underlying TinyCloudNode,
+// mirroring `get sql()`/`get kv()`. We inject a fake node so the test doesn't
+// require WASM/sign-in, and assert the spaceId forwards and the node's
+// space-scoped service is returned unchanged.
+function withFakeNode() {
+  const tcw = new TinyCloudWeb();
+  const calls = { sql: [], kv: [] };
+  const sqlService = { tag: 'sql-for-space' };
+  const kvService = { tag: 'kv-for-space' };
+  const fakeNode = {
+    sqlForSpace: (spaceId) => {
+      calls.sql.push(spaceId);
+      return sqlService;
+    },
+    kvForSpace: (spaceId) => {
+      calls.kv.push(spaceId);
+      return kvService;
+    },
+  };
+  tcw._node = fakeNode;
+  return { tcw, calls, sqlService, kvService };
+}
+
+const SPACE = 'tinycloud:pkh:eip155:1:0xowner:applications';
+
+test('sqlForSpace forwards the space URI to node.sqlForSpace and returns its service', () => {
+  const { tcw, calls, sqlService } = withFakeNode();
+  expect(tcw.sqlForSpace(SPACE)).toBe(sqlService);
+  expect(calls.sql).toEqual([SPACE]);
+});
+
+test('kvForSpace forwards the space URI to node.kvForSpace and returns its service', () => {
+  const { tcw, calls, kvService } = withFakeNode();
+  expect(tcw.kvForSpace(SPACE)).toBe(kvService);
+  expect(calls.kv).toEqual([SPACE]);
+});
+
+test('space-scoped accessors throw before initialization (no _node)', () => {
+  const tcw = new TinyCloudWeb();
+  expect(() => tcw.sqlForSpace(SPACE)).toThrow(/not yet initialized/);
+  expect(() => tcw.kvForSpace(SPACE)).toThrow(/not yet initialized/);
+});


### PR DESCRIPTION
Implements the auth/hosting developer-experience pieces for the **delegate-asks-owner-to-host** model in the artifact-pipeline greenfield contract (`.context/greenfield-contract.md` §3.2, §3.3, §9.5; auth flow proven in `.context/tc-write-delegation-verified.md`).

## Three pieces

### 1. `tc space host-request <name> --emit <file>` (delegate-only)
Emits a `tinycloud.host.request` artifact naming the space (short name + resolved owner space DID + requester session DID) so an agent can hand it to the owner, who runs `tc space host <name>`. If the caller **is** the root authority of the resolved space, it refuses (`ALREADY_ROOT_AUTHORITY`) and tells them to host directly — no request emitted. Pure local emit, mirroring `tc auth request --emit`; never contacts the node.

### 2. Identity-aware `SPACE_NOT_HOSTED`
An unhosted-space write/read previously surfaced as opaque `404 - Space not found`. The kv and sql commands now normalize **only** that exact condition (404 + `Space not found` body) to a `SPACE_NOT_HOSTED` error code carrying an identity-aware `hint`. The branch key `is_root_authority(space, active session)` is computed **locally** from the profile address + space DID (no network):
- **Owner** → "you own this; run `tc space host <name>`"
- **Delegate** → "you can't host (only the owner can); run `tc space host-request <name> --emit ...`"

A wrong db/table/path or permission error is **not** relabeled (verified live: a missing table inside a hosted space returns `SQL_ERROR`/400, not `SPACE_NOT_HOSTED`).

Seam: `packages/cli/src/lib/host.ts` `unhostedSpaceError(...)`, routed from the kv/sql `!result.ok` throw sites through `throwKvError`/`throwSqlError`, surfaced via the single `handleError` path (which now honors a pre-built `metadata.hint`).

### 3. SDK `grantAuthRequest(authority, request, options?)` (`@tinycloud/node-sdk`)
Lifts the body of `tc auth grant` into the SDK: takes a delegation request artifact, signs a scoped delegation via `delegateTo` audienced to the requester's session DID, and returns the `tinycloud.auth.delegation` grant artifact. `tc auth grant` is now a thin wrapper. Adds `AuthRequestArtifact`, `AuthDelegationArtifact`, `DelegationAuthority` types. Authorization stays cryptographically enforced by `delegateTo` (non-derivable caps throw).

## Tests
- `packages/node-sdk/src/delegation.test.ts` — grant fn round-trips request→grant, forwards/overrides expiry, rejects non-request / empty caps.
- `packages/cli/src/lib/host.test.ts` — `isRootAuthority` (owner vs delegate, case-insensitive, fallbacks), `unhostedSpaceError` (right hint per identity, fires only on the true unhosted case, ignores wrong-table/permission/primary-space).
- `packages/cli/src/commands/space.test.ts` — host-request emits the correct artifact to file/stdout, refuses for owner, never authenticates.

Also verified live against the running node: delegate + owner `SPACE_NOT_HOSTED` hints, the no-mislabel guard, host-request emit/refuse, and a full `auth request → grant → import` round-trip through the new SDK fn.

## Notes for reviewer
- Built `packages/cli/dist` is gitignored on master now (release-bot territory); this PR is **source-only**.
- Pre-existing on master (not touched here): `packages/cli/src/lib/space.test.ts` has 2 failing tests on the clean base; `tsc --noEmit` reports pre-existing errors in unrelated files. My edited files (`lib/host.ts`, `commands/space.ts`, `kv.ts`, `sql.ts`, `errors.ts`, `node-sdk/delegation.ts`) typecheck clean and the `turbo build` DTS step passes.
- **Server-side boundary:** KV `get`/`head` 404s are mapped to `KV_NOT_FOUND`/"Key not found" by the SDK *before* the body is inspected, so an unhosted-space **read** via `get`/`head` is indistinguishable from a genuinely-missing key and is NOT normalized. KV `put`/`delete`/`list` and all SQL ops carry the raw `404 - Space not found` body and ARE normalized. Making `get`/`head` reads identity-aware would need a server/SDK change (tinycloud-node).

Do not merge — merging master auto-publishes a beta; lead coordinates after Codex review.