### PR TITLE
fix(sdk-core,node-sdk): run host-activation ceremony in spaces.create()

### DIFF
--- a/.changeset/spaces-create-host-activation.md
+++ b/.changeset/spaces-create-host-activation.md
@@ -1,0 +1,12 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+---
+
+Fix `spaces.create(name)` to run the host-activation ceremony instead of a bare session-key invocation.
+
+`SpaceService.create()` previously issued a `tinycloud.space/create` invocation to `POST /invoke`, which never registered the space host-side. The node then committed an epoch/event row for an unregistered space, triggering a SQLite foreign-key error that surfaced to the client as `404 - Space not found`.
+
+`SpaceService` now accepts an injectable `hostSpace` function (mirroring the existing `createDelegation` injection). `create()` computes the full space id and runs the platform-provided host-activation ceremony (`peer/generate` → host SIWE → `POST /delegate` → session activation) instead of the invocation, then returns a locally-built `SpaceInfo`. When no `hostSpace` function is injected, `create()` returns a `NOT_INITIALIZED` error rather than falling back to the FK-triggering invocation. `TinyCloudNode` supplies `hostSpace` by reusing its existing `hostPublicSpace` ceremony plus `activateSessionWithHost`.
+
+As a result, `spaces.create('default')` returns an id equal to the session's primary space id, and immediate KV/SQL operations on that space succeed.

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -2280,6 +2280,65 @@ export class TinyCloudNode {
           };
         }
       },
+      // Enable space.create() via the host-activation ceremony (register the
+      // space owner-side, then activate the current session on it). Uses the
+      // same host the session's delegationHeader was minted against.
+      hostSpace: async (spaceId: string) => {
+        try {
+          const created = await (
+            this.auth as NodeUserAuthorization
+          ).hostPublicSpace(spaceId); // routes to hostSpace(spaceId)
+          if (!created) {
+            return {
+              ok: false as const,
+              error: {
+                code: "SPACE_CREATION_FAILED",
+                message: `Failed to host space: ${spaceId}`,
+                service: "space",
+              },
+            };
+          }
+
+          const host = this.hosts[0] ?? this.config.host;
+          const tcSession = this.auth?.tinyCloudSession;
+          if (!host || !tcSession) {
+            return {
+              ok: false as const,
+              error: {
+                code: "SPACE_CREATION_FAILED",
+                message: "Space hosting requires an active session and host",
+                service: "space",
+              },
+            };
+          }
+
+          const act = await activateSessionWithHost(
+            host,
+            tcSession.delegationHeader,
+          );
+          if (!act.success) {
+            return {
+              ok: false as const,
+              error: {
+                code: "SPACE_CREATION_FAILED",
+                message: `Activation failed: ${act.error ?? act.status}`,
+                service: "space",
+              },
+            };
+          }
+
+          return { ok: true as const, data: undefined };
+        } catch (error) {
+          return {
+            ok: false as const,
+            error: {
+              code: "NETWORK_ERROR",
+              message: error instanceof Error ? error.message : String(error),
+              service: "space",
+            },
+          };
+        }
+      },
       onSpaceRegistered: async (space) => {
         await this.account.spaces.register(space);
       },

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -430,6 +430,8 @@ export {
   // Delegation creation types
   SpaceDelegationParams,
   CreateDelegationFunction,
+  // Space hosting type
+  HostSpaceFunction,
 } from "./spaces";
 
 // Protocol version checking

--- a/packages/sdk-core/src/spaces/SpaceService.hostSpace.test.ts
+++ b/packages/sdk-core/src/spaces/SpaceService.hostSpace.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import type { Result, ServiceError } from "@tinycloud/sdk-services";
+
+import {
+  SpaceService,
+  SpaceErrorCodes,
+  type SpaceServiceConfig,
+  type HostSpaceFunction,
+} from "./SpaceService";
+
+const OWNER_DID = "did:pkh:eip155:1:0x0000000000000000000000000000000000000001";
+const PRIMARY_SPACE_ID =
+  "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default";
+
+const session = {
+  delegationHeader: { Authorization: "Bearer test" },
+  delegationCid: "bafy-test",
+  spaceId: PRIMARY_SPACE_ID,
+  verificationMethod: "did:key:z6MkTest",
+  jwk: {},
+};
+
+function makeConfig(overrides: Partial<SpaceServiceConfig> = {}): SpaceServiceConfig {
+  return {
+    hosts: ["https://node.tinycloud.xyz"],
+    session,
+    userDid: OWNER_DID,
+    // The bare invoke path must never be exercised by create() anymore.
+    invoke: () => {
+      throw new Error("invoke must not be called by create()");
+    },
+    // Any network access from create() is a regression (it used to POST /invoke
+    // with tinycloud.space/create).
+    fetch: (async () => {
+      throw new Error("fetch must not be called by create()");
+    }) as unknown as SpaceServiceConfig["fetch"],
+    ...overrides,
+  };
+}
+
+describe("SpaceService.create host-activation", () => {
+  it("returns NOT_INITIALIZED when no hostSpace function is injected", async () => {
+    const spaces = new SpaceService(makeConfig());
+
+    const result = await spaces.create("default");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(SpaceErrorCodes.NOT_INITIALIZED);
+    }
+  });
+
+  it("runs the injected hostSpace ceremony without hitting the network", async () => {
+    const hostedSpaces: string[] = [];
+    const hostSpace: HostSpaceFunction = async (spaceId) => {
+      hostedSpaces.push(spaceId);
+      return { ok: true, data: undefined } as Result<void, ServiceError>;
+    };
+
+    const spaces = new SpaceService(makeConfig({ hostSpace }));
+
+    const result = await spaces.create("default");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // The returned id is the primary session space id (the ceremony target).
+      expect(result.data.id).toBe(PRIMARY_SPACE_ID);
+      expect(result.data.type).toBe("owned");
+    }
+    // The ceremony was invoked with the full space id, and nothing else.
+    expect(hostedSpaces).toEqual([PRIMARY_SPACE_ID]);
+  });
+});

--- a/packages/sdk-core/src/spaces/SpaceService.ts
+++ b/packages/sdk-core/src/spaces/SpaceService.ts
@@ -39,7 +39,6 @@ import {
 import {
   validateServerDelegationsResponse,
   validateServerOwnedSpacesResponse,
-  validateServerCreateSpaceResponse,
   validateServerSpaceInfoResponse,
   type ServerDelegationsResponse,
 } from "./spaces.schema.js";
@@ -111,6 +110,18 @@ export type CreateDelegationFunction = (
 ) => Promise<Result<Delegation, ServiceError>>;
 
 /**
+ * Function type for hosting (provisioning) a space on the node.
+ *
+ * Performs the full host-activation ceremony for the given space ID:
+ * `peer/generate` → wallet-owner host SIWE → `POST /delegate` (registers the
+ * space owner-side) → session activation. Platform SDKs (web-sdk, node-sdk)
+ * provide this using their WASM bindings and wallet signer.
+ */
+export type HostSpaceFunction = (
+  spaceId: string
+) => Promise<Result<void, ServiceError>>;
+
+/**
  * Configuration for SpaceService.
  */
 export interface SpaceServiceConfig {
@@ -140,6 +151,12 @@ export interface SpaceServiceConfig {
    * Required for space.delegations.create() to work.
    */
   createDelegation?: CreateDelegationFunction;
+  /**
+   * Function to host (provision) a space on the node using the host-activation
+   * ceremony. Platform SDKs (web-sdk, node-sdk) provide this using their WASM
+   * bindings. Required for space.create() to work.
+   */
+  hostSpace?: HostSpaceFunction;
   /** Optional best-effort hook after the SDK discovers or creates a space. */
   onSpaceRegistered?: (space: SpaceInfo) => void | Promise<void>;
 }
@@ -383,6 +400,7 @@ export class SpaceService implements ISpaceService {
   private _userDid?: string;
   private sharingService?: ISharingService;
   private createDelegationFn?: CreateDelegationFunction;
+  private hostSpaceFn?: HostSpaceFunction;
   private onSpaceRegisteredFn?: (space: SpaceInfo) => void | Promise<void>;
 
   /** Cache of created Space objects */
@@ -411,6 +429,7 @@ export class SpaceService implements ISpaceService {
     this._userDid = config.userDid;
     this.sharingService = config.sharingService;
     this.createDelegationFn = config.createDelegation;
+    this.hostSpaceFn = config.hostSpace;
     this.onSpaceRegisteredFn = config.onSpaceRegistered;
   }
 
@@ -429,6 +448,7 @@ export class SpaceService implements ISpaceService {
     if (config.userDid !== undefined) this._userDid = config.userDid;
     if (config.sharingService) this.sharingService = config.sharingService;
     if (config.createDelegation) this.createDelegationFn = config.createDelegation;
+    if (config.hostSpace) this.hostSpaceFn = config.hostSpace;
     if (config.onSpaceRegistered) this.onSpaceRegisteredFn = config.onSpaceRegistered;
 
     // Clear caches when config changes
@@ -681,57 +701,45 @@ export class SpaceService implements ISpaceService {
       );
     }
 
+    // Host-activation ceremony is platform-provided (WASM + wallet signer).
+    // Without it we cannot provision the space; never fall back to a bare
+    // session-key invocation (that writes an epoch event with no backing
+    // space row → server FK error → "404 - Space not found").
+    if (!this.hostSpaceFn) {
+      return err(
+        serviceError(
+          SpaceErrorCodes.NOT_INITIALIZED,
+          "Space creation requires a hostSpace function. " +
+            "This should be provided by the platform SDK (web-sdk or node-sdk).",
+          SERVICE_NAME
+        )
+      );
+    }
+
+    // Compute the full space ID (matches the ceremony's target and, for the
+    // primary space, the active session's spaceId).
+    const spaceId = this.userDid ? buildSpaceUri(this.userDid, name) : this.resolveSpaceId(name);
+
     try {
-      const headers = this.invoke(this.session, "space", name, "tinycloud.space/create");
-
-      const response = await this.fetchFn(`${this.host}/invoke`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ name }),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-
-        if (response.status === 409) {
-          return err(
-            serviceError(
-              SpaceErrorCodes.ALREADY_EXISTS,
-              `Space "${name}" already exists`,
-              SERVICE_NAME
-            )
-          );
-        }
-
+      // Run the host-activation ceremony (registers the space owner-side and
+      // activates the current session on it). Re-running on an existing space
+      // is safe — the owner delegation dedupes server-side.
+      const hosted = await this.hostSpaceFn(spaceId);
+      if (!hosted.ok) {
         return err(
           serviceError(
             SpaceErrorCodes.CREATION_FAILED,
-            `Failed to create space: ${response.status} - ${errorText}`,
+            hosted.error.message,
             SERVICE_NAME,
-            { meta: { status: response.status } }
-          )
-        );
-      }
-
-      const rawData = await response.json();
-
-      // Validate server response
-      const validationResult = validateServerCreateSpaceResponse(rawData);
-      if (!validationResult.ok) {
-        return err(
-          serviceError(
-            SpaceErrorCodes.CREATION_FAILED,
-            validationResult.error.message,
-            SERVICE_NAME,
-            { meta: validationResult.error.meta }
+            { meta: hosted.error.meta }
           )
         );
       }
 
       const spaceInfo: SpaceInfo = {
-        id: validationResult.data.id,
-        name: validationResult.data.name || name,
-        owner: validationResult.data.owner || this.userDid || "",
+        id: spaceId,
+        name,
+        owner: this.userDid ?? "",
         type: "owned",
         permissions: ["*"],
       };

--- a/packages/sdk-core/src/spaces/index.ts
+++ b/packages/sdk-core/src/spaces/index.ts
@@ -31,6 +31,8 @@ export {
   // Delegation creation types
   SpaceDelegationParams,
   CreateDelegationFunction,
+  // Space hosting type
+  HostSpaceFunction,
 } from "./SpaceService";
 
 // Validation schemas and types


### PR DESCRIPTION
## Problem

`SpaceService.create()` issued a bare session-key `tinycloud.space/create` invocation to `POST /invoke`, which never registered the space host-side. The node then committed an epoch row for the unregistered space, hit a SQLite foreign-key error (FK 787), and surfaced it to the client as `404 - Space not found` — so `spaces.create()` could never succeed.

## Fix

- `SpaceService` accepts an injectable `hostSpace` function (mirroring the existing `createDelegation` DI seam).
- `create()` computes the full space id and runs the platform-provided host-activation ceremony (`peer/generate` → host SIWE → `POST /delegate` → session activation), then returns a locally-built `SpaceInfo`. Re-running on an existing space is safe (owner delegation dedupes server-side).
- Without an injected `hostSpace`, `create()` returns `NOT_INITIALIZED` instead of falling back to the FK-triggering invocation.
- `TinyCloudNode` injects `hostSpace` by reusing `hostPublicSpace` + `activateSessionWithHost` against the session host. (`packages/web-sdk` constructs no `SpaceService` on master, so no web-sdk change is needed.)

## Verification

- Unit test: `create()` without `hostSpace` → `NOT_INITIALIZED`, and the ceremony path never touches `invoke`/`fetch`.
- Live-proven by a headless driver against a throwaway node (7/7 hard checks): `create('default')` succeeds, returned id equals the session's primary space id, immediate KV put/list works, second create is idempotent, and the node log contains **no FK-787 / no SpaceNotFound**. The pre-fix red run reproduced the live `404 - Space not found`.
- Deterministic regression gate fully green (30/30 checks).

Ships with a patch changeset for `@tinycloud/sdk-core` + `@tinycloud/node-sdk`.

Related: TinyCloudLabs/js-sdk#303 (account index bootstrap) and TinyCloudLabs/tinycloud-node#90 (epoch error mapping) — the three fixes came out of the same account-app e2e investigation and land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)