### PR TITLE
chore(changeset): node-sdk patch for DelegatedAccess invokeAny multi-action SQL

### DIFF
--- a/.changeset/delegated-access-invokeany.md
+++ b/.changeset/delegated-access-invokeany.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/node-sdk": patch
+---
+
+Thread `invokeAny` into `DelegatedAccess` so delegated sessions can form multi-action SQL invocations. `DelegatedAccess` previously built its `ServiceContext` with only the single-action `invoke`, so any SQL operation needing more than one action in a single `/invoke` — e.g. the migration runner's `ensureMigrationsTable`, which bundles a `CREATE TABLE` schema action with the tracking-row `write` — threw `SQL operation requires multiple permissions ... but this SDK runtime does not support multi-resource invocations`. `DelegatedAccess` now accepts an optional `invokeAny`, and both `TinyCloudNode` construction sites pass `wasmBindings.invokeAny`, mirroring how the top-level node session already wires it.


### PR DESCRIPTION
Followup changeset for #287 (`fix(node-sdk): thread invokeAny into DelegatedAccess for multi-action SQL`).

That PR merged the code fix without a changeset entry, so the linked package set won't pick up a version bump on the next release run. This adds a `@tinycloud/node-sdk: patch` changeset describing the fix.

Refs #286, #287.