### PR TITLE
Support replication delegation permissions

### DIFF
--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -734,6 +734,55 @@ describe("TinyCloudNode runtime permission delegations", () => {
     );
   });
 
+  test("useDelegation preserves multi-resource SQL and KV grants", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const spaceId = `tinycloud:pkh:eip155:1:${address}:default`;
+    const delegation = {
+      cid: "multi-resource-cid",
+      delegationHeader: { Authorization: "multi-resource-token" },
+      spaceId,
+      path: "com.listen.app/",
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      resources: [
+        {
+          service: "kv",
+          space: spaceId,
+          path: "com.listen.app/",
+          actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+        },
+        {
+          service: "sql",
+          space: spaceId,
+          path: "com.listen.app/data.sqlite",
+          actions: ["tinycloud.sql/read", "tinycloud.sql/write"],
+        },
+      ],
+      expiry: new Date(Date.now() + 3600_000),
+      delegateDID: "did:key:default",
+      ownerAddress: address,
+      chainId: 1,
+      host: "https://tinycloud.test",
+    };
+
+    await withActivatedDelegations(async () => {
+      await node.useDelegation(delegation as any);
+    });
+
+    const prepareSession = (node as any).wasmBindings.prepareSession;
+    expect(prepareSession.mock.calls[0][0].abilities).toEqual({
+      kv: {
+        "com.listen.app/": ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+      sql: {
+        "com.listen.app/data.sqlite": ["tinycloud.sql/read", "tinycloud.sql/write"],
+      },
+    });
+  });
+
   test("encryption discovery falls back to the well-known cache record", async () => {
     const invoke = mock((session: any) => ({
       Authorization: session.delegationHeader.Authorization,

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -868,6 +868,17 @@ export class TinyCloudNode {
   }
 
   /**
+   * Prepare a signed host delegation header for the current host and space
+   * without submitting it to the server.
+   */
+  async prepareHostDelegation(spaceId?: string): Promise<Record<string, string>> {
+    if (!this.auth) {
+      throw new Error("prepareHostDelegation requires wallet mode");
+    }
+    return this.auth.prepareHostDelegation(spaceId);
+  }
+
+  /**
    * Restore a previously established session from stored delegation data.
    *
    * This is used by the CLI to restore a session that was created via the
@@ -3571,9 +3582,13 @@ export class TinyCloudNode {
 
     // Build abilities for the delegation
     const abilities: Record<string, Record<string, string[]>> = {};
+    const spaceActions = params.actions.filter(a => a.startsWith("tinycloud.space/"));
     const kvActions = params.actions.filter(a => a.startsWith("tinycloud.kv/"));
     const sqlActions = params.actions.filter(a => a.startsWith("tinycloud.sql/"));
     const duckdbActions = params.actions.filter(a => a.startsWith("tinycloud.duckdb/"));
+    if (spaceActions.length > 0) {
+      abilities.space = { [params.path]: spaceActions };
+    }
     if (kvActions.length > 0) {
       abilities.kv = { [params.path]: kvActions };
     }
@@ -3747,7 +3762,12 @@ export class TinyCloudNode {
         delegation.expiry,
       );
 
-      return new DelegatedAccess(session, delegation, targetHost, this.wasmBindings.invoke);
+      return new DelegatedAccess(
+        session,
+        delegation,
+        targetHost,
+        this.invokeWithRuntimePermissions,
+      );
     }
 
     // Wallet mode: create a SIWE sub-delegation
@@ -3760,29 +3780,44 @@ export class TinyCloudNode {
     // We must use the same key that the delegation was created for
     const jwk = mySession.jwk;
 
-    // Build abilities from the delegation
+    // Build abilities from the full resource list when available so
+    // multi-resource delegations preserve every service/path pair.
+    // Fall back to the legacy flat shape when receiving older single-
+    // resource delegations.
+    const resources =
+      delegation.resources !== undefined && delegation.resources.length > 0
+        ? delegation.resources
+        : this.flatDelegationResources(delegation);
     const abilities: Record<string, Record<string, string[]>> = {};
-    const kvActions = delegation.actions.filter(a => a.startsWith("tinycloud.kv/"));
-    const sqlActions = delegation.actions.filter(a => a.startsWith("tinycloud.sql/"));
-    const duckdbActions = delegation.actions.filter(a => a.startsWith("tinycloud.duckdb/"));
-    const encryptionActions = delegation.actions.filter(a =>
-      a.startsWith("tinycloud.encryption/"),
-    );
     const rawAbilities: Record<string, string[]> = {};
-    if (kvActions.length > 0) {
-      abilities.kv = { [delegation.path]: kvActions };
-    }
-    if (sqlActions.length > 0) {
-      abilities.sql = { [delegation.path]: sqlActions };
-    }
-    if (duckdbActions.length > 0) {
-      abilities.duckdb = { [delegation.path]: duckdbActions };
-    }
-    if (
-      encryptionActions.length > 0 &&
-      delegation.path.startsWith("urn:tinycloud:encryption:")
-    ) {
-      rawAbilities[delegation.path] = encryptionActions;
+    for (const resource of resources) {
+      const actions = [...resource.actions];
+      if (
+        resource.service === "encryption" &&
+        resource.path.startsWith("urn:tinycloud:encryption:")
+      ) {
+        const existing = rawAbilities[resource.path] ?? [];
+        const seen = new Set(existing);
+        for (const action of actions) {
+          if (!seen.has(action)) {
+            existing.push(action);
+            seen.add(action);
+          }
+        }
+        rawAbilities[resource.path] = existing;
+        continue;
+      }
+
+      abilities[resource.service] ??= {};
+      const existing = abilities[resource.service][resource.path] ?? [];
+      const seen = new Set(existing);
+      for (const action of actions) {
+        if (!seen.has(action)) {
+          existing.push(action);
+          seen.add(action);
+        }
+      }
+      abilities[resource.service][resource.path] = existing;
     }
 
     const now = new Date();
@@ -3855,7 +3890,12 @@ export class TinyCloudNode {
       expirationTime,
     );
 
-    return new DelegatedAccess(session, delegation, targetHost, this.wasmBindings.invoke);
+    return new DelegatedAccess(
+      session,
+      delegation,
+      targetHost,
+      this.invokeWithRuntimePermissions,
+    );
   }
 
   /**
@@ -3922,9 +3962,13 @@ export class TinyCloudNode {
 
     // Build abilities for the sub-delegation
     const abilities: Record<string, Record<string, string[]>> = {};
+    const spaceActions = params.actions.filter(a => a.startsWith("tinycloud.space/"));
     const kvActions = params.actions.filter(a => a.startsWith("tinycloud.kv/"));
     const sqlActions = params.actions.filter(a => a.startsWith("tinycloud.sql/"));
     const duckdbActions = params.actions.filter(a => a.startsWith("tinycloud.duckdb/"));
+    if (spaceActions.length > 0) {
+      abilities.space = { [params.path]: spaceActions };
+    }
     if (kvActions.length > 0) {
       abilities.kv = { [params.path]: kvActions };
     }

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -543,7 +543,9 @@ export class NodeUserAuthorization implements IUserAuthorization {
    * Create the space on the TinyCloud server (host delegation).
    * This registers the user as the owner of the space.
    */
-  private async hostSpace(targetSpaceId?: string): Promise<boolean> {
+  private async buildHostDelegationHeaders(
+    targetSpaceId?: string,
+  ): Promise<Record<string, string>> {
     if (!this._tinyCloudSession || !this._address || !this._chainId) {
       throw new Error("Must be signed in to host space");
     }
@@ -568,7 +570,16 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const signature = await this.signMessage(siwe);
 
     // Convert to delegation headers and submit
-    const headers = this.wasm.siweToDelegationHeaders({ siwe, signature });
+    return this.wasm.siweToDelegationHeaders({ siwe, signature });
+  }
+
+  async prepareHostDelegation(spaceId?: string): Promise<Record<string, string>> {
+    return this.buildHostDelegationHeaders(spaceId);
+  }
+
+  private async hostSpace(targetSpaceId?: string): Promise<boolean> {
+    const host = this.primaryTinyCloudHost;
+    const headers = await this.buildHostDelegationHeaders(targetSpaceId);
     const result = await submitHostDelegation(host, headers);
 
     return result.success;

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -333,6 +333,6 @@ export type { KeyProvider } from "@tinycloud/sdk-core";
 // Key management for node-sdk
 export {
   WasmKeyProvider,
-  WasmKeyProviderConfig,
   createWasmKeyProvider,
 } from "./keys/WasmKeyProvider";
+export type { WasmKeyProviderConfig } from "./keys/WasmKeyProvider";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -460,6 +460,6 @@ export type { KeyProvider } from "@tinycloud/sdk-core";
 // Key management for node-sdk
 export {
   WasmKeyProvider,
-  WasmKeyProviderConfig,
   createWasmKeyProvider,
 } from "./keys/WasmKeyProvider";
+export type { WasmKeyProviderConfig } from "./keys/WasmKeyProvider";

--- a/packages/node-sdk/src/keys/index.ts
+++ b/packages/node-sdk/src/keys/index.ts
@@ -4,4 +4,5 @@
  * @packageDocumentation
  */
 
-export { WasmKeyProvider, WasmKeyProviderConfig, createWasmKeyProvider } from "./WasmKeyProvider";
+export { WasmKeyProvider, createWasmKeyProvider } from "./WasmKeyProvider";
+export type { WasmKeyProviderConfig } from "./WasmKeyProvider";

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -27,12 +27,12 @@ import { resolveSecretPath, SECRET_NAME_RE } from "@tinycloud/sdk-services";
  * in their `manifest.json` and the shape we compare against when performing
  * the capability-subset derivability check in the delegation flow.
  *
- * `service` uses the long form (e.g. `"tinycloud.kv"`, `"tinycloud.sql"`).
+ * `service` uses the long form (e.g. `"tinycloud.space"`, `"tinycloud.kv"`, `"tinycloud.sql"`).
  * `"tinycloud.vault"` is an SDK-only shorthand that expands to the KV
  * resources the vault service uses; it is never encoded as a recap service.
  */
 export interface PermissionEntry {
-  /** Service namespace, e.g. "tinycloud.kv", "tinycloud.sql", "tinycloud.duckdb", "tinycloud.capabilities". */
+  /** Service namespace, e.g. "tinycloud.space", "tinycloud.kv", "tinycloud.sql", "tinycloud.duckdb", "tinycloud.capabilities". */
   service: string;
   /** Space name or full space URI. Defaults to "applications" inside manifests. */
   space?: string;
@@ -279,6 +279,7 @@ interface VaultActionExpansion {
  */
 export const SERVICE_SHORT_TO_LONG: Readonly<Record<string, string>> =
   Object.freeze({
+    space: "tinycloud.space",
     kv: "tinycloud.kv",
     sql: "tinycloud.sql",
     duckdb: "tinycloud.duckdb",


### PR DESCRIPTION
## Summary
- add tinycloud.space action/resource mapping for host and sync delegations
- preserve multi-resource delegation grants through node authorization
- expose host delegation preparation helpers for real delegation flows

## Current status
This PR is **not merge-ready as-is**. It was produced as a one-commit delta during the local replication Smithers run, from the submodule revision pinned in `tinycloud-dev` at the time. That revision was behind `master`, and this branch is not stacked on the existing replication PR #174 (`feat/replication-e2e-bootstrap`). GitHub correctly reports it as conflicting with `master`.

Treat this PR as a small extracted patch/reference for the peer-host-set direction. The next clean step is to rebase or replay the useful delegation changes onto the intended replication branch/stack, then rerun the replication harness.

## Related
- Existing replication PR: https://github.com/TinyCloudLabs/js-sdk/pull/174
- Workflow/harness PR: https://github.com/TinyCloudLabs/protocol-experiments/pull/1
- Coordination PR: https://github.com/skgbafa/tinycloud-dev/pull/11

## Verification
- bun test packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
- cd packages/sdk-core && bun run build
- cd packages/node-sdk && bun run build