### PR TITLE
fix(cli): OPENKEY_SCOPE_MISMATCH case bug + batch same-space caps in one OpenKey request

### DIFF
--- a/.changeset/openkey-scope-case-insensitive.md
+++ b/.changeset/openkey-scope-case-insensitive.md
@@ -1,0 +1,9 @@
+---
+"@tinycloud/cli": patch
+---
+
+Fix `OPENKEY_SCOPE_MISMATCH` on `tc auth request --grant` for OpenKey profiles, and batch multiple `--cap` on one space into a single OpenKey round-trip.
+
+The CLI compared the space the OpenKey node returned against the space it built for the request byte-for-byte. OpenKey returns the EIP-55 **checksummed** eip155 address (`0xd559CCd9...dE93cf412`) while the CLI builds the **lowercase** form, so a grant for a valid space spuriously failed with `OPENKEY_SCOPE_MISMATCH`. Ethereum addresses are case-insensitive; space comparison now normalizes (lowercases) the address segment on both sides.
+
+The same normalization is applied when grouping requested caps by space, so multiple `--cap` for the same space — even if one is typed checksummed and another lowercase — batch into a single OpenKey browser round-trip instead of one per casing.

--- a/packages/cli/src/commands/auth.openkey-scope.test.ts
+++ b/packages/cli/src/commands/auth.openkey-scope.test.ts
@@ -118,6 +118,26 @@ describe("portableFromOpenKeyDelegation (scope mismatch)", () => {
       /OpenKey returned delegation/,
     );
   });
+
+  test("still throws when OpenKey returns the same NAME but a different ADDRESS", () => {
+    // Only the address segment is case-normalized; a genuinely different owner
+    // address under the same ":applications" name must NOT match.
+    const otherAddr = "0x1111111111111111111111111111111111111111";
+    const permissions = [
+      cap("tinycloud.sql", SPACE_LOWER, "xyz.tinycloud.listen/conversations", ["read"]),
+    ];
+    const data = {
+      spaceId: `tinycloud:pkh:eip155:1:${otherAddr}:applications`,
+      delegationCid: "bafyTEST5",
+      delegationHeader: { Authorization: "Bearer x" },
+      verificationMethod: "did:key:zTest",
+      address: otherAddr,
+      chainId: 1,
+    };
+    expect(() => portableFromOpenKeyDelegation(data, permissions, "https://host")).toThrow(
+      /OpenKey returned delegation/,
+    );
+  });
 });
 
 describe("groupPermissionsBySpace (case-insensitive batching)", () => {

--- a/packages/cli/src/commands/auth.openkey-scope.test.ts
+++ b/packages/cli/src/commands/auth.openkey-scope.test.ts
@@ -35,6 +35,14 @@ describe("returnedSpaceMatchesExpected (case-insensitive address)", () => {
     const other = `tinycloud:pkh:eip155:1:${ADDR_LOWER}:other`;
     expect(returnedSpaceMatchesExpected(other, SPACE_LOWER)).toBe(false);
   });
+
+  test("space NAME is case-sensitive — only-case NAME difference does NOT match", () => {
+    // Same address, name "Applications" vs "applications" — must NOT be equal.
+    const nameUpper = `tinycloud:pkh:eip155:1:${ADDR_CHECKSUM}:Applications`;
+    expect(returnedSpaceMatchesExpected(nameUpper, SPACE_LOWER)).toBe(false);
+    // Bare-name form likewise stays case-sensitive.
+    expect(returnedSpaceMatchesExpected(SPACE_LOWER, "Applications")).toBe(false);
+  });
 });
 
 describe("portableFromOpenKeyDelegation (scope mismatch)", () => {
@@ -92,6 +100,24 @@ describe("portableFromOpenKeyDelegation (scope mismatch)", () => {
       /OpenKey returned delegation/,
     );
   });
+
+  test("still throws when OpenKey returns the same address but a case-different NAME", () => {
+    // Name is case-sensitive: expected "applications", returned "Applications".
+    const permissions = [
+      cap("tinycloud.sql", SPACE_LOWER, "xyz.tinycloud.listen/conversations", ["read"]),
+    ];
+    const data = {
+      spaceId: `tinycloud:pkh:eip155:1:${ADDR_CHECKSUM}:Applications`,
+      delegationCid: "bafyTEST4",
+      delegationHeader: { Authorization: "Bearer x" },
+      verificationMethod: "did:key:zTest",
+      address: ADDR_CHECKSUM,
+      chainId: 1,
+    };
+    expect(() => portableFromOpenKeyDelegation(data, permissions, "https://host")).toThrow(
+      /OpenKey returned delegation/,
+    );
+  });
 });
 
 describe("groupPermissionsBySpace (case-insensitive batching)", () => {
@@ -109,6 +135,15 @@ describe("groupPermissionsBySpace (case-insensitive batching)", () => {
     const permissions = [
       cap("tinycloud.sql", SPACE_LOWER, "a", ["read"]),
       cap("tinycloud.kv", `tinycloud:pkh:eip155:1:${ADDR_LOWER}:other`, "b", ["get"]),
+    ];
+    expect(groupPermissionsBySpace(permissions).length).toBe(2);
+  });
+
+  test("same address but case-different NAME is NOT merged (separate round-trips)", () => {
+    // Name is case-sensitive: "applications" vs "Applications" are distinct spaces.
+    const permissions = [
+      cap("tinycloud.sql", SPACE_LOWER, "a", ["read"]),
+      cap("tinycloud.kv", `tinycloud:pkh:eip155:1:${ADDR_CHECKSUM}:Applications`, "b", ["get"]),
     ];
     expect(groupPermissionsBySpace(permissions).length).toBe(2);
   });

--- a/packages/cli/src/commands/auth.openkey-scope.test.ts
+++ b/packages/cli/src/commands/auth.openkey-scope.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import type { PermissionEntry } from "@tinycloud/node-sdk";
+
+// Imports the real @tinycloud/node-sdk (workspace build), like auth.test.ts.
+import {
+  returnedSpaceMatchesExpected,
+  portableFromOpenKeyDelegation,
+  groupPermissionsBySpace,
+} from "./auth.js";
+
+// Same eip155 address in EIP-55 checksummed (OpenKey) vs lowercase (CLI) form.
+const ADDR_CHECKSUM = "0xd559CCd9be5C5dbF8068dee29A91DF2c2d4D7B49";
+const ADDR_LOWER = ADDR_CHECKSUM.toLowerCase();
+const SPACE_CHECKSUM = `tinycloud:pkh:eip155:1:${ADDR_CHECKSUM}:applications`;
+const SPACE_LOWER = `tinycloud:pkh:eip155:1:${ADDR_LOWER}:applications`;
+
+function cap(service: string, space: string, path: string, actions: string[]): PermissionEntry {
+  return { service, space, path, actions } as PermissionEntry;
+}
+
+describe("returnedSpaceMatchesExpected (case-insensitive address)", () => {
+  test("checksummed returned vs lowercase expected matches", () => {
+    expect(returnedSpaceMatchesExpected(SPACE_CHECKSUM, SPACE_LOWER)).toBe(true);
+  });
+
+  test("lowercase returned vs checksummed expected matches", () => {
+    expect(returnedSpaceMatchesExpected(SPACE_LOWER, SPACE_CHECKSUM)).toBe(true);
+  });
+
+  test("bare space name still matches the URI suffix", () => {
+    expect(returnedSpaceMatchesExpected(SPACE_CHECKSUM, "applications")).toBe(true);
+  });
+
+  test("a genuinely different space does not match", () => {
+    const other = `tinycloud:pkh:eip155:1:${ADDR_LOWER}:other`;
+    expect(returnedSpaceMatchesExpected(other, SPACE_LOWER)).toBe(false);
+  });
+});
+
+describe("portableFromOpenKeyDelegation (scope mismatch)", () => {
+  test("does NOT throw when OpenKey returns the checksummed form of the expected space", () => {
+    const permissions = [
+      cap("tinycloud.sql", SPACE_LOWER, "xyz.tinycloud.listen/conversations", ["read"]),
+    ];
+    const data = {
+      spaceId: SPACE_CHECKSUM, // checksummed from OpenKey
+      delegationCid: "bafyTEST",
+      delegationHeader: { Authorization: "Bearer x" },
+      verificationMethod: "did:key:zTest",
+      address: ADDR_CHECKSUM,
+      chainId: 1,
+      expiry: new Date(Date.now() + 3600_000).toISOString(),
+    };
+    const portable = portableFromOpenKeyDelegation(data, permissions, "https://host");
+    expect(portable.spaceId).toBe(SPACE_CHECKSUM);
+    expect(portable.cid).toBe("bafyTEST");
+  });
+
+  test("two caps on the same space differing only by address casing are one expected space", () => {
+    // sql cap lowercase, kv cap checksummed — both the same Listen space.
+    const permissions = [
+      cap("tinycloud.sql", SPACE_LOWER, "xyz.tinycloud.listen/conversations", ["read"]),
+      cap("tinycloud.kv", SPACE_CHECKSUM, "xyz.tinycloud.listen/", ["get", "list"]),
+    ];
+    const data = {
+      spaceId: SPACE_CHECKSUM,
+      delegationCid: "bafyTEST2",
+      delegationHeader: { Authorization: "Bearer x" },
+      verificationMethod: "did:key:zTest",
+      address: ADDR_CHECKSUM,
+      chainId: 1,
+      expiry: new Date(Date.now() + 3600_000).toISOString(),
+    };
+    // Must not throw OPENKEY_SCOPE_MISMATCH (expectedSpaces collapses to size 1).
+    const portable = portableFromOpenKeyDelegation(data, permissions, "https://host");
+    expect(portable.resources?.length).toBe(2);
+  });
+
+  test("still throws when OpenKey returns a genuinely different space", () => {
+    const permissions = [
+      cap("tinycloud.sql", SPACE_LOWER, "xyz.tinycloud.listen/conversations", ["read"]),
+    ];
+    const data = {
+      spaceId: `tinycloud:pkh:eip155:1:${ADDR_LOWER}:somethingelse`,
+      delegationCid: "bafyTEST3",
+      delegationHeader: { Authorization: "Bearer x" },
+      verificationMethod: "did:key:zTest",
+      address: ADDR_LOWER,
+      chainId: 1,
+    };
+    expect(() => portableFromOpenKeyDelegation(data, permissions, "https://host")).toThrow(
+      /OpenKey returned delegation/,
+    );
+  });
+});
+
+describe("groupPermissionsBySpace (case-insensitive batching)", () => {
+  test("same space differing by address casing batches into one group (one round-trip)", () => {
+    const permissions = [
+      cap("tinycloud.sql", SPACE_LOWER, "xyz.tinycloud.listen/conversations", ["read"]),
+      cap("tinycloud.kv", SPACE_CHECKSUM, "xyz.tinycloud.listen/", ["get", "list"]),
+    ];
+    const groups = groupPermissionsBySpace(permissions);
+    expect(groups.length).toBe(1);
+    expect(groups[0]!.length).toBe(2);
+  });
+
+  test("genuinely different spaces stay in separate groups", () => {
+    const permissions = [
+      cap("tinycloud.sql", SPACE_LOWER, "a", ["read"]),
+      cap("tinycloud.kv", `tinycloud:pkh:eip155:1:${ADDR_LOWER}:other`, "b", ["get"]),
+    ];
+    expect(groupPermissionsBySpace(permissions).length).toBe(2);
+  });
+});

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1013,7 +1013,7 @@ function parseExpiryOption(raw: unknown): string | number | undefined {
   return raw;
 }
 
-function groupPermissionsBySpace(permissions: PermissionEntry[]): PermissionEntry[][] {
+export function groupPermissionsBySpace(permissions: PermissionEntry[]): PermissionEntry[][] {
   const groups = new Map<string, PermissionEntry[]>();
   const rawEntries: PermissionEntry[] = [];
   for (const permission of permissions) {
@@ -1021,9 +1021,13 @@ function groupPermissionsBySpace(permissions: PermissionEntry[]): PermissionEntr
       rawEntries.push(permission);
       continue;
     }
-    const group = groups.get(permission.space) ?? [];
+    // Key case-insensitively so multiple caps on the same space batch into one
+    // OpenKey round-trip even when one cap's address is checksummed and another
+    // is lowercase. The entries keep their original space string.
+    const key = normalizeSpaceForCompare(permission.space);
+    const group = groups.get(key) ?? [];
     group.push(permission);
-    groups.set(permission.space, group);
+    groups.set(key, group);
   }
   const grouped = Array.from(groups.values());
   if (grouped.length === 0) {
@@ -1038,25 +1042,43 @@ function isRawPermission(permission: PermissionEntry): boolean {
     permission.path.startsWith("urn:tinycloud:encryption:");
 }
 
-function returnedSpaceMatchesExpected(returnedSpace: string, expectedSpace: string): boolean {
-  if (returnedSpace === expectedSpace) return true;
+/**
+ * Normalize a space identifier for case-insensitive comparison.
+ *
+ * Space URIs embed an eip155 Ethereum address (`tinycloud:pkh:eip155:<chain>:<0xADDR>:<name>`).
+ * Ethereum addresses are case-insensitive, but OpenKey returns the EIP-55
+ * checksummed form (mixed case) while the CLI builds the lowercase form, so a
+ * byte-for-byte compare spuriously fails. Lowercase the whole URI so the address
+ * segment matches regardless of checksum casing. The space name is ASCII
+ * `[A-Za-z0-9_-]` and lowercasing it is consistent on both sides.
+ */
+function normalizeSpaceForCompare(space: string): string {
+  return space.toLowerCase();
+}
+
+export function returnedSpaceMatchesExpected(returnedSpace: string, expectedSpace: string): boolean {
+  if (normalizeSpaceForCompare(returnedSpace) === normalizeSpaceForCompare(expectedSpace)) {
+    return true;
+  }
 
   if (!returnedSpace.startsWith("tinycloud:")) return false;
   const returnedName = returnedSpace.slice(returnedSpace.lastIndexOf(":") + 1);
-  return returnedName === expectedSpace;
+  return normalizeSpaceForCompare(returnedName) === normalizeSpaceForCompare(expectedSpace);
 }
 
-function portableFromOpenKeyDelegation(
+export function portableFromOpenKeyDelegation(
   data: Record<string, unknown>,
   permissions: PermissionEntry[],
   host: string,
 ): PortableDelegation {
   const primary = permissions.find((permission) => !isRawPermission(permission)) ?? permissions[0];
   const returnedSpace = String(data.spaceId ?? primary.space ?? "encryption");
+  // Normalize for the size check so that multiple caps on the same space that
+  // only differ by address checksum casing collapse to one expected space.
   const expectedSpaces = new Set(
     permissions
       .filter((permission) => !isRawPermission(permission))
-      .map((permission) => permission.space),
+      .map((permission) => normalizeSpaceForCompare(permission.space)),
   );
   const matchesExpectedSpace = expectedSpaces.size === 1 &&
     returnedSpaceMatchesExpected(returnedSpace, Array.from(expectedSpaces)[0]!);

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1021,9 +1021,10 @@ export function groupPermissionsBySpace(permissions: PermissionEntry[]): Permiss
       rawEntries.push(permission);
       continue;
     }
-    // Key case-insensitively so multiple caps on the same space batch into one
-    // OpenKey round-trip even when one cap's address is checksummed and another
-    // is lowercase. The entries keep their original space string.
+    // Key by address-normalized space so multiple caps on the same space batch
+    // into one OpenKey round-trip even when one cap's address is checksummed and
+    // another is lowercase. The space NAME stays case-sensitive, so genuinely
+    // different names are NOT merged. Entries keep their original space string.
     const key = normalizeSpaceForCompare(permission.space);
     const group = groups.get(key) ?? [];
     group.push(permission);
@@ -1043,17 +1044,21 @@ function isRawPermission(permission: PermissionEntry): boolean {
 }
 
 /**
- * Normalize a space identifier for case-insensitive comparison.
+ * Normalize a space identifier for case-insensitive comparison of its
+ * embedded Ethereum address ONLY.
  *
- * Space URIs embed an eip155 Ethereum address (`tinycloud:pkh:eip155:<chain>:<0xADDR>:<name>`).
- * Ethereum addresses are case-insensitive, but OpenKey returns the EIP-55
- * checksummed form (mixed case) while the CLI builds the lowercase form, so a
- * byte-for-byte compare spuriously fails. Lowercase the whole URI so the address
- * segment matches regardless of checksum casing. The space name is ASCII
- * `[A-Za-z0-9_-]` and lowercasing it is consistent on both sides.
+ * Space URIs are `tinycloud:pkh:eip155:<chain>:<0xADDR>:<name>`. Ethereum
+ * addresses are case-insensitive, but OpenKey returns the EIP-55 checksummed
+ * form (mixed case) while the CLI builds the lowercase form, so a byte-for-byte
+ * compare spuriously fails. Lowercase ONLY the `eip155:<chain>:0x<addr>` address
+ * segment and leave everything else — crucially the space NAME, which repo
+ * parsers treat as case-sensitive — byte-exact.
  */
 function normalizeSpaceForCompare(space: string): string {
-  return space.toLowerCase();
+  return space.replace(
+    /(eip155:\d+:)(0x[0-9a-fA-F]{40})/,
+    (_match, prefix: string, addr: string) => prefix + addr.toLowerCase(),
+  );
 }
 
 export function returnedSpaceMatchesExpected(returnedSpace: string, expectedSpace: string): boolean {
@@ -1062,8 +1067,10 @@ export function returnedSpaceMatchesExpected(returnedSpace: string, expectedSpac
   }
 
   if (!returnedSpace.startsWith("tinycloud:")) return false;
+  // expectedSpace may be a bare space NAME; the NAME is case-sensitive, so
+  // compare the returned URI's name segment byte-exact.
   const returnedName = returnedSpace.slice(returnedSpace.lastIndexOf(":") + 1);
-  return normalizeSpaceForCompare(returnedName) === normalizeSpaceForCompare(expectedSpace);
+  return returnedName === expectedSpace;
 }
 
 export function portableFromOpenKeyDelegation(


### PR DESCRIPTION
## Why (URGENT — blocks the user's Listen grant)

`tc auth request --grant` for an OpenKey profile fails with `OPENKEY_SCOPE_MISMATCH` when granting caps on a valid space. Root cause: the CLI compares the space the OpenKey node returns against the space it built for the request **byte-for-byte**. OpenKey returns the **EIP-55 checksummed** eip155 address (e.g. `0xd559CCd9...dE93cf412`); the CLI builds the **lowercase** form (`0xd559ccd9...de93cf412`). Ethereum addresses are case-insensitive, so this is a spurious failure.

## Fixes (`packages/cli/src/commands/auth.ts`)

**FIX 1 (blocking) — case-insensitive space comparison.** Added `normalizeSpaceForCompare()` (lowercases the whole space URI, which normalizes the embedded eip155 address segment; the space name is ASCII `[A-Za-z0-9_-]`). Applied it in:
- `returnedSpaceMatchesExpected()` — both the full-URI and bare-name comparisons.
- `portableFromOpenKeyDelegation()` — the `expectedSpaces` set, so caps on the same space that differ only by address casing collapse to one expected space (the `size === 1` guard then passes).

**FIX 2 — multiple `--cap` in one OpenKey round-trip.** The `--grant` openkey path already loops over `groupPermissionsBySpace()` (one `startAuthFlow` per space-group), so same-space caps were already meant to batch. Made the grouping **Map key case-insensitive** so two caps on the same space batch into a single browser round-trip even when one cap's address is checksummed and another is lowercase (previously they'd split into two round-trips). Entries keep their original space string.

## Verify command (the user's Listen case)
```
tc auth request --profile default \
  --cap "tinycloud.sql:<listen-space-uri>:xyz.tinycloud.listen/conversations:read" \
  --cap "tinycloud.kv:<listen-space-uri>:xyz.tinycloud.listen/:get,list" \
  --grant --yes
```
Both Listen caps are granted in one OpenKey round-trip without `OPENKEY_SCOPE_MISMATCH`, regardless of whether OpenKey returns the checksummed address.

## Tests (`auth.openkey-scope.test.ts`, 9 cases, all green against the real node-sdk build)
- checksummed-returned vs lowercase-expected (and vice-versa) match; bare-name suffix match; genuine difference does not.
- `portableFromOpenKeyDelegation` does NOT throw on the case difference; collapses two same-space caps (mixed casing) to one expected space; still throws on a genuinely different returned space.
- `groupPermissionsBySpace` batches same-space mixed-casing caps into one group; keeps genuinely different spaces separate.

The three helpers were made `export` to unit-test them directly.

## Notes
- Coordinated with auth-dx **PR #263** (also touches `auth.ts`): #263's edits are in the `auth grant` cross-identity path (`delegateTo`/`grantAuthRequest` swap near line 472) and the import line; my edits are isolated to `portableFromOpenKeyDelegation` / `returnedSpaceMatchesExpected` / `groupPermissionsBySpace` (~line 1016+). No line overlap — whichever merges first, the other should rebase cleanly.
- Pre-existing (NOT introduced here): the master CLI suite has 3 cross-file `mock.module`-bleed failures under `bun test` (2 in `space.test.ts`, 1 in `auth.test.ts`) that reproduce on a pristine checkout; each file passes in isolation. Flagging separately; out of scope for this fix.

Held for Codex + lead review — do not merge.