### PR TITLE
Persist local auth session after runtime grants

### DIFF
--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -78,6 +78,9 @@ let sessions = new Map<string, object>();
 let generatedKeys: GeneratedKey[] = [];
 let openKeyDelegation: Record<string, unknown>;
 let localSignInResult: LocalSignInResult;
+let authNodeHasRuntimePermissions: boolean;
+let authNodeRestorableSession: Record<string, unknown> | undefined;
+let authNodeGrantDelegations: Array<{ cid: string; expiry: Date }>;
 
 function resetState(): void {
   recorded.outputs.length = 0;
@@ -103,6 +106,7 @@ function resetState(): void {
     spaceId: "space-openkey-new",
     ownerDid: "did:pkh:eip155:1:0xowner",
     verificationMethod: "did:key:new-openkey",
+    expiry: "2026-07-07T00:00:00.000Z",
   };
   localSignInResult = {
     spaceId: "space-local-new",
@@ -115,6 +119,9 @@ function resetState(): void {
     siwe: "local-siwe",
     signature: "0xsig",
   };
+  authNodeHasRuntimePermissions = true;
+  authNodeRestorableSession = undefined;
+  authNodeGrantDelegations = [];
 }
 
 function makeProfile(overrides: Partial<ProfileLike> = {}): ProfileLike {
@@ -209,7 +216,11 @@ const importRecorded = {
 
 mock.module("../lib/sdk.js", () => ({
   ensureAuthenticated: async () => ({
-    hasRuntimePermissions: () => true,
+    hasRuntimePermissions: () => authNodeHasRuntimePermissions,
+    grantRuntimePermissions: async () => authNodeGrantDelegations,
+    get restorableSession() {
+      return authNodeRestorableSession;
+    },
     getRuntimePermissionDelegations: () => [],
     get sessionDid() {
       return importSessionDid;
@@ -486,6 +497,7 @@ describe("CLI auth rotate command", () => {
       spaceId: "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:secrets",
       ownerDid: "did:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412",
       verificationMethod: "did:key:openkey-session",
+      expiry: "2026-07-07T00:00:00.000Z",
     };
     const node = {
       hasRuntimePermissions: mock(() => false),
@@ -651,6 +663,87 @@ describe("mergePrivateJwkIntoSession (write-side JWK sanitization)", () => {
   });
 });
 
+describe("CLI auth request command", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  test("persists the active local session after granting runtime permissions", async () => {
+    const sessionJwk = {
+      kty: "OKP",
+      crv: "Ed25519",
+      x: "runtime-session",
+      d: "runtime-private",
+    };
+    profiles.set("default", makeProfile({
+      did: "did:pkh:eip155:1:0xLocalOwner",
+      sessionDid: "did:key:old-local-session",
+      authMethod: "local",
+      posture: "local-owner-key",
+      privateKey: "0xowner-private",
+      address: "0xLocalOwner",
+      spaceId: "space-local-old",
+    }));
+    sessions.set("default", {
+      authMethod: "local",
+      address: "0xLocalOwner",
+      chainId: 1,
+      spaceId: "space-local-old",
+    });
+    authNodeHasRuntimePermissions = false;
+    authNodeGrantDelegations = [
+      { cid: "bafy-runtime-grant", expiry: new Date("2026-07-07T00:00:00.000Z") },
+    ];
+    authNodeRestorableSession = {
+      address: "0xLocalOwner",
+      chainId: 1,
+      sessionKey: JSON.stringify(sessionJwk),
+      spaceId: "space-local-new",
+      delegationHeader: { Authorization: "Bearer runtime-session" },
+      delegationCid: "bafy-runtime-session",
+      jwk: sessionJwk,
+      verificationMethod: "did:key:runtime-session",
+      siwe: "runtime-siwe",
+      signature: "0xruntime",
+    };
+
+    await runAuthCommand([
+      "auth",
+      "request",
+      "--grant",
+      "--yes",
+      "--cap",
+      "tinycloud.kv:default/:list",
+    ]);
+
+    expect(recorded.errors).toEqual([]);
+    expect(sessions.get("default")).toEqual({
+      authMethod: "local",
+      address: "0xLocalOwner",
+      chainId: 1,
+      spaceId: "space-local-new",
+      delegationHeader: { Authorization: "Bearer runtime-session" },
+      delegationCid: "bafy-runtime-session",
+      jwk: sessionJwk,
+      verificationMethod: "did:key:runtime-session",
+      siwe: "runtime-siwe",
+      signature: "0xruntime",
+    });
+    expect(profiles.get("default")).toEqual(expect.objectContaining({
+      sessionDid: "did:key:runtime-session",
+      spaceId: "space-local-new",
+    }));
+    expect(recorded.outputs).toEqual([
+      expect.objectContaining({
+        changed: true,
+        delegationCid: "bafy-runtime-grant",
+        delegationCids: ["bafy-runtime-grant"],
+        expiry: "2026-07-07T00:00:00.000Z",
+      }),
+    ]);
+  });
+});
+
 describe("refreshOpenKeySession sanitizes persisted session JWK", () => {
   beforeEach(() => {
     resetState();
@@ -670,6 +763,7 @@ describe("refreshOpenKeySession sanitizes persisted session JWK", () => {
       spaceId: "tinycloud:space",
       ownerDid: "did:pkh:eip155:1:0xowner",
       verificationMethod: "did:key:z6MkSession",
+      expiry: "2026-07-07T00:00:00.000Z",
       // The public-only JWK OpenKey echoes back (public-only because
       // browser-auth.ts strips `d` before sending to OpenKey).
       jwk: { kty: "OKP", crv: "Ed25519", x: "key-public" },
@@ -697,6 +791,7 @@ describe("refreshOpenKeySession sanitizes persisted session JWK", () => {
       spaceId: "tinycloud:space",
       ownerDid: "did:pkh:eip155:1:0xowner",
       verificationMethod: "did:key:z6MkSession",
+      expiry: "2026-07-07T00:00:00.000Z",
       jwk: { kty: "OKP", crv: "Ed25519", x: "key-public", d: "openkey-returned-private" },
     };
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -6,7 +6,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { createInterface } from "node:readline";
 import type { IncomingMessage } from "node:http";
-import { grantAuthRequest, principalDidEquals, type PermissionEntry, type PortableDelegation } from "@tinycloud/node-sdk";
+import { grantAuthRequest, principalDidEquals, type PermissionEntry, type PortableDelegation, type TinyCloudSession } from "@tinycloud/node-sdk";
 import { ProfileManager } from "../config/profiles.js";
 import { outputJson, shouldOutputJson, formatField, formatTable, isInteractive, withSpinner } from "../output/formatter.js";
 import { handleError, CLIError } from "../output/errors.js";
@@ -342,6 +342,7 @@ export function registerAuthCommand(program: Command): void {
           requested,
           expiryOption !== undefined ? { expiry: expiryOption } : undefined,
         );
+        await persistCurrentLocalSession(ctx.profile, profile, node.restorableSession);
         const delegationCids: string[] = [];
         let expiry: string | undefined;
         for (const delegation of delegations) {
@@ -1230,6 +1231,35 @@ function outputRotationResult(
     authMethod,
     spaceId: profile.spaceId ?? null,
   });
+}
+
+async function persistCurrentLocalSession(
+  profileName: string,
+  profile: ProfileConfig,
+  session: TinyCloudSession | undefined,
+): Promise<void> {
+  if (!session) return;
+
+  await ProfileManager.setSession(profileName, {
+    authMethod: "local",
+    address: session.address,
+    chainId: session.chainId,
+    spaceId: session.spaceId,
+    delegationHeader: session.delegationHeader,
+    delegationCid: session.delegationCid,
+    jwk: session.jwk,
+    verificationMethod: session.verificationMethod,
+    siwe: session.siwe,
+    signature: session.signature,
+  });
+
+  if (profile.sessionDid !== session.verificationMethod || profile.spaceId !== session.spaceId) {
+    await ProfileManager.setProfile(profileName, {
+      ...profile,
+      sessionDid: session.verificationMethod,
+      spaceId: session.spaceId,
+    });
+  }
 }
 
 type LocalAuthResult = {

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -819,6 +819,14 @@ export class TinyCloudNode {
   }
 
   /**
+   * Get the currently active session in the shape callers can persist and later
+   * pass back to {@link restoreSession}.
+   */
+  get restorableSession(): TinyCloudSession | undefined {
+    return this.currentTinyCloudSession();
+  }
+
+  /**
    * Sign in and create a new session.
    * This creates the user's space if it doesn't exist.
    * Requires wallet mode (privateKey in config).


### PR DESCRIPTION
## Summary
- expose a restorable TinyCloudNode session shape for callers that need to persist active sessions
- persist the local-auth session after auth request --grant issues runtime permissions
- add regression coverage for preserving the newly granted session

## Verification
- bun test packages/cli/src/commands/auth.test.ts