### PR TITLE
fix(node-sdk): thread invokeAny into DelegatedAccess for multi-action SQL

### DIFF
--- a/packages/node-sdk/src/DelegatedAccess.ts
+++ b/packages/node-sdk/src/DelegatedAccess.ts
@@ -12,7 +12,7 @@ import {
   ServiceContext,
   type TelemetryConfig,
 } from "@tinycloud/sdk-core";
-import type { InvokeFunction } from "@tinycloud/sdk-services";
+import type { InvokeFunction, InvokeAnyFunction } from "@tinycloud/sdk-services";
 import { PortableDelegation } from "./delegation";
 
 /**
@@ -58,15 +58,21 @@ export class DelegatedAccess {
     delegation: PortableDelegation,
     host: string,
     invoke: InvokeFunction,
+    invokeAny?: InvokeAnyFunction,
     telemetry?: TelemetryConfig,
   ) {
     this.session = session;
     this._delegation = delegation;
     this.host = host;
 
-    // Create service context
+    // Create service context. invokeAny is required for SQL operations whose
+    // statements span multiple actions in a single invocation (e.g. the
+    // migration runner batches a CREATE TABLE (ddl) with the tracking-row
+    // INSERT (write)); without it those calls throw "multi-resource
+    // invocations" not supported.
     this._serviceContext = new ServiceContext({
       invoke,
+      invokeAny,
       fetch: globalThis.fetch.bind(globalThis),
       hosts: [host],
       telemetry,

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -4234,6 +4234,7 @@ export class TinyCloudNode {
         delegation,
         targetHost,
         this.wasmBindings.invoke,
+        this.wasmBindings.invokeAny,
         this.config.telemetry,
       );
     }
@@ -4331,6 +4332,7 @@ export class TinyCloudNode {
       delegation,
       targetHost,
       this.wasmBindings.invoke,
+      this.wasmBindings.invokeAny,
       this.config.telemetry,
     );
   }


### PR DESCRIPTION
Fixes #286.

## Problem

`DelegatedAccess` built its `ServiceContext` with only a single-action `invoke` and no `invokeAny`, so any SQL op needing more than one action in a single `/invoke` threw:

```
SQL operation requires multiple permissions (tinycloud.sql/ddl, tinycloud.sql/write)
but this SDK runtime does not support multi-resource invocations
```

The migration runner always produces such a batch — `ensureMigrationsTable` bundles a `CREATE TABLE` (ddl) with the tracking-row `INSERT` (write) — so **any** delegated backend that runs migrations is broken. Granting `tinycloud.sql/ddl` doesn't help; the code path can't form the multi-action invocation. The top-level node session already works because its `ServiceContext` wires `invokeAny: this.invokeAnyWithRuntimePermissions`; `DelegatedAccess` was the only path omitting it.

## Change

- `DelegatedAccess` takes an optional `invokeAny?: InvokeAnyFunction` and passes it into its `ServiceContext`.
- Both `new DelegatedAccess(...)` sites in `TinyCloudNode` pass `this.wasmBindings.invokeAny`, mirroring how `this.wasmBindings.invoke` is already passed.

## Verification

- `bun run build` on `node-sdk` (tsup + DTS typecheck) passes.
- Confirmed the compiled `DelegatedAccess` now forwards `invokeAny` into its `ServiceContext` and both construction sites pass `wasmBindings.invokeAny`.
- End-to-end: a delegated backend's `ensureSchema` (CREATE TABLE + migration-tracking INSERT) previously threw the multi-resource error; with this change the multi-action invocation is formed and the migration applies.
