### PR TITLE
feat(web-sdk): allow suppressing runtime permission prompt

### DIFF
--- a/.changeset/permission-prompt-suppression.md
+++ b/.changeset/permission-prompt-suppression.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/web-sdk": patch
+---
+
+Add a 30-day opt-out checkbox to the runtime permission request prompt so repeat permission escalations on the same page can skip the SDK explainer modal while still requiring the runtime permission grant.

--- a/packages/web-sdk/src/modules/permissionPromptSuppression.ts
+++ b/packages/web-sdk/src/modules/permissionPromptSuppression.ts
@@ -1,0 +1,102 @@
+import type { Manifest } from "@tinycloud/sdk-core";
+
+const STORAGE_PREFIX = "tinycloud:permission-prompt-suppression:";
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface SuppressionRecord {
+  expiresAt: number;
+}
+
+interface SuppressionOptions {
+  storage?: Storage;
+  now?: () => number;
+  pageScope?: string;
+}
+
+function defaultStorage(): Storage | undefined {
+  return typeof globalThis.localStorage !== "undefined"
+    ? globalThis.localStorage
+    : undefined;
+}
+
+function defaultPageScope(): string {
+  if (typeof globalThis.location === "undefined") {
+    return "unknown-page";
+  }
+
+  return `${globalThis.location.origin}${globalThis.location.pathname}`;
+}
+
+function storageKey(manifest: Manifest, pageScope: string): string {
+  return `${STORAGE_PREFIX}${encodeURIComponent(pageScope)}:${encodeURIComponent(
+    manifest.app_id,
+  )}`;
+}
+
+export function isPermissionPromptSuppressed(
+  manifest: Manifest,
+  options: SuppressionOptions = {},
+): boolean {
+  const storage = options.storage ?? defaultStorage();
+  if (!storage) return false;
+
+  const key = storageKey(
+    manifest,
+    options.pageScope ?? defaultPageScope(),
+  );
+  let raw: string | null;
+  try {
+    raw = storage.getItem(key);
+  } catch {
+    return false;
+  }
+  if (!raw) return false;
+
+  try {
+    const parsed = JSON.parse(raw) as SuppressionRecord;
+    const now = options.now?.() ?? Date.now();
+    if (
+      typeof parsed.expiresAt !== "number" ||
+      !Number.isFinite(parsed.expiresAt) ||
+      parsed.expiresAt <= now
+    ) {
+      try {
+        storage.removeItem(key);
+      } catch {
+        // A failed cleanup should not block the permission flow.
+      }
+      return false;
+    }
+    return true;
+  } catch {
+    try {
+      storage.removeItem(key);
+    } catch {
+      // A failed cleanup should not block the permission flow.
+    }
+    return false;
+  }
+}
+
+export function suppressPermissionPromptFor30Days(
+  manifest: Manifest,
+  options: SuppressionOptions = {},
+): void {
+  const storage = options.storage ?? defaultStorage();
+  if (!storage) return;
+
+  const now = options.now?.() ?? Date.now();
+  const key = storageKey(
+    manifest,
+    options.pageScope ?? defaultPageScope(),
+  );
+  try {
+    storage.setItem(
+      key,
+      JSON.stringify({ expiresAt: now + THIRTY_DAYS_MS }),
+    );
+  } catch {
+    // Storage is a convenience for suppressing this SDK prompt. If it is
+    // unavailable, the grant itself should still succeed.
+  }
+}

--- a/packages/web-sdk/src/modules/requestPermissionsCore.ts
+++ b/packages/web-sdk/src/modules/requestPermissionsCore.ts
@@ -26,7 +26,14 @@ export interface RequestPermissionsCoreDeps {
     appName: string;
     appIcon?: string;
     additional: PermissionEntry[];
-  }) => Promise<{ approved: boolean }>;
+  }) => Promise<{
+    approved: boolean;
+    suppressPromptFor30Days?: boolean;
+  }>;
+  /** Whether this page/app has opted out of the SDK explainer prompt. */
+  isPromptSuppressed?: () => boolean;
+  /** Persist a successful opt-out from the SDK explainer prompt. */
+  suppressPromptFor30Days?: () => void;
   /** Store approved permissions as runtime delegations. */
   grantPermissions: (
     additional: PermissionEntry[],
@@ -63,17 +70,26 @@ export async function requestPermissionsCore(
 ): Promise<RequestPermissionsCoreResult> {
   validateAdditionalPermissions(additional);
 
-  const modalResult = await deps.showModal({
-    appName: deps.manifest.name,
-    appIcon: deps.manifest.icon,
-    additional,
-  });
+  let shouldSuppressPrompt = false;
+  if (deps.isPromptSuppressed?.() !== true) {
+    const modalResult = await deps.showModal({
+      appName: deps.manifest.name,
+      appIcon: deps.manifest.icon,
+      additional,
+    });
 
-  if (!modalResult.approved) {
-    return { approved: false };
+    if (!modalResult.approved) {
+      return { approved: false };
+    }
+
+    shouldSuppressPrompt = modalResult.suppressPromptFor30Days === true;
   }
 
   const delegations = await deps.grantPermissions(additional);
+
+  if (shouldSuppressPrompt) {
+    deps.suppressPromptFor30Days?.();
+  }
 
   return Array.isArray(delegations)
     ? { approved: true, delegations }

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -57,6 +57,10 @@ import {
   validateAdditionalPermissions,
 } from "./requestPermissionsCore";
 import {
+  isPermissionPromptSuppressed,
+  suppressPermissionPromptFor30Days,
+} from "./permissionPromptSuppression";
+import {
   clientSessionFromPersisted,
   restoreDataFromPersisted,
 } from "./browserSessionPersistence";
@@ -288,7 +292,10 @@ export class TinyCloudWeb {
       appName: string;
       appIcon?: string;
       additional: PermissionEntry[];
-    }) => Promise<{ approved: boolean }>;
+    }) => Promise<{
+      approved: boolean;
+      suppressPromptFor30Days?: boolean;
+    }>;
     hasRuntimePermissions?: (additional: PermissionEntry[]) => boolean;
     grantPermissions?: (
       additional: PermissionEntry[],
@@ -743,6 +750,9 @@ export class TinyCloudWeb {
     const result = await requestPermissionsCore(additional, {
       manifest,
       showModal: this._testHooks?.showModal ?? showPermissionRequestModal,
+      isPromptSuppressed: () => isPermissionPromptSuppressed(manifest),
+      suppressPromptFor30Days: () =>
+        suppressPermissionPromptFor30Days(manifest),
       grantPermissions: this._testHooks?.grantPermissions ??
         ((approved) => node.grantRuntimePermissions(approved)),
     });

--- a/packages/web-sdk/src/notifications/PermissionRequestModal.ts
+++ b/packages/web-sdk/src/notifications/PermissionRequestModal.ts
@@ -29,6 +29,8 @@ export interface PermissionRequestModalOptions {
 export interface PermissionRequestResult {
   /** True when the user clicked Approve, false when they declined or dismissed. */
   approved: boolean;
+  /** True when the user opted out of this SDK prompt for the next 30 days. */
+  suppressPromptFor30Days?: boolean;
 }
 
 export class TinyCloudPermissionRequestModal extends HTMLElement {
@@ -99,6 +101,10 @@ export class TinyCloudPermissionRequestModal extends HTMLElement {
                 This app is asking you to grant scoped permission. Review what it will be allowed to do before approving.
               </p>
               <ul class="permission-list">${entriesHtml}</ul>
+              <label class="suppression-option">
+                <input type="checkbox" class="suppression-checkbox" data-role="suppress-prompt" />
+                <span>Do not show me again for 30 days</span>
+              </label>
             </div>
 
             <div class="modal-actions">
@@ -240,6 +246,16 @@ export class TinyCloudPermissionRequestModal extends HTMLElement {
         border: 1px solid var(--modal-border);
         border-radius: 10px; padding: 14px;
       }
+      .suppression-option {
+        display: flex; align-items: center; gap: 10px;
+        margin-top: 16px; color: var(--modal-muted);
+        font-size: 13px; line-height: 1.4; cursor: pointer;
+      }
+      .suppression-checkbox {
+        width: 16px; height: 16px; flex: 0 0 auto;
+        margin: 0; accent-color: var(--modal-accent);
+      }
+      .suppression-option:hover { color: var(--modal-foreground); }
       .entry-summary {
         font-size: 13px; line-height: 1.45; color: var(--modal-muted);
         margin: 10px 0;
@@ -362,7 +378,13 @@ export class TinyCloudPermissionRequestModal extends HTMLElement {
   };
 
   private handleApprove(): void {
-    this.resolveResult?.({ approved: true });
+    const checkbox = this.shadowRoot!.querySelector(
+      '[data-role="suppress-prompt"]',
+    ) as HTMLInputElement | null;
+    this.resolveResult?.({
+      approved: true,
+      suppressPromptFor30Days: checkbox?.checked === true,
+    });
     this.hide();
   }
 

--- a/packages/web-sdk/tests/PermissionRequestModal.test.ts
+++ b/packages/web-sdk/tests/PermissionRequestModal.test.ts
@@ -166,6 +166,9 @@ describe("TinyCloudPermissionRequestModal", () => {
     expect(modal.shadowRoot.innerHTML).toContain("Read key-value data");
     expect(modal.shadowRoot.innerHTML).toContain("Show technical details");
     expect(modal.shadowRoot.innerHTML).toContain("This app is asking you");
+    expect(modal.shadowRoot.innerHTML).toContain(
+      "Do not show me again for 30 days",
+    );
   });
 
   test("describes secret writes as secret permissions", async () => {
@@ -227,7 +230,29 @@ describe("TinyCloudPermissionRequestModal", () => {
     (modal as any).handleApprove();
 
     const result = await modal.getCompletionPromise();
-    expect(result).toEqual({ approved: true });
+    expect(result).toEqual({
+      approved: true,
+      suppressPromptFor30Days: false,
+    });
+  });
+
+  test("approve includes prompt suppression when checkbox is checked", async () => {
+    const Modal = await loadModal();
+    const modal = new Modal(sampleOptions);
+    modal.connectedCallback();
+
+    const checkedElement = {
+      checked: true,
+      setAttribute: () => {},
+    };
+    modal.shadowRoot.querySelector = () => checkedElement as any;
+    (modal as any).handleApprove();
+
+    const result = await modal.getCompletionPromise();
+    expect(result).toEqual({
+      approved: true,
+      suppressPromptFor30Days: true,
+    });
   });
 
   test("dismiss resolves with { approved: false }", async () => {

--- a/packages/web-sdk/tests/permissionPromptSuppression.test.ts
+++ b/packages/web-sdk/tests/permissionPromptSuppression.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Manifest } from "@tinycloud/sdk-core";
+
+import {
+  isPermissionPromptSuppressed,
+  suppressPermissionPromptFor30Days,
+} from "../src/modules/permissionPromptSuppression";
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length(): number {
+    return this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.items.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value);
+  }
+}
+
+class ThrowingStorage extends MemoryStorage {
+  getItem(_key: string): string | null {
+    throw new Error("storage unavailable");
+  }
+
+  setItem(_key: string, _value: string): void {
+    throw new Error("storage unavailable");
+  }
+}
+
+const manifest: Manifest = {
+  app_id: "com.test.app",
+  name: "Test App",
+};
+
+describe("permission prompt suppression", () => {
+  test("remembers suppression for the same page and app", () => {
+    const storage = new MemoryStorage();
+
+    suppressPermissionPromptFor30Days(manifest, {
+      storage,
+      now: () => 1_000,
+      pageScope: "https://example.com/app",
+    });
+
+    expect(
+      isPermissionPromptSuppressed(manifest, {
+        storage,
+        now: () => 2_000,
+        pageScope: "https://example.com/app",
+      }),
+    ).toBe(true);
+  });
+
+  test("does not carry suppression to a different page", () => {
+    const storage = new MemoryStorage();
+
+    suppressPermissionPromptFor30Days(manifest, {
+      storage,
+      now: () => 1_000,
+      pageScope: "https://example.com/app",
+    });
+
+    expect(
+      isPermissionPromptSuppressed(manifest, {
+        storage,
+        now: () => 2_000,
+        pageScope: "https://example.com/other",
+      }),
+    ).toBe(false);
+  });
+
+  test("expires and removes old suppression records", () => {
+    const storage = new MemoryStorage();
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+
+    suppressPermissionPromptFor30Days(manifest, {
+      storage,
+      now: () => 1_000,
+      pageScope: "https://example.com/app",
+    });
+
+    expect(
+      isPermissionPromptSuppressed(manifest, {
+        storage,
+        now: () => 1_000 + thirtyDaysMs + 1,
+        pageScope: "https://example.com/app",
+      }),
+    ).toBe(false);
+    expect(storage.length).toBe(0);
+  });
+
+  test("falls back to showing the prompt when storage is unavailable", () => {
+    expect(
+      isPermissionPromptSuppressed(manifest, {
+        storage: new ThrowingStorage(),
+        pageScope: "https://example.com/app",
+      }),
+    ).toBe(false);
+    expect(() =>
+      suppressPermissionPromptFor30Days(manifest, {
+        storage: new ThrowingStorage(),
+        pageScope: "https://example.com/app",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/web-sdk/tests/requestPermissionsCore.test.ts
+++ b/packages/web-sdk/tests/requestPermissionsCore.test.ts
@@ -128,6 +128,65 @@ describe("requestPermissionsCore: approve", () => {
     expect(granted).toEqual(additional);
   });
 
+  test("persists prompt suppression after approved permissions are granted", async () => {
+    const order: string[] = [];
+    const suppressPromptFor30Days = mock(() => {
+      order.push("suppressPromptFor30Days");
+    });
+
+    await requestPermissionsCore(additional, {
+      manifest: baseManifest,
+      showModal: async () => ({
+        approved: true,
+        suppressPromptFor30Days: true,
+      }),
+      suppressPromptFor30Days,
+      grantPermissions: async () => {
+        order.push("grantPermissions");
+      },
+    });
+
+    expect(suppressPromptFor30Days).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["grantPermissions", "suppressPromptFor30Days"]);
+  });
+
+  test("does not persist prompt suppression when granting fails", async () => {
+    const err = new Error("grant failed");
+    const suppressPromptFor30Days = mock(() => {});
+
+    await expect(
+      requestPermissionsCore(additional, {
+        manifest: baseManifest,
+        showModal: async () => ({
+          approved: true,
+          suppressPromptFor30Days: true,
+        }),
+        suppressPromptFor30Days,
+        grantPermissions: async () => {
+          throw err;
+        },
+      }),
+    ).rejects.toBe(err);
+
+    expect(suppressPromptFor30Days).not.toHaveBeenCalled();
+  });
+
+  test("skips the modal when the page/app prompt is suppressed", async () => {
+    const showModal = mock(async () => ({ approved: false }));
+    const grantPermissions = mock(async () => {});
+
+    const result = await requestPermissionsCore(additional, {
+      manifest: baseManifest,
+      showModal,
+      isPromptSuppressed: () => true,
+      grantPermissions,
+    });
+
+    expect(result).toEqual({ approved: true });
+    expect(showModal).not.toHaveBeenCalled();
+    expect(grantPermissions).toHaveBeenCalledWith(additional);
+  });
+
   test("returns runtime delegations from the grant step", async () => {
     const delegation = { cid: "runtime-cid" } as any;
 


### PR DESCRIPTION
## Summary
- add a "Do not show me again for 30 days" checkbox to the web-sdk runtime permission modal
- persist the SDK prompt suppression per app/page for 30 days in localStorage
- skip only the SDK explainer modal when suppressed; runtime permission grants still call node.grantRuntimePermissions
- add focused tests and a web-sdk patch changeset

## Verification
- bun test packages/web-sdk/tests/requestPermissionsCore.test.ts packages/web-sdk/tests/permissionPromptSuppression.test.ts packages/web-sdk/tests/PermissionRequestModal.test.ts

## Notes
- Full packages/web-sdk test folder had unrelated existing failures before PR creation: missing eth-testing, missing dist/index.cjs, old @tinycloud/sdk-core package resolution, and SIWE extension expectation failures.