### PR TITLE
Send OpenKey permission request reasons from TinyCloud CLI

### DIFF
--- a/.changeset/openkey-reason.md
+++ b/.changeset/openkey-reason.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/cli": patch
+---
+
+Send a user-facing `reason` when TinyCloud CLI opens OpenKey permission approval flows, so the consent page can show why the requested capabilities are needed.

--- a/packages/cli/src/auth/browser-auth.test.ts
+++ b/packages/cli/src/auth/browser-auth.test.ts
@@ -43,4 +43,30 @@ describe("browser auth delegation URLs", () => {
       x: "public-key",
     });
   });
+
+  test("includes permission request reason for OpenKey consent", () => {
+    const url = buildAuthUrl("did:key:z6MkDelegate", {
+      openkeyHost: "https://openkey.test",
+      reason: "Allow `tc secrets get DEPLOY_KEY` to read and decrypt this secret.",
+      permissions: [
+        {
+          service: "tinycloud.kv",
+          space: "secrets",
+          path: "vault/secrets/DEPLOY_KEY",
+          actions: ["tinycloud.kv/get"],
+        },
+      ],
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("reason")).toBe(
+      "Allow `tc secrets get DEPLOY_KEY` to read and decrypt this secret.",
+    );
+
+    const payload = JSON.parse(
+      Buffer.from(parsed.searchParams.get("permissions")!, "base64url").toString("utf8"),
+    );
+    expect(payload.reason).toBe("Allow `tc secrets get DEPLOY_KEY` to read and decrypt this secret.");
+    expect(payload.permissions).toHaveLength(1);
+  });
 });

--- a/packages/cli/src/auth/browser-auth.ts
+++ b/packages/cli/src/auth/browser-auth.ts
@@ -18,6 +18,12 @@ interface AuthFlowOptions {
   host?: string;
   permissions?: PermissionEntry[];
   /**
+   * User-facing context shown on the OpenKey approval page. Optional at the
+   * OpenKey protocol boundary, but TinyCloud CLI permission-grant call sites
+   * should always provide it.
+   */
+  reason?: string;
+  /**
    * OpenKey base URL. Resolution order in callers: TC_OPENKEY_HOST env →
    * profile.openkeyHost → DEFAULT_OPENKEY_HOST. Threaded explicitly so this
    * module stays free of profile lookups.
@@ -96,11 +102,18 @@ export function buildAuthUrl(did: string, options: AuthFlowOptions & { callback?
   if (options.host) {
     params.set("host", options.host);
   }
+  const reason = typeof options.reason === "string" ? options.reason.trim() : "";
   if (options.permissions?.length) {
     params.set(
       "permissions",
-      Buffer.from(JSON.stringify({ permissions: options.permissions })).toString("base64url"),
+      Buffer.from(JSON.stringify({
+        permissions: options.permissions,
+        ...(reason ? { reason } : {}),
+      })).toString("base64url"),
     );
+  }
+  if (reason) {
+    params.set("reason", reason);
   }
   if (options.expiry !== undefined) {
     params.set("expiry", String(options.expiry));

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -62,6 +62,7 @@ const recorded = {
       openkeyHost?: string;
       permissions?: unknown[];
       expiry?: string | number;
+      reason?: string;
     };
   }>,
   localSignIns: [] as Array<{ privateKey: string; host: string }>,
@@ -505,6 +506,7 @@ describe("CLI auth rotate command", () => {
         },
       ],
       expiryOption: undefined,
+      reason: "Test missing capability grant.",
       yes: true,
     });
 
@@ -516,6 +518,7 @@ describe("CLI auth rotate command", () => {
         jwk: key,
         host: activeHost,
         openkeyHost: "https://openkey.test",
+        reason: expect.stringContaining("Test missing capability grant."),
         permissions: [
           {
             service: "tinycloud.kv",

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -292,6 +292,10 @@ export function registerAuthCommand(program: Command): void {
               jwk: key,
               host: ctx.host,
               permissions: group,
+              reason: permissionGrantReason(
+                "Grant requested TinyCloud permissions from `tc auth request --grant`.",
+                group,
+              ),
               openkeyHost,
               expiry: expiryOption,
               noPopup: options.popup === false,
@@ -470,6 +474,7 @@ export function registerAuthCommand(program: Command): void {
           node,
           requested: parsed.requested,
           expiryOption: parsed.requestedExpiry,
+          reason: "Grant permissions requested by a TinyCloud auth request artifact.",
           yes: options.yes === true,
         });
 
@@ -821,6 +826,7 @@ export async function ensureDelegationAuthority(params: {
   node: Awaited<ReturnType<typeof ensureAuthenticated>>;
   requested: PermissionEntry[];
   expiryOption: string | number | undefined;
+  reason: string;
   yes: boolean;
   force?: boolean;
 }): Promise<void> {
@@ -841,6 +847,7 @@ export async function ensureDelegationAuthority(params: {
         jwk: key,
         host: params.ctx.host,
         permissions: group,
+        reason: permissionGrantReason(params.reason, group),
         openkeyHost,
         expiry: params.expiryOption,
       });
@@ -889,6 +896,15 @@ export async function ensureDelegationAuthority(params: {
       expiry: delegation.expiry.toISOString(),
     });
   }
+}
+
+function permissionGrantReason(context: string, permissions: PermissionEntry[]): string {
+  const first = permissions[0];
+  const summary = first ? compactPermission(first) : "no permissions";
+  const more = permissions.length > 1
+    ? ` and ${permissions.length - 1} more permission${permissions.length === 2 ? "" : "s"}`
+    : "";
+  return `${context} Requested: ${summary}${more}.`;
 }
 
 function execCapturedCommand(command: { argv: string[]; cwd: string }): Promise<void> {

--- a/packages/cli/src/commands/secrets.ts
+++ b/packages/cli/src/commands/secrets.ts
@@ -228,12 +228,18 @@ async function runSecretOperation<T>(params: {
       node: params.node,
       requested,
       expiryOption: undefined,
+      reason: secretPermissionReason(params.action, params.name),
       yes: true,
       force: true,
     }),
   );
 
   return runSecretOperationAttempt(params.label, params.operation);
+}
+
+function secretPermissionReason(action: SecretAction, name?: string): string {
+  const target = name ? ` secret "${name}"` : " secrets";
+  return `Allow \`tc secrets ${action}${name ? ` ${name}` : ""}\` to access${target} with the required TinyCloud permissions.`;
 }
 
 async function runSecretOperationAttempt<T>(


### PR DESCRIPTION
## Summary
- Add optional `reason` support to CLI OpenKey auth URL construction
- Encode the reason in both the query string and permissions payload
- Require TinyCloud CLI permission escalation call sites to provide user-facing context
- Add a changeset for `@tinycloud/cli`

## Verification
- `cd packages/sdk-rs && bun run build:wasm:node`
- `cd packages/sdk-rs/packages/node && bun run build`
- `bun test packages/cli/src/auth/browser-auth.test.ts packages/cli/src/commands/auth.test.ts`
- `bun --filter @tinycloud/cli build`
- `git diff --check`