### PR TITLE
fix(node-sdk): case-insensitive eip155 address in runtime-grant space match

### DIFF
--- a/.changeset/runtime-grant-space-case-insensitive.md
+++ b/.changeset/runtime-grant-space-case-insensitive.md
@@ -1,0 +1,9 @@
+---
+"@tinycloud/node-sdk": patch
+---
+
+Fix runtime permission grants silently failing to match across EIP-155 address-case differences.
+
+`TinyCloudNode.operationCovers` compared a runtime grant's `spaceId` against the requested operation's `spaceId` byte-for-byte. Stored runtime delegations (e.g. from `tc auth request --grant`, replayed on every node create) keep the EIP-55 **checksummed** address, while a space URI built by the CLI is **lowercased** — so a valid granted capability never matched and the invocation fell back to the base session, surfacing as a spurious `401 AUTH_UNAUTHORIZED` ("active session missing capability") even though `tc auth caps` showed the cap.
+
+Ethereum addresses are case-insensitive; space comparison now lowercases ONLY the `eip155:<chain>:0x<addr>` address segment before comparing, leaving the case-sensitive space NAME byte-exact. This is the runtime-grant analogue of the CLI-layer `OPENKEY_SCOPE_MISMATCH` fix (`normalizeSpaceForCompare`).

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -274,6 +274,98 @@ describe("TinyCloudNode runtime permission delegations", () => {
     );
   });
 
+  test("matches a runtime grant across EIP-155 address-case differences", async () => {
+    // The grant stores its operation spaceId with the EIP-55 checksummed
+    // address (from the session). A real invocation routed through the CLI
+    // arrives with the SAME address lowercased (the CLI canonicalizes space
+    // URIs to lowercase). The casing is cosmetic — the grant must still match.
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const lowercasedSpaceId = `tinycloud:pkh:eip155:1:${address.toLowerCase()}:secrets`;
+    const permission: PermissionEntry = {
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "vault/secrets/ANTHROPIC_API_KEY",
+      actions: ["tinycloud.kv/put"],
+    };
+
+    await withActivatedDelegations(async () => {
+      await node.grantRuntimePermissions([permission]);
+    });
+
+    // Fallback (the base session for the request) carries the lowercased
+    // address; the granted operation carries the checksummed one.
+    const lowercasedFallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: lowercasedSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      lowercasedFallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/put",
+    );
+    // Before the fix the strict spaceId === comparison missed and fell back to
+    // base-token; now the case-insensitive compare selects the runtime grant.
+    expect(invoke.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "runtime-token",
+    );
+
+    // Symmetry: a checksummed-address request against a grant whose op space is
+    // lowercased must also match. Reinstall the grant under a lowercased space.
+    const lowercaseAddrNode = (() => {
+      const n = makeNode(invoke);
+      (n as any).auth.tinyCloudSession.address = address.toLowerCase();
+      (n as any).auth.tinyCloudSession.spaceId =
+        `tinycloud:pkh:eip155:1:${address.toLowerCase()}:default`;
+      return n;
+    })();
+    await withActivatedDelegations(async () => {
+      await lowercaseAddrNode.grantRuntimePermissions([permission]);
+    });
+    const checksummedFallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: `tinycloud:pkh:eip155:1:${address}:secrets`,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+    (lowercaseAddrNode as any).invokeWithRuntimePermissions(
+      checksummedFallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/put",
+    );
+    const lastCall = invoke.mock.calls[invoke.mock.calls.length - 1];
+    expect(lastCall[0].delegationHeader.Authorization).toBe("runtime-token");
+
+    // Only the address segment is case-normalized — the space NAME stays
+    // case-sensitive. A request for a differently-cased NAME must NOT match the
+    // grant (it falls back to the base session).
+    const wrongNameFallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: `tinycloud:pkh:eip155:1:${address.toLowerCase()}:SECRETS`,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+    (node as any).invokeWithRuntimePermissions(
+      wrongNameFallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/put",
+    );
+    const wrongNameCall = invoke.mock.calls[invoke.mock.calls.length - 1];
+    expect(wrongNameCall[0].delegationHeader.Authorization).toBe("base-token");
+  });
+
   test("expands vault shorthand before storing runtime delegation operations", async () => {
     const invoke = mock((session: any) => ({
       Authorization: session.delegationHeader.Authorization,

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -366,6 +366,70 @@ describe("TinyCloudNode runtime permission delegations", () => {
     expect(wrongNameCall[0].delegationHeader.Authorization).toBe("base-token");
   });
 
+  test("does NOT match a runtime grant for a different address or chain", async () => {
+    // The case-insensitive compare normalizes ONLY the casing of the eip155
+    // address segment. A genuinely different owner (a different 40-hex address)
+    // or a different chain id is NOT the same space and must never be covered by
+    // the grant — the request falls back to the base session token.
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const permission: PermissionEntry = {
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "vault/secrets/ANTHROPIC_API_KEY",
+      actions: ["tinycloud.kv/put"],
+    };
+
+    await withActivatedDelegations(async () => {
+      await node.grantRuntimePermissions([permission]);
+    });
+
+    // A request whose space embeds a DIFFERENT owner address (same length, same
+    // chain, same name) must not be covered — case normalization is not address
+    // equivalence.
+    const otherAddress = "0xAbAdBabeAbAdBabeAbAdBabeAbAdBabeAbAdBabe";
+    const otherAddressFallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: `tinycloud:pkh:eip155:1:${otherAddress}:secrets`,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+    (node as any).invokeWithRuntimePermissions(
+      otherAddressFallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/put",
+    );
+    expect(
+      invoke.mock.calls[invoke.mock.calls.length - 1][0].delegationHeader
+        .Authorization,
+    ).toBe("base-token");
+
+    // A request on a DIFFERENT chain id (same address, same name) must not be
+    // covered either — the chain segment is part of the space identity.
+    const otherChainFallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: `tinycloud:pkh:eip155:137:${address}:secrets`,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+    (node as any).invokeWithRuntimePermissions(
+      otherChainFallback,
+      "kv",
+      "vault/secrets/ANTHROPIC_API_KEY",
+      "tinycloud.kv/put",
+    );
+    expect(
+      invoke.mock.calls[invoke.mock.calls.length - 1][0].delegationHeader
+        .Authorization,
+    ).toBe("base-token");
+  });
+
   test("expands vault shorthand before storing runtime delegation operations", async () => {
     const invoke = mock((session: any) => ({
       Authorization: session.delegationHeader.Authorization,

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -3505,8 +3505,26 @@ export class TinyCloudNode {
 
     return granted.spaceId !== undefined &&
       requested.spaceId !== undefined &&
-      granted.spaceId === requested.spaceId &&
+      this.spaceIdsEqual(granted.spaceId, requested.spaceId) &&
       this.pathContains(granted.path, requested.path);
+  }
+
+  // Space IDs are `tinycloud:pkh:eip155:<chain>:<0xADDR>:<name>`. The embedded
+  // EIP-155 address is case-insensitive, but the CLI canonicalizes it to
+  // lowercase when building a space URI while stored runtime delegations keep
+  // the EIP-55 checksummed form — so a byte-for-byte compare spuriously rejects
+  // an otherwise-valid grant. Lowercase ONLY the `eip155:<chain>:0x<addr>`
+  // segment and leave everything else (crucially the case-sensitive space NAME)
+  // byte-exact. Mirrors the CLI's `normalizeSpaceForCompare` (OPENKEY_SCOPE_MISMATCH fix).
+  private spaceIdsEqual(a: string, b: string): boolean {
+    return this.normalizeSpaceAddress(a) === this.normalizeSpaceAddress(b);
+  }
+
+  private normalizeSpaceAddress(space: string): string {
+    return space.replace(
+      /(eip155:\d+:)(0x[0-9a-fA-F]{40})/,
+      (_match, prefix: string, addr: string) => prefix + addr.toLowerCase(),
+    );
   }
 
   private actionContains(grantedAction: string, requestedAction: string): boolean {


### PR DESCRIPTION
## Problem

A granted *additional* runtime delegation (e.g. from `tc auth request --grant`, replayed on every node create via `lib/sdk.ts`) showed up in `tc auth caps` but a fresh cross-space SQL/KV invoke still returned `401 AUTH_UNAUTHORIZED` ("active session missing capability").

Root cause: `TinyCloudNode.operationCovers` compared the runtime grant's `spaceId` to the requested operation's `spaceId` byte-for-byte (`granted.spaceId === requested.spaceId`). Stored runtime delegations keep the **EIP-55 checksummed** address (`0xd559CCd9...dE93cf412`) while a space URI built by the CLI is **lowercased** (`resolveSpaceUri` / `canonicalizeAddress`). The casing difference alone made a valid granted capability fail to match, so the invocation fell back to the base session and 401'd.

This is the runtime-grant analogue of the CLI-layer `OPENKEY_SCOPE_MISMATCH` fix (#264).

## Fix

Lowercase **only** the `eip155:<chain>:0x<addr>` segment before comparing, leaving everything else — crucially the case-sensitive space NAME — byte-exact. Mirrors the CLI's `normalizeSpaceForCompare`.

```diff
-      granted.spaceId === requested.spaceId &&
+      this.spaceIdsEqual(granted.spaceId, requested.spaceId) &&
```

## Test

New regression test `matches a runtime grant across EIP-155 address-case differences`:
- checksummed-address grant covers a lowercased-address operation (the production case),
- the reverse direction (lowercased grant, checksummed request),
- and locks that a differently-cased space NAME does **not** match (address-only normalization).

Verified the test fails without the fix (`base-token` instead of `runtime-token`, reproducing the 401) and passes with it. Full node-sdk suite: 76 pass / 0 fail.

## Verification context

This unblocked the first real Listen → distillery artifact → TinyCloud publish (read Listen conversations from the owner's `applications` space via a granted delegation that previously 401'd).

🤖 Found and fixed while running the artifact-pipeline; flagged for Codex review before merge.