### PR TITLE
Add SQL migrations helper

### DIFF
--- a/.changeset/sql-migrations-primitive.md
+++ b/.changeset/sql-migrations-primitive.md
@@ -1,0 +1,10 @@
+---
+"@tinycloud/sdk-services": patch
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Add a SQL migrations helper on database handles: `sql.db(name).migrations.apply({ namespace, migrations })`. The helper records applied migration ids in a TinyCloud-managed table, signs migration DDL/write/read actions through the SQL service, and returns whether migrations were applied or already current.
+
+The account registry index now uses the migrations helper for its schema setup, and SQL/DuckDB service errors sanitize non-JSON proxy HTML pages into concise retryable messages while preserving a bounded debug snippet in error metadata.

--- a/packages/node-sdk/src/account/AccountService.test.ts
+++ b/packages/node-sdk/src/account/AccountService.test.ts
@@ -28,8 +28,33 @@ function makeAccountService(options: {
   const revoke = mock(async () => ({ ok: true, data: undefined }));
   const ensureAccountSpaceHosted = mock(async () => {});
   const batches: any[] = [];
+  const migrations: any[] = [];
   const queries: Array<{ sql: string; params?: unknown[] }> = [];
   const db = {
+    migrations: {
+      apply: mock(async (migrationOptions: any) => {
+        migrations.push(migrationOptions);
+        if (options.failingIndexUpdates) {
+          return {
+            ok: false,
+            error: {
+              code: "SQL_PERMISSION_DENIED",
+              message: "SQL migration failed: 403 - not authorized",
+            },
+          };
+        }
+        return {
+          ok: true,
+          data: {
+            database: "account",
+            namespace: migrationOptions.namespace,
+            status: "already_current",
+            applied: [],
+            skipped: migrationOptions.migrations.map((migration: any) => migration.id),
+          },
+        };
+      }),
+    },
     batch: mock(async (statements: any[]) => {
       batches.push(statements);
       if (options.failingIndexUpdates) {
@@ -271,7 +296,7 @@ function makeAccountService(options: {
     getAccountDb: () => db as any,
   });
 
-  return { batches, db, del, ensureAccountSpaceHosted, put, queries, records, revoke, service };
+  return { batches, db, del, ensureAccountSpaceHosted, migrations, put, queries, records, revoke, service };
 }
 
 describe("AccountService applications", () => {
@@ -365,7 +390,7 @@ describe("AccountService delegations", () => {
 
 describe("AccountService index", () => {
   test("rebuilds the materialized account SQLite index", async () => {
-    const { batches, service } = makeAccountService();
+    const { batches, migrations, service } = makeAccountService();
 
     const result = await service.index.rebuild();
 
@@ -375,8 +400,17 @@ describe("AccountService index", () => {
       applications: 1,
       delegations: 2,
     });
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0]).toMatchObject({
+      namespace: "tinycloud.account.index",
+      migrations: [
+        {
+          id: "001_initial",
+        },
+      ],
+    });
+    expect(migrations[0].migrations[0].sql.some((sql: string) => sql.includes("CREATE TABLE IF NOT EXISTS applications"))).toBe(true);
     expect(batches).toHaveLength(1);
-    expect(batches[0].some((s: any) => s.sql.includes("CREATE TABLE IF NOT EXISTS applications"))).toBe(true);
     expect(batches[0].some((s: any) => s.sql.includes("INSERT INTO applications"))).toBe(true);
     expect(batches[0].some((s: any) => s.sql.includes("INSERT INTO delegations"))).toBe(true);
   });
@@ -400,7 +434,7 @@ describe("AccountService index", () => {
   });
 
   test("falls back to canonical applications when preferred index is missing", async () => {
-    const { batches, service } = makeAccountService({ missingIndexTables: ["applications"] });
+    const { migrations, service } = makeAccountService({ missingIndexTables: ["applications"] });
 
     const result = await service.applications.list({ preferIndex: true });
 
@@ -411,7 +445,7 @@ describe("AccountService index", () => {
         name: "Listen",
       }),
     ]);
-    expect(batches.at(-1).some((statement: any) => statement.sql.includes("CREATE TABLE IF NOT EXISTS applications"))).toBe(true);
+    expect(migrations[0].migrations[0].sql.some((sql: string) => sql.includes("CREATE TABLE IF NOT EXISTS applications"))).toBe(true);
   });
 
   test("falls back to canonical applications when preferred index is empty", async () => {
@@ -448,7 +482,7 @@ describe("AccountService index", () => {
   });
 
   test("falls back to accessible spaces when preferred index is missing", async () => {
-    const { batches, service } = makeAccountService({ missingIndexTables: ["spaces"] });
+    const { migrations, service } = makeAccountService({ missingIndexTables: ["spaces"] });
 
     const result = await service.spaces.list({ preferIndex: true });
 
@@ -459,7 +493,7 @@ describe("AccountService index", () => {
         name: "applications",
       }),
     ]);
-    expect(batches.at(-1).some((statement: any) => statement.sql.includes("CREATE TABLE IF NOT EXISTS spaces"))).toBe(true);
+    expect(migrations[0].migrations[0].sql.some((sql: string) => sql.includes("CREATE TABLE IF NOT EXISTS spaces"))).toBe(true);
   });
 
   test("lists delegations from the materialized index with filters", async () => {
@@ -483,7 +517,7 @@ describe("AccountService index", () => {
   });
 
   test("falls back to live delegations when preferred index is missing", async () => {
-    const { batches, service } = makeAccountService({ missingIndexTables: ["delegations"] });
+    const { migrations, service } = makeAccountService({ missingIndexTables: ["delegations"] });
 
     const result = await service.delegations.list({ preferIndex: true });
 
@@ -492,7 +526,7 @@ describe("AccountService index", () => {
       "bafy-granted",
       "bafy-received",
     ]);
-    expect(batches.at(-1).some((statement: any) => statement.sql.includes("CREATE TABLE IF NOT EXISTS delegations"))).toBe(true);
+    expect(migrations[0].migrations[0].sql.some((sql: string) => sql.includes("CREATE TABLE IF NOT EXISTS delegations"))).toBe(true);
   });
 
   test("runs custom read queries against the materialized index", async () => {

--- a/packages/sdk-core/src/account/AccountService.ts
+++ b/packages/sdk-core/src/account/AccountService.ts
@@ -19,6 +19,7 @@ import type { ISpaceService } from "../spaces/SpaceService";
 
 const SERVICE_NAME = "account";
 const ACCOUNT_INDEX_DB = "account";
+const ACCOUNT_INDEX_NAMESPACE = "tinycloud.account.index";
 const ACCOUNT_SPACES_PATH = "spaces/";
 
 export interface AccountApplication {
@@ -382,8 +383,10 @@ export class AccountService {
       if (!delegations.ok) return delegations;
 
       const syncedAt = new Date().toISOString();
+      const schema = await this.ensureAccountIndex(dbResult.data);
+      if (!schema.ok) return schema;
+
       const statements = [
-        ...ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })),
         { sql: "DELETE FROM applications" },
         { sql: "DELETE FROM application_state" },
         { sql: "DELETE FROM spaces" },
@@ -590,7 +593,7 @@ export class AccountService {
     const dbResult = this.accountDb();
     if (!dbResult.ok) return false;
 
-    const schema = await dbResult.data.batch(ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })));
+    const schema = await this.ensureAccountIndex(dbResult.data);
     if (!schema.ok) return false;
 
     const queried = await dbResult.data.query<string>(
@@ -608,10 +611,12 @@ export class AccountService {
     const dbResult = this.accountDb();
     if (!dbResult.ok) return ok(undefined);
 
+    const schema = await this.ensureAccountIndex(dbResult.data);
+    if (!schema.ok) return schema;
+
     const updatedAt = app.updatedAt ?? new Date().toISOString();
     const manifestHash = app.manifestHash ?? hashJson(app.manifests);
     const written = await dbResult.data.batch([
-      ...ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })),
       {
         sql:
           "INSERT OR REPLACE INTO applications (app_id, name, description, updated_at, manifest_json) VALUES (?, ?, ?, ?, ?)",
@@ -640,8 +645,10 @@ export class AccountService {
   private async deleteApplicationIndex(appId: string): Promise<Result<void>> {
     const dbResult = this.accountDb();
     if (!dbResult.ok) return ok(undefined);
+    const schema = await this.ensureAccountIndex(dbResult.data);
+    if (!schema.ok) return schema;
+
     const deleted = await dbResult.data.batch([
-      ...ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })),
       { sql: "DELETE FROM applications WHERE app_id = ?", params: [appId] },
       { sql: "DELETE FROM application_state WHERE app_id = ?", params: [appId] },
     ]);
@@ -656,9 +663,11 @@ export class AccountService {
   private async upsertSpaceIndex(space: AccountSpace): Promise<Result<void>> {
     const dbResult = this.accountDb();
     if (!dbResult.ok) return ok(undefined);
+    const schema = await this.ensureAccountIndex(dbResult.data);
+    if (!schema.ok) return schema;
+
     const updatedAt = space.updatedAt ?? new Date().toISOString();
     const written = await dbResult.data.batch([
-      ...ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })),
       {
         sql:
           "INSERT OR REPLACE INTO spaces (space_id, name, owner_did, type, permissions_json, status, registered_at, updated_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -686,8 +695,10 @@ export class AccountService {
   private async deleteSpaceIndex(spaceId: string): Promise<Result<void>> {
     const dbResult = this.accountDb();
     if (!dbResult.ok) return ok(undefined);
+    const schema = await this.ensureAccountIndex(dbResult.data);
+    if (!schema.ok) return schema;
+
     const deleted = await dbResult.data.batch([
-      ...ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })),
       { sql: "DELETE FROM spaces WHERE space_id = ?", params: [spaceId] },
     ]);
     if (!deleted.ok) return accountErr(deleted.error);
@@ -712,8 +723,10 @@ export class AccountService {
       const dbResult = this.accountDb();
       if (!dbResult.ok) return;
       const syncedAt = new Date().toISOString();
+      const schema = await this.ensureAccountIndex(dbResult.data);
+      if (!schema.ok) return;
+
       await dbResult.data.batch([
-        ...ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })),
         { sql: "DELETE FROM applications" },
         { sql: "DELETE FROM application_state" },
         ...applications.map((app) => ({
@@ -745,8 +758,10 @@ export class AccountService {
       const dbResult = this.accountDb();
       if (!dbResult.ok) return;
       const syncedAt = new Date().toISOString();
+      const schema = await this.ensureAccountIndex(dbResult.data);
+      if (!schema.ok) return;
+
       await dbResult.data.batch([
-        ...ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })),
         { sql: "DELETE FROM spaces" },
         ...spaces.map((space) => ({
           sql:
@@ -776,8 +791,10 @@ export class AccountService {
       const dbResult = this.accountDb();
       if (!dbResult.ok) return;
       const syncedAt = new Date().toISOString();
+      const schema = await this.ensureAccountIndex(dbResult.data);
+      if (!schema.ok) return;
+
       await dbResult.data.batch([
-        ...ACCOUNT_INDEX_SCHEMA.map((sql) => ({ sql })),
         { sql: "DELETE FROM delegations" },
         ...delegations.map((delegation) => ({
           sql:
@@ -804,6 +821,20 @@ export class AccountService {
         },
       ]);
     });
+  }
+
+  private async ensureAccountIndex(db: IDatabaseHandle): Promise<Result<void>> {
+    const migrated = await db.migrations.apply({
+      namespace: ACCOUNT_INDEX_NAMESPACE,
+      migrations: [
+        {
+          id: "001_initial",
+          sql: ACCOUNT_INDEX_SCHEMA,
+        },
+      ],
+    });
+    if (!migrated.ok) return accountErr(migrated.error);
+    return ok(undefined);
   }
 }
 

--- a/packages/sdk-services/src/duckdb/DuckDbService.ts
+++ b/packages/sdk-services/src/duckdb/DuckDbService.ts
@@ -15,6 +15,11 @@ import {
   type FetchResponse,
 } from "../types";
 import { authRequiredError, wrapError, parseAuthError } from "../errors";
+import {
+  formatServiceResponseError,
+  parseServiceErrorBody,
+  responseErrorMeta,
+} from "../responseErrors";
 import type { IDuckDbService, IDuckDbDatabaseHandle } from "./IDuckDbService";
 import { DuckDbDatabaseHandle } from "./DuckDbDatabaseHandle";
 import {
@@ -408,22 +413,21 @@ export class DuckDbService extends BaseService implements IDuckDbService {
   ): Promise<Result<never>> {
     const errorText = await response.text();
 
-    let errorBody: { error?: string; message?: string; code?: string } = {};
-    try {
-      errorBody = JSON.parse(errorText);
-    } catch {
-      // Not JSON
-    }
+    const errorBody = parseServiceErrorBody(errorText);
 
     const errorCode = this.mapHttpStatusToErrorCode(
       response.status,
       errorBody.error
     );
-    const message =
-      errorBody.message ||
-      `DuckDB ${operation} failed: ${response.status} - ${errorText}`;
+    const message = formatServiceResponseError(
+      "DuckDB",
+      operation,
+      response.status,
+      errorText,
+      errorBody,
+    );
 
-    const meta: Record<string, unknown> = { status: response.status, statusText: response.statusText };
+    const meta = responseErrorMeta(response.status, response.statusText, errorText);
 
     if (response.status === 401) {
       const { resource, action } = parseAuthError(errorText);

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -176,8 +176,8 @@ export type {
 } from "./kv";
 
 // SQL service
-export { SQLService, DatabaseHandle, SQLAction } from "./sql";
-export type { ISQLService, IDatabaseHandle } from "./sql";
+export { SQLService, DatabaseHandle, SQLMigrations, SQLAction } from "./sql";
+export type { ISQLService, IDatabaseHandle, ISQLMigrations } from "./sql";
 export type {
   SQLServiceConfig,
   QueryOptions,
@@ -188,6 +188,9 @@ export type {
   QueryResponse,
   ExecuteResponse,
   BatchResponse,
+  SqlMigration,
+  SqlMigrationApplyOptions,
+  SqlMigrationApplyResponse,
   SQLActionType,
 } from "./sql";
 

--- a/packages/sdk-services/src/responseErrors.ts
+++ b/packages/sdk-services/src/responseErrors.ts
@@ -1,0 +1,56 @@
+export interface ParsedServiceErrorBody {
+  error?: string;
+  message?: string;
+  code?: string;
+}
+
+export function parseServiceErrorBody(errorText: string): ParsedServiceErrorBody {
+  try {
+    return JSON.parse(errorText) as ParsedServiceErrorBody;
+  } catch {
+    return {};
+  }
+}
+
+export function formatServiceResponseError(
+  serviceLabel: string,
+  operation: string,
+  status: number,
+  errorText: string,
+  parsed: ParsedServiceErrorBody,
+): string {
+  if (parsed.message) {
+    return compactMessage(parsed.message);
+  }
+
+  if (looksLikeHtml(errorText)) {
+    if (status === 524 || /524\s*[:-]/i.test(errorText) || /a timeout occurred/i.test(errorText)) {
+      return `${serviceLabel} ${operation} failed: upstream request timed out. Please retry.`;
+    }
+    return `${serviceLabel} ${operation} failed: upstream service returned an HTML error page (${status}).`;
+  }
+
+  return `${serviceLabel} ${operation} failed: ${status} - ${compactMessage(errorText)}`;
+}
+
+export function responseErrorMeta(
+  status: number,
+  statusText: string,
+  errorText: string,
+): Record<string, unknown> {
+  const meta: Record<string, unknown> = { status, statusText };
+  const snippet = compactMessage(errorText);
+  if (snippet) {
+    meta.responseSnippet = snippet.slice(0, 300);
+  }
+  return meta;
+}
+
+function looksLikeHtml(text: string): boolean {
+  return /<!doctype html/i.test(text) || /<html[\s>]/i.test(text);
+}
+
+function compactMessage(message: string): string {
+  const compact = message.replace(/\s+/g, " ").trim();
+  return compact.length > 500 ? `${compact.slice(0, 500)}...` : compact;
+}

--- a/packages/sdk-services/src/sql/DatabaseHandle.ts
+++ b/packages/sdk-services/src/sql/DatabaseHandle.ts
@@ -5,8 +5,9 @@
  */
 
 import type { Result } from "../types";
-import type { IDatabaseHandle } from "./ISQLService";
+import type { IDatabaseHandle, ISQLMigrations } from "./ISQLService";
 import type { SQLService } from "./SQLService";
+import { SQLMigrations } from "./SQLMigrations";
 import type {
   SqlValue,
   SqlStatement,
@@ -21,10 +22,12 @@ import type {
 export class DatabaseHandle implements IDatabaseHandle {
   private service: SQLService;
   public readonly name: string;
+  public readonly migrations: ISQLMigrations;
 
   constructor(service: SQLService, name: string) {
     this.service = service;
     this.name = name;
+    this.migrations = new SQLMigrations(service, name);
   }
 
   async query<T = Record<string, unknown>>(

--- a/packages/sdk-services/src/sql/ISQLService.ts
+++ b/packages/sdk-services/src/sql/ISQLService.ts
@@ -15,7 +15,19 @@ import type {
   QueryResponse,
   ExecuteResponse,
   BatchResponse,
+  SqlMigrationApplyOptions,
+  SqlMigrationApplyResponse,
 } from "./types";
+
+/**
+ * Migration helper bound to a specific database.
+ */
+export interface ISQLMigrations {
+  /**
+   * Apply ordered, app-owned migrations and record completed ids.
+   */
+  apply(options: SqlMigrationApplyOptions): Promise<Result<SqlMigrationApplyResponse>>;
+}
 
 /**
  * Database handle interface for operations on a specific named database.
@@ -23,6 +35,9 @@ import type {
 export interface IDatabaseHandle {
   /** The database name */
   readonly name: string;
+
+  /** Versioned schema migration helper. */
+  readonly migrations: ISQLMigrations;
 
   /**
    * Execute a SQL query and return rows.

--- a/packages/sdk-services/src/sql/SQLMigrations.ts
+++ b/packages/sdk-services/src/sql/SQLMigrations.ts
@@ -1,0 +1,18 @@
+import type { Result } from "../types";
+import type { SQLService } from "./SQLService";
+import type { ISQLMigrations } from "./ISQLService";
+import type {
+  SqlMigrationApplyOptions,
+  SqlMigrationApplyResponse,
+} from "./types";
+
+export class SQLMigrations implements ISQLMigrations {
+  constructor(
+    private readonly service: SQLService,
+    private readonly dbName: string,
+  ) {}
+
+  apply(options: SqlMigrationApplyOptions): Promise<Result<SqlMigrationApplyResponse>> {
+    return this.service.applyMigrationsOnDb(this.dbName, options);
+  }
+}

--- a/packages/sdk-services/src/sql/SQLService.test.ts
+++ b/packages/sdk-services/src/sql/SQLService.test.ts
@@ -228,4 +228,190 @@ describe("SQLService permissions", () => {
       },
     ]);
   });
+
+  test("migrations.apply creates metadata table, applies pending SQL, and records ids", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    const invokeAnyCalls: Array<{ entries: Array<{ service: string; path: string; action: string }> }> = [];
+    const bodies: any[] = [];
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async (_url, init) => {
+        const body = JSON.parse(init?.body as string);
+        bodies.push(body);
+
+        if (body.action === "query") {
+          return response(true, 200, {
+            columns: ["id"],
+            rows: [],
+            rowCount: 0,
+          });
+        }
+
+        if (body.action === "batch") {
+          return response(true, 200, {
+            results: body.statements.map(() => ({ changes: 1, lastInsertRowId: null })),
+          });
+        }
+
+        return response(true, 200, {
+          changes: 0,
+          lastInsertRowId: null,
+        });
+      }, invokeCalls, invokeAnyCalls),
+    );
+
+    const result = await service.db("app.db").migrations.apply({
+      namespace: "com.example.app",
+      migrations: [
+        {
+          id: "001_initial",
+          sql: [
+            "CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, body TEXT)",
+            { sql: "CREATE INDEX IF NOT EXISTS idx_notes_body ON notes(body)" },
+          ],
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({
+        database: "app.db",
+        namespace: "com.example.app",
+        status: "applied",
+        applied: ["001_initial"],
+        skipped: [],
+      });
+    }
+    expect(invokeCalls).toEqual([
+      { service: "sql", path: "app.db", action: SQLAction.READ },
+    ]);
+    expect(invokeAnyCalls).toEqual([
+      {
+        entries: [
+          { service: "sql", path: "app.db", action: SQLAction.DDL },
+          { service: "sql", path: "app.db", action: SQLAction.WRITE },
+        ],
+      },
+      {
+        entries: [
+          { service: "sql", path: "app.db", action: SQLAction.DDL },
+          { service: "sql", path: "app.db", action: SQLAction.WRITE },
+        ],
+      },
+    ]);
+    expect(bodies[0].action).toBe("batch");
+    expect(bodies[0].statements[0].sql).toContain("__tinycloud_sql_migrations");
+    expect(bodies[0].statements[1].params[1]).toBe("tinycloud.sql.migrations");
+    expect(bodies[1]).toEqual({
+      action: "query",
+      sql: "SELECT id FROM __tinycloud_sql_migrations WHERE namespace = ? ORDER BY applied_at, id",
+      params: ["com.example.app"],
+    });
+    expect(bodies[2]).toEqual({
+      action: "batch",
+      statements: [
+        { sql: "CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, body TEXT)" },
+        { sql: "CREATE INDEX IF NOT EXISTS idx_notes_body ON notes(body)" },
+        {
+          sql: "INSERT OR REPLACE INTO __tinycloud_sql_migrations (key, namespace, id, applied_at, statement_count) VALUES (?, ?, ?, ?, ?)",
+          params: [
+            "com.example.app:001_initial",
+            "com.example.app",
+            "001_initial",
+            bodies[2].statements[2].params[3],
+            2,
+          ],
+        },
+      ],
+    });
+  });
+
+  test("migrations.apply skips already recorded migrations", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    const invokeAnyCalls: Array<{ entries: Array<{ service: string; path: string; action: string }> }> = [];
+    const bodies: any[] = [];
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async (_url, init) => {
+        const body = JSON.parse(init?.body as string);
+        bodies.push(body);
+
+        if (body.action === "query") {
+          return response(true, 200, {
+            columns: ["id"],
+            rows: [["001_initial"]],
+            rowCount: 1,
+          });
+        }
+
+        if (body.action === "batch") {
+          return response(true, 200, {
+            results: body.statements.map(() => ({ changes: 1, lastInsertRowId: null })),
+          });
+        }
+
+        return response(true, 200, {
+          changes: 0,
+          lastInsertRowId: null,
+        });
+      }, invokeCalls, invokeAnyCalls),
+    );
+
+    const result = await service.db("app.db").migrations.apply({
+      namespace: "com.example.app",
+      migrations: [
+        {
+          id: "001_initial",
+          sql: ["CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, body TEXT)"],
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({
+        database: "app.db",
+        namespace: "com.example.app",
+        status: "already_current",
+        applied: [],
+        skipped: ["001_initial"],
+      });
+    }
+    expect(invokeCalls).toEqual([
+      { service: "sql", path: "app.db", action: SQLAction.READ },
+    ]);
+    expect(invokeAnyCalls).toEqual([
+      {
+        entries: [
+          { service: "sql", path: "app.db", action: SQLAction.DDL },
+          { service: "sql", path: "app.db", action: SQLAction.WRITE },
+        ],
+      },
+    ]);
+    expect(bodies.map((body) => body.action)).toEqual(["batch", "query"]);
+  });
+
+  test("SQL errors sanitize proxy HTML pages", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async () => response(false, 524,
+        "<!DOCTYPE html><html><head><title>tinycloud.xyz | 524: A timeout occurred</title></head><body>Error code 524</body></html>",
+        "Timeout",
+      ), invokeCalls),
+    );
+
+    const result = await service.execute("CREATE TABLE IF NOT EXISTS notes (body TEXT)");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe("SQL execute failed: upstream request timed out. Please retry.");
+      expect(result.error.message).not.toContain("<!DOCTYPE html>");
+      expect(result.error.meta?.responseSnippet).toContain("<!DOCTYPE html>");
+    }
+  });
 });

--- a/packages/sdk-services/src/sql/SQLService.ts
+++ b/packages/sdk-services/src/sql/SQLService.ts
@@ -17,6 +17,11 @@ import {
   type ServiceSession,
 } from "../types";
 import { authRequiredError, wrapError, parseAuthError } from "../errors";
+import {
+  formatServiceResponseError,
+  parseServiceErrorBody,
+  responseErrorMeta,
+} from "../responseErrors";
 import type { ISQLService } from "./ISQLService";
 import type { IDatabaseHandle } from "./ISQLService";
 import { DatabaseHandle } from "./DatabaseHandle";
@@ -30,15 +35,29 @@ import {
   type QueryResponse,
   type ExecuteResponse,
   type BatchResponse,
+  type SqlMigration,
+  type SqlMigrationApplyOptions,
+  type SqlMigrationApplyResponse,
   SQLAction,
 } from "./types";
 
 const DDL_TOKENS = new Set(["alter", "create", "drop"]);
+const MIGRATIONS_TABLE = "__tinycloud_sql_migrations";
+const MIGRATIONS_SCHEMA = `CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+  key TEXT PRIMARY KEY,
+  namespace TEXT NOT NULL,
+  id TEXT NOT NULL,
+  applied_at TEXT NOT NULL,
+  statement_count INTEGER NOT NULL
+)`;
+const MIGRATIONS_META_NAMESPACE = "tinycloud.sql.migrations";
+const MIGRATIONS_META_ID = "000_metadata";
 
 export class SQLService extends BaseService implements ISQLService {
   static readonly serviceName = "sql";
 
   declare protected _config: SQLServiceConfig;
+  private readonly migrationLocks = new Map<string, Promise<Result<SqlMigrationApplyResponse>>>();
 
   constructor(config: SQLServiceConfig = {}) {
     super();
@@ -94,6 +113,30 @@ export class SQLService extends BaseService implements ISQLService {
     options?: BatchOptions
   ): Promise<Result<BatchResponse>> {
     return this.batchOnDb(this.defaultDbName, statements, options);
+  }
+
+  async applyMigrationsOnDb(
+    dbName: string,
+    options: SqlMigrationApplyOptions,
+  ): Promise<Result<SqlMigrationApplyResponse>> {
+    const validationError = validateMigrationOptions(options);
+    if (validationError) {
+      return err(serviceError(ErrorCodes.INVALID_INPUT, validationError, "sql"));
+    }
+
+    const lockKey = `${dbName}\0${options.namespace}`;
+    const existing = this.migrationLocks.get(lockKey);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = this.applyMigrationsOnDbUnlocked(dbName, options);
+    this.migrationLocks.set(lockKey, promise);
+    try {
+      return await promise;
+    } finally {
+      this.migrationLocks.delete(lockKey);
+    }
   }
 
   // === Internal methods called by DatabaseHandle ===
@@ -275,6 +318,101 @@ export class SQLService extends BaseService implements ISQLService {
     });
   }
 
+  private async applyMigrationsOnDbUnlocked(
+    dbName: string,
+    options: SqlMigrationApplyOptions,
+  ): Promise<Result<SqlMigrationApplyResponse>> {
+    return this.withTelemetry("migrations.apply", dbName, async () => {
+      const created = await this.ensureMigrationsTable(dbName, options.signal);
+      if (!created.ok) return created;
+
+      const listed = await this.queryOnDb<{ id: string }>(
+        dbName,
+        `SELECT id FROM ${MIGRATIONS_TABLE} WHERE namespace = ? ORDER BY applied_at, id`,
+        [options.namespace],
+        { signal: options.signal },
+      );
+      if (!listed.ok) return listed;
+
+      const appliedIds = new Set(
+        listed.data.rows
+          .map((row) => rowValue(row, 0))
+          .filter((id): id is string => typeof id === "string"),
+      );
+      const skipped = options.migrations
+        .filter((migration) => appliedIds.has(migration.id))
+        .map((migration) => migration.id);
+      const pending = options.migrations.filter((migration) => !appliedIds.has(migration.id));
+      const applied: string[] = [];
+
+      for (const migration of pending) {
+        const result = await this.applyOneMigration(dbName, options.namespace, migration, options.signal);
+        if (!result.ok) return result;
+        applied.push(migration.id);
+      }
+
+      return ok({
+        database: dbName,
+        namespace: options.namespace,
+        status: applied.length > 0 ? "applied" : "already_current",
+        applied,
+        skipped,
+      });
+    });
+  }
+
+  private async applyOneMigration(
+    dbName: string,
+    namespace: string,
+    migration: SqlMigration,
+    signal?: AbortSignal,
+  ): Promise<Result<void>> {
+    const statements = [
+      ...migration.sql.map((statement) =>
+        typeof statement === "string" ? { sql: statement } : statement,
+      ),
+      {
+        sql: `INSERT OR REPLACE INTO ${MIGRATIONS_TABLE} (key, namespace, id, applied_at, statement_count) VALUES (?, ?, ?, ?, ?)`,
+        params: [
+          migrationKey(namespace, migration.id),
+          namespace,
+          migration.id,
+          new Date().toISOString(),
+          migration.sql.length,
+        ],
+      },
+    ];
+
+    const result = await this.batchOnDb(dbName, statements, { signal });
+    if (!result.ok) return result;
+    return ok(undefined);
+  }
+
+  private async ensureMigrationsTable(
+    dbName: string,
+    signal?: AbortSignal,
+  ): Promise<Result<void>> {
+    const result = await this.batchOnDb(
+      dbName,
+      [
+        { sql: MIGRATIONS_SCHEMA },
+        {
+          sql: `INSERT OR REPLACE INTO ${MIGRATIONS_TABLE} (key, namespace, id, applied_at, statement_count) VALUES (?, ?, ?, ?, ?)`,
+          params: [
+            migrationKey(MIGRATIONS_META_NAMESPACE, MIGRATIONS_META_ID),
+            MIGRATIONS_META_NAMESPACE,
+            MIGRATIONS_META_ID,
+            new Date().toISOString(),
+            1,
+          ],
+        },
+      ],
+      { signal },
+    );
+    if (!result.ok) return result;
+    return ok(undefined);
+  }
+
   // === Private helpers ===
 
   private async invokeSQL(
@@ -346,22 +484,21 @@ export class SQLService extends BaseService implements ISQLService {
   ): Promise<Result<never>> {
     const errorText = await response.text();
 
-    let errorBody: { error?: string; message?: string; code?: string } = {};
-    try {
-      errorBody = JSON.parse(errorText);
-    } catch {
-      // Not JSON
-    }
+    const errorBody = parseServiceErrorBody(errorText);
 
     const errorCode = this.mapHttpStatusToErrorCode(
       response.status,
       errorBody.error
     );
-    const message =
-      errorBody.message ||
-      `SQL ${operation} failed: ${response.status} - ${errorText}`;
+    const message = formatServiceResponseError(
+      "SQL",
+      operation,
+      response.status,
+      errorText,
+      errorBody,
+    );
 
-    const meta: Record<string, unknown> = { status: response.status, statusText: response.statusText };
+    const meta = responseErrorMeta(response.status, response.statusText, errorText);
 
     if (response.status === 401) {
       const { resource, action } = parseAuthError(errorText);
@@ -431,4 +568,57 @@ function firstSqlToken(sql: string): string | undefined {
 
   const match = /^[A-Za-z_]+/.exec(sql.slice(index));
   return match?.[0].toLowerCase();
+}
+
+function validateMigrationOptions(options: SqlMigrationApplyOptions): string | null {
+  if (!options || typeof options !== "object") {
+    return "SQL migrations require options";
+  }
+  if (!options.namespace || typeof options.namespace !== "string") {
+    return "SQL migrations require a non-empty namespace";
+  }
+  if (!Array.isArray(options.migrations)) {
+    return "SQL migrations require an ordered migrations array";
+  }
+
+  const ids = new Set<string>();
+  for (const migration of options.migrations) {
+    if (!migration.id || typeof migration.id !== "string") {
+      return "SQL migrations require every migration to have a non-empty id";
+    }
+    if (ids.has(migration.id)) {
+      return `Duplicate SQL migration id: ${migration.id}`;
+    }
+    ids.add(migration.id);
+
+    if (!Array.isArray(migration.sql)) {
+      return `SQL migration ${migration.id} requires a sql array`;
+    }
+    for (const statement of migration.sql) {
+      if (typeof statement === "string") {
+        if (statement.trim() === "") {
+          return `SQL migration ${migration.id} contains an empty statement`;
+        }
+        continue;
+      }
+      if (!statement || typeof statement.sql !== "string" || statement.sql.trim() === "") {
+        return `SQL migration ${migration.id} contains an invalid statement`;
+      }
+    }
+  }
+
+  return null;
+}
+
+function migrationKey(namespace: string, id: string): string {
+  return `${encodeURIComponent(namespace)}:${encodeURIComponent(id)}`;
+}
+
+function rowValue(row: unknown, index: number): unknown {
+  if (Array.isArray(row)) return row[index];
+  if (row && typeof row === "object") {
+    const values = Object.values(row as Record<string, unknown>);
+    return values[index];
+  }
+  return undefined;
 }

--- a/packages/sdk-services/src/sql/index.ts
+++ b/packages/sdk-services/src/sql/index.ts
@@ -6,7 +6,8 @@
 
 export { SQLService } from "./SQLService";
 export { DatabaseHandle } from "./DatabaseHandle";
-export type { ISQLService, IDatabaseHandle } from "./ISQLService";
+export { SQLMigrations } from "./SQLMigrations";
+export type { ISQLService, IDatabaseHandle, ISQLMigrations } from "./ISQLService";
 export {
   SQLAction,
   type SQLActionType,
@@ -19,4 +20,7 @@ export {
   type QueryResponse,
   type ExecuteResponse,
   type BatchResponse,
+  type SqlMigration,
+  type SqlMigrationApplyOptions,
+  type SqlMigrationApplyResponse,
 } from "./types";

--- a/packages/sdk-services/src/sql/types.ts
+++ b/packages/sdk-services/src/sql/types.ts
@@ -97,6 +97,53 @@ export interface BatchResponse {
 }
 
 /**
+ * A versioned SQL migration owned by an application or SDK subsystem.
+ */
+export interface SqlMigration {
+  /**
+   * Stable migration id within the namespace, e.g. "001_initial".
+   */
+  id: string;
+
+  /**
+   * SQL statements to apply when this migration has not been recorded.
+   * Statements should be idempotent where SQLite supports it.
+   */
+  sql: Array<string | SqlStatement>;
+}
+
+/**
+ * Options for applying SQL migrations.
+ */
+export interface SqlMigrationApplyOptions {
+  /**
+   * Namespace for this migration set, usually an app id or SDK subsystem.
+   */
+  namespace: string;
+
+  /**
+   * Ordered migration list.
+   */
+  migrations: SqlMigration[];
+
+  /**
+   * Custom abort signal for migration operations.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Result from applying SQL migrations.
+ */
+export interface SqlMigrationApplyResponse {
+  database: string;
+  namespace: string;
+  status: "already_current" | "applied";
+  applied: string[];
+  skipped: string[];
+}
+
+/**
  * SQL service action types.
  */
 export const SQLAction = {


### PR DESCRIPTION
## Summary
- add a database-scoped SQL migrations helper: `sql.db(name).migrations.apply({ namespace, migrations })`
- store applied migration ids in an SDK-managed SQL metadata table and sign migration batches with DDL/write/read capabilities
- move the account registry SQLite index schema setup onto the migrations helper
- sanitize non-JSON proxy HTML errors from SQL and DuckDB into concise retry messages with bounded debug metadata

## Verification
- `bun test packages/sdk-services/src/sql/SQLService.test.ts packages/node-sdk/src/account/AccountService.test.ts packages/sdk-core/src/manifest.test.ts packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts`
- `bun run build` in `packages/sdk-services`
- `bun run build` in `packages/sdk-core`
- `bun run build` in `packages/node-sdk`
- `bun run build` in `packages/web-sdk`