### PR TITLE
feat(sdk): public ensureOwnedSpaceHosted for manifest-recap sessions

### DIFF
--- a/.changeset/public-ensure-owned-space-hosted.md
+++ b/.changeset/public-ensure-owned-space-hosted.md
@@ -1,0 +1,10 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/sdk-services": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+---
+
+Add a public `ensureOwnedSpaceHosted(name)` method to `TinyCloudNode` and `TinyCloudWeb` for hosting an owner's owned space (e.g. `"secrets"`) from a session created with a manifest / capabilityRequest.
+
+A full-authority sign-in auto-hosts the owner's `secrets` space, but a session created with a manifest / capabilityRequest does not. Such a session could hold valid `tinycloud.kv/*` capabilities for the owned `secrets` space yet still fail its first scoped `secrets.put(...)` with `404 Space not found`, because the space was never registered on the node. `ensureOwnedSpaceHosted(name)` resolves the name to the owner's owned-space URI and hosts it via the host-SIWE delegation flow (one signature, idempotent server-side), so subsequent scoped secret writes succeed.

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -545,7 +545,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
         }),
       ],
       async () => {
-        await (node as any).ensureOwnedSpaceHosted(
+        await (node as any).ensureOwnedSpaceHostedById(
           "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:account",
         );
       },
@@ -576,7 +576,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
         }),
       ],
       async () => {
-        await (node as any).ensureOwnedSpaceHosted(accountSpaceId);
+        await (node as any).ensureOwnedSpaceHostedById(accountSpaceId);
       },
     );
 
@@ -602,10 +602,10 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     const node = makeNodeWithSigner(makeFakeWasmBindings(), { manifest });
     const accountSpaceId =
       "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:account";
-    const ensureOwnedSpaceHosted = mock(async () => {});
+    const ensureOwnedSpaceHostedById = mock(async () => {});
     const put = mock(async () => ({ ok: true, data: undefined, headers: {} }));
 
-    (node as any).ensureOwnedSpaceHosted = ensureOwnedSpaceHosted;
+    (node as any).ensureOwnedSpaceHostedById = ensureOwnedSpaceHostedById;
     Object.defineProperty(node, "spaces", {
       configurable: true,
       value: {
@@ -638,7 +638,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     );
 
     await waitFor(() => put.mock.calls.length > 0);
-    expect(ensureOwnedSpaceHosted).toHaveBeenCalledWith(accountSpaceId);
+    expect(ensureOwnedSpaceHostedById).toHaveBeenCalledWith(accountSpaceId);
     expect(put).toHaveBeenCalledTimes(1);
     expect(put).toHaveBeenCalledWith("applications/com.listen.app", {
       app_id: "com.listen.app",

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -770,7 +770,7 @@ export class TinyCloudNode {
             : undefined,
         ensureAccountSpaceHosted: async () => {
           if (this.accountSpaceId && this.auth) {
-            await this.ensureOwnedSpaceHosted(this.accountSpaceId);
+            await this.ensureOwnedSpaceHostedById(this.accountSpaceId);
           }
         },
       });
@@ -828,7 +828,7 @@ export class TinyCloudNode {
     await this.ensureRequestedEncryptionNetworks();
 
     if (this.config.manifest === undefined && this.config.capabilityRequest === undefined) {
-      await this.ensureOwnedSpaceHosted(this.ownedSpaceId("secrets"));
+      await this.ensureOwnedSpaceHostedById(this.ownedSpaceId("secrets"));
     }
 
     this.scheduleAccountRegistrySync();
@@ -853,7 +853,7 @@ export class TinyCloudNode {
     }
 
     const accountSpaceId = this.ownedSpaceId(ACCOUNT_REGISTRY_SPACE);
-    await this.ensureOwnedSpaceHosted(accountSpaceId);
+    await this.ensureOwnedSpaceHostedById(accountSpaceId);
 
     const result = await this.account.applications.register(request.manifests);
     if (!result.ok) {
@@ -927,7 +927,7 @@ export class TinyCloudNode {
     }
   }
 
-  private async ensureOwnedSpaceHosted(spaceId: string): Promise<void> {
+  private async ensureOwnedSpaceHostedById(spaceId: string): Promise<void> {
     if (!this.auth) {
       throw new Error("Owned space hosting requires wallet mode");
     }
@@ -980,7 +980,7 @@ export class TinyCloudNode {
    * caller is the root authority of their own owned spaces, so no additional
    * delegation is required.
    *
-   * Unlike {@link ensureOwnedSpaceHosted}, this always submits the host
+   * Unlike {@link ensureOwnedSpaceHostedById}, this always submits the host
    * delegation rather than inferring hosting from session activation: a space
    * the current session has never referenced is reported neither as
    * `activated` nor `skipped`, so activation-based detection would wrongly
@@ -1037,6 +1037,30 @@ export class TinyCloudNode {
       .catch(() => {});
 
     return spaceId;
+  }
+
+  /**
+   * Ensure one of this user's owned spaces (e.g. `"secrets"`) is hosted on the
+   * server.
+   *
+   * At sign-in, a full-authority session auto-hosts the owner's `secrets`
+   * space, but a session created with a manifest / capabilityRequest does not.
+   * Such a session can therefore hold valid `tinycloud.kv/*` capabilities for
+   * the owned `secrets` space yet still fail its first scoped
+   * `secrets.put(...)` with `404 Space not found`, because the space was never
+   * registered on the node.
+   *
+   * Calling this resolves `name` to the owner's owned-space URI
+   * (`tinycloud:pkh:eip155:<chain>:<addr>:<name>`) and hosts it via the
+   * host-SIWE delegation flow. The host SIWE is idempotent server-side, so it
+   * is safe to call whether or not the space already exists; do not gate it on
+   * a prior existence check. Must be called after {@link signIn}.
+   *
+   * @param name - The owned space name (e.g. `"secrets"`).
+   * @returns The hosted owned-space URI.
+   */
+  async ensureOwnedSpaceHosted(name: string): Promise<string> {
+    return this.hostOwnedSpace(name);
   }
 
   /**

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -474,6 +474,28 @@ export class TinyCloudWeb {
     return node.ensureEncryptionNetwork(name);
   }
 
+  /**
+   * Ensure one of this user's owned spaces (e.g. `"secrets"`) is hosted on the
+   * server.
+   *
+   * A full-authority sign-in auto-hosts the owner's `secrets` space, but a
+   * session created with a manifest / capabilityRequest does not. Such a
+   * session can hold valid `tinycloud.kv/*` capabilities for the owned
+   * `secrets` space yet still fail its first scoped `secrets.put(...)` with
+   * `404 Space not found`, because the space was never registered on the node.
+   *
+   * Calling this resolves `name` to the owner's owned-space URI and hosts it
+   * via the host-SIWE delegation flow (one signature, idempotent server-side).
+   * Must be called after {@link signIn}.
+   *
+   * @param name - The owned space name (e.g. `"secrets"`).
+   * @returns The hosted owned-space URI.
+   */
+  async ensureOwnedSpaceHosted(name: string): Promise<string> {
+    const node = await this.ensureNode();
+    return node.ensureOwnedSpaceHosted(name);
+  }
+
   // ===========================================================================
   // Auth Methods (delegate to TinyCloudNode)
   // ===========================================================================

--- a/tests/node-sdk/secrets/host-owned-space-live.test.ts
+++ b/tests/node-sdk/secrets/host-owned-space-live.test.ts
@@ -1,0 +1,108 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { Wallet } from "ethers";
+import { TinyCloudNode, type Manifest } from "@tinycloud/node-sdk";
+import { checkServerHealth, SERVER_URL } from "../setup";
+
+/**
+ * Live regression for the manifest-recap owned-space hosting gap.
+ *
+ * A full-authority sign-in auto-hosts the owner's `secrets` owned space, but a
+ * session created WITH a manifest / capabilityRequest does not (the node only
+ * auto-hosts when both are undefined). Such an owner therefore holds valid
+ * `tinycloud.kv/*` capabilities for the `secrets` space yet its first scoped
+ * `secrets.put(...)` fails with `404 Space not found` until the space is
+ * explicitly hosted.
+ *
+ * This test uses a BRAND-NEW random-key owner with a manifest-recap-limited
+ * session, calls the new public `ensureOwnedSpaceHosted('secrets')`, and proves
+ * the subsequent scoped put succeeds. It also documents that the host call is
+ * server-idempotent (safe to call twice).
+ */
+describe("manifest-recap owner secrets-space hosting (live)", () => {
+  // Fresh owner per run so the secrets space starts unhosted on the node.
+  const ownerKey = Wallet.createRandom().privateKey.slice(2);
+  const ownerAddress = new Wallet(ownerKey).address;
+  const ownerDid = `did:pkh:eip155:1:${ownerAddress}`;
+  // Secrets are encrypted to the owner's default encryption network, so the
+  // manifest must also grant it (mirrors git-haiku's owner recap). signIn's
+  // ensureRequestedEncryptionNetworks() then auto-creates it.
+  const defaultNetworkId = `urn:tinycloud:encryption:${ownerDid}:default`;
+  const SCOPE = "githaiku";
+  const SECRET_NAME = "GITHUB_TOKEN";
+  const SECRET_VALUE = `ghp_live_${Date.now()}`;
+
+  // Manifest-recap (NOT full authority): defaults:false, only the scoped
+  // GITHUB_TOKEN secret plus the owner's default encryption network are
+  // granted. This is the shape git-haiku's owner flow uses, and it is exactly
+  // the path that skips the sign-in auto-host of the `secrets` space.
+  const manifest: Manifest = {
+    manifest_version: 1,
+    app_id: "dev.tinycloud.githaiku-host-test",
+    name: "Git Haiku Owned-Space Host Test",
+    defaults: false,
+    permissions: [
+      {
+        service: "tinycloud.encryption",
+        path: defaultNetworkId,
+        actions: ["network.create", "decrypt"],
+      },
+    ],
+    secrets: {
+      [SECRET_NAME]: {
+        scope: SCOPE,
+        actions: ["get", "put", "del", "list"],
+      },
+    },
+  };
+
+  let owner: TinyCloudNode;
+
+  beforeAll(async () => {
+    await checkServerHealth();
+    owner = new TinyCloudNode({
+      privateKey: ownerKey,
+      host: SERVER_URL,
+      prefix: `githaiku-host-${Date.now()}`,
+      autoCreateSpace: true,
+      manifest,
+      includeAccountRegistryPermissions: false,
+    });
+    await owner.signIn();
+    console.log("[Setup] Manifest-recap owner signed in, DID:", owner.did);
+  });
+
+  test("ensureOwnedSpaceHosted('secrets') resolves the owner's secrets space URI", async () => {
+    const spaceId = await owner.ensureOwnedSpaceHosted("secrets");
+    console.log("[Host] secrets space hosted:", spaceId);
+    expect(spaceId).toContain(":secrets");
+    expect(spaceId.startsWith("tinycloud:pkh:eip155:")).toBe(true);
+  });
+
+  test("ensureOwnedSpaceHosted is idempotent (safe to call again)", async () => {
+    // Server-side host SIWE is idempotent; calling again must not throw and must
+    // resolve to the same space URI.
+    const first = await owner.ensureOwnedSpaceHosted("secrets");
+    const second = await owner.ensureOwnedSpaceHosted("secrets");
+    expect(second).toBe(first);
+  });
+
+  test("scoped secrets.put SUCCEEDS after hosting (the case that 404s today)", async () => {
+    // Without the host step this returns `404 Space not found` /
+    // `Unauthorized ... tinycloud.kv/put`. After hosting it must succeed.
+    const putResult = await owner.secrets.put(SECRET_NAME, SECRET_VALUE, {
+      scope: SCOPE,
+    });
+    if (!putResult.ok) {
+      console.error("[Put] failed:", putResult.error);
+    }
+    expect(putResult.ok).toBe(true);
+  });
+
+  test("scoped secrets.get round-trips the value", async () => {
+    const getResult = await owner.secrets.get(SECRET_NAME, { scope: SCOPE });
+    expect(getResult.ok).toBe(true);
+    if (getResult.ok) {
+      expect(getResult.data).toBe(SECRET_VALUE);
+    }
+  });
+});


### PR DESCRIPTION
## The gap

A full-authority sign-in auto-hosts the owner's `secrets` owned space, but a session created **with a manifest / capabilityRequest** does not. The node only auto-hosts the owner's `secrets` space at sign-in when both `manifest` and `capabilityRequest` are `undefined`:

```ts
if (this.config.manifest === undefined && this.config.capabilityRequest === undefined) {
  await this.ensureOwnedSpaceHostedById(this.ownedSpaceId("secrets"));
}
```

Apps that sign in with a manifest/recap (e.g. git-haiku's OpenKey owner flow) therefore never host the `secrets` space. Such an owner can hold valid `tinycloud.kv/*` capabilities for the owned `secrets` space yet still have its **first scoped `secrets.put(...)` fail with `404 Space not found` / `Unauthorized ... tinycloud.kv/put`**, because the space was never registered on the node. Until now the only working remedy was reaching into private internals (`node.auth.hostOwnedSpace(...)`).

## The public API added

`ensureOwnedSpaceHosted(name: string): Promise<string>` on both `TinyCloudNode` and `TinyCloudWeb`.

- Resolves the current owner's owned-space URI for `name` (e.g. `"secrets"` → `tinycloud:pkh:eip155:<chain>:<addr>:secrets`).
- Hosts it via the existing host-SIWE delegation flow (one signature, **idempotent server-side**); delegates to the proven `hostOwnedSpace(name)` path. It does **not** gate on a prior existence check (a freshly-hosted space is reported neither `activated` nor `skipped`, so existence checks are unreliable — the host call is just made).
- Returns the hosted owned-space URI. Must be called after `signIn()`.

To free the public name, the private by-id activation-detection helper was renamed `ensureOwnedSpaceHosted(spaceId)` → `ensureOwnedSpaceHostedById` (callers + unit tests updated).

`TinyCloudNode` already had a public `hostOwnedSpace(name)` (added for the CLI); `ensureOwnedSpaceHosted(name)` is the task-requested public surface and delegates to it.

## Live-verified proof (fresh owner, recap session, local node)

Added a gated live node-sdk integration test (`tests/node-sdk/secrets/host-owned-space-live.test.ts`). Against a local `tinycloud-node`, it:

1. Creates a **brand-new random-key owner** with a **manifest-recap-limited** session (`TinyCloudNode` with `manifest` + `defaults:false`, granting only the scoped `GITHUB_TOKEN` secret and the owner's default encryption network — i.e. **not** a full-authority signIn).
2. Calls `ensureOwnedSpaceHosted('secrets')` → resolves & hosts the secrets space (idempotency asserted by calling twice).
3. `secrets.put('GITHUB_TOKEN', value, { scope: 'githaiku' })` → **SUCCEEDS** (the case that 404s today).
4. `secrets.get('GITHUB_TOKEN', { scope: 'githaiku' })` round-trips the value.

```
[Setup] Manifest-recap owner signed in, DID: did:pkh:eip155:1:0xECD3...
[Host] secrets space hosted: tinycloud:pkh:eip155:1:0xECD3...:secrets
 4 pass  0 fail
```

## Verification

- Build: `bunx turbo build --filter=@tinycloud/node-sdk --filter=@tinycloud/web-sdk` → green (7/7 tasks).
- node-sdk unit tests: **96 pass, 0 fail**.
- web-sdk unit tests: unchanged vs base (1 suite / 22 tests pass; 9 pre-existing jest TS-transform suite failures + 3 pre-existing extension-test failures, confirmed identical on the clean base before this change). The one passing suite (`tcw-spaceId`) exercises the modified `TinyCloudWeb`.
- Changeset: minor bump for the linked group (`@tinycloud/web-sdk`, `@tinycloud/node-sdk`, `@tinycloud/sdk-core`, `@tinycloud/sdk-services`).

## For the git-haiku frontend

After `await tcw.signIn(...)` with the owner manifest, call:

```ts
await tcw.ensureOwnedSpaceHosted("secrets");
await tcw.secrets.put("GITHUB_TOKEN", token, { scope: "githaiku" });
```