### PR TITLE
Remove SQL DDL action alias

### DIFF
--- a/.changeset/drop-sql-ddl.md
+++ b/.changeset/drop-sql-ddl.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/sdk-services": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/cli": patch
+---
+
+Remove the deprecated `SQLAction.DDL` export and the `tinycloud.sql/ddl` permission display path. SQL schema changes use `SQLAction.SCHEMA` and `tinycloud.sql/schema`.

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -984,7 +984,6 @@ function isDangerousPermission(permission: PermissionEntry): boolean {
     action.endsWith("/write") ||
     action.endsWith("/admin") ||
     action.endsWith("/schema") ||
-    action.endsWith("/ddl") ||
     action.endsWith("/del"),
   );
 }

--- a/packages/sdk-services/src/sql/SQLService.test.ts
+++ b/packages/sdk-services/src/sql/SQLService.test.ts
@@ -80,6 +80,10 @@ function createContext(
 }
 
 describe("SQLService permissions", () => {
+  test("does not export the old DDL action alias", () => {
+    expect("DDL" in SQLAction).toBe(false);
+  });
+
   test("query signs SELECT statements with read permission", async () => {
     const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
     let requestInit: FetchRequestInit | undefined;

--- a/packages/sdk-services/src/sql/types.ts
+++ b/packages/sdk-services/src/sql/types.ts
@@ -150,8 +150,6 @@ export const SQLAction = {
   READ: "tinycloud.sql/read",
   WRITE: "tinycloud.sql/write",
   SCHEMA: "tinycloud.sql/schema",
-  /** @deprecated Use SQLAction.SCHEMA. */
-  DDL: "tinycloud.sql/schema",
   ADMIN: "tinycloud.sql/admin",
   SELECT: "tinycloud.sql/select",
   INSERT: "tinycloud.sql/insert",

--- a/packages/web-sdk/src/notifications/PermissionRequestModal.ts
+++ b/packages/web-sdk/src/notifications/PermissionRequestModal.ts
@@ -485,11 +485,6 @@ const CAPABILITY_DESCRIPTIONS: Record<string, CapabilityDescription> = {
     description:
       "Allows this app to create, alter, or drop SQL tables, indexes, and schema objects.",
   },
-  "tinycloud.sql/ddl": {
-    title: "Change SQL schema",
-    description:
-      "Allows this app to create, alter, or drop SQL tables, indexes, and schema objects.",
-  },
   "tinycloud.sql/admin": {
     title: "Administer SQL storage",
     description:


### PR DESCRIPTION
## Summary
- remove the deprecated `SQLAction.DDL` runtime export
- remove the web permission modal entry for `tinycloud.sql/ddl`
- stop classifying `/ddl` as a supported CLI permission shape

## Tests
- `bun test packages/sdk-services/src/sql/SQLService.test.ts packages/sdk-core/src/manifest.test.ts packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts packages/web-sdk/tests/signInManifestRestore.test.ts`

## Notes
- `bun run --cwd packages/sdk-services build` and `bun run --cwd packages/sdk-core build` passed.
- `bun run --cwd packages/node-sdk build` emitted JS but failed during DTS generation because this temp worktree could not resolve `@tinycloud/node-sdk-wasm` types.
