### PR TITLE
Rename SQL DDL permission to schema

### DIFF
--- a/.changeset/sql-schema-action.md
+++ b/.changeset/sql-schema-action.md
@@ -1,0 +1,11 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/sdk-services": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/cli": patch
+---
+
+Rename the SDK-emitted SQL schema-change permission from `tinycloud.sql/ddl` to `tinycloud.sql/schema`, including manifest defaults and account-registry grants.
+
+TinyCloudWeb now treats a restored persisted session as stale when it does not cover the currently configured manifest permissions, then runs the normal manifest sign-in flow instead of letting apps request those manifest permissions separately after login.

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -983,6 +983,7 @@ function isDangerousPermission(permission: PermissionEntry): boolean {
     action.includes("*") ||
     action.endsWith("/write") ||
     action.endsWith("/admin") ||
+    action.endsWith("/schema") ||
     action.endsWith("/ddl") ||
     action.endsWith("/del"),
   );

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -824,7 +824,7 @@ describe("TinyCloudNode runtime permission delegations", () => {
     );
   });
 
-  test("uses a single runtime SQL grant for migration-style ddl and write batches", async () => {
+  test("uses a single runtime SQL grant for migration-style schema and write batches", async () => {
     const invoke = mock((session: any) => ({
       Authorization: session.delegationHeader.Authorization,
     })) as any;
@@ -835,7 +835,7 @@ describe("TinyCloudNode runtime permission delegations", () => {
       service: "tinycloud.sql",
       space: "secrets",
       path: "default",
-      actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/ddl"],
+      actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/schema"],
     };
 
     await withActivatedDelegations(async () => {
@@ -857,7 +857,7 @@ describe("TinyCloudNode runtime permission delegations", () => {
           spaceId: secretsSpaceId,
           service: "sql",
           path: "default",
-          action: "tinycloud.sql/ddl",
+          action: "tinycloud.sql/schema",
         },
         {
           spaceId: secretsSpaceId,

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -239,7 +239,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     // legacy default table.
     expect(cfg.abilities.kv).toHaveProperty("");
     expect(cfg.abilities.kv[""]).toContain("tinycloud.kv/get");
-    expect(cfg.abilities.sql[""]).toContain("tinycloud.sql/ddl");
+    expect(cfg.abilities.sql[""]).toContain("tinycloud.sql/schema");
     expect(cfg.spaceAbilities[cfg.spaceId]).toEqual(cfg.abilities);
     const secretsSpaceId = Object.keys(cfg.spaceAbilities).find((spaceId) =>
       spaceId.endsWith(":secrets"),
@@ -362,7 +362,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
           account: [
             "tinycloud.sql/read",
             "tinycloud.sql/write",
-            "tinycloud.sql/ddl",
+            "tinycloud.sql/schema",
           ],
         },
       },

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -227,7 +227,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
         "": [
           "tinycloud.sql/read",
           "tinycloud.sql/write",
-          "tinycloud.sql/ddl",
+          "tinycloud.sql/schema",
           "tinycloud.sql/admin",
           "tinycloud.sql/export",
         ],

--- a/packages/sdk-core/src/manifest.test.ts
+++ b/packages/sdk-core/src/manifest.test.ts
@@ -72,9 +72,9 @@ describe("expandActionShortNames", () => {
   });
 
   it("handles arbitrary services", () => {
-    expect(expandActionShortNames("tinycloud.sql", ["read", "ddl"])).toEqual([
+    expect(expandActionShortNames("tinycloud.sql", ["read", "schema"])).toEqual([
       "tinycloud.sql/read",
-      "tinycloud.sql/ddl",
+      "tinycloud.sql/schema",
     ]);
   });
 });
@@ -389,14 +389,14 @@ describe("resolveManifest — defaults tiers", () => {
     expect(resolved.resources).toEqual([]);
   });
 
-  it("admin includes sql/ddl and only implicit capabilities/read", () => {
+  it("admin includes sql/schema and only implicit capabilities/read", () => {
     const resolved = resolveManifest({
       app_id: "a.b.c",
       name: "x",
       defaults: "admin",
     });
     const sql = resolved.resources.find((r) => r.service === "tinycloud.sql");
-    expect(sql?.actions).toContain("tinycloud.sql/ddl");
+    expect(sql?.actions).toContain("tinycloud.sql/schema");
     const caps = resolved.resources.find(
       (r) => r.service === "tinycloud.capabilities",
     );
@@ -431,7 +431,7 @@ describe("resolveManifest — defaults tiers", () => {
     });
     // Standard tier, not admin or all.
     const sql = resolved.resources.find((r) => r.service === "tinycloud.sql");
-    expect(sql?.actions).not.toContain("tinycloud.sql/ddl");
+    expect(sql?.actions).not.toContain("tinycloud.sql/schema");
   });
 
   it("adds capabilities read for explicit permission spaces", () => {
@@ -919,7 +919,7 @@ describe("resolveManifest — end-to-end composition", () => {
           service: "tinycloud.sql",
           space: "account",
           path: "account",
-          actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/ddl"],
+          actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/schema"],
         }),
         expect.objectContaining({
           service: "tinycloud.capabilities",

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -45,7 +45,7 @@ export interface PermissionEntry {
    */
   path: string;
   /**
-   * Short action names (e.g. "get", "put", "read", "ddl"). The SDK expands
+   * Short action names (e.g. "get", "put", "read", "schema"). The SDK expands
    * these to full URNs (e.g. `tinycloud.kv/get`) during resolution.
    * Already-expanded URNs are passed through unchanged.
    */
@@ -77,7 +77,7 @@ export type ManifestSecretActions =
  *
  * - `false` → no auto-included permissions
  * - `true` → standard tier (KV + SQL read/write + capabilities:read)
- * - `"admin"` → standard + SQL ddl
+ * - `"admin"` → standard + SQL schema
  * - `"all"` → everything the SDK supports (including DuckDB)
  *
  * Unknown string values silently fall back to `true`. Values are normalized
@@ -351,7 +351,7 @@ const DEFAULT_STANDARD_ENTRIES: readonly PermissionEntry[] = [
 ];
 
 /**
- * Default permission entries for the `"admin"` tier: standard + sql/ddl.
+ * Default permission entries for the `"admin"` tier: standard + sql/schema.
  */
 const DEFAULT_ADMIN_ENTRIES: readonly PermissionEntry[] = [
   {
@@ -364,7 +364,7 @@ const DEFAULT_ADMIN_ENTRIES: readonly PermissionEntry[] = [
     service: "tinycloud.sql",
     space: DEFAULT_MANIFEST_SPACE,
     path: "/",
-    actions: ["read", "write", "ddl"],
+    actions: ["read", "write", "schema"],
   },
 ];
 
@@ -385,7 +385,7 @@ const DEFAULT_ALL_ENTRIES: readonly PermissionEntry[] = [
     service: "tinycloud.sql",
     space: DEFAULT_MANIFEST_SPACE,
     path: "/",
-    actions: ["read", "write", "ddl"],
+    actions: ["read", "write", "schema"],
   },
   {
     service: "tinycloud.duckdb",
@@ -1253,7 +1253,7 @@ function accountRegistryIndexPermission(): ResourceCapability {
     service: "tinycloud.sql",
     space: ACCOUNT_REGISTRY_SPACE,
     path: "account",
-    actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/ddl"],
+    actions: ["tinycloud.sql/read", "tinycloud.sql/write", "tinycloud.sql/schema"],
   };
 }
 

--- a/packages/sdk-services/src/sql/SQLService.test.ts
+++ b/packages/sdk-services/src/sql/SQLService.test.ts
@@ -166,7 +166,7 @@ describe("SQLService permissions", () => {
     ]);
   });
 
-  test("execute and batch sign DDL statements with ddl permission", async () => {
+  test("execute and batch sign schema statements with schema permission", async () => {
     const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
     const invokeAnyCalls: Array<{ entries: Array<{ service: string; path: string; action: string }> }> = [];
 
@@ -187,19 +187,19 @@ describe("SQLService permissions", () => {
     expect(executeResult.ok).toBe(true);
     expect(batchResult.ok).toBe(true);
     expect(invokeCalls).toEqual([
-      { service: "sql", path: "default", action: SQLAction.DDL },
+      { service: "sql", path: "default", action: SQLAction.SCHEMA },
     ]);
     expect(invokeAnyCalls).toEqual([
       {
         entries: [
-          { service: "sql", path: "default", action: SQLAction.DDL },
+          { service: "sql", path: "default", action: SQLAction.SCHEMA },
           { service: "sql", path: "default", action: SQLAction.WRITE },
         ],
       },
     ]);
   });
 
-  test("execute with schema signs both schema ddl and statement write permissions", async () => {
+  test("execute with schema signs both schema and statement write permissions", async () => {
     const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
     const invokeAnyCalls: Array<{ entries: Array<{ service: string; path: string; action: string }> }> = [];
 
@@ -223,7 +223,7 @@ describe("SQLService permissions", () => {
       {
         entries: [
           { service: "sql", path: "default", action: SQLAction.WRITE },
-          { service: "sql", path: "default", action: SQLAction.DDL },
+          { service: "sql", path: "default", action: SQLAction.SCHEMA },
         ],
       },
     ]);
@@ -290,13 +290,13 @@ describe("SQLService permissions", () => {
     expect(invokeAnyCalls).toEqual([
       {
         entries: [
-          { service: "sql", path: "app.db", action: SQLAction.DDL },
+          { service: "sql", path: "app.db", action: SQLAction.SCHEMA },
           { service: "sql", path: "app.db", action: SQLAction.WRITE },
         ],
       },
       {
         entries: [
-          { service: "sql", path: "app.db", action: SQLAction.DDL },
+          { service: "sql", path: "app.db", action: SQLAction.SCHEMA },
           { service: "sql", path: "app.db", action: SQLAction.WRITE },
         ],
       },
@@ -386,7 +386,7 @@ describe("SQLService permissions", () => {
     expect(invokeAnyCalls).toEqual([
       {
         entries: [
-          { service: "sql", path: "app.db", action: SQLAction.DDL },
+          { service: "sql", path: "app.db", action: SQLAction.SCHEMA },
           { service: "sql", path: "app.db", action: SQLAction.WRITE },
         ],
       },

--- a/packages/sdk-services/src/sql/SQLService.ts
+++ b/packages/sdk-services/src/sql/SQLService.ts
@@ -196,7 +196,7 @@ export class SQLService extends BaseService implements ISQLService {
         const actions = [
           this.actionForSql(sql, SQLAction.WRITE),
           ...(options?.schema ?? []).map((statement) =>
-            this.actionForSql(statement, SQLAction.DDL),
+            this.actionForSql(statement, SQLAction.SCHEMA),
           ),
         ];
         const response = await this.invokeSQL(
@@ -442,7 +442,7 @@ export class SQLService extends BaseService implements ISQLService {
   private actionForSql(sql: string, fallback: string): string {
     const token = firstSqlToken(sql);
     if (token === "pragma") return SQLAction.ADMIN;
-    if (token !== undefined && DDL_TOKENS.has(token)) return SQLAction.DDL;
+    if (token !== undefined && DDL_TOKENS.has(token)) return SQLAction.SCHEMA;
     return fallback;
   }
 

--- a/packages/sdk-services/src/sql/types.ts
+++ b/packages/sdk-services/src/sql/types.ts
@@ -149,7 +149,9 @@ export interface SqlMigrationApplyResponse {
 export const SQLAction = {
   READ: "tinycloud.sql/read",
   WRITE: "tinycloud.sql/write",
-  DDL: "tinycloud.sql/ddl",
+  SCHEMA: "tinycloud.sql/schema",
+  /** @deprecated Use SQLAction.SCHEMA. */
+  DDL: "tinycloud.sql/schema",
   ADMIN: "tinycloud.sql/admin",
   SELECT: "tinycloud.sql/select",
   INSERT: "tinycloud.sql/insert",

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -51,6 +51,7 @@ import {
   type PermissionEntry,
   type NetworkDescriptor,
   SignInOptions,
+  composeManifestRequest,
 } from "@tinycloud/sdk-core";
 import { showPermissionRequestModal } from "../notifications/ModalManager";
 import {
@@ -80,7 +81,7 @@ import { RPCProviders, ClientConfig, Extension as ExtensionType } from "../provi
 import {
   ModalSpaceCreationHandler,
   defaultWebSpaceCreationHandler,
-} from "../authorization";
+} from "../authorization/WebSpaceCreationHandler";
 import type { NotificationConfig } from "../notifications/types";
 import { WasmInitializer } from "./WasmInitializer";
 import { invoke } from "./Storage/tinycloud/module";
@@ -181,6 +182,7 @@ export type SessionRestoreStatus =
   | "corrupt"
   | "storage-unavailable"
   | "restore-failed"
+  | "stale"
   | "logging-in";
 
 export interface SessionRestoreResult {
@@ -565,10 +567,35 @@ export class TinyCloudWeb {
     }
   }
 
+  private configuredManifestPermissions(): PermissionEntry[] {
+    const request =
+      this._capabilityRequest ??
+      (this._manifest === undefined
+        ? undefined
+        : composeManifestRequest(
+            Array.isArray(this._manifest) ? this._manifest : [this._manifest],
+            {
+              includeAccountRegistryPermissions:
+                this.config.includeAccountRegistryPermissions,
+            },
+          ));
+    return (request?.resources as PermissionEntry[] | undefined) ?? [];
+  }
+
+  private restoredSessionCoversConfiguredManifest(node: TinyCloudNode): boolean {
+    const permissions = this.configuredManifestPermissions();
+    return permissions.length === 0 || node.hasRuntimePermissions(permissions);
+  }
+
   signIn = async (options?: SignInOptions): Promise<ClientSession> => {
     const restored = await this.restoreSession();
     if (restored.status === "restored" && restored.session) {
-      return restored.session;
+      const node = await this.ensureNode();
+      if (this.restoredSessionCoversConfiguredManifest(node)) {
+        return restored.session;
+      }
+      await this.clearPersistedSession(restored.session.address);
+      this._sessionRestoreStatus = "stale";
     }
 
     this._sessionRestoreStatus = "logging-in";

--- a/packages/web-sdk/src/notifications/PermissionRequestModal.ts
+++ b/packages/web-sdk/src/notifications/PermissionRequestModal.ts
@@ -480,6 +480,11 @@ const CAPABILITY_DESCRIPTIONS: Record<string, CapabilityDescription> = {
     description:
       "Allows this app to insert, update, or delete rows in the selected SQL database.",
   },
+  "tinycloud.sql/schema": {
+    title: "Change SQL schema",
+    description:
+      "Allows this app to create, alter, or drop SQL tables, indexes, and schema objects.",
+  },
   "tinycloud.sql/ddl": {
     title: "Change SQL schema",
     description:

--- a/packages/web-sdk/tests/signInManifestRestore.test.ts
+++ b/packages/web-sdk/tests/signInManifestRestore.test.ts
@@ -1,0 +1,145 @@
+import { expect, mock, test } from "bun:test";
+
+const { TextEncoder: TE, TextDecoder: TD } = require("util");
+
+global.TextEncoder = TE;
+global.TextDecoder = TD;
+(globalThis as any).HTMLElement = class {
+  shadowRoot: any;
+  attachShadow() {
+    this.shadowRoot = { innerHTML: "", querySelector: () => null };
+    return this.shadowRoot;
+  }
+  remove() {}
+};
+(globalThis as any).customElements = {
+  define: () => undefined,
+  get: () => undefined,
+};
+(globalThis as any).window = {
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined,
+  location: { hostname: "test.local" },
+};
+(globalThis as any).document = {
+  createElement: () => ({
+    setAttribute: () => undefined,
+    appendChild: () => undefined,
+    remove: () => undefined,
+    style: {},
+  }),
+  body: {
+    appendChild: () => undefined,
+    style: {},
+  },
+};
+
+mock.module("@tinycloud/web-sdk-wasm", () => ({
+  initialized: Promise.resolve(),
+  tinycloud: {
+    computeCid: () => "bafk-test",
+    ensureEip55: (address: string) => address,
+    makeSpaceId: (address: string, chainId: number, prefix: string) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${prefix}`,
+    createDelegation: () => ({}),
+    parseRecapFromSiwe: () => [],
+    generateHostSIWEMessage: () => "",
+    siweToDelegationHeaders: () => ({}),
+    protocolVersion: () => 1,
+    vault_encrypt: () => new Uint8Array(),
+    vault_decrypt: () => new Uint8Array(),
+    vault_derive_key: () => new Uint8Array(),
+    vault_x25519_from_seed: () => new Uint8Array(),
+    vault_x25519_dh: () => new Uint8Array(),
+    vault_random_bytes: (length: number) => new Uint8Array(length),
+    vault_sha256: () => new Uint8Array(),
+  },
+  tcwSession: {
+    TCWSessionManager: class {
+      createSessionKey(id: string) { return id; }
+      renameSessionKeyId() {}
+      getDID(keyId: string) { return `did:key:${keyId}`; }
+      jwk() {
+        return JSON.stringify({
+          kty: "OKP",
+          crv: "Ed25519",
+          x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        });
+      }
+    },
+  },
+}));
+
+const { TinyCloudWeb } = require("../src/modules/tcw");
+
+test("signIn refreshes a restored session that does not cover the configured manifest", async () => {
+  const tcw = new TinyCloudWeb({
+    manifest: {
+      app_id: "xyz.tinycloud.secrets",
+      name: "TinyCloud Secrets",
+      defaults: false,
+      permissions: [
+        {
+          service: "tinycloud.sql",
+          space: "secrets",
+          path: "default",
+          actions: ["read", "write", "schema"],
+        },
+      ],
+    },
+  });
+
+  const restoredSession = {
+    address: "0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1",
+    walletAddress: "0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1",
+    chainId: 1,
+    sessionKey: {} as any,
+    siwe: "old-siwe",
+    signature: "old-signature",
+  };
+  const freshSession = {
+    address: restoredSession.address,
+    chainId: 1,
+    sessionKey: {} as any,
+    siwe: "fresh-siwe",
+    signature: "fresh-signature",
+  };
+  await (tcw as any)._initPromise;
+
+  const node = {
+    hasRuntimePermissions: mock(() => false),
+    signIn: mock(async () => undefined),
+    session: freshSession,
+  };
+
+  (tcw as any)._node = node;
+  (tcw as any)._initPromise = Promise.resolve();
+  (tcw as any).restoreSession = mock(async () => ({
+    status: "restored",
+    session: restoredSession,
+  }));
+  (tcw as any).clearPersistedSession = mock(async () => undefined);
+
+  const session = await tcw.signIn();
+
+  expect(node.hasRuntimePermissions).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({
+        service: "tinycloud.sql",
+        space: "secrets",
+        path: "xyz.tinycloud.secrets/default",
+        actions: [
+          "tinycloud.sql/read",
+          "tinycloud.sql/write",
+          "tinycloud.sql/schema",
+        ],
+      }),
+    ]),
+  );
+  expect((tcw as any).clearPersistedSession).toHaveBeenCalledWith(
+    restoredSession.address,
+  );
+  expect(node.signIn).toHaveBeenCalledTimes(1);
+  expect(session.siwe).toBe("fresh-siwe");
+  expect(tcw.sessionRestoreStatus).toBe("logging-in");
+});

--- a/tests/node-sdk/sql/sql-basics.test.ts
+++ b/tests/node-sdk/sql/sql-basics.test.ts
@@ -177,7 +177,7 @@ describe("SQL Basics", () => {
 
   // PART 5: Migration permission repair
   describe("Migrations", () => {
-    test("runtime SQL ddl repair lets a legacy read/write session apply migrations", async () => {
+    test("runtime SQL schema repair lets a legacy read/write session apply migrations", async () => {
       const runId = Date.now();
       const space = `secrets-e2e-${runId}`;
       const table = `secret_metadata_${runId}`;
@@ -213,7 +213,7 @@ describe("SQL Basics", () => {
           service: "tinycloud.sql",
           space,
           path: "default",
-          actions: ["read", "write", "ddl"],
+          actions: ["read", "write", "schema"],
           skipPrefix: true,
         },
       ]);


### PR DESCRIPTION
## Summary
- emit `tinycloud.sql/schema` for schema-changing SQL instead of `tinycloud.sql/ddl`
- update manifest defaults, account registry permissions, permission copy, CLI dangerous-permission detection, and tests
- refresh stale TinyCloudWeb persisted sessions when they do not cover the configured manifest so manifest permissions are granted during sign-in instead of via a later prompt

## Tests
- `bun test packages/sdk-services/src/sql/SQLService.test.ts packages/sdk-core/src/manifest.test.ts packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts`
- `bun test packages/web-sdk/tests/signInManifestRestore.test.ts`

## Notes
- `bun run --cwd packages/sdk-services build` and `bun run --cwd packages/sdk-core build` passed.
- `bun run --cwd packages/node-sdk build` emitted JS but failed during DTS generation because this temp worktree could not resolve `@tinycloud/node-sdk-wasm` types.
