### PR TITLE
Fix root sharing service inference

### DIFF
--- a/.changeset/sql-sharing-root-service.md
+++ b/.changeset/sql-sharing-root-service.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Fix root sharing delegations to infer the delegated service from action URNs instead of always minting KV resources. Long-lived SQL share links now sign `tinycloud.sql/*` capabilities under the SQL service path.

--- a/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { ISessionManager, IWasmBindings } from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+const originalFetch = globalThis.fetch;
+
+function makeFakeSessionManager(): ISessionManager {
+  return {
+    createSessionKey: (id: string) => id,
+    renameSessionKeyId: () => {},
+    getDID: (keyId: string) => `did:key:${keyId}`,
+    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+  };
+}
+
+function makeWasmBindings(): IWasmBindings {
+  return {
+    createSessionManager: makeFakeSessionManager,
+    prepareSession: mock((config: unknown) => ({
+      ...(config as object),
+      siwe: "share-siwe",
+    })),
+    completeSessionSetup: mock((config: unknown) => ({
+      ...(config as object),
+      delegationCid: "share-delegation-cid",
+      delegationHeader: { Authorization: "share-auth-header" },
+    })),
+    ensureEip55: (address: string) => address,
+  } as unknown as IWasmBindings;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("TinyCloudNode sharing", () => {
+  test("root sharing delegates SQL actions under the SQL service", async () => {
+    const wasmBindings = makeWasmBindings();
+    globalThis.fetch = mock(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ activated: ["share-delegation-cid"] }),
+      text: async () => "",
+    })) as unknown as typeof fetch;
+
+    const node = new TinyCloudNode({
+      host: "https://node.example",
+      signer: {
+        signMessage: mock(async () => "signature"),
+      } as any,
+      wasmBindings,
+    });
+    (node as any)._restoredTcSession = {
+      address: "0xD559CCd9EB87c530A9a349262669386dE93cf412",
+      chainId: 1,
+      spaceId: "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:applications",
+    };
+
+    const delegation = await (node as any).createRootDelegationForSharing({
+      shareKeyDID: "did:key:z6MkShare",
+      spaceId: "tinycloud:pkh:eip155:1:0xd559CCd9EB87c530A9a349262669386dE93cf412:applications",
+      path: "xyz.tinycloud.tinychat/threads",
+      actions: ["tinycloud.sql/read"],
+      requestedExpiry: new Date("2026-07-09T15:17:04.758Z"),
+    });
+
+    expect(delegation?.authHeader).toBe("share-auth-header");
+    expect((wasmBindings.prepareSession as any).mock.calls[0][0].abilities).toEqual({
+      sql: {
+        "xyz.tinycloud.tinychat/threads": ["tinycloud.sql/read"],
+      },
+    });
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -155,6 +155,24 @@ function didPrincipalMatches(actual: string, expected: string): boolean {
   }
 }
 
+function sharingActionsToAbilities(path: string, actions: string[]): AbilitiesMap | undefined {
+  const abilities: AbilitiesMap = {};
+
+  for (const action of actions) {
+    const slash = action.indexOf("/");
+    if (slash === -1) return undefined;
+
+    const shortService = SERVICE_LONG_TO_SHORT[action.slice(0, slash)];
+    if (shortService === undefined) return undefined;
+
+    abilities[shortService] ??= {};
+    abilities[shortService][path] ??= [];
+    abilities[shortService][path].push(action);
+  }
+
+  return Object.keys(abilities).length > 0 ? abilities : undefined;
+}
+
 /**
  * Configuration for TinyCloudNode.
  * All fields are optional - TinyCloudNode can work with zero configuration.
@@ -2068,12 +2086,10 @@ export class TinyCloudNode {
       const host = this.config.host!;
       const now = new Date();
 
-      // Build abilities for the share key
-      const abilities: Record<string, Record<string, string[]>> = {
-        kv: {
-          [params.path]: params.actions,
-        },
-      };
+      const abilities = sharingActionsToAbilities(params.path, params.actions);
+      if (!abilities) {
+        return undefined;
+      }
 
       // Prepare a direct delegation to the share key (no parents = root delegation)
       const prepared = this.wasmBindings.prepareSession({


### PR DESCRIPTION
## Summary
- fix root sharing delegation creation to infer the delegated service from action URNs instead of hardcoding KV
- add a regression test for long-lived SQL share links minting SQL resources
- add a changeset for node-sdk/web-sdk patch releases

## Root Cause
TinyChat's seven-day share links use the SDK root-sharing path because they outlive the normal session. That path hardcoded the root delegation abilities under `kv`, even when the requested action was `tinycloud.sql/read`. The share payload metadata still said SQL, but the signed root delegation resource was KV, so later SQL invocation requested `.../sql/xyz.tinycloud.tinychat/threads` and tinycloud-node correctly rejected it as unauthorized.

## Testing
- `bun run --cwd packages/sdk-services build`
- `bun run --cwd packages/sdk-core build`
- `bun test packages/node-sdk/src/TinyCloudNode.sharing.test.ts`

Note: `bun run --cwd packages/node-sdk build` built JS bundles but failed during DTS generation because this checkout had no generated `@tinycloud/node-sdk-wasm` declarations.