### PR TITLE
fix(cli): fall back to profile key when session.jwk lacks private parameter

### DIFF
--- a/.changeset/cli-session-jwk-fallback.md
+++ b/.changeset/cli-session-jwk-fallback.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/cli": patch
+---
+
+Fix `tc kv` and `tc sql` failing with `Missing private key parameter in JWK` after an OpenKey login. The OpenKey delegation flow sends only the public JWK (no `d`) to OpenKey, and the public-only JWK that OpenKey echoes back was being persisted verbatim to `session.json`, shadowing the full keypair in `key.json` whenever the SDK reconstructed the WASM signer. Two-pronged fix: (1) on read, `sdk.ts` falls back to `key.json` whenever `session.jwk` lacks the `d` parameter, and (2) on write, `refreshOpenKeySession` merges `d` from `key.json` into the persisted session JWK so future invocations don't hit the same path. `tc auth status` and `tc secrets get` were unaffected because neither hits the WASM signer in this code path.
+
+Affected users on existing installs can unblock without re-authenticating by jq-merging `key.json`'s `d` into `session.json`'s `.jwk` field.

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -300,7 +300,7 @@ mock.module("../output/errors.js", () => ({
   setActiveProfileName: () => {},
 }));
 
-const { ensureDelegationAuthority, registerAuthCommand } = await import("./auth.js");
+const { ensureDelegationAuthority, mergePrivateJwkIntoSession, refreshOpenKeySession, registerAuthCommand } = await import("./auth.js");
 
 async function runAuthCommand(args: string[]): Promise<void> {
   const program = new Command();
@@ -618,5 +618,91 @@ describe("CLI auth import command", () => {
       activated: true,
       delegationCid: "bafy-self-session",
     });
+  });
+});
+
+describe("mergePrivateJwkIntoSession (write-side JWK sanitization)", () => {
+  const FULL_KEY = { kty: "OKP", crv: "Ed25519", x: "key-public", d: "key-private" };
+
+  test("splices `d` from key.json into a public-only session JWK", () => {
+    const session = {
+      delegationCid: "bafy",
+      spaceId: "tinycloud:space",
+      jwk: { kty: "OKP", crv: "Ed25519", x: "session-public" },
+    };
+    const merged = mergePrivateJwkIntoSession(session, FULL_KEY);
+    expect((merged.jwk as { d?: string }).d).toBe("key-private");
+    // Keeps everything else
+    expect((merged.jwk as { x?: string }).x).toBe("session-public");
+    expect(merged.spaceId).toBe("tinycloud:space");
+  });
+
+  test("does not overwrite a session JWK that already has `d`", () => {
+    const sessionJwk = { kty: "OKP", crv: "Ed25519", x: "session-public", d: "session-private" };
+    const session = { delegationCid: "bafy", jwk: sessionJwk };
+    const merged = mergePrivateJwkIntoSession(session, FULL_KEY);
+    expect((merged.jwk as { d?: string }).d).toBe("session-private");
+  });
+
+  test("returns the session unchanged when no `jwk` field is present", () => {
+    const session = { delegationCid: "bafy", spaceId: "tinycloud:space" };
+    const merged = mergePrivateJwkIntoSession(session, FULL_KEY);
+    expect(merged).toBe(session);
+  });
+});
+
+describe("refreshOpenKeySession sanitizes persisted session JWK", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  test("when OpenKey returns a public-only JWK, persisted session.json has `d` merged in from key.json", async () => {
+    const fullKey = { kty: "OKP", crv: "Ed25519", x: "key-public", d: "key-private" };
+    profiles.set("default", makeProfile({
+      did: "did:key:z6MkSession",
+      authMethod: "openkey",
+      posture: "owner-openkey",
+    }));
+    keys.set("default", fullKey);
+    openKeyDelegation = {
+      delegationHeader: { Authorization: "Bearer openkey-new" },
+      delegationCid: "bafy-openkey",
+      spaceId: "tinycloud:space",
+      ownerDid: "did:pkh:eip155:1:0xowner",
+      verificationMethod: "did:key:z6MkSession",
+      // The public-only JWK OpenKey echoes back (public-only because
+      // browser-auth.ts strips `d` before sending to OpenKey).
+      jwk: { kty: "OKP", crv: "Ed25519", x: "key-public" },
+    };
+
+    await refreshOpenKeySession("default", activeHost);
+
+    const persisted = sessions.get("default") as { jwk: { d?: string; x?: string } };
+    expect(persisted).toBeDefined();
+    expect(persisted.jwk.d).toBe("key-private");
+    expect(persisted.jwk.x).toBe("key-public");
+  });
+
+  test("when OpenKey returns a full JWK (with `d`), persisted session.json keeps OpenKey's `d`", async () => {
+    const fullKey = { kty: "OKP", crv: "Ed25519", x: "key-public", d: "key-private" };
+    profiles.set("default", makeProfile({
+      did: "did:key:z6MkSession",
+      authMethod: "openkey",
+      posture: "owner-openkey",
+    }));
+    keys.set("default", fullKey);
+    openKeyDelegation = {
+      delegationHeader: { Authorization: "Bearer openkey-new" },
+      delegationCid: "bafy-openkey",
+      spaceId: "tinycloud:space",
+      ownerDid: "did:pkh:eip155:1:0xowner",
+      verificationMethod: "did:key:z6MkSession",
+      jwk: { kty: "OKP", crv: "Ed25519", x: "key-public", d: "openkey-returned-private" },
+    };
+
+    await refreshOpenKeySession("default", activeHost);
+
+    const persisted = sessions.get("default") as { jwk: { d?: string } };
+    expect(persisted.jwk.d).toBe("openkey-returned-private");
   });
 });

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1347,6 +1347,45 @@ async function handleOpenKeyAuth(
   });
 }
 
+/**
+ * If the OpenKey callback returned a public-only JWK (no `d`), splice the
+ * private parameter from the profile's `key.json` back in so the persisted
+ * session is usable for WASM signing later.
+ *
+ * Why this exists: `browser-auth.ts:publicJwkForDelegation` strips `d` before
+ * sending the JWK to OpenKey, OpenKey echoes the public-only JWK back, and
+ * the previous code path persisted it verbatim. Downstream callers
+ * (`tc kv get`, `tc sql execute`) then hit `Missing private key parameter in
+ * JWK` because `sdk.ts` preferred `session.jwk` over `key.json`.
+ *
+ * Note: `key` here is the profile's full JWK (loaded from `key.json` above)
+ * and is exported with `d`. If the delegation flow ever evolves so OpenKey
+ * legitimately returns a session JWK with its own private parameter, this
+ * function leaves that JWK untouched.
+ */
+export function mergePrivateJwkIntoSession(
+  session: Record<string, unknown>,
+  key: object,
+): Record<string, unknown> {
+  const sessionJwk = session.jwk;
+  if (!sessionJwk || typeof sessionJwk !== "object") {
+    return session;
+  }
+  const sessionJwkRecord = sessionJwk as Record<string, unknown>;
+  const sessionD = sessionJwkRecord.d;
+  if (typeof sessionD === "string" && sessionD.length > 0) {
+    return session;
+  }
+  const keyD = (key as Record<string, unknown>).d;
+  if (typeof keyD !== "string" || keyD.length === 0) {
+    return session;
+  }
+  return {
+    ...session,
+    jwk: { ...sessionJwkRecord, d: keyD },
+  };
+}
+
 export async function refreshOpenKeySession(
   profileName: string,
   host: string,
@@ -1373,8 +1412,15 @@ export async function refreshOpenKeySession(
     openkeyHost: resolveOpenKeyHost(profile),
   });
 
+  // Defensive: OpenKey only ever receives the public JWK (see
+  // browser-auth.ts `publicJwkForDelegation`), so any JWK it echoes back is
+  // public-only. Persisting that verbatim shadows the full keypair in
+  // key.json and breaks anything that needs the WASM signer (kv/sql). Merge
+  // the private parameter from key.json back in before writing session.json.
+  const sanitizedSession = mergePrivateJwkIntoSession(delegationData, key);
+
   // Store session
-  await ProfileManager.setSession(profileName, delegationData);
+  await ProfileManager.setSession(profileName, sanitizedSession);
 
   // Update profile with owner DID if present
   const updatedProfile = {
@@ -1385,12 +1431,12 @@ export async function refreshOpenKeySession(
     authMethod: "openkey" as const,
   };
 
-  if (delegationData.spaceId) {
-    updatedProfile.spaceId = delegationData.spaceId;
-    updatedProfile.ownerDid = delegationData.ownerDid as string | undefined;
+  if (sanitizedSession.spaceId) {
+    updatedProfile.spaceId = sanitizedSession.spaceId as string;
+    updatedProfile.ownerDid = sanitizedSession.ownerDid as string | undefined;
   }
 
   await ProfileManager.setProfile(profileName, updatedProfile);
 
-  return { profile: updatedProfile, delegationData };
+  return { profile: updatedProfile, delegationData: sanitizedSession };
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,6 +5,7 @@ import { handleError, CLIError } from "../output/errors.js";
 import { ExitCode, DEFAULT_HOST, DEFAULT_CHAIN_ID } from "../config/constants.js";
 import { generateKey } from "../auth/local-key.js";
 import { startAuthFlow } from "../auth/browser-auth.js";
+import { mergePrivateJwkIntoSession } from "./auth.js";
 
 export function registerInitCommand(program: Command): void {
   program
@@ -85,21 +86,27 @@ export function registerInitCommand(program: Command): void {
           host,
         });
 
+        // Defensive: OpenKey only ever receives the public JWK (browser-auth.ts
+        // strips `d`), so any JWK it echoes back is public-only. Splice `d`
+        // back in from the freshly-generated JWK before persisting so the
+        // signer can find it on the next CLI invocation.
+        const sanitizedSession = mergePrivateJwkIntoSession(delegationData, jwk);
+
         // Store session
-        await ProfileManager.setSession(profileName, delegationData);
+        await ProfileManager.setSession(profileName, sanitizedSession);
 
         // Update profile with auth data
         await ProfileManager.setProfile(profileName, {
           ...profileConfig,
-          spaceId: delegationData.spaceId,
-          ownerDid: delegationData.ownerDid as string | undefined,
+          spaceId: sanitizedSession.spaceId as string,
+          ownerDid: sanitizedSession.ownerDid as string | undefined,
         });
 
         outputJson({
           profile: profileName,
           did,
           host,
-          spaceId: delegationData.spaceId,
+          spaceId: sanitizedSession.spaceId,
           authenticated: true,
         });
       } catch (error) {

--- a/packages/cli/src/lib/sdk.test.ts
+++ b/packages/cli/src/lib/sdk.test.ts
@@ -25,6 +25,10 @@ mock.module("../config/profiles.js", () => ({
 // key path actually builds and signs in a node.
 const nodeCalls: { privateKey?: string; signedIn: boolean }[] = [];
 
+// Record restoreSession args (specifically the jwk handed to the WASM signer)
+// so tests can assert the public-only-session-jwk fallback to key.json works.
+const restoreCalls: Array<{ jwk: unknown }> = [];
+
 mock.module("@tinycloud/node-sdk", () => ({
   TinyCloudNode: class {
     private _call: { privateKey?: string; signedIn: boolean };
@@ -35,7 +39,9 @@ mock.module("@tinycloud/node-sdk", () => ({
     async signIn() {
       this._call.signedIn = true;
     }
-    async restoreSession() {}
+    async restoreSession(args: { jwk: unknown }) {
+      restoreCalls.push({ jwk: args.jwk });
+    }
   },
 }));
 
@@ -48,7 +54,7 @@ mock.module("./permissions.js", () => ({
   replayAdditionalDelegations: async () => {},
 }));
 
-const { ensureAuthenticated } = await import("./sdk.js");
+const { ensureAuthenticated, jwkHasPrivateParameter, selectSignerJwk } = await import("./sdk.js");
 
 const ctx = { profile: "tc-sdk-test-headless", host: "https://node.tinycloud.xyz", verbose: false, noCache: false, quiet: false };
 const HEX_KEY = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
@@ -58,6 +64,7 @@ beforeEach(() => {
   session = null;
   key = null;
   nodeCalls.length = 0;
+  restoreCalls.length = 0;
   delete process.env.TC_PRIVATE_KEY;
 });
 
@@ -103,5 +110,88 @@ describe("ensureAuthenticated headless private-key identity", () => {
     // The provided key, not the profile's stored key, builds the node.
     expect(nodeCalls.some((c) => c.privateKey === HEX_KEY)).toBe(true);
     expect(nodeCalls.some((c) => c.privateKey === "0xother")).toBe(false);
+  });
+});
+
+describe("selectSignerJwk fallback", () => {
+  const PUBLIC_ONLY_SESSION_JWK = { kty: "OKP", crv: "Ed25519", x: "session-public" };
+  const FULL_KEY_JWK = { kty: "OKP", crv: "Ed25519", x: "key-public", d: "key-private" };
+  const FULL_SESSION_JWK = { kty: "OKP", crv: "Ed25519", x: "session-public", d: "session-private" };
+
+  test("jwkHasPrivateParameter returns false for a public-only OKP JWK", () => {
+    expect(jwkHasPrivateParameter(PUBLIC_ONLY_SESSION_JWK)).toBe(false);
+  });
+
+  test("jwkHasPrivateParameter returns true when `d` is present", () => {
+    expect(jwkHasPrivateParameter(FULL_KEY_JWK)).toBe(true);
+  });
+
+  test("jwkHasPrivateParameter is defensive against null/undefined/empty `d`", () => {
+    expect(jwkHasPrivateParameter(null)).toBe(false);
+    expect(jwkHasPrivateParameter(undefined)).toBe(false);
+    expect(jwkHasPrivateParameter({ kty: "OKP", crv: "Ed25519", x: "p", d: "" })).toBe(false);
+  });
+
+  test("selectSignerJwk prefers session JWK when it has `d`", () => {
+    expect(selectSignerJwk(FULL_SESSION_JWK, FULL_KEY_JWK)).toBe(FULL_SESSION_JWK);
+  });
+
+  test("selectSignerJwk falls back to key when session JWK is public-only", () => {
+    expect(selectSignerJwk(PUBLIC_ONLY_SESSION_JWK, FULL_KEY_JWK)).toBe(FULL_KEY_JWK);
+  });
+
+  test("selectSignerJwk falls back to key when session JWK is missing", () => {
+    expect(selectSignerJwk(undefined, FULL_KEY_JWK)).toBe(FULL_KEY_JWK);
+  });
+});
+
+describe("ensureAuthenticated restoreSession uses full keypair from key.json", () => {
+  // This is the regression guard for the JWK-private-fallback bug: a
+  // session.json carrying a public-only JWK (because OpenKey echoed back the
+  // stripped delegation key) used to be handed verbatim to the WASM signer,
+  // which then threw `Missing private key parameter in JWK` on every
+  // tc kv / tc sql call. The fix in sdk.ts must prefer key.json instead.
+  const FULL_KEY_JWK = { kty: "OKP", crv: "Ed25519", x: "key-public", d: "key-private" };
+  const PUBLIC_ONLY_SESSION_JWK = { kty: "OKP", crv: "Ed25519", x: "session-public" };
+  const sessionShell = {
+    delegationHeader: { Authorization: "Bearer x" },
+    delegationCid: "bafy-session",
+    spaceId: "tinycloud:space",
+    verificationMethod: "did:key:zSession",
+  };
+
+  test("OpenKey path: public-only session.jwk falls back to key.json (the full keypair)", async () => {
+    profile = { authMethod: "openkey", did: "did:key:zSession" };
+    session = { ...sessionShell, jwk: PUBLIC_ONLY_SESSION_JWK };
+    key = FULL_KEY_JWK;
+
+    await ensureAuthenticated(ctx);
+
+    expect(restoreCalls).toHaveLength(1);
+    expect(restoreCalls[0]!.jwk).toBe(FULL_KEY_JWK);
+    expect((restoreCalls[0]!.jwk as { d?: string }).d).toBe("key-private");
+  });
+
+  test("OpenKey path: session.jwk that already has `d` is preserved", async () => {
+    profile = { authMethod: "openkey", did: "did:key:zSession" };
+    const fullSessionJwk = { kty: "OKP", crv: "Ed25519", x: "session-public", d: "session-private" };
+    session = { ...sessionShell, jwk: fullSessionJwk };
+    key = FULL_KEY_JWK;
+
+    await ensureAuthenticated(ctx);
+
+    expect(restoreCalls).toHaveLength(1);
+    expect(restoreCalls[0]!.jwk).toBe(fullSessionJwk);
+  });
+
+  test("local-auth path: public-only session.jwk also falls back to key.json", async () => {
+    profile = { authMethod: "local", privateKey: "0xowner", did: "did:pkh:eip155:1:0xowner", sessionDid: "did:key:zSession" };
+    session = { ...sessionShell, jwk: PUBLIC_ONLY_SESSION_JWK };
+    key = FULL_KEY_JWK;
+
+    await ensureAuthenticated(ctx);
+
+    expect(restoreCalls).toHaveLength(1);
+    expect(restoreCalls[0]!.jwk).toBe(FULL_KEY_JWK);
   });
 });

--- a/packages/cli/src/lib/sdk.ts
+++ b/packages/cli/src/lib/sdk.ts
@@ -6,6 +6,36 @@ import { ExitCode } from "../config/constants.js";
 import { replayAdditionalDelegations } from "./permissions.js";
 
 /**
+ * Returns true when a JWK carries the private-key parameter required by the
+ * WASM signer. The CLI is OKP/EC-only (Ed25519, secp256k1) where `d` is the
+ * private scalar — RSA's `p`/`q`/etc. are out of scope.
+ *
+ * Defensive: a public-only JWK (e.g. one echoed back by OpenKey after the
+ * delegation flow stripped `d`) must not be used to construct the signer.
+ */
+export function jwkHasPrivateParameter(jwk: unknown): boolean {
+  if (!jwk || typeof jwk !== "object") return false;
+  const d = (jwk as Record<string, unknown>).d;
+  return typeof d === "string" && d.length > 0;
+}
+
+/**
+ * Pick the JWK to hand to the signer: the persisted session's JWK only if it
+ * carries the private parameter, otherwise the profile's `key.json` (which is
+ * always the full keypair). This guards against `session.json` containing a
+ * public-only JWK — e.g. when OpenKey echoes back the stripped delegation key.
+ */
+export function selectSignerJwk(
+  sessionJwk: unknown,
+  key: object | null,
+): object | undefined {
+  if (jwkHasPrivateParameter(sessionJwk)) {
+    return sessionJwk as object;
+  }
+  return key ?? undefined;
+}
+
+/**
  * Create a TinyCloudNode instance from the current CLI context.
  * Uses the profile's persisted session and key.
  *
@@ -49,7 +79,7 @@ export async function createSDKInstance(
         delegationHeader: session.delegationHeader as { Authorization: string },
         delegationCid: session.delegationCid as string,
         spaceId: session.spaceId as string,
-        jwk: (session.jwk as object) ?? key,
+        jwk: selectSignerJwk(session.jwk, key),
         verificationMethod: (session.verificationMethod as string) ?? profile?.sessionDid ?? profile?.did,
         address: session.address as string | undefined,
         chainId: session.chainId as number | undefined,
@@ -78,7 +108,7 @@ export async function createSDKInstance(
       delegationHeader: session.delegationHeader as { Authorization: string },
       delegationCid: session.delegationCid as string,
       spaceId: session.spaceId as string,
-      jwk: (session.jwk as object) ?? key,
+      jwk: selectSignerJwk(session.jwk, key),
       verificationMethod: (session.verificationMethod as string) ?? profile?.did,
       address: session.address as string | undefined,
       chainId: session.chainId as number | undefined,


### PR DESCRIPTION
## Symptom

After an OpenKey login, `tc kv get <path>` and `tc sql execute ... --db ...` fail with:

```
Missing private key parameter in JWK
```

`tc auth status` and `tc secrets get` succeed on the same profile.

## Root cause

- `packages/cli/src/auth/browser-auth.ts:52` `publicJwkForDelegation` strips `d` from the session JWK before sending it to OpenKey (this is correct — you should not ship a private key to OpenKey).
- OpenKey echoes the public-only JWK back in the delegation response.
- `refreshOpenKeySession` in `packages/cli/src/commands/auth.ts` persisted the OpenKey response verbatim via `ProfileManager.setSession`, dropping the private `d` parameter into `session.json`. `tc init` (`packages/cli/src/commands/init.ts:81-89`) had the same write-path bug.
- `packages/cli/src/lib/sdk.ts:81` (and `:52`) used `jwk: (session.jwk as object) ?? key`. The `??` makes `session.jwk` win whenever it's truthy, so the public-only JWK shadowed the full keypair in `key.json` whenever the SDK reconstructed the WASM signer.
- The signer needs `d` and threw on every invocation.
- `tc auth status` never builds a signer, and `tc secrets get` short-circuits at `DataVaultService.ts:837` (`VAULT_LOCKED`) before reaching `invoke`, so neither surfaced the bug.

## Fix

Two-pronged so a corrupt `session.json` can't be reintroduced:

1. **Read side** (`packages/cli/src/lib/sdk.ts`) — add `jwkHasPrivateParameter` + `selectSignerJwk` helpers. Both `restoreSession` call sites (local-auth path and OpenKey path) now use `selectSignerJwk(session.jwk, key)` instead of `(session.jwk as object) ?? key`. The helper prefers `session.jwk` only when it has a non-empty `d`, otherwise it returns `key`.
2. **Write side** (`packages/cli/src/commands/auth.ts` and `packages/cli/src/commands/init.ts`) — add `mergePrivateJwkIntoSession` helper. `refreshOpenKeySession` and the `tc init` OpenKey path now splice `d` from the profile's `key.json` (or the freshly generated JWK in init) into the session JWK before calling `ProfileManager.setSession`. So fresh logins persist a usable JWK; the read-side fallback is the safety net for sessions already on disk.

The OpenKey flow itself is unchanged. The delegation step still correctly sends the public-only JWK to OpenKey — we just no longer trust what it echoes back to contain `d`.

## Why this only broke `kv`/`sql` and not `auth`/`secrets`

- `tc auth status` reads profile/session files directly without ever building a `TinyCloudNode` — it never hits the WASM signer.
- `tc secrets get` short-circuits at `DataVaultService.ts:837` with `VAULT_LOCKED` before reaching `invoke` (i.e., before the signer is exercised on the read path).
- `tc kv` and `tc sql` both go through `node.invoke(...)` → WASM signer → `d` lookup → throw.

## Manual unblock for affected users

Users on an existing install can unblock without re-authenticating by jq-merging `key.json`'s `d` into `session.json`'s `.jwk`:

```sh
profile=~/.tinycloud/profiles/default
jq --slurpfile k "$profile/key.json" '.jwk.d = $k[0].d' "$profile/session.json" \
  > "$profile/session.json.new" && mv "$profile/session.json.new" "$profile/session.json"
```

After this patch ships, this is no longer necessary — both new sessions and existing-but-broken sessions are handled automatically.

## Tests

New unit tests in `packages/cli/src/lib/sdk.test.ts` and `packages/cli/src/commands/auth.test.ts`:

- `jwkHasPrivateParameter` / `selectSignerJwk` behavior (public-only, full, missing).
- `ensureAuthenticated` restores using `key.json` when `session.jwk` is public-only (both OpenKey and local-auth paths).
- `mergePrivateJwkIntoSession` merges `d`, preserves full JWKs, and is a no-op when no `jwk` field is present.
- `refreshOpenKeySession` persists a session with `d` merged in when OpenKey returns a public-only JWK.

Test results: 9 new tests pass, no new failures vs. baseline (60→69 pass; same 8 fail / 4 errors from pre-existing `grantAuthRequest` / `compactPermission` export issues unrelated to this change).

## Test plan

- [x] `bun test src/lib/sdk.test.ts` — 14/14 pass
- [x] `bun test src/commands/auth.test.ts` — 12/12 pass (including new tests)
- [x] `bun test` (full cli suite) — 69 pass / 8 fail / 4 errors (baseline: 60 / 8 / 4)
- [x] `bun run build` — clean
- [x] Codex review confirmed both write sites are sanitized and read side is fixed.