### PR TITLE
fix(sdk): resolve/rehydrate tinycloudHosts on restored sessions

### DIFF
--- a/.changeset/restore-host-resolution.md
+++ b/.changeset/restore-host-resolution.md
@@ -1,0 +1,33 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+"@tinycloud/sdk-services": minor
+---
+
+Resolve and rehydrate `tinycloudHosts` on restored sessions.
+
+A restored session never resolved its TinyCloud hosts: the restore path
+rehydrated the delegation/address/chainId but never set the hosts, and the
+hosts a session was created with weren't persisted. The first kv/secrets/
+space/encryption call on a restored session therefore threw "TinyCloud
+hosts have not been resolved. Call signIn() first." (notably when
+`signIn()` short-circuited to a restored session).
+
+Fix (three parts):
+
+- Persist the hosts: `PersistedSessionData` gains an optional
+  `tinycloudHosts` field (back-compat — old persisted sessions still
+  validate), and both sign-in save paths write the just-resolved hosts.
+- Rehydrate on restore: `TinyCloudNode.restoreSession` accepts the
+  persisted `tinycloudHosts`, adopts them for the service context and the
+  auth layer (`setRestoredTinyCloudSession`), and the web SDK threads the
+  field through `restoreDataFromPersisted`.
+- Lazy fallback: sessions persisted before this field re-resolve their
+  hosts lazily (registry → `node.tinycloud.xyz` fallback) on the first
+  host-needing call, exactly like a fresh sign-in. Resolution failures
+  surface rather than being masked.
+
+A restored session now targets the same node as the original sign-in, so
+apps no longer need to pass `tinycloudHosts` explicitly or call
+`clearPersistedSession()` before sign-in.

--- a/packages/node-sdk/scripts/live-restore-host-resolution.ts
+++ b/packages/node-sdk/scripts/live-restore-host-resolution.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+/**
+ * Gated live test: a RESTORED session resolves/rehydrates its TinyCloud
+ * hosts and can do a real service call without re-running the wallet
+ * sign-in flow.
+ *
+ * Proves the fix for "TinyCloud hosts have not been resolved. Call
+ * signIn() first." on restored sessions:
+ *   1. Owner signs in against a LOCAL tinycloud node (explicit host) and
+ *      the session — including its `tinycloudHosts` — is persisted to disk.
+ *   2. A FRESH TinyCloudNode (no explicit host, no signer wallet flow)
+ *      restores that persisted session, threading the persisted hosts
+ *      through restoreSession.
+ *   3. The restored node does a real KV put/get against the same local
+ *      node — proving the host was rehydrated from persistence and the
+ *      restored session targets the right node without re-signing.
+ *
+ * Gated: set TC_LIVE_RESTORE=1 to run. Requires the local tinycloud
+ * binary (built debug) — override path with TC_NODE_BIN.
+ *
+ *   TC_LIVE_RESTORE=1 bun run packages/node-sdk/scripts/live-restore-host-resolution.ts
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const ENABLED = process.env.TC_LIVE_RESTORE === "1";
+const NODE_BIN =
+  process.env.TC_NODE_BIN ??
+  "/Users/samgbafa/Documents/github/tinycloud-dev/repositories/tinycloud-node/target/debug/tinycloud";
+const PORT = Number(process.env.TINYCLOUD_PORT ?? 9123);
+
+if (!ENABLED) {
+  process.stderr.write(
+    "[skip] Set TC_LIVE_RESTORE=1 to run the restore host-resolution live test.\n",
+  );
+  process.exit(0);
+}
+
+const TINYCLOUD_TOML = `[global.keys]
+type = "Static"
+`;
+
+async function waitForNode(host: string, timeoutMs = 20000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${host}/info`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Local tinycloud node at ${host} did not become ready.`);
+}
+
+async function main(): Promise<void> {
+  const { TinyCloudNode } = await import("../src/index.ts");
+  const { FileSessionStorage } = await import(
+    "../src/storage/FileSessionStorage.ts"
+  );
+
+  const dataDir = await mkdtemp(join(tmpdir(), "tc-restore-host-data-"));
+  const runDir = await mkdtemp(join(tmpdir(), "tc-restore-host-run-"));
+  const sessionDir = await mkdtemp(join(tmpdir(), "tc-restore-host-session-"));
+  await writeFile(join(runDir, "tinycloud.toml"), TINYCLOUD_TOML, "utf8");
+
+  const host = `http://localhost:${PORT}`;
+  let child: ChildProcess | undefined;
+
+  try {
+    child = spawn(NODE_BIN, [], {
+      cwd: runDir,
+      env: {
+        ...process.env,
+        TINYCLOUD_LOG_LEVEL: "normal",
+        TINYCLOUD_PORT: String(PORT),
+        TINYCLOUD_STORAGE_DATADIR: dataDir,
+        TINYCLOUD_CORS: "true",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr?.on("data", (c) =>
+      process.stderr.write(`[node] ${c.toString()}`),
+    );
+
+    await waitForNode(host);
+    console.log(`[live] local tinycloud node ready at ${host}`);
+
+    // A deterministic dev key (Hardhat account #0) so both nodes share an
+    // address — restore is keyed by address.
+    const privateKey =
+      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    // --- PART 1: owner signs in (explicit local host) and persists ---
+    const ownerStorage = new FileSessionStorage(sessionDir);
+    const owner = new TinyCloudNode({
+      privateKey,
+      host, // explicit local host
+      autoCreateSpace: true,
+      sessionStorage: ownerStorage,
+    });
+    await owner.signIn();
+    const address = owner.address!;
+    console.log(`[live] owner signed in: ${address}`);
+
+    const persisted = await ownerStorage.load(address);
+    if (!persisted) throw new Error("Owner session was not persisted.");
+    if (!persisted.tinycloudHosts || persisted.tinycloudHosts.length === 0) {
+      throw new Error(
+        "FAIL: persisted session is missing tinycloudHosts (persist step broken).",
+      );
+    }
+    if (persisted.tinycloudHosts[0] !== host) {
+      throw new Error(
+        `FAIL: persisted host mismatch. Expected ${host}, got ${persisted.tinycloudHosts[0]}.`,
+      );
+    }
+    console.log(
+      `[live] persisted tinycloudHosts = ${JSON.stringify(persisted.tinycloudHosts)}`,
+    );
+
+    // Write a value as the owner so the restored session can read it.
+    const key = `restore-proof-${Date.now()}`;
+    const value = `value-${Math.random().toString(36).slice(2)}`;
+    const putOwner = await owner.kv.put(key, value);
+    if (!putOwner.ok) {
+      throw new Error(
+        `Owner kv.put failed: ${putOwner.error.code} ${putOwner.error.message}`,
+      );
+    }
+
+    // --- PART 2: fresh node restores WITHOUT explicit host or wallet ---
+    // No `host`, no `privateKey` — purely session-only restore. This is the
+    // exact shape that triggered "hosts have not been resolved".
+    const restored = new TinyCloudNode({});
+
+    const data = persisted;
+    if (!data.tinycloudSession) {
+      throw new Error("Persisted session missing tinycloudSession.");
+    }
+    await restored.restoreSession({
+      delegationHeader: data.tinycloudSession.delegationHeader,
+      delegationCid: data.tinycloudSession.delegationCid,
+      spaceId: data.tinycloudSession.spaceId,
+      jwk: JSON.parse(data.sessionKey),
+      verificationMethod: data.tinycloudSession.verificationMethod,
+      address: data.address,
+      chainId: data.chainId,
+      siwe: data.siwe,
+      signature: data.signature,
+      tinycloudHosts: data.tinycloudHosts, // the fix: thread persisted hosts
+    });
+
+    console.log(`[live] restored node hosts = ${JSON.stringify(restored.hosts)}`);
+    if (!restored.hosts.includes(host)) {
+      throw new Error(
+        `FAIL: restored node did not rehydrate the local host. hosts=${JSON.stringify(restored.hosts)}`,
+      );
+    }
+
+    // --- PART 3: real service call on the restored session ---
+    const getRestored = await restored.kv.get(key);
+    if (!getRestored.ok) {
+      throw new Error(
+        `FAIL: restored kv.get failed (likely 'hosts not resolved' or wrong host): ${getRestored.error.code} ${getRestored.error.message}`,
+      );
+    }
+    const readValue = getRestored.data.data;
+    if (readValue !== value) {
+      throw new Error(
+        `FAIL: restored kv.get returned wrong value. Expected ${value}, got ${String(readValue)}.`,
+      );
+    }
+
+    console.log(
+      `[live] PASS: restored session read key=${key} value=${String(readValue)} ` +
+        `with no re-sign-in and no 'hosts not resolved' error.`,
+    );
+    process.stdout.write(
+      JSON.stringify({ ok: true, host, address, key }) + "\n",
+    );
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  } finally {
+    if (child && !child.killed) {
+      child.kill("SIGTERM");
+    }
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(runDir, { recursive: true, force: true });
+    await rm(sessionDir, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -107,6 +107,7 @@ import {
   verifyDidKeyEd25519Signature,
   canonicalizeAddress,
   pkhDid,
+  resolveTinyCloudHosts,
   principalDidEquals,
   parseNetworkId,
   type BuildDecryptInvocationInput,
@@ -1095,6 +1096,16 @@ export class TinyCloudNode {
      * for callers that need to round-trip the full session shape.
      */
     signature?: string;
+    /**
+     * The TinyCloud hosts this session was created against (from
+     * {@link PersistedSessionData.tinycloudHosts}). When present they are
+     * adopted so the restored session targets the same node as the
+     * original sign-in — without this, service calls fall back to the
+     * default host and the auth layer throws "TinyCloud hosts have not
+     * been resolved". When absent (old persisted session) hosts resolve
+     * lazily via the registry/fallback on the first host-needing call.
+     */
+    tinycloudHosts?: string[];
   }): Promise<void> {
     // Ensure WASM is ready (critical for browser where WASM loads asynchronously)
     await this.wasmBindings.ensureInitialized?.();
@@ -1120,6 +1131,23 @@ export class TinyCloudNode {
     }
     if (sessionData.chainId) {
       this._chainId = sessionData.chainId;
+    }
+
+    // Resolve the host the restored session should target, mirroring what a
+    // fresh signIn() would have done. Priority:
+    //   1. explicitHost   — local dev / pinned node, never override
+    //   2. persisted hosts — the node this session was created against
+    //   3. registry/fallback resolution — old sessions that predate the
+    //      persisted tinycloudHosts field
+    // Without this, the ServiceContext below (and every service call) would
+    // silently target the default host instead of the user's actual node.
+    const resolvedHost = await this.resolveRestoredHost(
+      sessionData.tinycloudHosts,
+      restoredAddress,
+      sessionData.chainId,
+    );
+    if (resolvedHost) {
+      this.config.host = resolvedHost;
     }
 
     // Create service context
@@ -1191,11 +1219,52 @@ export class TinyCloudNode {
         signature: sessionData.signature ?? "",
       };
       if (this.auth) {
-        this.auth.setRestoredTinyCloudSession(tcSession);
+        // Pass the now-resolved host so the auth layer's host-needing
+        // methods (ensureSpaceExists/hostSpace) don't throw "hosts have
+        // not been resolved" on a restored session.
+        this.auth.setRestoredTinyCloudSession(
+          tcSession,
+          this.config.host ? [this.config.host] : undefined,
+        );
       } else {
         this._restoredTcSession = tcSession;
       }
     }
+  }
+
+  /**
+   * Resolve the host a restored session should target.
+   *
+   * Mirrors fresh sign-in host resolution but for the restore path:
+   * an explicit/pinned host always wins, then the hosts the session was
+   * persisted with, then a lazy registry/fallback resolution for sessions
+   * that predate the persisted `tinycloudHosts` field. Returns `undefined`
+   * only when there's nothing to resolve from (no explicit host, no
+   * persisted hosts, and no address/chainId) — in which case the existing
+   * `config.host` (default) is left in place.
+   *
+   * Resolution failures are surfaced, not swallowed: a genuinely broken
+   * registry lookup throws rather than silently falling back to a wrong host.
+   */
+  private async resolveRestoredHost(
+    persistedHosts: string[] | undefined,
+    address: string | undefined,
+    chainId: number | undefined,
+  ): Promise<string | undefined> {
+    if (this.explicitHost) {
+      return this.explicitHost;
+    }
+    if (persistedHosts && persistedHosts.length > 0) {
+      return persistedHosts[0];
+    }
+    if (address === undefined || chainId === undefined) {
+      return undefined;
+    }
+    const resolved = await resolveTinyCloudHosts(pkhDid(address, chainId), {
+      registryUrl: this.config.tinycloudRegistryUrl,
+      fallbackHosts: this.config.tinycloudFallbackHosts,
+    });
+    return resolved.hosts[0];
   }
 
   /**

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
@@ -5,6 +5,7 @@ import {
   type IWasmBindings,
   type ISessionManager,
   type ISigner,
+  type TinyCloudSession,
 } from "@tinycloud/sdk-core";
 import { NodeUserAuthorization } from "./NodeUserAuthorization";
 import { MemorySessionStorage } from "../storage/MemorySessionStorage";
@@ -229,4 +230,111 @@ test("NodeUserAuthorization.signIn resolves TinyCloud hosts when none are explic
     )}`,
   );
   expect(requests).toContain(`${DEFAULT_TINYCLOUD_FALLBACK_HOST}/info`);
+});
+
+function restoredTinyCloudSession(): TinyCloudSession {
+  return {
+    address: "0x1234567890abcdef1234567890abcdef12345678",
+    chainId: 1,
+    sessionKey: "session-key",
+    spaceId: "tinycloud:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678:default",
+    delegationCid: "bafy-restored",
+    delegationHeader: { Authorization: "Bearer restored" },
+    verificationMethod: "did:key:restored#restored",
+    jwk: { kty: "OKP", kid: "session-key" },
+    siwe: "example.com wants you to sign in...",
+    signature: "0xrestored",
+  };
+}
+
+test("restored session adopts persisted hosts WITHOUT the wallet flow and a host-needing call does not throw", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const signedMessages: string[] = [];
+  const requests: string[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).__originalFetch = originalFetch;
+  globalThis.fetch = async (input: any, init?: any) => {
+    const url = String(input);
+    requests.push(url);
+    if (url.endsWith("/delegate") && init?.method === "POST") {
+      // Primary space already activated — no creation needed.
+      return new Response(
+        JSON.stringify({ activated: ["space"], skipped: [] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  const auth = new NodeUserAuthorization({
+    signer: createSigner(signedMessages),
+    wasmBindings: createWasmBindings(captured),
+    signStrategy: { type: "auto-sign" },
+    domain: "example.com",
+    sessionStorage: new MemorySessionStorage(),
+  });
+
+  // Restore the session with the hosts that were persisted at sign-in time.
+  const persistedHosts = ["https://persisted.node.test"];
+  auth.setRestoredTinyCloudSession(restoredTinyCloudSession(), persistedHosts);
+
+  // Hosts are adopted immediately, with NO wallet signing and NO registry hit.
+  expect(auth.hosts).toEqual(persistedHosts);
+
+  // A host-needing call must NOT throw "hosts have not been resolved".
+  await auth.ensureSpaceExists();
+
+  expect(signedMessages.length).toBe(0); // no wallet flow
+  // No registry lookup — persisted hosts were used directly.
+  expect(
+    requests.some((u) => u.startsWith(DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL)),
+  ).toBe(false);
+  // The host-needing call targeted the persisted host.
+  expect(requests).toContain(`${persistedHosts[0]}/delegate`);
+});
+
+test("restored session with NO persisted hosts lazily resolves via registry/fallback", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const signedMessages: string[] = [];
+  const requests: string[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).__originalFetch = originalFetch;
+  globalThis.fetch = async (input: any, init?: any) => {
+    const url = String(input);
+    requests.push(url);
+    if (url.startsWith(`${DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL}/v1/locations/`)) {
+      return new Response("{}", { status: 404 });
+    }
+    if (url.endsWith("/delegate") && init?.method === "POST") {
+      return new Response(
+        JSON.stringify({ activated: ["space"], skipped: [] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  const auth = new NodeUserAuthorization({
+    signer: createSigner(signedMessages),
+    wasmBindings: createWasmBindings(captured),
+    signStrategy: { type: "auto-sign" },
+    domain: "example.com",
+    sessionStorage: new MemorySessionStorage(),
+  });
+
+  // Old persisted session: no hosts supplied on restore.
+  auth.setRestoredTinyCloudSession(restoredTinyCloudSession());
+  expect(auth.hosts).toEqual([]); // not yet resolved
+
+  // First host-needing call resolves lazily via registry -> fallback.
+  await auth.ensureSpaceExists();
+
+  expect(auth.hosts).toEqual([DEFAULT_TINYCLOUD_FALLBACK_HOST]);
+  expect(requests).toContain(
+    `${DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL}/v1/locations/${encodeURIComponent(
+      "did:pkh:eip155:1:0x1234567890AbcdEF1234567890aBcdef12345678",
+    )}`,
+  );
+  expect(requests).toContain(`${DEFAULT_TINYCLOUD_FALLBACK_HOST}/delegate`);
+  expect(signedMessages.length).toBe(0); // still no wallet flow
 });

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -330,12 +330,60 @@ export class NodeUserAuthorization implements IUserAuthorization {
    * `siwe` is the load-bearing one because `extractSiweExpiration` returns
    * undefined for missing SIWEs and the SDK then treats the session as
    * expired-at-epoch-zero.
+   *
+   * @param hosts - The TinyCloud hosts this session was created against,
+   *   as persisted in {@link PersistedSessionData.tinycloudHosts}. When
+   *   present (and non-empty) they are adopted directly so the restored
+   *   session resolves to the same node as the original sign-in without
+   *   re-running registry/fallback resolution. When absent (old session)
+   *   hosts are resolved lazily on the first host-needing call via
+   *   {@link ensureTinyCloudHosts}.
    */
-  setRestoredTinyCloudSession(session: TinyCloudSession): void {
+  setRestoredTinyCloudSession(
+    session: TinyCloudSession,
+    hosts?: string[],
+  ): void {
     const address = canonicalizeAddress(session.address);
     this._tinyCloudSession = { ...session, address };
     this._address = address;
     this._chainId = session.chainId;
+    // Don't overwrite an explicitly-configured host (e.g. local dev) with a
+    // possibly-stale persisted value: only adopt persisted hosts when none
+    // are already set.
+    if (
+      (!this.tinycloudHosts || this.tinycloudHosts.length === 0) &&
+      hosts &&
+      hosts.length > 0
+    ) {
+      this.tinycloudHosts = [...hosts];
+    }
+  }
+
+  /**
+   * Ensure `tinycloudHosts` are resolved before a host-needing call.
+   *
+   * Fresh sign-in resolves hosts up front; a restored session may not have
+   * (old persisted sessions predate {@link PersistedSessionData.tinycloudHosts}).
+   * This guard makes a restored session resolve the node exactly like a fresh
+   * sign-in — persisted hosts are preferred (already set by
+   * {@link setRestoredTinyCloudSession}), otherwise the registry/fallback
+   * resolution runs lazily here. Idempotent: {@link resolveTinyCloudHostsForSignIn}
+   * early-returns when hosts are already set.
+   *
+   * Throws if hosts are unset and the restored session has no address/chainId
+   * to resolve from — a real failure that must surface, not be masked.
+   */
+  async ensureTinyCloudHosts(): Promise<void> {
+    if (this.tinycloudHosts && this.tinycloudHosts.length > 0) {
+      return;
+    }
+    if (this._address === undefined || this._chainId === undefined) {
+      throw new Error(
+        "Cannot resolve TinyCloud hosts: no address/chainId available. " +
+          "Sign in or restore a session first.",
+      );
+    }
+    await this.resolveTinyCloudHostsForSignIn(this._address, this._chainId);
   }
 
   private async resolveTinyCloudHostsForSignIn(
@@ -577,6 +625,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       throw new Error("Must be signed in to host space");
     }
 
+    await this.ensureTinyCloudHosts();
     const host = this.primaryTinyCloudHost;
     const spaceId = targetSpaceId ?? this._tinyCloudSession.spaceId;
 
@@ -632,6 +681,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       throw new Error("Must be signed in to ensure space exists");
     }
 
+    await this.ensureTinyCloudHosts();
     const host = this.primaryTinyCloudHost;
     const primarySpaceId = this._tinyCloudSession.spaceId;
 
@@ -890,6 +940,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       expiresAt: expirationTime.toISOString(),
       createdAt: now.toISOString(),
       version: "1.0",
+      tinycloudHosts: this.tinycloudHosts,
     };
     await this.sessionStorage.save(address, persistedData);
 
@@ -1134,6 +1185,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       expiresAt,
       createdAt,
       version: "1.0",
+      tinycloudHosts: this.tinycloudHosts,
     };
     await this.sessionStorage.save(address, persistedData);
 

--- a/packages/sdk-core/src/storage.schema.test.ts
+++ b/packages/sdk-core/src/storage.schema.test.ts
@@ -154,6 +154,37 @@ describe("PersistedSessionDataSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  describe("tinycloudHosts (host rehydration)", () => {
+    it("round-trips tinycloudHosts through parse", () => {
+      const hosts = ["https://node.example.test", "https://backup.example.test"];
+      const data = { ...validPersistedSessionData, tinycloudHosts: hosts };
+      const result = PersistedSessionDataSchema.safeParse(data);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tinycloudHosts).toEqual(hosts);
+      }
+    });
+
+    it("validates without tinycloudHosts (back-compat with old sessions)", () => {
+      const data = { ...validPersistedSessionData };
+      delete (data as Record<string, unknown>).tinycloudHosts;
+      const result = PersistedSessionDataSchema.safeParse(data);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tinycloudHosts).toBeUndefined();
+      }
+    });
+
+    it("rejects non-string entries in tinycloudHosts", () => {
+      const data = {
+        ...validPersistedSessionData,
+        tinycloudHosts: ["https://ok.test", 42],
+      };
+      const result = PersistedSessionDataSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe("address validation", () => {
     it("rejects address without 0x prefix", () => {
       const data = {

--- a/packages/sdk-core/src/storage.schema.ts
+++ b/packages/sdk-core/src/storage.schema.ts
@@ -93,6 +93,14 @@ export const PersistedSessionDataSchema = z.object({
   version: z.string(),
   /** Optional ENS data */
   ens: EnsDataSchema.optional(),
+  /**
+   * TinyCloud hosts this session was created against. Persisted so a
+   * restored session resolves to the same node without re-running the
+   * registry/fallback resolution (or the wallet sign-in flow). Optional
+   * for backward compatibility with sessions persisted before this field
+   * existed — those restore and lazily re-resolve their hosts.
+   */
+  tinycloudHosts: z.array(z.string()).optional(),
 });
 
 export type PersistedSessionData = z.infer<typeof PersistedSessionDataSchema>;

--- a/packages/web-sdk/src/modules/browserSessionPersistence.ts
+++ b/packages/web-sdk/src/modules/browserSessionPersistence.ts
@@ -10,6 +10,11 @@ export interface RestorableSessionData {
   chainId: number;
   siwe: string;
   signature: string;
+  /**
+   * Hosts the session was created against. Absent for sessions persisted
+   * before this field existed; in that case the node re-resolves lazily.
+   */
+  tinycloudHosts?: string[];
 }
 
 export function clientSessionFromPersisted(
@@ -53,5 +58,6 @@ export function restoreDataFromPersisted(
     chainId: data.chainId,
     siwe: data.siwe,
     signature: data.signature,
+    tinycloudHosts: data.tinycloudHosts,
   };
 }


### PR DESCRIPTION
## Root cause

A **restored** session never resolved its TinyCloud hosts, so the first service call on it threw:

> `TinyCloud hosts have not been resolved. Call signIn() first.`

Two gaps combined:

1. **Restore path skipped host resolution.** `NodeUserAuthorization.setRestoredTinyCloudSession()` rehydrated `_tinyCloudSession` / `_address` / `_chainId` but never set `this.tinycloudHosts`. Host resolution (`resolveTinyCloudHostsForSignIn` → registry/`node.tinycloud.xyz` fallback) ran **only** from the fresh sign-in paths (`signIn`, `signInWithPreparedSession`). `requireTinyCloudHosts()` then threw on the next kv/secrets/space/encryption call.
2. **Hosts were never persisted.** `PersistedSessionData` had no `tinycloudHosts`, so the node a session was created against couldn't be rehydrated. `TinyCloudNode.restoreSession` also built its `ServiceContext` with the **default** `config.host`, not the user's actual node.

Net effect: `web-sdk signIn()` short-circuits to a restored session (skipping the wallet flow that resolves hosts), and the restored session has empty hosts → throws. This broke the git-haiku owner flow.

## Fix (three parts)

1. **Persist hosts** — `PersistedSessionData` gains an optional `tinycloudHosts?: string[]` (zod + type, back-compat so old sessions still validate). Both sign-in save paths write the just-resolved hosts.
2. **Rehydrate on restore** — `TinyCloudNode.restoreSession` accepts `tinycloudHosts`, resolves the effective host (explicit > persisted > registry/fallback) and sets `config.host` + the service context accordingly, and passes the hosts into `setRestoredTinyCloudSession` so the auth layer's host-needing methods work. The web SDK threads the field through `restoreDataFromPersisted`.
3. **Lazy fallback** — old sessions (no persisted hosts) re-resolve lazily via `ensureTinyCloudHosts()` (idempotent `resolveTinyCloudHostsForSignIn`) on the first host-needing call (`ensureSpaceExists` / `hostSpace`), exactly like a fresh sign-in. Resolution failures surface; they are **not** masked.

A restored session now resolves the node exactly like a fresh sign-in (persisted hosts preferred, registry/fallback otherwise), so apps no longer need to pass `tinycloudHosts` explicitly or `clearPersistedSession()` before sign-in.

## Verification

- Build green: `bunx turbo build --filter=@tinycloud/node-sdk --filter=@tinycloud/web-sdk --filter=@tinycloud/sdk-core` (7/7).
- Unit tests added:
  - `PersistedSessionData` round-trips `tinycloudHosts` and still validates without it (back-compat); rejects non-string entries.
  - Restored session adopts persisted hosts **without** the wallet flow, and a host-needing call (`ensureSpaceExists`) does not throw and targets the persisted host.
  - Restored session with **no** persisted hosts lazily resolves via registry → fallback (still no wallet flow).
  - Full `node-sdk` suite passes (98 pass). The 3 pre-existing failures in `web-sdk/tests/siwe-signature-init.test.js` are unrelated (confirmed failing on base).
- **Live restore-without-resign proof** (`packages/node-sdk/scripts/live-restore-host-resolution.ts`, gated by `TC_LIVE_RESTORE=1`): spawns a local `tinycloud` node, owner signs in (explicit local host) and persists, then a **fresh** `TinyCloudNode` (no host, no signer) restores the persisted session and does a real KV get — proving the host was rehydrated from persistence with no re-sign-in and no "hosts not resolved":
  ```
  [live] persisted tinycloudHosts = ["http://localhost:9137"]
  [live] restored node hosts = ["http://localhost:9137"]
  [live] PASS: restored session read key=... with no re-sign-in and no 'hosts not resolved' error.
  ```

## Changeset

`.changeset/restore-host-resolution.md` — minor for the linked group (`@tinycloud/sdk-core`, `@tinycloud/node-sdk`, `@tinycloud/web-sdk`, `@tinycloud/sdk-services`).