### PR TITLE
Fix SQL DDL permissions for account index

### DIFF
--- a/.changeset/account-index-ddl-permission.md
+++ b/.changeset/account-index-ddl-permission.md
@@ -1,0 +1,8 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/sdk-services": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Include `tinycloud.sql/ddl` in the implicit account registry index permission and legacy default SQL grant so account registry writes can create their SQLite tables and indexes on first use. SQL execute and batch calls now sign DDL statements with `tinycloud.sql/ddl`, and mixed batches sign with every required SQL action instead of collapsing to write-only.

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -239,6 +239,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     // legacy default table.
     expect(cfg.abilities.kv).toHaveProperty("");
     expect(cfg.abilities.kv[""]).toContain("tinycloud.kv/get");
+    expect(cfg.abilities.sql[""]).toContain("tinycloud.sql/ddl");
     expect(cfg.spaceAbilities[cfg.spaceId]).toEqual(cfg.abilities);
     const secretsSpaceId = Object.keys(cfg.spaceAbilities).find((spaceId) =>
       spaceId.endsWith(":secrets"),
@@ -361,6 +362,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
           account: [
             "tinycloud.sql/read",
             "tinycloud.sql/write",
+            "tinycloud.sql/ddl",
           ],
         },
       },

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -227,6 +227,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
         "": [
           "tinycloud.sql/read",
           "tinycloud.sql/write",
+          "tinycloud.sql/ddl",
           "tinycloud.sql/admin",
           "tinycloud.sql/export",
         ],

--- a/packages/sdk-core/src/manifest.test.ts
+++ b/packages/sdk-core/src/manifest.test.ts
@@ -856,7 +856,7 @@ describe("resolveManifest — end-to-end composition", () => {
           service: "tinycloud.sql",
           space: "account",
           path: "account",
-          actions: ["tinycloud.sql/read", "tinycloud.sql/write"],
+          actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/ddl"],
         }),
         expect.objectContaining({
           service: "tinycloud.capabilities",

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -1210,7 +1210,7 @@ function accountRegistryIndexPermission(): ResourceCapability {
     service: "tinycloud.sql",
     space: ACCOUNT_REGISTRY_SPACE,
     path: "account",
-    actions: ["tinycloud.sql/read", "tinycloud.sql/write"],
+    actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/ddl"],
   };
 }
 

--- a/packages/sdk-services/src/sql/SQLService.test.ts
+++ b/packages/sdk-services/src/sql/SQLService.test.ts
@@ -34,6 +34,7 @@ function response(
 function createContext(
   fetchImpl: IServiceContext["fetch"],
   invokeCalls: Array<{ service: string; path: string; action: string }>,
+  invokeAnyCalls: Array<{ entries: Array<{ service: string; path: string; action: string }> }> = [],
 ): IServiceContext {
   return {
     session: {
@@ -48,6 +49,18 @@ function createContext(
       invokeCalls.push({ service, path, action });
       return {
         Authorization: "Bearer signed-invocation",
+      };
+    },
+    invokeAny: (_session, entries) => {
+      invokeAnyCalls.push({
+        entries: entries.map((entry) => ({
+          service: entry.service,
+          path: entry.path,
+          action: entry.action,
+        })),
+      });
+      return {
+        Authorization: "Bearer signed-multi-invocation",
       };
     },
     fetch: fetchImpl,
@@ -122,13 +135,14 @@ describe("SQLService permissions", () => {
 
   test("execute and batch sign PRAGMA statements with admin permission", async () => {
     const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    const invokeAnyCalls: Array<{ entries: Array<{ service: string; path: string; action: string }> }> = [];
 
     const service = new SQLService();
     service.initialize(
       createContext(async () => response(true, 200, {
         changes: 0,
         lastInsertRowId: null,
-      }), invokeCalls),
+      }), invokeCalls, invokeAnyCalls),
     );
 
     const executeResult = await service.execute("pragma user_version = 1");
@@ -141,7 +155,77 @@ describe("SQLService permissions", () => {
     expect(batchResult.ok).toBe(true);
     expect(invokeCalls).toEqual([
       { service: "sql", path: "default", action: SQLAction.ADMIN },
-      { service: "sql", path: "default", action: SQLAction.ADMIN },
+    ]);
+    expect(invokeAnyCalls).toEqual([
+      {
+        entries: [
+          { service: "sql", path: "default", action: SQLAction.WRITE },
+          { service: "sql", path: "default", action: SQLAction.ADMIN },
+        ],
+      },
+    ]);
+  });
+
+  test("execute and batch sign DDL statements with ddl permission", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    const invokeAnyCalls: Array<{ entries: Array<{ service: string; path: string; action: string }> }> = [];
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async () => response(true, 200, {
+        changes: 0,
+        lastInsertRowId: null,
+      }), invokeCalls, invokeAnyCalls),
+    );
+
+    const executeResult = await service.execute("CREATE TABLE IF NOT EXISTS notes (body TEXT)");
+    const batchResult = await service.batch([
+      { sql: "CREATE TABLE IF NOT EXISTS notes (body TEXT)" },
+      { sql: "INSERT INTO notes (body) VALUES (?)", params: ["hello"] },
+    ]);
+
+    expect(executeResult.ok).toBe(true);
+    expect(batchResult.ok).toBe(true);
+    expect(invokeCalls).toEqual([
+      { service: "sql", path: "default", action: SQLAction.DDL },
+    ]);
+    expect(invokeAnyCalls).toEqual([
+      {
+        entries: [
+          { service: "sql", path: "default", action: SQLAction.DDL },
+          { service: "sql", path: "default", action: SQLAction.WRITE },
+        ],
+      },
+    ]);
+  });
+
+  test("execute with schema signs both schema ddl and statement write permissions", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    const invokeAnyCalls: Array<{ entries: Array<{ service: string; path: string; action: string }> }> = [];
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async () => response(true, 200, {
+        changes: 1,
+        lastInsertRowId: 1,
+      }), invokeCalls, invokeAnyCalls),
+    );
+
+    const result = await service.execute(
+      "INSERT INTO notes (body) VALUES (?)",
+      ["hello"],
+      { schema: ["CREATE TABLE IF NOT EXISTS notes (body TEXT)"] },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(invokeCalls).toEqual([]);
+    expect(invokeAnyCalls).toEqual([
+      {
+        entries: [
+          { service: "sql", path: "default", action: SQLAction.WRITE },
+          { service: "sql", path: "default", action: SQLAction.DDL },
+        ],
+      },
     ]);
   });
 });

--- a/packages/sdk-services/src/sql/SQLService.ts
+++ b/packages/sdk-services/src/sql/SQLService.ts
@@ -13,6 +13,8 @@ import {
   ErrorCodes,
   serviceError,
   type FetchResponse,
+  type ServiceHeaders,
+  type ServiceSession,
 } from "../types";
 import { authRequiredError, wrapError, parseAuthError } from "../errors";
 import type { ISQLService } from "./ISQLService";
@@ -30,6 +32,8 @@ import {
   type BatchResponse,
   SQLAction,
 } from "./types";
+
+const DDL_TOKENS = new Set(["alter", "create", "drop"]);
 
 export class SQLService extends BaseService implements ISQLService {
   static readonly serviceName = "sql";
@@ -146,9 +150,15 @@ export class SQLService extends BaseService implements ISQLService {
           body.schema = options.schema;
         }
 
+        const actions = [
+          this.actionForSql(sql, SQLAction.WRITE),
+          ...(options?.schema ?? []).map((statement) =>
+            this.actionForSql(statement, SQLAction.DDL),
+          ),
+        ];
         const response = await this.invokeSQL(
           dbName,
-          this.actionForSql(sql, SQLAction.WRITE),
+          this.dedupeActions(actions),
           body,
           options?.signal
         );
@@ -178,7 +188,7 @@ export class SQLService extends BaseService implements ISQLService {
       try {
         const response = await this.invokeSQL(
           dbName,
-          this.actionForSqlBatch(statements),
+          this.actionsForSqlBatch(statements),
           { action: "batch", statements },
           options?.signal
         );
@@ -269,12 +279,16 @@ export class SQLService extends BaseService implements ISQLService {
 
   private async invokeSQL(
     dbName: string,
-    action: string,
+    actions: string | string[],
     body: Record<string, unknown>,
     signal?: AbortSignal
   ): Promise<FetchResponse> {
     const session = this.context.session!;
-    const headers = this.context.invoke(session, "sql", dbName, action);
+    const actionList = Array.isArray(actions) ? actions : [actions];
+    const headers =
+      actionList.length === 1
+        ? this.context.invoke(session, "sql", dbName, actionList[0]!)
+        : this.invokeSQLAny(session, dbName, actionList);
 
     return this.context.fetch(`${this.host}/invoke`, {
       method: "POST",
@@ -288,15 +302,42 @@ export class SQLService extends BaseService implements ISQLService {
   }
 
   private actionForSql(sql: string, fallback: string): string {
-    return firstSqlToken(sql) === "pragma" ? SQLAction.ADMIN : fallback;
+    const token = firstSqlToken(sql);
+    if (token === "pragma") return SQLAction.ADMIN;
+    if (token !== undefined && DDL_TOKENS.has(token)) return SQLAction.DDL;
+    return fallback;
   }
 
-  private actionForSqlBatch(statements: SqlStatement[]): string {
-    return statements.some(
-      (statement) => this.actionForSql(statement.sql, SQLAction.WRITE) === SQLAction.ADMIN,
-    )
-      ? SQLAction.ADMIN
-      : SQLAction.WRITE;
+  private actionsForSqlBatch(statements: SqlStatement[]): string[] {
+    return this.dedupeActions(
+      statements.map((statement) => this.actionForSql(statement.sql, SQLAction.WRITE)),
+    );
+  }
+
+  private dedupeActions(actions: string[]): string[] {
+    return [...new Set(actions)];
+  }
+
+  private invokeSQLAny(
+    session: ServiceSession,
+    dbName: string,
+    actions: string[],
+  ): ServiceHeaders {
+    if (!this.context.invokeAny) {
+      throw new Error(
+        `SQL operation requires multiple permissions (${actions.join(", ")}) but this SDK runtime does not support multi-resource invocations`,
+      );
+    }
+
+    return this.context.invokeAny(
+      session,
+      actions.map((action) => ({
+        spaceId: session.spaceId,
+        service: "sql",
+        path: dbName,
+        action,
+      })),
+    );
   }
 
   private async handleErrorResponse(

--- a/packages/sdk-services/src/sql/types.ts
+++ b/packages/sdk-services/src/sql/types.ts
@@ -102,6 +102,7 @@ export interface BatchResponse {
 export const SQLAction = {
   READ: "tinycloud.sql/read",
   WRITE: "tinycloud.sql/write",
+  DDL: "tinycloud.sql/ddl",
   ADMIN: "tinycloud.sql/admin",
   SELECT: "tinycloud.sql/select",
   INSERT: "tinycloud.sql/insert",


### PR DESCRIPTION
## Summary
- add `tinycloud.sql/ddl` to the implicit account registry SQL permission and legacy default SQL grant
- classify `CREATE`/`ALTER`/`DROP` as SQL DDL operations
- sign mixed SQL `execute` schema setup and `batch` calls with every required SQL action via `invokeAny` instead of narrowing to write-only
- add a changeset for sdk-core, sdk-services, node-sdk, and web-sdk

## Root Cause
The account dashboard/index setup creates SQLite tables and indexes, but the account manifest only granted SQL read/write and the SDK batched `CREATE TABLE` plus `INSERT` calls under a write-only invocation token. The node rejected that with `SQLite error: not authorized`.

## Tests
- `bun test packages/sdk-services/src/sql/SQLService.test.ts packages/sdk-core/src/manifest.test.ts packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts`
- `bun run build` in `packages/sdk-services`
- `bun run build` in `packages/sdk-core`
- `bun run build` in `packages/node-sdk`
- `bun run build` in `packages/web-sdk`

Note: first parallel `web-sdk` build failed while `sdk-core` was concurrently cleaning/rebuilding `dist`; rerunning serially passed.