### PR TITLE
Add debug logger changeset

### DIFF
--- a/.changeset/tinycloud-debug-logger.md
+++ b/.changeset/tinycloud-debug-logger.md
@@ -1,0 +1,8 @@
+---
+"@tinycloud/sdk-services": patch
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Add an opt-in TinyCloud debug logger controlled by `TinyCloud_debug`. The logger keeps a 1000-event in-memory ring buffer, writes structured events to `console.debug` when enabled, exposes browser console helpers for enabling, disabling, inspecting, and clearing logs, persists browser debug mode through `localStorage`, and captures service events plus `fetch`, `invoke`, and `invokeAny` timings.


### PR DESCRIPTION
## Summary
- add a patch changeset for the TinyCloud debug logger added in #291
- covers sdk-services, sdk-core, node-sdk, and web-sdk

## Validation
- PASS: git diff --check