### PR TITLE
Add secrets SQL DDL regression coverage

### DIFF
--- a/.changeset/secrets-ddl-regression.md
+++ b/.changeset/secrets-ddl-regression.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/sdk-services": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Add regression coverage for SQL migration batches that require both `tinycloud.sql/ddl` and `tinycloud.sql/write`, including the legacy-session runtime permission repair path used by TinyCloud Secrets.

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -824,6 +824,57 @@ describe("TinyCloudNode runtime permission delegations", () => {
     );
   });
 
+  test("uses a single runtime SQL grant for migration-style ddl and write batches", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const secretsSpaceId = `tinycloud:pkh:eip155:1:${address}:secrets`;
+    const permission: PermissionEntry = {
+      service: "tinycloud.sql",
+      space: "secrets",
+      path: "default",
+      actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/ddl"],
+    };
+
+    await withActivatedDelegations(async () => {
+      await node.grantRuntimePermissions([permission]);
+    });
+
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: secretsSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeAnyWithRuntimePermissions(
+      fallback,
+      [
+        {
+          spaceId: secretsSpaceId,
+          service: "sql",
+          path: "default",
+          action: "tinycloud.sql/ddl",
+        },
+        {
+          spaceId: secretsSpaceId,
+          service: "sql",
+          path: "default",
+          action: "tinycloud.sql/write",
+        },
+      ],
+      [{}, {}],
+    );
+
+    const invokeAny = (node as any).wasmBindings.invokeAny;
+    expect(invokeAny.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "runtime-token",
+    );
+  });
+
   test("useDelegation installs encryption delegations as raw runtime grants", async () => {
     const invoke = mock((session: any) => ({
       Authorization: session.delegationHeader.Authorization,

--- a/tests/node-sdk/sql/sql-basics.test.ts
+++ b/tests/node-sdk/sql/sql-basics.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { checkServerHealth, createClient, TEST_KEY } from "../setup";
-import type { TinyCloudNode } from "@tinycloud/node-sdk";
+import { checkServerHealth, createClient, SERVER_URL, TEST_KEY } from "../setup";
+import { TinyCloudNode, type Manifest } from "@tinycloud/node-sdk";
 
 const TABLE = `sdk_test_sql_users_${Date.now()}`;
 const ANALYTICS_TABLE = `sdk_test_sql_analytics_${Date.now()}`;
@@ -175,7 +175,70 @@ describe("SQL Basics", () => {
     });
   });
 
-  // PART 5: Delegated Access
+  // PART 5: Migration permission repair
+  describe("Migrations", () => {
+    test("runtime SQL ddl repair lets a legacy read/write session apply migrations", async () => {
+      const runId = Date.now();
+      const space = `secrets-e2e-${runId}`;
+      const table = `secret_metadata_${runId}`;
+      const legacyManifest: Manifest = {
+        manifest_version: 1,
+        app_id: "xyz.tinycloud.secrets.e2e",
+        name: "TinyCloud Secrets E2E",
+        space,
+        prefix: "",
+        defaults: false,
+        includePublicSpace: false,
+        permissions: [
+          {
+            service: "tinycloud.sql",
+            space,
+            path: "default",
+            actions: ["read", "write"],
+            skipPrefix: true,
+          },
+        ],
+      };
+      const legacy = new TinyCloudNode({
+        privateKey: TEST_KEY,
+        host: SERVER_URL,
+        prefix: space,
+        autoCreateSpace: true,
+        manifest: legacyManifest,
+      });
+
+      await legacy.signIn();
+      await legacy.grantRuntimePermissions([
+        {
+          service: "tinycloud.sql",
+          space,
+          path: "default",
+          actions: ["read", "write", "ddl"],
+          skipPrefix: true,
+        },
+      ]);
+
+      const result = await legacy.sql.db("default").migrations.apply({
+        namespace: "xyz.tinycloud.secrets",
+        migrations: [
+          {
+            id: "001_secret_metadata",
+            sql: [
+              `CREATE TABLE IF NOT EXISTS ${table} (scope TEXT NOT NULL, name TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY (scope, name))`,
+            ],
+          },
+        ],
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.status).toBe("applied");
+        expect(result.data.applied).toEqual(["001_secret_metadata"]);
+      }
+    });
+  });
+
+  // PART 6: Delegated Access
   describe("Delegated Access", () => {
     test("bob can query via read-only delegation", async () => {
       const bob = createClient("bob-sql");
@@ -217,7 +280,7 @@ describe("SQL Basics", () => {
     });
   });
 
-  // PART 6: Export
+  // PART 7: Export
   describe("Export", () => {
     test("export returns a Blob", async () => {
       const result = await alice.sql.db().export();


### PR DESCRIPTION
## Summary\n- add runtime-permission coverage for SQL migration batches that require ddl + write\n- add live SQL E2E coverage for repairing a legacy read/write secrets session before applying migrations\n\n## Tests\n- bun test packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts packages/sdk-services/src/sql/SQLService.test.ts\n- bun test tests/node-sdk/sql/sql-basics.test.ts (against local tinycloud-node)