### PR TITLE
fix(sdk): ensureOwnedSpaceHosted checks account spaces registry before hosting

### DIFF
--- a/.changeset/ensure-owned-space-registry-check.md
+++ b/.changeset/ensure-owned-space-registry-check.md
@@ -1,0 +1,29 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+"@tinycloud/sdk-services": minor
+---
+
+`ensureOwnedSpaceHosted` now consults the account spaces registry before hosting
+
+Previously `TinyCloudNode.ensureOwnedSpaceHosted(name)` always delegated to
+`hostOwnedSpace`, which unconditionally submits the host-SIWE delegation. Owners
+who already had the space hosted (e.g. a git-haiku owner re-running TinyCloud
+Secrets setup) were therefore prompted to "host" their `secrets` space on every
+run.
+
+`ensureOwnedSpaceHosted` now resolves the owned space id and first checks the
+account spaces registry: the fast SQLite index (`account.index.spaces.list()`)
+as a best-effort short-circuit, falling back to the canonical, recap-readable KV
+record `account/spaces/{space_id}` (`account.spaces.get`). If the space is
+already registered/hosted it returns the id WITHOUT submitting a host delegation
+(no redundant signature). Only when the space is absent — or the registry check
+fails in any way (e.g. a cold index reporting `no such table: spaces`) — does it
+fall through to `hostOwnedSpace`. After hosting it durably write-through
+registers the space so subsequent calls short-circuit on the registry.
+
+`hostOwnedSpace` (always-host) is unchanged for callers that explicitly want it.
+The KV path is used rather than `syncAccessible()` because a manifest/recap
+session can read `account/spaces/` under the recap but does not hold
+`tinycloud.space/list`.

--- a/packages/node-sdk/scripts/live-ensure-owned-space-registry.ts
+++ b/packages/node-sdk/scripts/live-ensure-owned-space-registry.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env bun
+/**
+ * Gated live test: `ensureOwnedSpaceHosted` consults the account spaces
+ * registry FIRST and only hosts (the host-SIWE delegation) when the owned
+ * space is not already registered/hosted.
+ *
+ * Proves the redundant-host-prompt fix end-to-end against a LOCAL tinycloud
+ * node:
+ *   1. A manifest-recap-limited owner signs in (no full-authority auto-host
+ *      of `secrets`). The underlying `auth.hostOwnedSpace` is wrapped with a
+ *      call counter so we can observe whether a host-SIWE delegation is
+ *      submitted.
+ *   2. First `ensureOwnedSpaceHosted("secrets")` finds the space ABSENT from
+ *      the registry → hosts it (host count goes 0 → 1) and best-effort
+ *      registers it under `account/spaces/{id}`. A scoped `secrets.put`
+ *      succeeds.
+ *   3. Second `ensureOwnedSpaceHosted("secrets")` finds the space PRESENT in
+ *      the registry → returns WITHOUT hosting (host count stays 1: no second
+ *      SIWE). A scoped `secrets.put` still succeeds.
+ *
+ * Gated: set TC_LIVE_ENSURE_REGISTRY=1 to run. Requires the local tinycloud
+ * binary (built debug) — override path with TC_NODE_BIN.
+ *
+ *   TC_LIVE_ENSURE_REGISTRY=1 bun run \
+ *     packages/node-sdk/scripts/live-ensure-owned-space-registry.ts
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const ENABLED = process.env.TC_LIVE_ENSURE_REGISTRY === "1";
+const NODE_BIN =
+  process.env.TC_NODE_BIN ??
+  "/Users/samgbafa/Documents/github/tinycloud-dev/repositories/tinycloud-node/target/debug/tinycloud";
+const PORT = Number(process.env.TINYCLOUD_PORT ?? 9137);
+
+if (!ENABLED) {
+  process.stderr.write(
+    "[skip] Set TC_LIVE_ENSURE_REGISTRY=1 to run the ensureOwnedSpaceHosted registry live test.\n",
+  );
+  process.exit(0);
+}
+
+const TINYCLOUD_TOML = `[global.keys]
+type = "Static"
+`;
+
+async function waitForNode(host: string, timeoutMs = 20000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${host}/info`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Local tinycloud node at ${host} did not become ready.`);
+}
+
+async function main(): Promise<void> {
+  const { TinyCloudNode } = await import("../src/index.ts");
+
+  const dataDir = await mkdtemp(join(tmpdir(), "tc-ensure-reg-data-"));
+  const runDir = await mkdtemp(join(tmpdir(), "tc-ensure-reg-run-"));
+  await writeFile(join(runDir, "tinycloud.toml"), TINYCLOUD_TOML, "utf8");
+
+  const host = `http://localhost:${PORT}`;
+  let child: ChildProcess | undefined;
+
+  try {
+    child = spawn(NODE_BIN, [], {
+      cwd: runDir,
+      env: {
+        ...process.env,
+        TINYCLOUD_LOG_LEVEL: "normal",
+        TINYCLOUD_PORT: String(PORT),
+        TINYCLOUD_STORAGE_DATADIR: dataDir,
+        TINYCLOUD_CORS: "true",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr?.on("data", (c) =>
+      process.stderr.write(`[node] ${c.toString()}`),
+    );
+
+    await waitForNode(host);
+    console.log(`[live] local tinycloud node ready at ${host}`);
+
+    // Deterministic dev key (Hardhat account #0).
+    const privateKey =
+      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+    // A manifest-recap-limited owner: NO full-authority auto-host of `secrets`.
+    // Grants secrets get/put and decrypt on the owner's default encryption
+    // network; account-registry permissions are included by default so reading
+    // `account/spaces/` needs no extra prompt.
+    const networkId = `urn:tinycloud:encryption:did:pkh:eip155:1:${address}:default`;
+    const owner = new TinyCloudNode({
+      privateKey,
+      host,
+      manifest: {
+        app_id: "com.tinycloud.ensure-registry-live",
+        name: "Ensure Registry Live",
+        defaults: false,
+        secrets: {
+          ENSURE_REGISTRY_PROOF: ["get", "put", "del", "list"],
+        },
+        permissions: [
+          {
+            service: "tinycloud.encryption",
+            path: networkId,
+            actions: ["tinycloud.encryption/decrypt"],
+          },
+        ],
+      },
+    });
+
+    await owner.signIn();
+    console.log(`[live] manifest-recap owner signed in: ${owner.address}`);
+
+    const secretsSpaceId = `tinycloud:pkh:eip155:1:${address}:secrets`;
+
+    // Wrap the underlying host-SIWE delegation call with a counter scoped to the
+    // SECRETS space. (The account-registry space is hosted separately by the
+    // registry plumbing and is not what `ensureOwnedSpaceHosted("secrets")`
+    // should re-trigger.) Counting `secrets`-space host calls proves whether a
+    // redundant host prompt occurs.
+    const auth = (owner as any).auth;
+    const realHostOwnedSpace = auth.hostOwnedSpace.bind(auth);
+    let secretsHostCount = 0;
+    auth.hostOwnedSpace = async (spaceId: string) => {
+      if (spaceId === secretsSpaceId) {
+        secretsHostCount += 1;
+        console.log(
+          `[live] auth.hostOwnedSpace(secrets) called (#${secretsHostCount})`,
+        );
+      } else {
+        console.log(`[live] auth.hostOwnedSpace(other) called for ${spaceId}`);
+      }
+      return realHostOwnedSpace(spaceId);
+    };
+
+    // The owner is root of their own encryption network; create it so the
+    // vault put can encrypt.
+    await owner.ensureEncryptionNetwork("default");
+
+    // --- PART 1: first ensure → space ABSENT → hosts (count 0 → 1) ---
+    const firstId = await owner.ensureOwnedSpaceHosted("secrets");
+    console.log(`[live] first ensureOwnedSpaceHosted => ${firstId}`);
+    if (secretsHostCount !== 1) {
+      throw new Error(
+        `FAIL: expected exactly 1 secrets host after first ensure (space absent), got ${secretsHostCount}.`,
+      );
+    }
+
+    const putOne = await owner.secrets.put("ENSURE_REGISTRY_PROOF", "value-one");
+    if (!putOne.ok) {
+      throw new Error(
+        `FAIL: first scoped secrets.put failed: ${putOne.error.code} ${putOne.error.message}`,
+      );
+    }
+    console.log(`[live] first scoped secrets.put OK`);
+
+    // Sanity: the hosted secrets space must be discoverable through the exact
+    // registry path `ensureOwnedSpaceHosted` consults — the recap-readable KV
+    // record `account/spaces/{id}` (NOT `syncAccessible()`, which needs
+    // `tinycloud.space/list`, a capability a manifest-recap session lacks).
+    const record = await owner.account.spaces.get(firstId);
+    if (!record.ok) {
+      throw new Error(
+        `FAIL: hosted secrets space ${firstId} was not found in the account registry (account/spaces) after hosting: ${record.error.code} ${record.error.message}`,
+      );
+    }
+    console.log(`[live] secrets space present in registry (account/spaces)`);
+
+    // --- PART 2: second ensure → space PRESENT → NO host (count stays 1) ---
+    const secondId = await owner.ensureOwnedSpaceHosted("secrets");
+    console.log(`[live] second ensureOwnedSpaceHosted => ${secondId}`);
+    if (secondId !== firstId) {
+      throw new Error(
+        `FAIL: second ensure returned a different space id. ${secondId} !== ${firstId}`,
+      );
+    }
+    if (secretsHostCount !== 1) {
+      throw new Error(
+        `FAIL: registry-registered space triggered a redundant secrets host (count ${secretsHostCount} !== 1) — the fix did not take effect.`,
+      );
+    }
+    console.log(`[live] second ensure performed NO host (no redundant SIWE)`);
+
+    const putTwo = await owner.secrets.put("ENSURE_REGISTRY_PROOF", "value-two");
+    if (!putTwo.ok) {
+      throw new Error(
+        `FAIL: second scoped secrets.put failed: ${putTwo.error.code} ${putTwo.error.message}`,
+      );
+    }
+    console.log(`[live] second scoped secrets.put OK`);
+
+    console.log(
+      `[live] PASS: hosted secrets once (count=${secretsHostCount}); registry hit avoided the second host; secrets.put worked both times.`,
+    );
+    process.stdout.write(
+      JSON.stringify({ ok: true, host, spaceId: firstId, secretsHostCount }) +
+        "\n",
+    );
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  } finally {
+    if (child && !child.killed) {
+      child.kill("SIGTERM");
+    }
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(runDir, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/packages/node-sdk/src/TinyCloudNode.ensureOwnedSpaceHosted.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ensureOwnedSpaceHosted.test.ts
@@ -1,0 +1,195 @@
+import { expect, mock, test } from "bun:test";
+
+import type { ISessionManager, IWasmBindings } from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+const ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+const SECRETS = `tinycloud:pkh:eip155:1:${ADDRESS}:secrets`;
+
+function makeSessionManager(): ISessionManager {
+  return {
+    createSessionKey: (id: string) => id,
+    renameSessionKeyId: () => {},
+    getDID: (keyId: string) => `did:key:${keyId}`,
+    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+  };
+}
+
+function makeWasmBindings(): IWasmBindings {
+  return {
+    invoke: async () => undefined,
+    makeSpaceId: (address: string, chainId: number, name: string) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${name}`,
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    createSessionManager: makeSessionManager,
+  } as unknown as IWasmBindings;
+}
+
+function makeNode(): TinyCloudNode {
+  const signer = {
+    getAddress: async () => ADDRESS,
+    getChainId: async () => 1,
+    signMessage: mock(async () => "0xsig"),
+  };
+  const node = new TinyCloudNode({
+    host: "https://tinycloud.test",
+    signer: signer as any,
+    wasmBindings: makeWasmBindings(),
+  });
+  // Simulate post-signIn state.
+  (node as any)._address = ADDRESS;
+  (node as any)._chainId = 1;
+  (node as any).auth = {
+    tinyCloudSession: {
+      address: ADDRESS,
+      chainId: 1,
+      delegationHeader: { Authorization: "base-token" },
+      spaceId: `tinycloud:pkh:eip155:1:${ADDRESS}:default`,
+    },
+  };
+  return node;
+}
+
+/**
+ * Override the account registry so `ensureOwnedSpaceHosted`'s registry check
+ * (`account.index.spaces.list()` fast path, then canonical
+ * `account.spaces.get(spaceId)`) returns a deterministic result. `register` is
+ * a no-op spy so the post-host durable write does not blow up.
+ */
+function stubAccountRegistry(
+  node: TinyCloudNode,
+  opts: {
+    indexList?: ReturnType<typeof mock>;
+    get?: ReturnType<typeof mock>;
+  },
+): void {
+  const indexList =
+    opts.indexList ?? mock(async () => ({ ok: true as const, data: [] }));
+  const get =
+    opts.get ??
+    mock(async () => ({
+      ok: false as const,
+      error: { code: "KV_NOT_FOUND", message: "Key not found", service: "kv" },
+    }));
+  (node as any)._account = {
+    index: { spaces: { list: indexList } },
+    spaces: { get, register: mock(async () => ({ ok: true as const, data: {} })) },
+  };
+}
+
+test("ensureOwnedSpaceHosted does NOT host when the SQLite index already lists the space", async () => {
+  const node = makeNode();
+  const indexList = mock(async () => ({
+    ok: true as const,
+    data: [
+      { spaceId: SECRETS, name: "secrets", ownerDid: "", type: "owned", permissions: ["*"], status: "active" },
+    ],
+  }));
+  const get = mock(async () => ({ ok: true as const, data: {} }));
+  stubAccountRegistry(node, { indexList, get });
+
+  const hostOwnedSpace = mock(async () => SECRETS);
+  (node as any).hostOwnedSpace = hostOwnedSpace;
+
+  const spaceId = await node.ensureOwnedSpaceHosted("secrets");
+
+  expect(spaceId).toBe(SECRETS);
+  // Index hit => no host-SIWE prompt; canonical KV read not even needed.
+  expect(hostOwnedSpace).not.toHaveBeenCalled();
+  expect(get).not.toHaveBeenCalled();
+});
+
+test("ensureOwnedSpaceHosted does NOT host when the canonical KV record exists (index empty)", async () => {
+  const node = makeNode();
+  // Index has no rows; canonical `account/spaces/{id}` KV record is present.
+  const indexList = mock(async () => ({ ok: true as const, data: [] }));
+  const get = mock(async () => ({ ok: true as const, data: {} }));
+  stubAccountRegistry(node, { indexList, get });
+
+  const hostOwnedSpace = mock(async () => SECRETS);
+  (node as any).hostOwnedSpace = hostOwnedSpace;
+
+  const spaceId = await node.ensureOwnedSpaceHosted("secrets");
+
+  expect(spaceId).toBe(SECRETS);
+  expect(hostOwnedSpace).not.toHaveBeenCalled();
+  expect(get).toHaveBeenCalledTimes(1);
+});
+
+test("ensureOwnedSpaceHosted hosts when neither index nor canonical KV lists the space", async () => {
+  const node = makeNode();
+  const indexList = mock(async () => ({ ok: true as const, data: [] }));
+  const get = mock(async () => ({
+    ok: false as const,
+    error: { code: "KV_NOT_FOUND", message: "Key not found", service: "kv" },
+  }));
+  stubAccountRegistry(node, { indexList, get });
+
+  const hostOwnedSpace = mock(async () => SECRETS);
+  (node as any).hostOwnedSpace = hostOwnedSpace;
+
+  const spaceId = await node.ensureOwnedSpaceHosted("secrets");
+
+  expect(spaceId).toBe(SECRETS);
+  expect(hostOwnedSpace).toHaveBeenCalledTimes(1);
+  expect(hostOwnedSpace).toHaveBeenCalledWith("secrets");
+});
+
+test("ensureOwnedSpaceHosted falls back to canonical KV when the index THROWS (no such table: spaces)", async () => {
+  const node = makeNode();
+  // Cold SQLite index surfaces `no such table: spaces` as a throw.
+  const indexList = mock(async () => {
+    throw new Error("no such table: spaces");
+  });
+  // Canonical KV record exists => still no host.
+  const get = mock(async () => ({ ok: true as const, data: {} }));
+  stubAccountRegistry(node, { indexList, get });
+
+  const hostOwnedSpace = mock(async () => SECRETS);
+  (node as any).hostOwnedSpace = hostOwnedSpace;
+
+  const spaceId = await node.ensureOwnedSpaceHosted("secrets");
+
+  expect(spaceId).toBe(SECRETS);
+  // The cache error must NOT throw; canonical KV hit avoided the host.
+  expect(hostOwnedSpace).not.toHaveBeenCalled();
+  expect(get).toHaveBeenCalledTimes(1);
+});
+
+test("ensureOwnedSpaceHosted hosts (does not throw) when the entire registry check THROWS", async () => {
+  const node = makeNode();
+  const indexList = mock(async () => {
+    throw new Error("no such table: spaces");
+  });
+  const get = mock(async () => {
+    throw new Error("kv exploded");
+  });
+  stubAccountRegistry(node, { indexList, get });
+
+  const hostOwnedSpace = mock(async () => SECRETS);
+  (node as any).hostOwnedSpace = hostOwnedSpace;
+
+  // Must not throw the cache/KV error: falls through to hosting.
+  const spaceId = await node.ensureOwnedSpaceHosted("secrets");
+
+  expect(spaceId).toBe(SECRETS);
+  expect(hostOwnedSpace).toHaveBeenCalledTimes(1);
+});
+
+test("ensureOwnedSpaceHosted throws when not signed in", async () => {
+  const node = new TinyCloudNode({
+    host: "https://tinycloud.test",
+    signer: {
+      getAddress: async () => ADDRESS,
+      getChainId: async () => 1,
+      signMessage: async () => "0xsig",
+    } as any,
+    wasmBindings: makeWasmBindings(),
+  });
+  await expect(node.ensureOwnedSpaceHosted("secrets")).rejects.toThrow(
+    "Not signed in",
+  );
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -1052,16 +1052,98 @@ export class TinyCloudNode {
    * registered on the node.
    *
    * Calling this resolves `name` to the owner's owned-space URI
-   * (`tinycloud:pkh:eip155:<chain>:<addr>:<name>`) and hosts it via the
-   * host-SIWE delegation flow. The host SIWE is idempotent server-side, so it
-   * is safe to call whether or not the space already exists; do not gate it on
-   * a prior existence check. Must be called after {@link signIn}.
+   * (`tinycloud:pkh:eip155:<chain>:<addr>:<name>`). It first consults the
+   * account-space spaces registry (`account/spaces/{space_id}`, the canonical
+   * KV source of truth, fronted by a best-effort SQLite index): if the space is
+   * already registered/hosted it returns the URI WITHOUT submitting a host
+   * delegation, avoiding a redundant host-SIWE signature prompt for owners who
+   * already use the space. Only when the space is absent — or the registry
+   * check fails for any reason (e.g. a cold SQLite index reporting
+   * `no such table: spaces`) — does it fall through to {@link hostOwnedSpace}.
+   *
+   * The registry check is purely an optimization: any failure falls back to
+   * hosting, and the host SIWE is idempotent server-side, so re-hosting an
+   * existing space remains a safe no-op. Must be called after {@link signIn}.
    *
    * @param name - The owned space name (e.g. `"secrets"`).
    * @returns The hosted owned-space URI.
    */
   async ensureOwnedSpaceHosted(name: string): Promise<string> {
-    return this.hostOwnedSpace(name);
+    if (!this.auth || !this.auth.tinyCloudSession) {
+      throw new Error("Not signed in. Call signIn() first.");
+    }
+
+    const spaceId = this.ownedSpaceId(name);
+
+    if (await this.isOwnedSpaceRegistered(spaceId)) {
+      return spaceId;
+    }
+
+    const hosted = await this.hostOwnedSpace(name);
+
+    // hostOwnedSpace registers best-effort and fire-and-forget; await an
+    // explicit registry write here so the canonical `account/spaces/{id}`
+    // record is durably present and a subsequent ensure short-circuits on the
+    // registry instead of re-hosting. The host already succeeded, so a failed
+    // registry write must not fail this call.
+    try {
+      await this.account.spaces.register({
+        spaceId,
+        name,
+        ownerDid: this.did,
+        type: "owned",
+        permissions: ["*"],
+        status: "active",
+      });
+    } catch {
+      // Registry write is best-effort; the space is hosted regardless.
+    }
+
+    return hosted;
+  }
+
+  /**
+   * Check whether an owned space is already registered/hosted by consulting the
+   * account spaces registry.
+   *
+   * Source of truth is the canonical KV registry record
+   * `account/spaces/{space_id}`, read here via `account.spaces.get(spaceId)`.
+   * The KV path is used (rather than `syncAccessible()`) because it works under
+   * a manifest/recap session with NO extra prompt: the composed manifest recap
+   * already grants `tinycloud.kv get/list` on the account space `spaces/`
+   * prefix, whereas `syncAccessible()` depends on `tinycloud.space/list`, which
+   * a recap session does not hold. Before reading, it consults the fast SQLite
+   * index (`account.index.spaces.list()`) as a best-effort short-circuit; on a
+   * cold index (`no such table: spaces`) or any other index failure it falls
+   * back to the canonical KV read.
+   *
+   * This is a best-effort optimization. ANY failure of the check path (missing
+   * table, KV error, missing record, thrown exception) resolves to `false` so
+   * the caller falls through to hosting — per the directive, "if it fails in any
+   * way then create the space".
+   */
+  private async isOwnedSpaceRegistered(spaceId: string): Promise<boolean> {
+    // Best-effort fast path: the SQLite index. Only trust a positive hit; treat
+    // misses/empties/errors/throws (e.g. a cold `no such table: spaces`) as
+    // inconclusive and fall through to the canonical KV read.
+    try {
+      const indexed = await this.account.index.spaces.list();
+      if (indexed.ok && indexed.data.some((space) => space.spaceId === spaceId)) {
+        return true;
+      }
+    } catch {
+      // Cache miss/error — fall back to canonical below.
+    }
+
+    // Canonical: the `account/spaces/{space_id}` KV record. This is the registry
+    // source of truth and is recap-readable. Any failure here (missing record,
+    // KV error, throw) resolves to "not registered" so the caller hosts.
+    try {
+      const record = await this.account.spaces.get(spaceId);
+      return record.ok;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -486,9 +486,12 @@ export class TinyCloudWeb {
    * `secrets` space yet still fail its first scoped `secrets.put(...)` with
    * `404 Space not found`, because the space was never registered on the node.
    *
-   * Calling this resolves `name` to the owner's owned-space URI and hosts it
-   * via the host-SIWE delegation flow (one signature, idempotent server-side).
-   * Must be called after {@link signIn}.
+   * Calling this resolves `name` to the owner's owned-space URI. It first
+   * consults the account spaces registry and, if the space is already
+   * registered/hosted, returns without prompting for a host signature; only
+   * when the space is absent (or the registry check fails) does it host via the
+   * host-SIWE delegation flow (one signature, idempotent server-side). Must be
+   * called after {@link signIn}.
    *
    * @param name - The owned space name (e.g. `"secrets"`).
    * @returns The hosted owned-space URI.


### PR DESCRIPTION
## The bug

`TinyCloudNode.ensureOwnedSpaceHosted(name)` always delegated to `hostOwnedSpace`, whose own doc says it *"always submits the host delegation."* So it triggered a host-SIWE signature **even when the owner's space was already hosted**. A git-haiku owner who already uses TinyCloud Secrets was prompted to "host" their `secrets` space on every setup — a redundant signature.

## The fix — registry-based detection (Account Registry Parity)

`ensureOwnedSpaceHosted` now resolves the owned space id and consults the **account spaces registry** before hosting:

1. Fast path: the SQLite index (`account.index.spaces.list()`) as a best-effort short-circuit — trusted only on a positive hit.
2. Canonical fallback: the recap-readable KV record `account/spaces/{space_id}` via `account.spaces.get(spaceId)` — the registry **source of truth**.

If the space is already registered/hosted it returns the id **without** submitting a host delegation (no redundant prompt). Only when the space is absent — **or the registry check fails in any way** — does it fall through to `hostOwnedSpace`, then durably write-through registers the space so subsequent calls short-circuit on the registry.

Detection is registry-based, not session-activation and not timestamp-based, per the Account Registry Parity design.

### Cache-miss fallback (the recurring first-run trap)

The SQLite index is a cache, never the authority. A cold index throwing `no such table: spaces` (or any index error) is treated as inconclusive and falls through to the canonical KV read; any failure of the whole check resolves to "not registered" so the caller hosts — *"if it fails in any way then create the space."*

The KV path is used rather than `syncAccessible()` because a manifest/recap session can read `account/spaces/` under the composed manifest recap (`tinycloud.kv get/list` on the account `spaces/` prefix) but does **not** hold `tinycloud.space/list`, which `syncAccessible()` needs.

`hostOwnedSpace` (always-host) is unchanged for callers that explicitly want it. `TinyCloudWeb.ensureOwnedSpaceHosted` already delegates through; its doc was updated.

## Verification

- **Build**: `bunx turbo build --filter=@tinycloud/node-sdk --filter=@tinycloud/web-sdk --filter=@tinycloud/sdk-core` green.
- **Unit** (`TinyCloudNode.ensureOwnedSpaceHosted.test.ts`): index hit → no host; canonical KV hit (index empty) → no host; neither lists it → hosts; index **throws** → falls back to canonical KV (no throw); entire check **throws** → hosts (never throws the cache error); not-signed-in → throws. Existing `hostOwnedSpace` tests still pass (no regression). Full node-sdk suite: 105 pass.
- **Live** (gated, `packages/node-sdk/scripts/live-ensure-owned-space-registry.ts`, against a local `tinycloud` node): a manifest-recap-limited owner hosts `secrets` **once** (secrets host count = 1); the record appears under `account/spaces/{id}`; a **second** `ensureOwnedSpaceHosted('secrets')` finds it in the registry and performs **NO** host; a scoped `secrets.put` works **both** times.
- **Changeset**: `.changeset/ensure-owned-space-registry-check.md`, minor for the full linked group (sdk-core, web-sdk, node-sdk, sdk-services).