### PR TITLE
fix(cli): honor TC_PRIVATE_KEY/--private-key for delegate-mode auth (headless)

### DIFF
--- a/.changeset/cli-delegate-key-headless-auth.md
+++ b/.changeset/cli-delegate-key-headless-auth.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/cli": patch
+---
+
+Delegate-mode secrets commands now honor `TC_PRIVATE_KEY` / `--private-key` for headless auth. Previously `tc secrets get --delegation` (and the other `--private-key`-advertising secrets commands) threw `AUTH_REQUIRED` when only an explicit private key was supplied, because `ensureAuthenticated` consulted `options.privateKey` only after its profile/session gate. An explicitly provided private key is now treated as a first-class headless identity and accepted before that gate, so a delegate can authenticate with no persisted profile and no login session — exactly what the flags and env var already advertised.

--- a/packages/cli/src/lib/sdk.test.ts
+++ b/packages/cli/src/lib/sdk.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { CLIError } from "../output/errors.js";
+
+// Controllable profile/session/key state for each test. `null` means "absent"
+// — `getProfile` throws (as the real ProfileManager does) when no profile.json
+// exists, so a headless delegate has no profile, no session, and no key.
+let profile: Record<string, unknown> | null = null;
+let session: Record<string, unknown> | null = null;
+let key: object | null = null;
+
+mock.module("../config/profiles.js", () => ({
+  ProfileManager: {
+    getProfile: async () => {
+      if (profile === null) {
+        throw new CLIError("PROFILE_NOT_FOUND", "Profile does not exist.");
+      }
+      return profile;
+    },
+    getSession: async () => session,
+    getKey: async () => key,
+  },
+}));
+
+// Record TinyCloudNode construction + signIn so tests can assert the headless
+// key path actually builds and signs in a node.
+const nodeCalls: { privateKey?: string; signedIn: boolean }[] = [];
+
+mock.module("@tinycloud/node-sdk", () => ({
+  TinyCloudNode: class {
+    private _call: { privateKey?: string; signedIn: boolean };
+    constructor(opts: { host: string; privateKey?: string }) {
+      this._call = { privateKey: opts.privateKey, signedIn: false };
+      nodeCalls.push(this._call);
+    }
+    async signIn() {
+      this._call.signedIn = true;
+    }
+    async restoreSession() {}
+  },
+}));
+
+// sdk.js -> permissions.js -> sdk-core/manifest.js pulls in the published
+// @tinycloud/sdk-services dist, whose build is currently broken on import.
+// Stub the one symbol the resolver needs (replayAdditionalDelegations) so the
+// gate under test imports cleanly without that chain. Other CLI test files
+// already mock ../lib/permissions.js the same way.
+mock.module("./permissions.js", () => ({
+  replayAdditionalDelegations: async () => {},
+}));
+
+const { ensureAuthenticated } = await import("./sdk.js");
+
+const ctx = { profile: "tc-sdk-test-headless", host: "https://node.tinycloud.xyz", verbose: false, noCache: false, quiet: false };
+const HEX_KEY = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+
+beforeEach(() => {
+  profile = null;
+  session = null;
+  key = null;
+  nodeCalls.length = 0;
+  delete process.env.TC_PRIVATE_KEY;
+});
+
+afterEach(() => {
+  delete process.env.TC_PRIVATE_KEY;
+});
+
+describe("ensureAuthenticated headless private-key identity", () => {
+  test("an explicit options.privateKey authenticates with NO profile and NO session", async () => {
+    const node = await ensureAuthenticated(ctx, { privateKey: HEX_KEY });
+    expect(node).toBeDefined();
+    // The headless path builds a node from the key and signs in.
+    expect(nodeCalls).toHaveLength(1);
+    expect(nodeCalls[0]!.privateKey).toBe(HEX_KEY);
+    expect(nodeCalls[0]!.signedIn).toBe(true);
+  });
+
+  test("a key sourced from TC_PRIVATE_KEY (threaded as options.privateKey) authenticates headlessly", async () => {
+    // This is the shape the secrets commands produce: authOptions() reads
+    // TC_PRIVATE_KEY and passes it to ensureAuthenticated as options.privateKey.
+    process.env.TC_PRIVATE_KEY = HEX_KEY;
+    const fromEnv = process.env.TC_PRIVATE_KEY;
+    const node = await ensureAuthenticated(ctx, { privateKey: fromEnv });
+    expect(node).toBeDefined();
+    expect(nodeCalls).toHaveLength(1);
+    expect(nodeCalls[0]!.privateKey).toBe(HEX_KEY);
+    expect(nodeCalls[0]!.signedIn).toBe(true);
+  });
+
+  test("with no profile, no session, and no key, it still throws AUTH_REQUIRED", async () => {
+    await expect(ensureAuthenticated(ctx, {})).rejects.toMatchObject({ code: "AUTH_REQUIRED" });
+    expect(nodeCalls).toHaveLength(0);
+  });
+
+  test("with no profile, no session, and no options, it throws AUTH_REQUIRED", async () => {
+    await expect(ensureAuthenticated(ctx)).rejects.toMatchObject({ code: "AUTH_REQUIRED" });
+  });
+
+  test("an explicit key wins even when a local profile already exists", async () => {
+    profile = { authMethod: "local", privateKey: "0xother", did: "did:pkh:eip155:1:0xowner" };
+    const node = await ensureAuthenticated(ctx, { privateKey: HEX_KEY });
+    expect(node).toBeDefined();
+    // The provided key, not the profile's stored key, builds the node.
+    expect(nodeCalls.some((c) => c.privateKey === HEX_KEY)).toBe(true);
+    expect(nodeCalls.some((c) => c.privateKey === "0xother")).toBe(false);
+  });
+});

--- a/packages/cli/src/lib/sdk.ts
+++ b/packages/cli/src/lib/sdk.ts
@@ -17,12 +17,16 @@ export async function createSDKInstance(
   ctx: CLIContext,
   options?: { privateKey?: string }
 ): Promise<TinyCloudNode> {
-  const profile = await ProfileManager.getProfile(ctx.profile);
+  // A headless delegate may pass a private key with no persisted profile at all.
+  // Only require a profile when we have no explicit key to fall back on.
+  const profile = options?.privateKey
+    ? await ProfileManager.getProfile(ctx.profile).catch(() => null)
+    : await ProfileManager.getProfile(ctx.profile);
   const session = await ProfileManager.getSession(ctx.profile) as Record<string, unknown> | null;
   const key = await ProfileManager.getKey(ctx.profile);
 
   // For local auth, use the stored private key
-  const effectivePrivateKey = options?.privateKey ?? profile.privateKey;
+  const effectivePrivateKey = options?.privateKey ?? profile?.privateKey;
 
   if (!key && !effectivePrivateKey) {
     throw new CLIError(
@@ -32,7 +36,7 @@ export async function createSDKInstance(
     );
   }
 
-  if (profile.authMethod === "local" && effectivePrivateKey) {
+  if (profile?.authMethod === "local" && effectivePrivateKey) {
     // Local key auth: prefer the persisted TinyCloud session so the CLI
     // keeps the same session key DID across request/grant/import flows.
     const node = new TinyCloudNode({
@@ -46,7 +50,7 @@ export async function createSDKInstance(
         delegationCid: session.delegationCid as string,
         spaceId: session.spaceId as string,
         jwk: (session.jwk as object) ?? key,
-        verificationMethod: (session.verificationMethod as string) ?? profile.sessionDid ?? profile.did,
+        verificationMethod: (session.verificationMethod as string) ?? profile?.sessionDid ?? profile?.did,
         address: session.address as string | undefined,
         chainId: session.chainId as number | undefined,
         siwe: session.siwe as string | undefined,
@@ -75,7 +79,7 @@ export async function createSDKInstance(
       delegationCid: session.delegationCid as string,
       spaceId: session.spaceId as string,
       jwk: (session.jwk as object) ?? key,
-      verificationMethod: (session.verificationMethod as string) ?? profile.did,
+      verificationMethod: (session.verificationMethod as string) ?? profile?.did,
       address: session.address as string | undefined,
       chainId: session.chainId as number | undefined,
       siwe: session.siwe as string | undefined,
@@ -95,6 +99,13 @@ export async function ensureAuthenticated(
   ctx: CLIContext,
   options?: { privateKey?: string }
 ): Promise<TinyCloudNode> {
+  // An explicitly-provided private key (--private-key / TC_PRIVATE_KEY) is a
+  // first-class headless identity: accept it before any profile/session gate so
+  // delegates can authenticate with no persisted profile and no login session.
+  if (options?.privateKey) {
+    return createSDKInstance(ctx, options);
+  }
+
   const profile = await ProfileManager.getProfile(ctx.profile).catch(() => null);
 
   // For local auth, we can sign in directly without a stored session


### PR DESCRIPTION
## Problem

`tc secrets get --delegation` (and the other secrets subcommands that advertise `--private-key <hex>` "(or set TC_PRIVATE_KEY)") fail headlessly with:

```
AUTH_REQUIRED: Not authenticated. Run `tc auth login` or `tc init` first.
```

even when a delegate key is supplied via `TC_PRIVATE_KEY` env or `--private-key`. The flags/env are advertised on every secrets subcommand but were never honored for this path.

## Root cause

`ensureAuthenticated()` in `packages/cli/src/lib/sdk.ts` accepted identity only from (A) a persisted **local** profile or (B) a stored **login session**. The explicitly-provided `options.privateKey` (which carries `TC_PRIVATE_KEY` / `--private-key` via `authOptions()`) was consulted **only inside `createSDKInstance`, after** the throw gate:

```ts
async function ensureAuthenticated(ctx, options) {
  const profile = await ProfileManager.getProfile(ctx.profile).catch(() => null);
  if (profile?.authMethod === "local" && profile.privateKey) { ... }   // (A)
  const session = await ProfileManager.getSession(ctx.profile);        // (B)
  if (!session) { throw AUTH_REQUIRED; }                               // <-- gate fires first
  return createSDKInstance(ctx, options);                              // options.privateKey only reached HERE
}
```

So a headless delegate with no profile and no session — but a valid `TC_PRIVATE_KEY` — hit the throw before its key was ever examined.

The threading from the commands is already correct: each secrets subcommand passes `authOptions(options)` (which maps `TC_PRIVATE_KEY`/`--private-key` → `options.privateKey`) into `ensureAuthenticated` / `ensureSecretsNode`. The only defect was the gate ordering in the resolver.

## Fix

Treat an explicitly-provided private key as a **first-class headless identity** — accept it before the profile/session gate:

```ts
async function ensureAuthenticated(ctx, options) {
  if (options?.privateKey) {
    return createSDKInstance(ctx, options);   // headless delegate / explicit key
  }
  // ...existing local-profile / session logic unchanged...
}
```

`createSDKInstance` was also hardened so a truly headless delegate works with **no profile at all**: `getProfile` is now tolerated (returns null) when an explicit key is present, and the dependent `profile.*` reads are null-safe. The OpenKey branch (`new TinyCloudNode({ privateKey }).signIn()`) already handles the key path; `replayAdditionalDelegations` is a no-op when no delegations file exists. Existing local-profile + session behavior is preserved (a provided key still routes through the local-auth branch and restores the persisted session).

Because all secrets subcommands (`secrets get --delegation`, `secrets network show`, `secrets network init`, etc.) funnel through `ensureAuthenticated`, the single resolver fix makes the behavior uniform without touching individual commands.

End state: `TC_PRIVATE_KEY=<key> tc secrets get NAME --scope s --delegation f.json --host h --json` authenticates the delegate with **no profile and no session** — exactly what the flags/env already promise.

## Tests

Added `packages/cli/src/lib/sdk.test.ts` (Bun `bun:test`, matching the package's existing style):

- explicit `options.privateKey` authenticates with no profile and no session (builds a node + signs in)
- a key sourced from `TC_PRIVATE_KEY` (threaded as `options.privateKey`, the shape `authOptions()` produces) authenticates headlessly
- with no profile, no session, and no key, it still throws `AUTH_REQUIRED`
- an explicit key wins even when a local profile already exists

`5 pass / 0 fail` standalone. Each existing CLI test file remains green in isolation (the suite is run per-file; the aggregate run is pre-existing order-fragile due to a broken published `@tinycloud/sdk-services` / `@tinycloud/node-sdk` beta dist that some files mock — unrelated to this change). `bunx turbo build --filter=@tinycloud/cli` is clean (6/6 tasks), and the rebuilt `dist/index.js` contains the early `options.privateKey` branch as the first check in `ensureAuthenticated`.

## Impact

Unblocks server/agent delegates that authenticate purely from an env-supplied key, and lets git-haiku drop its `ensureLocalTcProfile` workaround.

## Changeset

`patch` for `@tinycloud/cli` (bugfix making already-advertised flags work).