### PR TITLE
Ensure requested encryption networks on sign-in

### DIFF
--- a/.changeset/encryption-network-signin-create.md
+++ b/.changeset/encryption-network-signin-create.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Automatically ensure owner-owned encryption networks exist during manifest-driven sign-in. When a requested `tinycloud.encryption/decrypt` permission targets the signed-in user's network ID, the SDK adds a separate scoped `tinycloud.encryption/network.create` sign-in grant and `signIn()` creates the network if the node reports it missing.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ This monorepo contains the following packages:
 
 ## Quick Start
 
+### Encryption Network Sign-In
+
+When a manifest or composed capability request includes
+`tinycloud.encryption/decrypt` for one of the signed-in user's own network IDs,
+the SDK adds a separate sign-in grant for
+`tinycloud.encryption/network.create` on that same network. After sign-in, the
+SDK checks whether the network exists and creates it when missing, mirroring
+`autoCreateSpace` behavior for newly hosted spaces.
+
+This is the path used by apps such as Listen that request the user's default
+network (`urn:tinycloud:encryption:<ownerDid>:default`) during manifest-driven
+sign-in before delegating decrypt access to a backend.
+
 ### Browser SDK
 
 ```bash

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -393,6 +393,119 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     );
   });
 
+  test("signIn adds a create grant and ensures requested owner encryption networks exist", async () => {
+    const networkId =
+      "urn:tinycloud:encryption:did:pkh:eip155:1:0x0000000000000000000000000000000000000001:default";
+    const wasm = makeFakeWasmBindings();
+    const node = makeNodeWithSigner(wasm, {
+      includeAccountRegistryPermissions: false,
+      manifest: {
+        app_id: "com.listen.app",
+        name: "Listen",
+        defaults: false,
+        permissions: [
+          {
+            service: "tinycloud.encryption",
+            path: networkId,
+            actions: ["decrypt"],
+          },
+        ],
+      },
+    });
+    const ensureEncryptionNetwork = mock(async () => ({
+      networkId,
+      name: "default",
+      ownerDid: "did:pkh:eip155:1:0x0000000000000000000000000000000000000001",
+      threshold: { n: 1, t: 1 },
+      participants: [],
+      publicEncryptionKey: "",
+      state: "active",
+      createdAt: new Date().toISOString(),
+    }));
+    (node as any).ensureEncryptionNetwork = ensureEncryptionNetwork;
+
+    await withFetchResponses(
+      [
+        new Response(
+          JSON.stringify({
+            protocol: 1,
+            version: "test",
+            features: ["encryption"],
+            nodeId: "did:key:z6MkNode",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        new Response(JSON.stringify({ activated: ["space://test"], skipped: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ],
+      async () => {
+        await node.signIn();
+      },
+    );
+
+    expect(ensureEncryptionNetwork).toHaveBeenCalledTimes(1);
+    expect(ensureEncryptionNetwork).toHaveBeenCalledWith(networkId);
+    expect((wasm.prepareSession as any).mock.calls[0][0].rawAbilities).toEqual({
+      [networkId]: [
+        "tinycloud.encryption/decrypt",
+        "tinycloud.encryption/network.create",
+      ],
+    });
+  });
+
+  test("signIn does not add a create grant for another owner's encryption network", async () => {
+    const networkId =
+      "urn:tinycloud:encryption:did:pkh:eip155:1:0x0000000000000000000000000000000000000002:default";
+    const wasm = makeFakeWasmBindings();
+    const node = makeNodeWithSigner(wasm, {
+      includeAccountRegistryPermissions: false,
+      manifest: {
+        app_id: "com.listen.app",
+        name: "Listen",
+        defaults: false,
+        permissions: [
+          {
+            service: "tinycloud.encryption",
+            path: networkId,
+            actions: ["decrypt"],
+          },
+        ],
+      },
+    });
+    const ensureEncryptionNetwork = mock(async () => {
+      throw new Error("should not create another owner's network");
+    });
+    (node as any).ensureEncryptionNetwork = ensureEncryptionNetwork;
+
+    await withFetchResponses(
+      [
+        new Response(
+          JSON.stringify({
+            protocol: 1,
+            version: "test",
+            features: ["encryption"],
+            nodeId: "did:key:z6MkNode",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        new Response(JSON.stringify({ activated: ["space://test"], skipped: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ],
+      async () => {
+        await node.signIn();
+      },
+    );
+
+    expect(ensureEncryptionNetwork).not.toHaveBeenCalled();
+    expect((wasm.prepareSession as any).mock.calls[0][0].rawAbilities).toEqual({
+      [networkId]: ["tinycloud.encryption/decrypt"],
+    });
+  });
+
   test("manifest registry write does not re-host existing account space", async () => {
     const node = makeNodeWithSigner(makeFakeWasmBindings());
     const auth = (node as any).auth;

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -108,6 +108,7 @@ import {
   canonicalizeAddress,
   pkhDid,
   principalDidEquals,
+  parseNetworkId,
   type BuildDecryptInvocationInput,
   type BuiltDecryptInvocation,
   type CanonicalJson,
@@ -786,6 +787,8 @@ export class TinyCloudNode {
     // Initialize service context with session
     this.initializeServices();
 
+    await this.ensureRequestedEncryptionNetworks();
+
     if (this.config.manifest === undefined && this.config.capabilityRequest === undefined) {
       await this.ensureOwnedSpaceHosted(this.ownedSpaceId("secrets"));
     }
@@ -826,6 +829,39 @@ export class TinyCloudNode {
           `Failed to write manifest registry record ${record.key}: ${result.error.message}`,
         );
       }
+    }
+  }
+
+  private requestedEncryptionNetworkIds(): string[] {
+    const request = this.capabilityRequest;
+    if (!request) {
+      return [];
+    }
+
+    const networkIds = new Set<string>();
+    for (const resource of request.resources) {
+      if (
+        resource.service === ENCRYPTION_PERMISSION_SERVICE &&
+        resource.path.startsWith("urn:tinycloud:encryption:") &&
+        resource.actions.includes(DECRYPT_ACTION)
+      ) {
+        networkIds.add(resource.path);
+      }
+    }
+    return [...networkIds];
+  }
+
+  private async ensureRequestedEncryptionNetworks(): Promise<void> {
+    if (!this.signer || !this.auth) {
+      return;
+    }
+
+    for (const networkId of this.requestedEncryptionNetworkIds()) {
+      const parsed = parseNetworkId(networkId);
+      if (!didPrincipalMatches(parsed.ownerDid, this.did)) {
+        continue;
+      }
+      await this.ensureEncryptionNetwork(networkId);
     }
   }
 
@@ -2055,13 +2091,22 @@ export class TinyCloudNode {
   }
 
   async ensureEncryptionNetwork(
-    name = DEFAULT_ENCRYPTION_NETWORK_NAME,
+    nameOrNetworkId = DEFAULT_ENCRYPTION_NETWORK_NAME,
   ): Promise<NetworkDescriptor> {
-    const existing = await this.getEncryptionNetwork(name);
+    const networkId = nameOrNetworkId.startsWith("urn:tinycloud:encryption:")
+      ? nameOrNetworkId
+      : this.getDefaultEncryptionNetworkId(nameOrNetworkId);
+    const existing = await this.getEncryptionNetwork(networkId);
     if (existing) {
       return existing;
     }
-    return this.createEncryptionNetwork(name);
+    const parsed = parseNetworkId(networkId);
+    if (!didPrincipalMatches(parsed.ownerDid, this.did)) {
+      throw new Error(
+        `Cannot create encryption network ${networkId}: owner ${parsed.ownerDid} does not match signed-in DID ${this.did}`,
+      );
+    }
+    return this.createEncryptionNetwork(parsed.name);
   }
 
   /**

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -23,6 +23,8 @@ import {
   DEFAULT_MANIFEST_SPACE,
   ENCRYPTION_PERMISSION_SERVICE,
   composeManifestRequest,
+  parseNetworkId,
+  principalDidEquals,
   resourceCapabilitiesToAbilitiesMap,
   resourceCapabilitiesToSpaceAbilitiesMap,
   resolveTinyCloudHosts,
@@ -38,6 +40,32 @@ import {
   defaultSignStrategy,
 } from "./strategies";
 import { MemorySessionStorage } from "../storage/MemorySessionStorage";
+
+const DECRYPT_ACTION = "tinycloud.encryption/decrypt";
+const NETWORK_CREATE_ACTION = "tinycloud.encryption/network.create";
+
+function didPrincipalMatches(actual: string, expected: string): boolean {
+  try {
+    return principalDidEquals(actual, expected);
+  } catch {
+    return actual === expected;
+  }
+}
+
+function addRawAbility(
+  rawAbilities: Record<string, string[]>,
+  resource: string,
+  action: string,
+): void {
+  const actions = rawAbilities[resource];
+  if (actions === undefined) {
+    rawAbilities[resource] = [action];
+    return;
+  }
+  if (!actions.includes(action)) {
+    actions.push(action);
+  }
+}
 
 /**
  * Configuration for NodeUserAuthorization.
@@ -435,20 +463,18 @@ export class NodeUserAuthorization implements IUserAuthorization {
     }
 
     const rawAbilities: Record<string, string[]> = {};
+    const currentDid = pkhDid(address, chainId);
     const spaceResources = request.resources.filter((entry) => {
       if (entry.service !== ENCRYPTION_PERMISSION_SERVICE) {
         return true;
       }
-      const existing = rawAbilities[entry.path];
-      if (existing === undefined) {
-        rawAbilities[entry.path] = [...entry.actions];
-      } else {
-        const seen = new Set(existing);
-        for (const action of entry.actions) {
-          if (!seen.has(action)) {
-            existing.push(action);
-            seen.add(action);
-          }
+      for (const action of entry.actions) {
+        addRawAbility(rawAbilities, entry.path, action);
+      }
+      if (entry.actions.includes(DECRYPT_ACTION)) {
+        const parsed = parseNetworkId(entry.path);
+        if (didPrincipalMatches(parsed.ownerDid, currentDid)) {
+          addRawAbility(rawAbilities, entry.path, NETWORK_CREATE_ACTION);
         }
       }
       return false;


### PR DESCRIPTION
## Summary
- add a scoped SDK-added network.create grant when sign-in requests decrypt on the signed-in user's encryption network
- ensure requested owner-owned encryption networks exist after sign-in service initialization
- cover owner and non-owner network behavior in manifest sign-in tests
- document the behavior and add a changeset

## Tests
- bun test packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts packages/sdk-core/src/manifest.encryption.test.ts packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
- bun run --cwd packages/client test (in Listen)

## Note
- bun run --cwd packages/node-sdk build still fails during DTS because @tinycloud/node-sdk-wasm does not export invokeAny or parseRecapFromSiwe in this local checkout; JS build output is emitted before DTS fails.