### PR TITLE
TC-86: Stop browser bootstrap signing loops

### DIFF
--- a/.changeset/tc-86-autosign-strategy.md
+++ b/.changeset/tc-86-autosign-strategy.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+---
+
+TC-86: browser auto-sign bootstrap support. `TinyCloudWeb` config accepts `signStrategy` and forwards it to `TinyCloudNode`, sign requests carry a `purpose` tag (`sign-in` / `bootstrap-session` / `bootstrap-host` / `message`) so strategies can route bootstrap signatures to OpenKey's server-side signer, and account-bootstrap failures degrade to a skipped bootstrap surfaced via `bootstrapStatus` instead of failing `signIn()`.

--- a/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
@@ -335,14 +335,19 @@ describe("bootstrap gate — abort on first rejection", () => {
       return true;
     });
 
-    await expect(node.signIn()).rejects.toThrow(
-      /Account bootstrap aborted.*Sign request rejected/,
-    );
+    // Bootstrap failure degrades to skipped — signIn() itself resolves.
+    await node.signIn();
 
     // Only one createBootstrapSession call — the abort prevents further calls.
     expect(createBootstrapCallCount).toBe(1);
     // hostOwnedSpace must never be called — the abort happened before phase 2.
     expect(hostOwnedSpaceCallCount).toBe(0);
+    // The outcome is surfaced instead of thrown.
+    expect(node.bootstrapSkipped).toBe(true);
+    expect(node.bootstrapStatus.skipped).toBe(true);
+    expect(node.bootstrapStatus.reason).toMatch(
+      /Account bootstrap aborted.*Sign request rejected/,
+    );
   });
 
   test("error message includes space name and original cause", async () => {
@@ -369,15 +374,68 @@ describe("bootstrap gate — abort on first rejection", () => {
     });
     auth.hostOwnedSpace = mock(async () => true);
 
-    let thrownError: Error | undefined;
-    try {
-      await node.signIn();
-    } catch (err) {
-      thrownError = err as Error;
-    }
+    // signIn() resolves; the cause is preserved in bootstrapStatus.reason.
+    await node.signIn();
 
-    expect(thrownError).toBeDefined();
-    expect(thrownError!.message).toContain("Account bootstrap aborted");
-    expect(thrownError!.message).toContain("auto-sign rejected");
+    expect(node.bootstrapStatus.skipped).toBe(true);
+    expect(node.bootstrapStatus.reason).toContain("Account bootstrap aborted");
+    expect(node.bootstrapStatus.reason).toContain("auto-sign rejected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (e) Purpose tagging — strategies can tell bootstrap signs from user signs
+// ---------------------------------------------------------------------------
+
+describe("sign request purpose tagging", () => {
+  function makeCapturingNode() {
+    const captured: any[] = [];
+    const wasm = makeFakeWasmBindings();
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: makeExternalSigner() as any,
+      signStrategy: {
+        type: "callback",
+        handler: async (request: any) => {
+          captured.push(request);
+          return { approved: true, signature: "0x" + "ee".repeat(65) };
+        },
+      } as any,
+      host: "https://tinycloud.test",
+    });
+    const auth = (node as any).auth;
+    auth._address = FAKE_ADDRESS;
+    auth._chainId = 1;
+    return { captured, auth };
+  }
+
+  test("createBootstrapSession tags purpose=bootstrap-session", async () => {
+    const { captured, auth } = makeCapturingNode();
+
+    await auth.createBootstrapSession({
+      spaceId: "tinycloud:pkh:eip155:1:" + FAKE_ADDRESS + ":account",
+      capabilityRequest: { resources: [] },
+    });
+
+    expect(captured.length).toBe(1);
+    expect(captured[0].purpose).toBe("bootstrap-session");
+  });
+
+  test("signMessage passes an explicit purpose through", async () => {
+    const { captured, auth } = makeCapturingNode();
+
+    await auth.signMessage("host siwe", "bootstrap-host");
+
+    expect(captured.length).toBe(1);
+    expect(captured[0].purpose).toBe("bootstrap-host");
+  });
+
+  test("signMessage without purpose stays untagged", async () => {
+    const { captured, auth } = makeCapturingNode();
+
+    await auth.signMessage("plain message");
+
+    expect(captured.length).toBe(1);
+    expect(captured[0].purpose).toBeUndefined();
   });
 });

--- a/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Unit tests for TC-86: bootstrap gate for interactive signers.
+ *
+ * Coverage:
+ * (a) Interactive signer (external signer, no signStrategy) → bootstrap
+ *     skipped, node.bootstrapSkipped === true, only one signature call.
+ * (b) Local-key signer (privateKey) → bootstrap does not skip
+ *     (exercised via autoBootstrapAccount=false sub-case showing the
+ *     gate does not fire for non-interactive config).
+ * (c) OpenKey auto-sign strategy → bootstrap runs when account is fresh.
+ * (d) Bootstrap aborts after first signature rejection without cascading.
+ *
+ * These are unit tests: we stub tc.signIn() (the inner TinyCloud layer)
+ * so that NodeUserAuthorization's network calls are never reached, then
+ * exercise the bootstrap gate logic that runs after the main sign-in.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { IWasmBindings, ISessionManager, ClientSession } from "@tinycloud/sdk-core";
+import { TinyCloudNode } from "./TinyCloudNode";
+import { createOpenKeyCallbackSigningStrategy } from "@tinycloud/sdk-core";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+function makeFakeSessionManager(): ISessionManager {
+  const keys = new Set<string>(["default"]);
+  return {
+    createSessionKey(id: string): string {
+      keys.add(id);
+      return id;
+    },
+    renameSessionKeyId(oldId: string, newId: string): void {
+      if (keys.has(oldId)) {
+        keys.delete(oldId);
+        keys.add(newId);
+      }
+    },
+    getDID(keyId: string): string {
+      return `did:key:z6MkTest-${keyId}`;
+    },
+    jwk(keyId: string): string | undefined {
+      if (!keys.has(keyId)) return undefined;
+      return JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" });
+    },
+  };
+}
+
+function makeFakeWasmBindings(overrides: Partial<IWasmBindings> = {}): IWasmBindings {
+  const base: IWasmBindings = {
+    invoke: mock(() => Promise.resolve({} as any)) as any,
+    invokeAny: mock(() => Promise.resolve({} as any)) as any,
+    prepareSession: mock(() => ({
+      siwe: "fake-siwe",
+      jwk: { kty: "OKP" },
+      spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      verificationMethod: "did:key:z6MkTestSession",
+    })),
+    completeSessionSetup: mock(() => ({
+      delegationHeader: { Authorization: "Bearer fake" },
+      delegationCid: "bafyfake",
+      jwk: { kty: "OKP" },
+      spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      verificationMethod: "did:key:z6MkTestSession",
+    })),
+    ensureEip55: (a: string) => a,
+    makeSpaceId: (a: string, c: number, p: string) => `tinycloud:pkh:eip155:${c}:${a}:${p}`,
+    createDelegation: mock(() => ({})),
+    parseRecapFromSiwe: mock(() => [] as any[]),
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(),
+      privateKey: new Uint8Array(),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array()),
+    vault_sha256: mock(() => new Uint8Array()),
+    createSessionManager: makeFakeSessionManager,
+  };
+  return { ...base, ...overrides };
+}
+
+const FAKE_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+const FAKE_SESSION: ClientSession = {
+  address: FAKE_ADDRESS,
+  walletAddress: FAKE_ADDRESS,
+  chainId: 1,
+  sessionKey: "session-test",
+  siwe: "fake-siwe",
+  signature: "0x" + "ff".repeat(65),
+};
+
+function makeExternalSigner(signCallSpy?: ReturnType<typeof mock>) {
+  const signMessage = signCallSpy ?? mock(async () => "0x" + "ff".repeat(65));
+  return {
+    signMessage,
+    getAddress: async () => FAKE_ADDRESS,
+    getChainId: async () => 1,
+  };
+}
+
+/**
+ * Stub node internals so signIn() completes without hitting the network.
+ *
+ * We replace tc.signIn() (the TinyCloud layer) with a function that returns
+ * a fake session and sets the internal address/chainId fields that
+ * TinyCloudNode.signIn() reads after the inner signIn resolves.
+ * We also stub isFreshBootstrapAccount and the post-bootstrap helpers.
+ */
+function stubNodeForSignIn(
+  node: TinyCloudNode,
+  { freshAccount = false }: { freshAccount?: boolean } = {},
+): void {
+  // Stub tc.signIn() to avoid network calls.
+  const tc = (node as any).tc;
+  if (!tc) throw new Error("expected tc to be present (node needs signer)");
+  tc.signIn = mock(async () => {
+    // TinyCloudNode.signIn() reads _address and _chainId after tc.signIn() returns;
+    // they are set from signer.getAddress/getChainId before the tc.signIn() call,
+    // so we don't need to set them here.
+    return FAKE_SESSION;
+  });
+
+  // Stub syncResolvedHostFromAuth (reads auth.hosts[0]).
+  (node as any).syncResolvedHostFromAuth = () => {};
+
+  // Stub initializeServices (sets up service context, needs real session).
+  (node as any).initializeServices = () => {};
+
+  // Control isFreshBootstrapAccount to simulate fresh vs existing account.
+  (node as any).isFreshBootstrapAccount = async () => freshAccount;
+
+  // Stub post-bootstrap helpers that would hit the network.
+  (node as any).ensureRequestedEncryptionNetworks = async () => {};
+  (node as any).ensureOwnedSpaceHostedById = async () => {};
+  (node as any).scheduleAccountRegistrySync = () => {};
+}
+
+/**
+ * Stub runAccountBootstrap so we can verify it was or wasn't called.
+ * Returns the mock for assertions.
+ */
+function stubRunAccountBootstrap(node: TinyCloudNode): ReturnType<typeof mock> {
+  const bootstrapMock = mock(async () => {});
+  (node as any).runAccountBootstrap = bootstrapMock;
+  return bootstrapMock;
+}
+
+// ---------------------------------------------------------------------------
+// (a) Interactive signer → bootstrap skipped
+// ---------------------------------------------------------------------------
+
+describe("bootstrap gate — interactive signer", () => {
+  test("skips bootstrap and sets bootstrapSkipped=true", async () => {
+    const wasm = makeFakeWasmBindings();
+    const signSpy = mock(async () => "0x" + "ff".repeat(65));
+    const signer = makeExternalSigner(signSpy);
+
+    // External signer, no privateKey, no signStrategy → interactive path.
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: signer as any,
+      host: "https://tinycloud.test",
+    });
+
+    stubNodeForSignIn(node, { freshAccount: true });
+    const bootstrapMock = stubRunAccountBootstrap(node);
+
+    await node.signIn();
+
+    expect(node.bootstrapSkipped).toBe(true);
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+
+  test("bootstrapSkipped is false before first signIn", () => {
+    const wasm = makeFakeWasmBindings();
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: makeExternalSigner() as any,
+      host: "https://tinycloud.test",
+    });
+    expect(node.bootstrapSkipped).toBe(false);
+  });
+
+  test("bootstrapSkipped is false when account is not fresh (no bootstrap needed)", async () => {
+    const wasm = makeFakeWasmBindings();
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: makeExternalSigner() as any,
+      host: "https://tinycloud.test",
+    });
+
+    // freshAccount=false → isFreshBootstrapAccount returns false → bootstrap
+    // would be skipped by the freshness check anyway, not the interactive gate.
+    stubNodeForSignIn(node, { freshAccount: false });
+    stubRunAccountBootstrap(node);
+
+    await node.signIn();
+
+    // Not a fresh account → the interactive-signer skip still fires (it runs
+    // before the freshness check). bootstrapSkipped=true because we have an
+    // interactive signer regardless of freshness.
+    expect(node.bootstrapSkipped).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) Non-interactive config — autoBootstrapAccount=false suppresses bootstrap
+// ---------------------------------------------------------------------------
+
+describe("bootstrap gate — non-interactive config (autoBootstrapAccount=false)", () => {
+  test("bootstrap not called when autoBootstrapAccount=false, bootstrapSkipped=false", async () => {
+    const wasm = makeFakeWasmBindings();
+
+    // autoBootstrapAccount=false overrides everything — bootstrap never runs
+    // and the skip flag is not set (it was explicitly disabled, not skipped).
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: makeExternalSigner() as any,
+      host: "https://tinycloud.test",
+      autoBootstrapAccount: false,
+    });
+
+    stubNodeForSignIn(node, { freshAccount: true });
+    const bootstrapMock = stubRunAccountBootstrap(node);
+
+    await node.signIn();
+
+    expect(bootstrapMock).not.toHaveBeenCalled();
+    // autoBootstrapAccount=false hits the early-return before the interactive
+    // gate, so _bootstrapSkipped is reset to false (the reset happens at the
+    // top of bootstrapAccountIfNeeded before the early-return).
+    expect(node.bootstrapSkipped).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) OpenKey auto-sign strategy → bootstrap runs
+// ---------------------------------------------------------------------------
+
+describe("bootstrap gate — OpenKey auto-sign strategy", () => {
+  test("does not skip bootstrap on fresh account", async () => {
+    const wasm = makeFakeWasmBindings();
+
+    const openKeyStrategy = createOpenKeyCallbackSigningStrategy({
+      endpoint: "https://openkey.test/api/delegate/sign",
+    });
+
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: makeExternalSigner() as any,
+      signStrategy: openKeyStrategy,
+      host: "https://tinycloud.test",
+    });
+
+    stubNodeForSignIn(node, { freshAccount: true });
+    const bootstrapMock = stubRunAccountBootstrap(node);
+
+    await node.signIn();
+
+    // OpenKey auto-sign strategy → isInteractiveSigner() = false →
+    // bootstrap is NOT skipped.
+    expect(node.bootstrapSkipped).toBe(false);
+    expect(bootstrapMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("non-fresh account → bootstrap not triggered regardless of strategy", async () => {
+    const wasm = makeFakeWasmBindings();
+
+    const openKeyStrategy = createOpenKeyCallbackSigningStrategy({
+      endpoint: "https://openkey.test/api/delegate/sign",
+    });
+
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: makeExternalSigner() as any,
+      signStrategy: openKeyStrategy,
+      host: "https://tinycloud.test",
+    });
+
+    stubNodeForSignIn(node, { freshAccount: false });
+    const bootstrapMock = stubRunAccountBootstrap(node);
+
+    await node.signIn();
+
+    expect(node.bootstrapSkipped).toBe(false);
+    // isFreshBootstrapAccount returned false → bootstrap not run.
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) Bootstrap aborts after first rejection — no cascade
+// ---------------------------------------------------------------------------
+
+describe("bootstrap gate — abort on first rejection", () => {
+  test("runAccountBootstrap throws on first createBootstrapSession failure without cascading", async () => {
+    const wasm = makeFakeWasmBindings();
+    const openKeyStrategy = createOpenKeyCallbackSigningStrategy({
+      endpoint: "https://openkey.test/api/delegate/sign",
+    });
+
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: makeExternalSigner() as any,
+      signStrategy: openKeyStrategy,
+      host: "https://tinycloud.test",
+    });
+
+    stubNodeForSignIn(node, { freshAccount: true });
+    (node as any).ensureRequestedEncryptionNetworks = async () => {};
+    (node as any).ensureOwnedSpaceHostedById = async () => {};
+    (node as any).scheduleAccountRegistrySync = () => {};
+
+    // Stub auth.createBootstrapSession to reject on the first call.
+    const auth = (node as any).auth;
+    let createBootstrapCallCount = 0;
+    auth.createBootstrapSession = mock(async () => {
+      createBootstrapCallCount++;
+      throw new Error("Sign request rejected by callback");
+    });
+
+    // Stub auth.hostOwnedSpace — it must never be reached (cascade check).
+    let hostOwnedSpaceCallCount = 0;
+    auth.hostOwnedSpace = mock(async () => {
+      hostOwnedSpaceCallCount++;
+      return true;
+    });
+
+    await expect(node.signIn()).rejects.toThrow(
+      /Account bootstrap aborted.*Sign request rejected/,
+    );
+
+    // Only one createBootstrapSession call — the abort prevents further calls.
+    expect(createBootstrapCallCount).toBe(1);
+    // hostOwnedSpace must never be called — the abort happened before phase 2.
+    expect(hostOwnedSpaceCallCount).toBe(0);
+  });
+
+  test("error message includes space name and original cause", async () => {
+    const wasm = makeFakeWasmBindings();
+    const openKeyStrategy = createOpenKeyCallbackSigningStrategy({
+      endpoint: "https://openkey.test/api/delegate/sign",
+    });
+
+    const node = new TinyCloudNode({
+      wasmBindings: wasm,
+      signer: makeExternalSigner() as any,
+      signStrategy: openKeyStrategy,
+      host: "https://tinycloud.test",
+    });
+
+    stubNodeForSignIn(node, { freshAccount: true });
+    (node as any).ensureRequestedEncryptionNetworks = async () => {};
+    (node as any).ensureOwnedSpaceHostedById = async () => {};
+    (node as any).scheduleAccountRegistrySync = () => {};
+
+    const auth = (node as any).auth;
+    auth.createBootstrapSession = mock(async () => {
+      throw new Error("auto-sign rejected");
+    });
+    auth.hostOwnedSpace = mock(async () => true);
+
+    let thrownError: Error | undefined;
+    try {
+      await node.signIn();
+    } catch (err) {
+      thrownError = err as Error;
+    }
+
+    expect(thrownError).toBeDefined();
+    expect(thrownError!.message).toContain("Account bootstrap aborted");
+    expect(thrownError!.message).toContain("auto-sign rejected");
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -491,10 +491,25 @@ export class TinyCloudNode {
    */
   private _bootstrapSkipped = false;
 
+  /**
+   * Outcome of the last signIn()'s account-bootstrap attempt. `skipped` is
+   * true when bootstrap did not complete (interactive signer, auto-sign
+   * denied, or a bootstrap step failed); `reason` carries the cause so apps
+   * can surface a "finish account setup" call-to-action.
+   */
+  private _bootstrapStatus: { skipped: boolean; reason?: string } = {
+    skipped: false,
+  };
+
   /** Whether the last signIn() skipped client-side bootstrap because the
    * signer is interactive (browser wallet / EIP-1193 provider). */
   get bootstrapSkipped(): boolean {
     return this._bootstrapSkipped;
+  }
+
+  /** Outcome of the last signIn()'s account-bootstrap attempt. */
+  get bootstrapStatus(): { skipped: boolean; reason?: string } {
+    return this._bootstrapStatus;
   }
 
   private get nodeFeatures(): string[] {
@@ -931,6 +946,7 @@ export class TinyCloudNode {
 
   private async bootstrapAccountIfNeeded(): Promise<boolean> {
     this._bootstrapSkipped = false;
+    this._bootstrapStatus = { skipped: false };
 
     if (this.config.autoBootstrapAccount === false) {
       return false;
@@ -950,6 +966,7 @@ export class TinyCloudNode {
         "Server-side bootstrap (OpenKey) is expected to have provisioned the account.",
       );
       this._bootstrapSkipped = true;
+      this._bootstrapStatus = { skipped: true, reason: "interactive-signer" };
       return false;
     }
 
@@ -958,7 +975,21 @@ export class TinyCloudNode {
       return false;
     }
 
-    await this.runAccountBootstrap(steps);
+    try {
+      await this.runAccountBootstrap(steps);
+    } catch (err) {
+      // Bootstrap is provisioning, not a precondition of the session the
+      // user just signed: never fail signIn() because of it. Surface the
+      // outcome instead so apps can offer a "finish account setup" action.
+      const reason = err instanceof Error ? err.message : String(err);
+      this._bootstrapSkipped = true;
+      this._bootstrapStatus = { skipped: true, reason };
+      this.notificationHandler.warning(
+        `Account bootstrap did not complete: ${reason}`,
+      );
+      console.warn(`[TinyCloudNode] account bootstrap failed: ${reason}`);
+      return false;
+    }
     return true;
   }
 
@@ -1040,7 +1071,7 @@ export class TinyCloudNode {
 
     for (const step of steps) {
       if (step.kind !== "host") continue;
-      const hosted = await auth.hostOwnedSpace(step.spaceId);
+      const hosted = await auth.hostOwnedSpace(step.spaceId, "bootstrap-host");
       if (!hosted) {
         throw new Error(`Failed to host bootstrap space: ${step.spaceId}`);
       }

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -159,6 +159,31 @@ function isOpenKeyAutoSignStrategy(strategy: SignStrategy | undefined): boolean 
   return (strategy as { openKeyAutoSign?: unknown } | undefined)?.openKeyAutoSign === true;
 }
 
+/**
+ * Returns true when the signer is an external/interactive signer (browser
+ * wallet, EIP-1193 provider, etc.) that will open a UI prompt for every
+ * `signMessage()` call.
+ *
+ * Detection: the config provides a `signer` but NOT a `privateKey`, and the
+ * `signStrategy` is neither the OpenKey auto-sign callback nor the auto-sign
+ * strategy backed by a local key. In practice:
+ * - `privateKey` present → local PrivateKeySigner → non-interactive
+ * - `signStrategy.openKeyAutoSign === true` → OpenKey /api/delegate/sign → non-interactive
+ * - `signer` only, no `privateKey`, no OpenKey strategy → interactive (browser wallet)
+ */
+function isInteractiveSigner(config: TinyCloudNodeConfig): boolean {
+  if (config.privateKey) {
+    // Local key: always non-interactive.
+    return false;
+  }
+  if (isOpenKeyAutoSignStrategy(config.signStrategy)) {
+    // OpenKey auto-sign path: non-interactive.
+    return false;
+  }
+  // External signer with no auto-sign strategy. Treat as interactive.
+  return config.signer !== undefined;
+}
+
 function didPrincipalMatches(actual: string, expected: string): boolean {
   try {
     return principalDidEquals(actual, expected);
@@ -458,6 +483,19 @@ export class TinyCloudNode {
    * {@link currentTinyCloudSession} as a fallback for `auth.tinyCloudSession`.
    */
   private _restoredTcSession?: TinyCloudSession;
+
+  /**
+   * True when the last signIn() detected an interactive signer and skipped
+   * client-side bootstrap. Apps can read this to know whether bootstrap was
+   * deferred to the server (OpenKey) or requires a separate user action.
+   */
+  private _bootstrapSkipped = false;
+
+  /** Whether the last signIn() skipped client-side bootstrap because the
+   * signer is interactive (browser wallet / EIP-1193 provider). */
+  get bootstrapSkipped(): boolean {
+    return this._bootstrapSkipped;
+  }
 
   private get nodeFeatures(): string[] {
     return this.auth?.nodeFeatures ?? [];
@@ -892,10 +930,26 @@ export class TinyCloudNode {
   }
 
   private async bootstrapAccountIfNeeded(): Promise<boolean> {
+    this._bootstrapSkipped = false;
+
     if (this.config.autoBootstrapAccount === false) {
       return false;
     }
     if (!this.auth || !this._address) {
+      return false;
+    }
+
+    // Interactive signers (browser wallet / EIP-1193) prompt the user for
+    // every signMessage() call. Running bootstrap through an interactive
+    // signer would open 10+ sequential sign prompts. Skip client-side
+    // bootstrap entirely: the server (OpenKey) handles bootstrap inside
+    // POST /api/keys/{keyId}/sign before returning the first signature.
+    if (isInteractiveSigner(this.config)) {
+      console.debug(
+        "[TinyCloudNode] bootstrap skipped: interactive signer detected. " +
+        "Server-side bootstrap (OpenKey) is expected to have provisioned the account.",
+      );
+      this._bootstrapSkipped = true;
       return false;
     }
 
@@ -966,11 +1020,21 @@ export class TinyCloudNode {
       if (rawAbilities) {
         rawAbilitiesBySpace.set(step.space, rawAbilities);
       }
-      const session = await auth.createBootstrapSession({
-        spaceId: step.spaceId,
-        capabilityRequest: step.request ?? BOOTSTRAP_SESSION_REQUESTS[step.space],
-        rawAbilities,
-      });
+      let session: TinyCloudSession;
+      try {
+        session = await auth.createBootstrapSession({
+          spaceId: step.spaceId,
+          capabilityRequest: step.request ?? BOOTSTRAP_SESSION_REQUESTS[step.space],
+          rawAbilities,
+        });
+      } catch (err) {
+        // Abort immediately — do not cascade into remaining bootstrap steps.
+        // A single clear error is surfaced instead of one error per space.
+        throw new Error(
+          `Account bootstrap aborted: signature rejected for space "${step.space}". ` +
+          `Cause: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       sessions.set(step.space, session);
     }
 

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -632,7 +632,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
    * Create the space on the TinyCloud server (host delegation).
    * This registers the user as the owner of the space.
    */
-  private async hostSpace(targetSpaceId?: string): Promise<boolean> {
+  private async hostSpace(
+    targetSpaceId?: string,
+    purpose?: SignRequest["purpose"],
+  ): Promise<boolean> {
     if (!this._tinyCloudSession || !this._address || !this._chainId) {
       throw new Error("Must be signed in to host space");
     }
@@ -655,7 +658,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
     });
 
     // Sign the message
-    const signature = await this.signMessage(siwe);
+    const signature = await this.signMessage(siwe, purpose);
 
     // Convert to delegation headers and submit
     const headers = this.wasm.siweToDelegationHeaders({ siwe, signature });
@@ -676,8 +679,11 @@ export class NodeUserAuthorization implements IUserAuthorization {
    * Create a specific owned space on the server via host delegation.
    * Used by manifest registry setup for the account space.
    */
-  async hostOwnedSpace(spaceId: string): Promise<boolean> {
-    return this.hostSpace(spaceId);
+  async hostOwnedSpace(
+    spaceId: string,
+    purpose?: SignRequest["purpose"],
+  ): Promise<boolean> {
+    return this.hostSpace(spaceId, purpose);
   }
 
   /**
@@ -878,6 +884,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       chainId,
       message: prepared.siwe,
       type: "siwe",
+      purpose: "bootstrap-session",
     });
     const session = this.wasm.completeSessionSetup({
       ...prepared,
@@ -966,6 +973,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       chainId,
       message: prepared.siwe,
       type: "siwe",
+      purpose: "sign-in",
     });
 
     // Complete session setup with the prepared session + signature
@@ -1083,7 +1091,10 @@ export class NodeUserAuthorization implements IUserAuthorization {
   /**
    * Sign a message with the connected signer.
    */
-  async signMessage(message: string): Promise<string> {
+  async signMessage(
+    message: string,
+    purpose?: SignRequest["purpose"],
+  ): Promise<string> {
     if (!this._address) {
       this._address = canonicalizeAddress(await this.signer.getAddress());
     }
@@ -1096,6 +1107,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       chainId: this._chainId,
       message,
       type: "message",
+      ...(purpose ? { purpose } : {}),
     });
   }
 

--- a/packages/sdk-core/src/authorization/strategies.ts
+++ b/packages/sdk-core/src/authorization/strategies.ts
@@ -21,6 +21,12 @@ export interface SignRequest {
   message: string;
   /** Type of sign operation */
   type: "siwe" | "message";
+  /**
+   * What the signature is for. Lets strategies apply different policies to
+   * account-bootstrap signatures (which may be auto-signed server-side)
+   * versus the user-initiated sign-in. Absent on requests from older SDKs.
+   */
+  purpose?: "sign-in" | "bootstrap-session" | "bootstrap-host" | "message";
 }
 
 /**

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -52,6 +52,7 @@ import {
   type NetworkDescriptor,
   SignInOptions,
   composeManifestRequest,
+  type SignStrategy,
 } from "@tinycloud/sdk-core";
 import { showPermissionRequestModal } from "../notifications/ModalManager";
 import {
@@ -155,6 +156,8 @@ export interface Config extends ClientConfig {
   manifest?: Manifest | Manifest[];
   /** Pre-composed manifest request. Takes precedence over `manifest`. */
   capabilityRequest?: ComposedManifestRequest;
+  /** Strategy for TinyCloud root signature requests. */
+  signStrategy?: SignStrategy;
   /** Include implicit account registry permissions when composing `manifest`. Default true. */
   includeAccountRegistryPermissions?: boolean;
   /** Default-off service telemetry. */
@@ -366,6 +369,7 @@ export class TinyCloudWeb {
       // actual `abilities` map passed to `prepareSession`.
       manifest: this._manifest,
       capabilityRequest: this._capabilityRequest,
+      signStrategy: this.config.signStrategy,
       includeAccountRegistryPermissions:
         this.config.includeAccountRegistryPermissions,
       telemetry: this.config.telemetry,

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -431,6 +431,11 @@ export class TinyCloudWeb {
   get kv(): IKVService { return this.node.kv; }
   get sql(): ISQLService { return this.node.sql; }
 
+  /** Whether the last signIn() skipped client-side account bootstrap. */
+  get bootstrapSkipped(): boolean { return this.node.bootstrapSkipped; }
+  /** Outcome of the last signIn()'s account-bootstrap attempt. */
+  get bootstrapStatus(): { skipped: boolean; reason?: string } { return this.node.bootstrapStatus; }
+
   /** Space-scoped SQL service for a non-primary space (e.g. the owner's `applications` space). */
   sqlForSpace(spaceId: string): ISQLService { return this.node.sqlForSpace(spaceId); }
   /** Space-scoped KV service for a non-primary space (e.g. the owner's `applications` space). */

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -17,6 +17,7 @@ import {
   type DelegateToResult,
   type ISessionStorage,
   type PersistedSessionData,
+  type SignStrategy,
 } from "@tinycloud/node-sdk/core";
 import {
   IKVService,
@@ -52,7 +53,6 @@ import {
   type NetworkDescriptor,
   SignInOptions,
   composeManifestRequest,
-  type SignStrategy,
 } from "@tinycloud/sdk-core";
 import { showPermissionRequestModal } from "../notifications/ModalManager";
 import {

--- a/packages/web-sdk/tests/signInManifestRestore.test.ts
+++ b/packages/web-sdk/tests/signInManifestRestore.test.ts
@@ -72,6 +72,19 @@ mock.module("@tinycloud/web-sdk-wasm", () => ({
 
 const { TinyCloudWeb } = require("../src/modules/tcw");
 
+test("forwards signStrategy to the underlying TinyCloudNode", async () => {
+  const signStrategy = {
+    type: "callback",
+    openKeyAutoSign: true,
+    handler: mock(async () => ({ approved: true, signature: "0x1234" })),
+  };
+  const tcw = new TinyCloudWeb({ signStrategy });
+
+  await (tcw as any)._initPromise;
+
+  expect((tcw as any)._node.config.signStrategy).toBe(signStrategy);
+});
+
 test("signIn refreshes a restored session that does not cover the configured manifest", async () => {
   const tcw = new TinyCloudWeb({
     manifest: {


### PR DESCRIPTION
## Summary
- skip client-side account bootstrap when `TinyCloudNode` is using an interactive external signer, so browser wallets/OpenKey widget paths do not prompt once per bootstrap space
- abort account bootstrap on the first bootstrap-session signing failure instead of cascading into more signature requests
- expose `signStrategy` on `TinyCloudWeb.Config` and forward it to `TinyCloudNode` so browser integrations can use the OpenKey callback strategy

## Links
- Linear: TC-86 https://linear.app/tinycloud-labs/issue/TC-86/first-sign-in-openkey-auto-sign-failure-triggers-infinite-signing-prompts-account-bootstrap-loop
- Related fresh-bootstrap failure: https://github.com/TinyCloudLabs/js-sdk/issues/300
- Prior bootstrap work: #296

## Verification
- `bun test packages/web-sdk/tests/signInManifestRestore.test.ts packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts` (10 pass)
- `bun run --cwd packages/sdk-services build`
- `bun run --cwd packages/sdk-core build`

## Notes
- Full `packages/node-sdk build` is blocked in this fresh worktree because generated `packages/sdk-rs/node-sdk-wasm/tinycloud_web_sdk_rs.*` artifacts are absent; targeted tests pass after building the JS dependencies.