### PR TITLE
fix: durable account-registry sync + rebased #303/#304 + gap#5 + SQL-402 code

### DIFF
--- a/.changeset/account-index-space-invokeany.md
+++ b/.changeset/account-index-space-invokeany.md
@@ -1,0 +1,14 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Wire `invokeAny` into the space-scoped service contexts built by
+`TinyCloudNode.sqlForSpace`, `kvForSpace`, and `createSpaceScopedKVService`.
+Previously these clones omitted `invokeAny`, so any space-scoped multi-ability
+operation — notably the `CREATE TABLE` + `INSERT` migrations batch that
+`account.index.ensure()` runs against the space-scoped `account` DB — threw
+`SQL operation ... does not support multi-resource invocations` client-side
+before any network call. Space-scoped SQL/KV multi-ability invocations now route
+through `invokeAnyWithRuntimePermissions` (signed by the session key, so no
+additional wallet signatures), matching the primary-space contexts.

--- a/.changeset/account-registry-durable-sync.md
+++ b/.changeset/account-registry-durable-sync.md
@@ -1,0 +1,22 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-core": patch
+---
+
+fix(node-sdk,sdk-core): durably sync the account registry within signIn
+
+Fresh accounts could sign in with their spaces created server-side yet see an
+empty Overview/Spaces UI, because the account-spaces registry records
+(`account/spaces/{id}`, which the account index reads) were written only as
+fire-and-forget best-effort with silently swallowed failures. A floating
+unawaited `index.ensure()` reached the account space before it was hosted,
+404'd, and the failure was hidden.
+
+`signIn()` now awaits `syncAccountRegistry()`: it proactively hosts the account
+space before writing to it, awaits the index ensure + accessible-spaces sync
+(keeping the existing 3-attempt retry), and surfaces a definitive failure as a
+non-fatal `node.registryStatus` (`{ synced, reason }`) instead of throwing —
+so an at-cap 402 on a registry write degrades to a status rather than locking
+the user out of sign-in. The three previously silent registry-write catch
+sites (owned-space hosting, the sync retry, and `SpaceService`'s create-path
+`onSpaceRegistered` callback) now log/propagate instead of swallowing.

--- a/.changeset/spaces-create-host-activation.md
+++ b/.changeset/spaces-create-host-activation.md
@@ -1,0 +1,12 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+---
+
+Fix `spaces.create(name)` to run the host-activation ceremony instead of a bare session-key invocation.
+
+`SpaceService.create()` previously issued a `tinycloud.space/create` invocation to `POST /invoke`, which never registered the space host-side. The node then committed an epoch/event row for an unregistered space, triggering a SQLite foreign-key error that surfaced to the client as `404 - Space not found`.
+
+`SpaceService` now accepts an injectable `hostSpace` function (mirroring the existing `createDelegation` injection). `create()` computes the full space id and runs the platform-provided host-activation ceremony (`peer/generate` → host SIWE → `POST /delegate` → session activation) instead of the invocation, then returns a locally-built `SpaceInfo`. When no `hostSpace` function is injected, `create()` returns a `NOT_INITIALIZED` error rather than falling back to the FK-triggering invocation. `TinyCloudNode` supplies `hostSpace` by reusing its existing `hostPublicSpace` ceremony plus `activateSessionWithHost`.
+
+As a result, `spaces.create('default')` returns an id equal to the session's primary space id, and immediate KV/SQL operations on that space succeed.

--- a/.changeset/sql-402-quota-code.md
+++ b/.changeset/sql-402-quota-code.md
@@ -1,0 +1,11 @@
+---
+"@tinycloud/sdk-services": patch
+---
+
+fix(sdk-services): map SQL 402 responses to SQL_QUOTA_EXCEEDED
+
+The node returns a plain-text `402 Payment Required` for a storage-quota-exceeded
+SQL write, but `SQLService.mapHttpStatusToErrorCode` had no 402 case, so the
+error fell through to `NETWORK_ERROR`. Apps switching on the error code
+mishandled SQL quota errors (KV already maps 402 correctly). Map 402 to
+`SQL_QUOTA_EXCEEDED`, matching the existing 429 case.

--- a/.changeset/web-forward-auto-bootstrap-account.md
+++ b/.changeset/web-forward-auto-bootstrap-account.md
@@ -1,0 +1,12 @@
+---
+"@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk": patch
+---
+
+fix(web-sdk): forward autoBootstrapAccount to node-sdk config
+
+The web `Config` interface neither declared nor forwarded `autoBootstrapAccount`
+into the assembled `nodeConfig`, so setting it in a web app (e.g.
+`autoBootstrapAccount: false` to suppress the multi-signature bootstrap loop)
+was silently inert — the node-sdk default (`true`) always won. Declare the
+option on `Config` and forward it, restoring the web↔node contract.

--- a/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
@@ -141,7 +141,7 @@ function stubNodeForSignIn(
   // Stub post-bootstrap helpers that would hit the network.
   (node as any).ensureRequestedEncryptionNetworks = async () => {};
   (node as any).ensureOwnedSpaceHostedById = async () => {};
-  (node as any).scheduleAccountRegistrySync = () => {};
+  (node as any).syncAccountRegistry = async () => {};
 }
 
 /**
@@ -318,7 +318,7 @@ describe("bootstrap gate — abort on first rejection", () => {
     stubNodeForSignIn(node, { freshAccount: true });
     (node as any).ensureRequestedEncryptionNetworks = async () => {};
     (node as any).ensureOwnedSpaceHostedById = async () => {};
-    (node as any).scheduleAccountRegistrySync = () => {};
+    (node as any).syncAccountRegistry = async () => {};
 
     // Stub auth.createBootstrapSession to reject on the first call.
     const auth = (node as any).auth;
@@ -366,7 +366,7 @@ describe("bootstrap gate — abort on first rejection", () => {
     stubNodeForSignIn(node, { freshAccount: true });
     (node as any).ensureRequestedEncryptionNetworks = async () => {};
     (node as any).ensureOwnedSpaceHostedById = async () => {};
-    (node as any).scheduleAccountRegistrySync = () => {};
+    (node as any).syncAccountRegistry = async () => {};
 
     const auth = (node as any).auth;
     auth.createBootstrapSession = mock(async () => {

--- a/packages/node-sdk/src/TinyCloudNode.registrySync.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.registrySync.test.ts
@@ -394,8 +394,12 @@ describe("account registry sync — durable owned-space registration flush", () 
     await node.signIn();
 
     expect((node as any).pendingSpaceRegistrations.size).toBe(0);
-    // 1 failed best-effort + 1 successful flush inside the sync
-    expect(account.spaces.register).toHaveBeenCalledTimes(2);
+    // The failed best-effort is retried during the sync (plus reconciliation
+    // registers for the session's expected spaces).
+    const flushCalls = account.spaces.register.mock.calls.filter(
+      (call: any[]) => (call[0].spaceId ?? call[0].id) === PENDING_SPACE.spaceId,
+    );
+    expect(flushCalls.length).toBe(2); // 1 failed best-effort + 1 successful flush
     expect(node.registryStatus.synced).toBe(true);
     // The flush happens inside the retry block, after index.ensure and
     // before syncAccessible.
@@ -445,5 +449,44 @@ describe("account registry sync — durable owned-space registration flush", () 
         "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
       ),
     ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (g) reconciliation heals accounts whose registry records were dropped
+// ---------------------------------------------------------------------------
+
+describe("account registry sync — reconciliation of missing records", () => {
+  test("registers expected session spaces whose records are missing (no pending needed)", async () => {
+    const { node, account, callLog } = makeRegistryNode();
+    // Nothing pending — this account's spaces already exist server-side (the
+    // legacy-bricked case) so no creation/hosting site fires on sign-in. The
+    // fake account has no index/get fastpath, so isOwnedSpaceRegistered
+    // resolves "not registered" and reconciliation must register them.
+    await node.signIn();
+
+    expect((node as any).pendingSpaceRegistrations.size).toBe(0);
+    const registeredIds = account.spaces.register.mock.calls.map(
+      (call: any[]) => call[0].spaceId ?? call[0].id,
+    );
+    expect(registeredIds).toContain(node.accountSpaceId!);
+    expect(node.registryStatus.synced).toBe(true);
+    // Reconciliation happens inside the retry block, before syncAccessible.
+    const firstRegisterIdx = callLog.findIndex((entry) =>
+      entry.startsWith("spaces.register:"),
+    );
+    expect(firstRegisterIdx).toBeGreaterThan(callLog.indexOf("index.ensure"));
+    expect(firstRegisterIdx).toBeLessThan(callLog.indexOf("spaces.syncAccessible"));
+  });
+
+  test("skips spaces whose registry record already exists", async () => {
+    const { node, account } = makeRegistryNode();
+    // Make the canonical KV check say "registered" for every space.
+    (node as any).isOwnedSpaceRegistered = async () => true;
+
+    await node.signIn();
+
+    expect(account.spaces.register).toHaveBeenCalledTimes(0);
+    expect(node.registryStatus.synced).toBe(true);
   });
 });

--- a/packages/node-sdk/src/TinyCloudNode.registrySync.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.registrySync.test.ts
@@ -111,7 +111,10 @@ function makeExternalSigner() {
 
 interface FakeAccount {
   index: { ensure: ReturnType<typeof mock> };
-  spaces: { syncAccessible: ReturnType<typeof mock> };
+  spaces: {
+    syncAccessible: ReturnType<typeof mock>;
+    register: ReturnType<typeof mock>;
+  };
 }
 
 /**
@@ -121,7 +124,10 @@ interface FakeAccount {
  */
 function makeRegistryNode(opts: {
   hostImpl?: (spaceId: string) => Promise<void>;
-  account?: Partial<FakeAccount>;
+  account?: {
+    index?: Partial<FakeAccount["index"]>;
+    spaces?: Partial<FakeAccount["spaces"]>;
+  };
 } = {}): {
   node: TinyCloudNode;
   callLog: string[];
@@ -134,14 +140,19 @@ function makeRegistryNode(opts: {
         callLog.push("index.ensure");
         return { ok: true, data: undefined } as any;
       }),
+      ...(opts.account?.index ?? {}),
     },
     spaces: {
       syncAccessible: mock(async () => {
         callLog.push("spaces.syncAccessible");
         return { ok: true, data: [] } as any;
       }),
+      register: mock(async (record: any) => {
+        callLog.push(`spaces.register:${record.spaceId ?? record.id}`);
+        return { ok: true, data: record } as any;
+      }),
+      ...(opts.account?.spaces ?? {}),
     },
-    ...opts.account,
   };
 
   const node = new TinyCloudNode({
@@ -340,5 +351,99 @@ describe("withAccountRegistryRetry", () => {
     } finally {
       (globalThis as any).setTimeout = realSetTimeout;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (f) owned-space registrations are durably flushed by the awaited sync
+// ---------------------------------------------------------------------------
+
+const PENDING_SPACE = {
+  spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:applications",
+  name: "applications",
+  ownerDid: "did:pkh:eip155:1:0x0000000000000000000000000000000000000001",
+  type: "owned" as const,
+  permissions: ["*"],
+  status: "active" as const,
+};
+
+describe("account registry sync — durable owned-space registration flush", () => {
+  test("a register() failure reported as {ok:false} keeps the record pending (no throw to notice)", async () => {
+    const { node, account } = makeRegistryNode();
+    account.spaces.register.mockImplementationOnce(async () => ({
+      ok: false,
+      error: { message: "404 space not found" },
+    }));
+
+    await (node as any).attemptSpaceRegistration(PENDING_SPACE);
+
+    expect((node as any).pendingSpaceRegistrations.size).toBe(1);
+  });
+
+  test("signIn's awaited sync flushes a previously failed registration", async () => {
+    const { node, account, callLog } = makeRegistryNode();
+    // Best-effort attempt fails as a Result — the pre-fix code silently
+    // dropped this record forever (the .catch never fires on {ok:false}).
+    account.spaces.register.mockImplementationOnce(async () => ({
+      ok: false,
+      error: { message: "404 space not found" },
+    }));
+    await (node as any).attemptSpaceRegistration(PENDING_SPACE);
+    expect((node as any).pendingSpaceRegistrations.size).toBe(1);
+
+    await node.signIn();
+
+    expect((node as any).pendingSpaceRegistrations.size).toBe(0);
+    // 1 failed best-effort + 1 successful flush inside the sync
+    expect(account.spaces.register).toHaveBeenCalledTimes(2);
+    expect(node.registryStatus.synced).toBe(true);
+    // The flush happens inside the retry block, after index.ensure and
+    // before syncAccessible.
+    const flushIdx = callLog.indexOf(`spaces.register:${PENDING_SPACE.spaceId}`);
+    const ensureIdx = callLog.indexOf("index.ensure");
+    const syncIdx = callLog.indexOf("spaces.syncAccessible");
+    expect(flushIdx).toBeGreaterThan(ensureIdx);
+    expect(flushIdx).toBeLessThan(syncIdx);
+  });
+
+  test("a flush that keeps failing surfaces registryStatus, keeps the record pending, and signIn resolves", async () => {
+    const { node, account } = makeRegistryNode();
+    account.spaces.register.mockImplementation(async () => ({
+      ok: false,
+      error: { message: "Storage quota exceeded (402)" },
+    }));
+    (node as any).withAccountRegistryRetry = async (task: () => Promise<void>) => {
+      await task();
+    };
+
+    await (node as any).attemptSpaceRegistration(PENDING_SPACE);
+    await node.signIn(); // must NOT throw
+
+    expect(node.registryStatus.synced).toBe(false);
+    expect(node.registryStatus.reason).toContain("402");
+    // Still pending: the next signIn retries it (retry-on-signIn policy).
+    expect((node as any).pendingSpaceRegistrations.size).toBe(1);
+  });
+
+  test("the create-path callback keeps SpaceInfo-shaped records pending on failure", async () => {
+    const { node, account } = makeRegistryNode();
+    account.spaces.register.mockImplementationOnce(async () => ({
+      ok: false,
+      error: { message: "404 space not found" },
+    }));
+
+    await (node as any).attemptSpaceRegistration({
+      id: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      name: "default",
+      owner: "did:pkh:eip155:1:0x0000000000000000000000000000000000000001",
+      type: "owned",
+      permissions: ["*"],
+    });
+
+    expect(
+      (node as any).pendingSpaceRegistrations.has(
+        "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/node-sdk/src/TinyCloudNode.registrySync.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.registrySync.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Unit tests for the amended G2 fix: durable, awaited account-registry sync.
+ *
+ * Coverage:
+ * (a) On the non-bootstrapped signIn path, syncAccountRegistry() runs and is
+ *     awaited — the account index ensure + spaces sync complete before
+ *     signIn() resolves (the app has no async refresh path).
+ * (b) The account space is proactively hosted BEFORE the registry sync writes
+ *     to it (this is the fix for the swallowed 404 that left fresh accounts
+ *     with an empty Overview).
+ * (c) A definitive registry failure surfaces a NON-FATAL registryStatus and
+ *     signIn() still resolves — never a thrown signIn.
+ * (d) A 402/404 from a registry write (e.g. at-cap) degrades to registryStatus,
+ *     it does NOT lock the user out of signIn().
+ * (e) withAccountRegistryRetry retries and resolves when a later attempt wins.
+ *
+ * These are unit tests: tc.signIn() (the inner TinyCloud layer) is stubbed so
+ * NodeUserAuthorization's network calls are never reached, and the account
+ * service is replaced with a fake so we can drive its results.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { IWasmBindings, ISessionManager, ClientSession } from "@tinycloud/sdk-core";
+import { TinyCloudNode } from "./TinyCloudNode";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures (mirrors TinyCloudNode.bootstrapGate.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeFakeSessionManager(): ISessionManager {
+  const keys = new Set<string>(["default"]);
+  return {
+    createSessionKey(id: string): string {
+      keys.add(id);
+      return id;
+    },
+    renameSessionKeyId(oldId: string, newId: string): void {
+      if (keys.has(oldId)) {
+        keys.delete(oldId);
+        keys.add(newId);
+      }
+    },
+    getDID(keyId: string): string {
+      return `did:key:z6MkTest-${keyId}`;
+    },
+    jwk(keyId: string): string | undefined {
+      if (!keys.has(keyId)) return undefined;
+      return JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" });
+    },
+  };
+}
+
+function makeFakeWasmBindings(overrides: Partial<IWasmBindings> = {}): IWasmBindings {
+  const base: IWasmBindings = {
+    invoke: mock(() => Promise.resolve({} as any)) as any,
+    invokeAny: mock(() => Promise.resolve({} as any)) as any,
+    prepareSession: mock(() => ({
+      siwe: "fake-siwe",
+      jwk: { kty: "OKP" },
+      spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      verificationMethod: "did:key:z6MkTestSession",
+    })),
+    completeSessionSetup: mock(() => ({
+      delegationHeader: { Authorization: "Bearer fake" },
+      delegationCid: "bafyfake",
+      jwk: { kty: "OKP" },
+      spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      verificationMethod: "did:key:z6MkTestSession",
+    })),
+    ensureEip55: (a: string) => a,
+    makeSpaceId: (a: string, c: number, p: string) => `tinycloud:pkh:eip155:${c}:${a}:${p}`,
+    createDelegation: mock(() => ({})),
+    parseRecapFromSiwe: mock(() => [] as any[]),
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(),
+      privateKey: new Uint8Array(),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array()),
+    vault_sha256: mock(() => new Uint8Array()),
+    createSessionManager: makeFakeSessionManager,
+  };
+  return { ...base, ...overrides };
+}
+
+const FAKE_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+const FAKE_SESSION: ClientSession = {
+  address: FAKE_ADDRESS,
+  walletAddress: FAKE_ADDRESS,
+  chainId: 1,
+  sessionKey: "session-test",
+  siwe: "fake-siwe",
+  signature: "0x" + "ff".repeat(65),
+};
+
+function makeExternalSigner() {
+  return {
+    signMessage: mock(async () => "0x" + "ff".repeat(65)),
+    getAddress: async () => FAKE_ADDRESS,
+    getChainId: async () => 1,
+  };
+}
+
+interface FakeAccount {
+  index: { ensure: ReturnType<typeof mock> };
+  spaces: { syncAccessible: ReturnType<typeof mock> };
+}
+
+/**
+ * Wire an interactive-signer node whose signIn() takes the non-bootstrapped
+ * path (bootstrap is skipped for interactive signers), so syncAccountRegistry()
+ * runs. Records the ordering of host + sync operations in `callLog`.
+ */
+function makeRegistryNode(opts: {
+  hostImpl?: (spaceId: string) => Promise<void>;
+  account?: Partial<FakeAccount>;
+} = {}): {
+  node: TinyCloudNode;
+  callLog: string[];
+  account: FakeAccount;
+} {
+  const callLog: string[] = [];
+  const account: FakeAccount = {
+    index: {
+      ensure: mock(async () => {
+        callLog.push("index.ensure");
+        return { ok: true, data: undefined } as any;
+      }),
+    },
+    spaces: {
+      syncAccessible: mock(async () => {
+        callLog.push("spaces.syncAccessible");
+        return { ok: true, data: [] } as any;
+      }),
+    },
+    ...opts.account,
+  };
+
+  const node = new TinyCloudNode({
+    wasmBindings: makeFakeWasmBindings(),
+    // External signer, no privateKey, no signStrategy → interactive path →
+    // bootstrap skipped → non-bootstrapped signIn tail runs the registry sync.
+    signer: makeExternalSigner() as any,
+    host: "https://tinycloud.test",
+  });
+
+  // Stub inner layers so signIn() completes offline.
+  const tc = (node as any).tc;
+  tc.signIn = mock(async () => FAKE_SESSION);
+  (node as any).syncResolvedHostFromAuth = () => {};
+  (node as any).initializeServices = () => {};
+  (node as any).ensureRequestedEncryptionNetworks = async () => {};
+  (node as any).writeManifestRegistryRecords = async () => {};
+
+  // Spy the proactive host used by both the SECRETS pre-host and the account
+  // space host inside syncAccountRegistry().
+  (node as any).ensureOwnedSpaceHostedById = mock(async (spaceId: string) => {
+    callLog.push(`host:${spaceId}`);
+    if (opts.hostImpl) await opts.hostImpl(spaceId);
+  });
+
+  // Replace the account getter with our fake so syncAccountRegistry's leaves
+  // are controllable without a real service context.
+  Object.defineProperty(node, "account", {
+    get: () => account,
+    configurable: true,
+  });
+
+  return { node, callLog, account };
+}
+
+// ---------------------------------------------------------------------------
+// (a) registry sync runs and is awaited on the non-bootstrapped path
+// ---------------------------------------------------------------------------
+
+describe("account registry sync — awaited durability", () => {
+  test("signIn awaits the registry sync (ensure + syncAccessible complete)", async () => {
+    const { node, account } = makeRegistryNode();
+
+    await node.signIn();
+
+    expect(account.index.ensure).toHaveBeenCalledTimes(1);
+    expect(account.spaces.syncAccessible).toHaveBeenCalledTimes(1);
+    expect(node.registryStatus.synced).toBe(true);
+    expect(node.registryStatus.reason).toBeUndefined();
+  });
+
+  test("registryStatus starts synced=true before any signIn", () => {
+    const node = new TinyCloudNode({
+      wasmBindings: makeFakeWasmBindings(),
+      signer: makeExternalSigner() as any,
+      host: "https://tinycloud.test",
+    });
+    expect(node.registryStatus.synced).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) account space is hosted BEFORE the sync writes to it
+// ---------------------------------------------------------------------------
+
+describe("account registry sync — proactive hosting order", () => {
+  test("hosts the account space before syncAccessible", async () => {
+    const { node, callLog } = makeRegistryNode();
+
+    await node.signIn();
+
+    const accountSpaceId = node.accountSpaceId!;
+    const hostAccountIdx = callLog.indexOf(`host:${accountSpaceId}`);
+    const syncIdx = callLog.indexOf("spaces.syncAccessible");
+
+    expect(hostAccountIdx).toBeGreaterThanOrEqual(0);
+    expect(syncIdx).toBeGreaterThanOrEqual(0);
+    expect(hostAccountIdx).toBeLessThan(syncIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) definitive sync failure surfaces a non-fatal status, signIn survives
+// ---------------------------------------------------------------------------
+
+describe("account registry sync — non-fatal failure surfacing", () => {
+  test("syncAccessible !ok surfaces registryStatus and signIn resolves", async () => {
+    const { node } = makeRegistryNode({
+      account: {
+        spaces: {
+          syncAccessible: mock(async () => ({
+            ok: false,
+            error: { message: "sync boom" },
+          })) as any,
+        },
+      },
+    });
+
+    // Skip the real backoff delays: exercise the surfacing, not the timers.
+    (node as any).withAccountRegistryRetry = async (task: () => Promise<void>) => {
+      await task();
+    };
+
+    await node.signIn(); // must NOT throw
+
+    expect(node.registryStatus.synced).toBe(false);
+    expect(node.registryStatus.reason).toContain("sync boom");
+  });
+
+  test("index.ensure !ok surfaces registryStatus and signIn resolves", async () => {
+    const { node } = makeRegistryNode({
+      account: {
+        index: {
+          ensure: mock(async () => ({
+            ok: false,
+            error: { message: "no such table" },
+          })) as any,
+        },
+      },
+    });
+    (node as any).withAccountRegistryRetry = async (task: () => Promise<void>) => {
+      await task();
+    };
+
+    await node.signIn();
+
+    expect(node.registryStatus.synced).toBe(false);
+    expect(node.registryStatus.reason).toContain("no such table");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) a 402/404 on a registry write must not lock the user out of signIn
+// ---------------------------------------------------------------------------
+
+describe("account registry sync — at-cap 402 does not fail signIn", () => {
+  test("a 402 from hosting the account space degrades to status, signIn resolves", async () => {
+    const { node } = makeRegistryNode({
+      hostImpl: async (spaceId) => {
+        // Fail only the account-space host (the registry-write target), the
+        // way an at-cap 402 would.
+        if (spaceId === /* account space */ node.accountSpaceId) {
+          throw new Error("Storage quota exceeded (402)");
+        }
+      },
+    });
+
+    await node.signIn(); // must NOT throw even though the registry host 402s
+
+    expect(node.registryStatus.synced).toBe(false);
+    expect(node.registryStatus.reason).toContain("402");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (e) withAccountRegistryRetry resolves when a later attempt wins
+// ---------------------------------------------------------------------------
+
+describe("withAccountRegistryRetry", () => {
+  test("retries and resolves when the second attempt succeeds", async () => {
+    const node = new TinyCloudNode({
+      wasmBindings: makeFakeWasmBindings(),
+      signer: makeExternalSigner() as any,
+      host: "https://tinycloud.test",
+    });
+
+    let attempts = 0;
+    const task = mock(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("transient");
+    });
+
+    await (node as any).withAccountRegistryRetry(task);
+
+    expect(attempts).toBe(2);
+  });
+
+  test("throws (de-swallowed) when every attempt fails", async () => {
+    const node = new TinyCloudNode({
+      wasmBindings: makeFakeWasmBindings(),
+      signer: makeExternalSigner() as any,
+      host: "https://tinycloud.test",
+    });
+
+    // Collapse the backoff delays so the exhaustion path is fast.
+    const realSetTimeout = globalThis.setTimeout;
+    (globalThis as any).setTimeout = (fn: () => void) => realSetTimeout(fn, 0);
+    try {
+      const task = mock(async () => {
+        throw new Error("permanent");
+      });
+      await expect(
+        (node as any).withAccountRegistryRetry(task),
+      ).rejects.toThrow("permanent");
+      expect(task).toHaveBeenCalledTimes(3);
+    } finally {
+      (globalThis as any).setTimeout = realSetTimeout;
+    }
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -648,7 +648,12 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
 
     await waitFor(() => put.mock.calls.length > 0);
     expect(ensureOwnedSpaceHostedById).toHaveBeenCalledWith(accountSpaceId);
-    expect(put).toHaveBeenCalledTimes(1);
+    // The sync also reconciles owned-space registry records (`spaces/...`
+    // puts); this test only pins the APPLICATIONS registry write.
+    const manifestPuts = put.mock.calls.filter((call: any[]) =>
+      String(call[0]).startsWith("applications/"),
+    );
+    expect(manifestPuts.length).toBe(1);
     expect(put).toHaveBeenCalledWith("applications/com.listen.app", {
       app_id: "com.listen.app",
       manifests: [manifest],

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -616,6 +616,15 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
       },
     });
 
+    // The account-registry sync is now awaited inside signIn (durable G2 fix):
+    // stub the index ensure + accessible-spaces sync (both make real fetches)
+    // so the sync completes in one pass and reaches the manifest-record write,
+    // which is what this test asserts. signIn does not reset _account, so
+    // pre-warming here survives into the sync.
+    const acct = (node as any).account;
+    acct.index.ensure = mock(async () => ({ ok: true, data: { created: false } }));
+    acct.spaces.syncAccessible = mock(async () => ({ ok: true, data: [] }));
+
     await withFetchResponses(
       [
         new Response(

--- a/packages/node-sdk/src/TinyCloudNode.spaceScopedContext.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.spaceScopedContext.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  ServiceContext,
+  type ISessionManager,
+  type IWasmBindings,
+} from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+// Regression coverage for the account-index bootstrap fix: the space-scoped
+// contexts built by `sqlForSpace`, `kvForSpace` (and `createSpaceScopedKVService`)
+// must carry `invokeAny`, otherwise any space-scoped multi-ability SQL/KV op
+// (e.g. the `CREATE TABLE` + `INSERT` migrations batch that
+// `account.index.ensure()` runs against the space-scoped `account` DB) throws
+// "does not support multi-resource invocations" client-side before any network
+// call. See docs/specs/web-sdk-account-index-bootstrap-plan.md.
+
+const ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+const HOST = "https://tinycloud.test";
+const PRIMARY_SPACE_ID = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+const OTHER_SPACE_ID = `tinycloud:pkh:eip155:1:${ADDRESS}:account`;
+
+function makeFakeSessionManager(): ISessionManager {
+  return {
+    createSessionKey: (id: string) => id,
+    renameSessionKeyId: () => {},
+    getDID: (keyId: string) => `did:key:${keyId}`,
+    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+  };
+}
+
+function makeFakeWasmBindings(
+  invoke: IWasmBindings["invoke"],
+): IWasmBindings {
+  return {
+    invoke,
+    invokeAny: mock(() => ({})) as any,
+    prepareSession: mock((cfg: any) => ({
+      siwe: "runtime-siwe",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: "did:key:runtime",
+    })),
+    completeSessionSetup: mock((cfg: any) => ({
+      delegationHeader: { Authorization: "runtime-token" },
+      delegationCid: "runtime-cid",
+      jwk: cfg.jwk,
+      spaceId: cfg.spaceId,
+      verificationMethod: cfg.verificationMethod,
+    })),
+    ensureEip55: (address: string) => address,
+    makeSpaceId: (address: string, chainId: number, name: string) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${name}`,
+    createDelegation: mock(() => ({
+      delegation: "child-runtime-token",
+      cid: "child-runtime-cid",
+      delegateDid: "did:key:default",
+      expiry: 0,
+      resources: [],
+    })),
+    parseRecapFromSiwe: mock(() => []),
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(),
+      privateKey: new Uint8Array(),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array()),
+    vault_sha256: mock(() => new Uint8Array()),
+    createSessionManager: makeFakeSessionManager,
+  };
+}
+
+/**
+ * Construct a TinyCloudNode and simulate a signed-in state by installing a
+ * primary `_serviceContext` with a session — the exact preconditions
+ * `sqlForSpace`/`kvForSpace` guard on. The space-scoped contexts those methods
+ * build clone from this primary context but must additionally wire `invokeAny`
+ * from the node's own `invokeAnyWithRuntimePermissions` class field.
+ */
+function makeSignedInNode(
+  bindings: IWasmBindings,
+): TinyCloudNode {
+  const signer = {
+    getAddress: async () => ADDRESS,
+    getChainId: async () => 1,
+    signMessage: mock(async () => "0xsig"),
+  };
+  const node = new TinyCloudNode({
+    host: HOST,
+    signer: signer as any,
+    wasmBindings: bindings,
+  });
+
+  const primaryContext = new ServiceContext({
+    invoke: bindings.invoke,
+    // The real primary context wires invokeAny; the space-scoped clones must
+    // wire it too (that is what this test asserts). It is intentionally set
+    // here so the clone path never silently reads it back from the parent.
+    invokeAny: (node as any).invokeAnyWithRuntimePermissions,
+    fetch: globalThis.fetch.bind(globalThis),
+    hosts: [HOST],
+  });
+  primaryContext.setSession({
+    delegationHeader: { Authorization: "base-token" },
+    delegationCid: "base-cid",
+    spaceId: PRIMARY_SPACE_ID,
+    verificationMethod: "did:key:default",
+    jwk: { kty: "OKP", crv: "Ed25519", x: "test" },
+  });
+  (node as any)._serviceContext = primaryContext;
+  return node;
+}
+
+describe("TinyCloudNode space-scoped context invokeAny wiring", () => {
+  test("sqlForSpace builds a context that exposes a defined invokeAny", () => {
+    const invoke = mock(() => ({ Authorization: "base-token" })) as any;
+    const bindings = makeFakeWasmBindings(invoke);
+    const node = makeSignedInNode(bindings);
+
+    const sql = node.sqlForSpace(OTHER_SPACE_ID);
+    const context = (sql as any).context;
+
+    expect(context.invokeAny).toBeDefined();
+    expect(typeof context.invokeAny).toBe("function");
+    // The session's spaceId is overridden to the requested space.
+    expect(context.session.spaceId).toBe(OTHER_SPACE_ID);
+  });
+
+  test("kvForSpace builds a context that exposes a defined invokeAny", () => {
+    const invoke = mock(() => ({ Authorization: "base-token" })) as any;
+    const bindings = makeFakeWasmBindings(invoke);
+    const node = makeSignedInNode(bindings);
+
+    const kv = node.kvForSpace(OTHER_SPACE_ID);
+    const context = (kv as any).context;
+
+    expect(context.invokeAny).toBeDefined();
+    expect(typeof context.invokeAny).toBe("function");
+    expect(context.session.spaceId).toBe(OTHER_SPACE_ID);
+  });
+
+  test("sqlForSpace invokeAny routes a multi-ability batch to the WASM binding", () => {
+    // A non-no-op assertion: the wired invokeAny is the node's
+    // invokeAnyWithRuntimePermissions, which (absent any runtime grant) forwards
+    // straight to wasmBindings.invokeAny. A migration-style CREATE TABLE +
+    // INSERT batch resolves to two abilities (sql/schema + sql/write) and must
+    // reach the binding rather than throwing "multi-resource invocations".
+    const invoke = mock(() => ({ Authorization: "base-token" })) as any;
+    const bindings = makeFakeWasmBindings(invoke);
+    const node = makeSignedInNode(bindings);
+
+    const sql = node.sqlForSpace(OTHER_SPACE_ID);
+    const context = (sql as any).context;
+
+    context.invokeAny(
+      context.session,
+      [
+        {
+          spaceId: OTHER_SPACE_ID,
+          service: "sql",
+          path: "account",
+          action: "tinycloud.sql/schema",
+        },
+        {
+          spaceId: OTHER_SPACE_ID,
+          service: "sql",
+          path: "account",
+          action: "tinycloud.sql/write",
+        },
+      ],
+      [{}, {}],
+    );
+
+    expect(bindings.invokeAny as any).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -530,6 +530,22 @@ export class TinyCloudNode {
     return this._bootstrapStatus;
   }
 
+  /**
+   * Outcome of the last signIn()'s account-registry sync. `synced` is false
+   * when the registry records (the `account/spaces/{id}` KV entries the
+   * Overview/Spaces UI reads via the account index) could not be durably
+   * written; `reason` carries the cause. This is non-fatal — signIn() always
+   * succeeds — so apps can surface a "refresh account index" call-to-action.
+   */
+  private _registryStatus: { synced: boolean; reason?: string } = {
+    synced: true,
+  };
+
+  /** Outcome of the last signIn()'s account-registry sync. */
+  get registryStatus(): { synced: boolean; reason?: string } {
+    return this._registryStatus;
+  }
+
   private get nodeFeatures(): string[] {
     return this.auth?.nodeFeatures ?? [];
   }
@@ -929,6 +945,7 @@ export class TinyCloudNode {
     this._spaceService = undefined;
     this._serviceContext = undefined;
     this.runtimePermissionGrants = [];
+    this._registryStatus = { synced: true };
 
     await this.tc.signIn(options);
     this.syncResolvedHostFromAuth();
@@ -949,7 +966,11 @@ export class TinyCloudNode {
     }
 
     if (!bootstrapped) {
-      this.scheduleAccountRegistrySync();
+      // Await the registry sync inside signIn: the account-spaces registry is
+      // what the Overview/Spaces UI reads, and the app has no async refresh
+      // path — records must be durably written before signIn() resolves so the
+      // first render populates. This never throws (see syncAccountRegistry).
+      await this.syncAccountRegistry();
     }
 
     this.notificationHandler.success("Successfully signed in");
@@ -1261,15 +1282,40 @@ export class TinyCloudNode {
     }
   }
 
-  private scheduleAccountRegistrySync(): void {
-    void this.withAccountRegistryRetry(async () => {
-      void this.account.index.ensure();
-      await this.writeManifestRegistryRecords();
-      const spaces = await this.account.spaces.syncAccessible();
-      if (!spaces.ok) {
-        throw new Error(`Failed to sync account spaces: ${spaces.error.message}`);
+  private async syncAccountRegistry(): Promise<void> {
+    this._registryStatus = { synced: true };
+    try {
+      // Proactively host the account space before writing to it. The registry
+      // records (account/spaces/{id}) and the account index both live in the
+      // account space's KV/SQL; if it is not yet hosted, index.ensure() and
+      // syncAccessible() 404. The legacy floating `void index.ensure()` hid
+      // exactly this failure, leaving fresh accounts with an empty Overview.
+      if (this.accountSpaceId) {
+        await this.ensureOwnedSpaceHostedById(this.accountSpaceId);
       }
-    });
+
+      await this.withAccountRegistryRetry(async () => {
+        const ensured = await this.account.index.ensure();
+        if (!ensured.ok) {
+          throw new Error(
+            `Failed to ensure account index: ${ensured.error.message}`,
+          );
+        }
+        await this.writeManifestRegistryRecords();
+        const spaces = await this.account.spaces.syncAccessible();
+        if (!spaces.ok) {
+          throw new Error(`Failed to sync account spaces: ${spaces.error.message}`);
+        }
+      });
+    } catch (error) {
+      // Registry sync is index maintenance, never a precondition of the
+      // session the user just signed (notably an at-cap 402 on the registry
+      // write must not lock the user out): never fail signIn(). Surface a
+      // non-fatal status so apps can offer a "refresh account index" action.
+      const reason = error instanceof Error ? error.message : String(error);
+      this._registryStatus = { synced: false, reason };
+      console.warn(`[TinyCloudNode] account registry sync failed: ${reason}`);
+    }
   }
 
   private async withAccountRegistryRetry(task: () => Promise<void>): Promise<void> {
@@ -1287,10 +1333,11 @@ export class TinyCloudNode {
       }
     }
 
-    console.warn(
-      "TinyCloud account registry sync failed after retries",
-      lastError,
-    );
+    // De-swallowed: propagate the final failure to the caller so it can be
+    // surfaced as a non-fatal registryStatus instead of a silent console.warn.
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`Account registry sync failed after retries: ${String(lastError)}`);
   }
 
   private requestedEncryptionNetworkIds(): string[] {
@@ -1433,7 +1480,16 @@ export class TinyCloudNode {
         permissions: ["*"],
         status: "active",
       })
-      .catch(() => {});
+      .catch((err) => {
+        // Best-effort: the durable registry write happens via the awaited
+        // syncAccountRegistry()/ensureOwnedSpaceHosted() paths. De-swallowed to
+        // a log so a silently-missing registry record is at least traceable.
+        console.warn(
+          `[TinyCloudNode] best-effort registry write for ${spaceId} failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      });
 
     return spaceId;
   }

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -1966,6 +1966,7 @@ export class TinyCloudNode {
     if (this._serviceContext) {
       const spaceScopedContext = new ServiceContext({
         invoke: this._serviceContext.invoke,
+        invokeAny: this.invokeAnyWithRuntimePermissions,
         fetch: this._serviceContext.fetch,
         hosts: this._serviceContext.hosts,
         telemetry: this.config.telemetry,
@@ -2634,6 +2635,7 @@ export class TinyCloudNode {
     const sql = new SQLService({});
     const spaceScopedContext = new ServiceContext({
       invoke: this._serviceContext.invoke,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
       fetch: this._serviceContext.fetch,
       hosts: this._serviceContext.hosts,
       telemetry: this.config.telemetry,
@@ -2665,6 +2667,7 @@ export class TinyCloudNode {
     const kv = new KVService({});
     const spaceScopedContext = new ServiceContext({
       invoke: this._serviceContext.invoke,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
       fetch: this._serviceContext.fetch,
       hosts: this._serviceContext.hosts,
     });

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -124,6 +124,8 @@ import {
   type DecryptTransport,
   type EncryptionCrypto,
   type NetworkDescriptor,
+  type AccountSpace,
+  type SpaceInfo,
 } from "@tinycloud/sdk-core";
 import { NodeUserAuthorization } from "./authorization/NodeUserAuthorization";
 import type { SignStrategy } from "./authorization/strategies";
@@ -544,6 +546,50 @@ export class TinyCloudNode {
   /** Outcome of the last signIn()'s account-registry sync. */
   get registryStatus(): { synced: boolean; reason?: string } {
     return this._registryStatus;
+  }
+
+  /**
+   * Owned-space registry records whose durable write has not been confirmed.
+   * Keyed by space id. Populated by every registration site (space hosting,
+   * create-path callback) and flushed — awaited, with results checked — by
+   * syncAccountRegistry() inside signIn(). This is the durability backstop:
+   * a recap/manifest session does not hold `tinycloud.space/list`, so
+   * `spaces.syncAccessible()` cannot rediscover owned spaces whose immediate
+   * registration attempt failed.
+   */
+  private pendingSpaceRegistrations = new Map<string, SpaceInfo | AccountSpace>();
+
+  private static spaceRegistrationKey(record: SpaceInfo | AccountSpace): string {
+    return "spaceId" in record ? record.spaceId : record.id;
+  }
+
+  /**
+   * Attempt an owned-space registry write without failing the caller. The
+   * record stays pending until a register() call CONFIRMS success — service
+   * methods report failures as `{ok:false}` Results, not exceptions, so a
+   * bare await/.catch() cannot be trusted to notice them.
+   */
+  private async attemptSpaceRegistration(
+    record: SpaceInfo | AccountSpace,
+  ): Promise<void> {
+    const key = TinyCloudNode.spaceRegistrationKey(record);
+    this.pendingSpaceRegistrations.set(key, record);
+    try {
+      const result = await this.account.spaces.register(record);
+      if (result.ok) {
+        this.pendingSpaceRegistrations.delete(key);
+        return;
+      }
+      console.warn(
+        `[TinyCloudNode] registry write for ${key} failed (kept pending): ${result.error.message}`,
+      );
+    } catch (err) {
+      console.warn(
+        `[TinyCloudNode] registry write for ${key} failed (kept pending): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 
   private get nodeFeatures(): string[] {
@@ -1301,6 +1347,23 @@ export class TinyCloudNode {
             `Failed to ensure account index: ${ensured.error.message}`,
           );
         }
+        // Durably write the owned-space registry records that earlier
+        // best-effort attempts could not confirm. This is what actually
+        // populates `account/spaces/{id}` for a fresh account:
+        // writeManifestRegistryRecords() covers the APPLICATIONS registry and
+        // syncAccessible() cannot see owned spaces at all under a
+        // recap/manifest session (no `tinycloud.space/list` capability).
+        for (const [key, record] of Array.from(
+          this.pendingSpaceRegistrations.entries(),
+        )) {
+          const registered = await this.account.spaces.register(record);
+          if (!registered.ok) {
+            throw new Error(
+              `Failed to register owned space ${key}: ${registered.error.message}`,
+            );
+          }
+          this.pendingSpaceRegistrations.delete(key);
+        }
         await this.writeManifestRegistryRecords();
         const spaces = await this.account.spaces.syncAccessible();
         if (!spaces.ok) {
@@ -1471,25 +1534,16 @@ export class TinyCloudNode {
       );
     }
 
-    void this.account.spaces
-      .register({
-        spaceId,
-        name,
-        ownerDid: this.did,
-        type: "owned",
-        permissions: ["*"],
-        status: "active",
-      })
-      .catch((err) => {
-        // Best-effort: the durable registry write happens via the awaited
-        // syncAccountRegistry()/ensureOwnedSpaceHosted() paths. De-swallowed to
-        // a log so a silently-missing registry record is at least traceable.
-        console.warn(
-          `[TinyCloudNode] best-effort registry write for ${spaceId} failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      });
+    // Best-effort immediate write; kept pending until confirmed so the awaited
+    // syncAccountRegistry() flush (inside signIn) durably retries it.
+    void this.attemptSpaceRegistration({
+      spaceId,
+      name,
+      ownerDid: this.did,
+      type: "owned",
+      permissions: ["*"],
+      status: "active",
+    });
 
     return spaceId;
   }
@@ -1540,18 +1594,14 @@ export class TinyCloudNode {
     // record is durably present and a subsequent ensure short-circuits on the
     // registry instead of re-hosting. The host already succeeded, so a failed
     // registry write must not fail this call.
-    try {
-      await this.account.spaces.register({
-        spaceId,
-        name,
-        ownerDid: this.did,
-        type: "owned",
-        permissions: ["*"],
-        status: "active",
-      });
-    } catch {
-      // Registry write is best-effort; the space is hosted regardless.
-    }
+    await this.attemptSpaceRegistration({
+      spaceId,
+      name,
+      ownerDid: this.did,
+      type: "owned",
+      permissions: ["*"],
+      status: "active",
+    });
 
     return hosted;
   }
@@ -2510,7 +2560,7 @@ export class TinyCloudNode {
         }
       },
       onSpaceRegistered: async (space) => {
-        await this.account.spaces.register(space);
+        await this.attemptSpaceRegistration(space);
       },
     });
 

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -2394,6 +2394,65 @@ export class TinyCloudNode {
           };
         }
       },
+      // Enable space.create() via the host-activation ceremony (register the
+      // space owner-side, then activate the current session on it). Uses the
+      // same host the session's delegationHeader was minted against.
+      hostSpace: async (spaceId: string) => {
+        try {
+          const created = await (
+            this.auth as NodeUserAuthorization
+          ).hostPublicSpace(spaceId); // routes to hostSpace(spaceId)
+          if (!created) {
+            return {
+              ok: false as const,
+              error: {
+                code: "SPACE_CREATION_FAILED",
+                message: `Failed to host space: ${spaceId}`,
+                service: "space",
+              },
+            };
+          }
+
+          const host = this.hosts[0] ?? this.config.host;
+          const tcSession = this.auth?.tinyCloudSession;
+          if (!host || !tcSession) {
+            return {
+              ok: false as const,
+              error: {
+                code: "SPACE_CREATION_FAILED",
+                message: "Space hosting requires an active session and host",
+                service: "space",
+              },
+            };
+          }
+
+          const act = await activateSessionWithHost(
+            host,
+            tcSession.delegationHeader,
+          );
+          if (!act.success) {
+            return {
+              ok: false as const,
+              error: {
+                code: "SPACE_CREATION_FAILED",
+                message: `Activation failed: ${act.error ?? act.status}`,
+                service: "space",
+              },
+            };
+          }
+
+          return { ok: true as const, data: undefined };
+        } catch (error) {
+          return {
+            ok: false as const,
+            error: {
+              code: "NETWORK_ERROR",
+              message: error instanceof Error ? error.message : String(error),
+              service: "space",
+            },
+          };
+        }
+      },
       onSpaceRegistered: async (space) => {
         await this.account.spaces.register(space);
       },

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -564,6 +564,39 @@ export class TinyCloudNode {
   }
 
   /**
+   * The owned spaces this session is expected to have registry records for:
+   * the primary and account spaces plus every owned space named by the
+   * composed manifest resources. Used by syncAccountRegistry() to RECONCILE —
+   * an account whose records were dropped by the legacy fire-and-forget
+   * writes never re-creates its spaces on sign-in, so pending-registration
+   * tracking alone can never heal it.
+   */
+  private expectedOwnedSpaces(): Map<string, string> {
+    const expected = new Map<string, string>();
+    const ownerAddress = this._address?.toLowerCase();
+    if (!ownerAddress) return expected;
+
+    const add = (nameOrUri: string | undefined) => {
+      if (!nameOrUri) return;
+      const spaceId = nameOrUri.includes(":")
+        ? nameOrUri
+        : this.ownedSpaceId(nameOrUri);
+      const segments = spaceId.split(":");
+      const name = segments[segments.length - 1];
+      const address = segments[segments.length - 2];
+      if (!name || address?.toLowerCase() !== ownerAddress) return;
+      expected.set(spaceId, name);
+    };
+
+    add(this.spaceId);
+    add(this.accountSpaceId);
+    for (const resource of this.capabilityRequest?.resources ?? []) {
+      add(resource.space);
+    }
+    return expected;
+  }
+
+  /**
    * Attempt an owned-space registry write without failing the caller. The
    * record stays pending until a register() call CONFIRMS success — service
    * methods report failures as `{ok:false}` Results, not exceptions, so a
@@ -1347,15 +1380,34 @@ export class TinyCloudNode {
             `Failed to ensure account index: ${ensured.error.message}`,
           );
         }
-        // Durably write the owned-space registry records that earlier
-        // best-effort attempts could not confirm. This is what actually
-        // populates `account/spaces/{id}` for a fresh account:
+        // Durably write the owned-space registry records. This is what
+        // actually populates `account/spaces/{id}`:
         // writeManifestRegistryRecords() covers the APPLICATIONS registry and
         // syncAccessible() cannot see owned spaces at all under a
         // recap/manifest session (no `tinycloud.space/list` capability).
-        for (const [key, record] of Array.from(
-          this.pendingSpaceRegistrations.entries(),
-        )) {
+        // Two sources:
+        // 1) pending records whose earlier best-effort attempt is unconfirmed;
+        // 2) expected owned spaces (session + manifest resources) whose
+        //    record is missing — RECONCILIATION, healing accounts whose
+        //    records were dropped by the legacy fire-and-forget writes
+        //    (sign-in never re-creates their spaces, so no registration
+        //    site fires for them).
+        const toRegister = new Map<string, SpaceInfo | AccountSpace>(
+          this.pendingSpaceRegistrations,
+        );
+        for (const [spaceId, name] of this.expectedOwnedSpaces()) {
+          if (toRegister.has(spaceId)) continue;
+          if (await this.isOwnedSpaceRegistered(spaceId)) continue;
+          toRegister.set(spaceId, {
+            spaceId,
+            name,
+            ownerDid: this.did,
+            type: "owned",
+            permissions: ["*"],
+            status: "active",
+          });
+        }
+        for (const [key, record] of Array.from(toRegister.entries())) {
           const registered = await this.account.spaces.register(record);
           if (!registered.ok) {
             throw new Error(

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -430,6 +430,8 @@ export {
   // Delegation creation types
   SpaceDelegationParams,
   CreateDelegationFunction,
+  // Space hosting type
+  HostSpaceFunction,
 } from "./spaces";
 
 // Protocol version checking

--- a/packages/sdk-core/src/spaces/SpaceService.hostSpace.test.ts
+++ b/packages/sdk-core/src/spaces/SpaceService.hostSpace.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import type { Result, ServiceError } from "@tinycloud/sdk-services";
+
+import {
+  SpaceService,
+  SpaceErrorCodes,
+  type SpaceServiceConfig,
+  type HostSpaceFunction,
+} from "./SpaceService";
+
+const OWNER_DID = "did:pkh:eip155:1:0x0000000000000000000000000000000000000001";
+const PRIMARY_SPACE_ID =
+  "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default";
+
+const session = {
+  delegationHeader: { Authorization: "Bearer test" },
+  delegationCid: "bafy-test",
+  spaceId: PRIMARY_SPACE_ID,
+  verificationMethod: "did:key:z6MkTest",
+  jwk: {},
+};
+
+function makeConfig(overrides: Partial<SpaceServiceConfig> = {}): SpaceServiceConfig {
+  return {
+    hosts: ["https://node.tinycloud.xyz"],
+    session,
+    userDid: OWNER_DID,
+    // The bare invoke path must never be exercised by create() anymore.
+    invoke: () => {
+      throw new Error("invoke must not be called by create()");
+    },
+    // Any network access from create() is a regression (it used to POST /invoke
+    // with tinycloud.space/create).
+    fetch: (async () => {
+      throw new Error("fetch must not be called by create()");
+    }) as unknown as SpaceServiceConfig["fetch"],
+    ...overrides,
+  };
+}
+
+describe("SpaceService.create host-activation", () => {
+  it("returns NOT_INITIALIZED when no hostSpace function is injected", async () => {
+    const spaces = new SpaceService(makeConfig());
+
+    const result = await spaces.create("default");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(SpaceErrorCodes.NOT_INITIALIZED);
+    }
+  });
+
+  it("runs the injected hostSpace ceremony without hitting the network", async () => {
+    const hostedSpaces: string[] = [];
+    const hostSpace: HostSpaceFunction = async (spaceId) => {
+      hostedSpaces.push(spaceId);
+      return { ok: true, data: undefined } as Result<void, ServiceError>;
+    };
+
+    const spaces = new SpaceService(makeConfig({ hostSpace }));
+
+    const result = await spaces.create("default");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // The returned id is the primary session space id (the ceremony target).
+      expect(result.data.id).toBe(PRIMARY_SPACE_ID);
+      expect(result.data.type).toBe("owned");
+    }
+    // The ceremony was invoked with the full space id, and nothing else.
+    expect(hostedSpaces).toEqual([PRIMARY_SPACE_ID]);
+  });
+});

--- a/packages/sdk-core/src/spaces/SpaceService.ts
+++ b/packages/sdk-core/src/spaces/SpaceService.ts
@@ -763,9 +763,15 @@ export class SpaceService implements ISpaceService {
 
   private notifySpaceRegistered(space: SpaceInfo): void {
     if (!this.onSpaceRegisteredFn) return;
-    void Promise.resolve(this.onSpaceRegisteredFn(space)).catch(() => {
+    void Promise.resolve(this.onSpaceRegisteredFn(space)).catch((error) => {
       // Account-space registration is an index maintenance side effect; it must
-      // not make the canonical space operation fail.
+      // not make the canonical space operation fail. But a silently-swallowed
+      // failure leaves the newly created space missing from the account
+      // registry (empty Overview), so surface it as a log instead of hiding it.
+      console.warn(
+        `[SpaceService] account registry write for ${space.id} failed:`,
+        error instanceof Error ? error.message : String(error)
+      );
     });
   }
 

--- a/packages/sdk-core/src/spaces/SpaceService.ts
+++ b/packages/sdk-core/src/spaces/SpaceService.ts
@@ -39,7 +39,6 @@ import {
 import {
   validateServerDelegationsResponse,
   validateServerOwnedSpacesResponse,
-  validateServerCreateSpaceResponse,
   validateServerSpaceInfoResponse,
   type ServerDelegationsResponse,
 } from "./spaces.schema.js";
@@ -111,6 +110,18 @@ export type CreateDelegationFunction = (
 ) => Promise<Result<Delegation, ServiceError>>;
 
 /**
+ * Function type for hosting (provisioning) a space on the node.
+ *
+ * Performs the full host-activation ceremony for the given space ID:
+ * `peer/generate` → wallet-owner host SIWE → `POST /delegate` (registers the
+ * space owner-side) → session activation. Platform SDKs (web-sdk, node-sdk)
+ * provide this using their WASM bindings and wallet signer.
+ */
+export type HostSpaceFunction = (
+  spaceId: string
+) => Promise<Result<void, ServiceError>>;
+
+/**
  * Configuration for SpaceService.
  */
 export interface SpaceServiceConfig {
@@ -140,6 +151,12 @@ export interface SpaceServiceConfig {
    * Required for space.delegations.create() to work.
    */
   createDelegation?: CreateDelegationFunction;
+  /**
+   * Function to host (provision) a space on the node using the host-activation
+   * ceremony. Platform SDKs (web-sdk, node-sdk) provide this using their WASM
+   * bindings. Required for space.create() to work.
+   */
+  hostSpace?: HostSpaceFunction;
   /** Optional best-effort hook after the SDK discovers or creates a space. */
   onSpaceRegistered?: (space: SpaceInfo) => void | Promise<void>;
 }
@@ -383,6 +400,7 @@ export class SpaceService implements ISpaceService {
   private _userDid?: string;
   private sharingService?: ISharingService;
   private createDelegationFn?: CreateDelegationFunction;
+  private hostSpaceFn?: HostSpaceFunction;
   private onSpaceRegisteredFn?: (space: SpaceInfo) => void | Promise<void>;
 
   /** Cache of created Space objects */
@@ -411,6 +429,7 @@ export class SpaceService implements ISpaceService {
     this._userDid = config.userDid;
     this.sharingService = config.sharingService;
     this.createDelegationFn = config.createDelegation;
+    this.hostSpaceFn = config.hostSpace;
     this.onSpaceRegisteredFn = config.onSpaceRegistered;
   }
 
@@ -429,6 +448,7 @@ export class SpaceService implements ISpaceService {
     if (config.userDid !== undefined) this._userDid = config.userDid;
     if (config.sharingService) this.sharingService = config.sharingService;
     if (config.createDelegation) this.createDelegationFn = config.createDelegation;
+    if (config.hostSpace) this.hostSpaceFn = config.hostSpace;
     if (config.onSpaceRegistered) this.onSpaceRegisteredFn = config.onSpaceRegistered;
 
     // Clear caches when config changes
@@ -681,57 +701,45 @@ export class SpaceService implements ISpaceService {
       );
     }
 
+    // Host-activation ceremony is platform-provided (WASM + wallet signer).
+    // Without it we cannot provision the space; never fall back to a bare
+    // session-key invocation (that writes an epoch event with no backing
+    // space row → server FK error → "404 - Space not found").
+    if (!this.hostSpaceFn) {
+      return err(
+        serviceError(
+          SpaceErrorCodes.NOT_INITIALIZED,
+          "Space creation requires a hostSpace function. " +
+            "This should be provided by the platform SDK (web-sdk or node-sdk).",
+          SERVICE_NAME
+        )
+      );
+    }
+
+    // Compute the full space ID (matches the ceremony's target and, for the
+    // primary space, the active session's spaceId).
+    const spaceId = this.userDid ? buildSpaceUri(this.userDid, name) : this.resolveSpaceId(name);
+
     try {
-      const headers = this.invoke(this.session, "space", name, "tinycloud.space/create");
-
-      const response = await this.fetchFn(`${this.host}/invoke`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ name }),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-
-        if (response.status === 409) {
-          return err(
-            serviceError(
-              SpaceErrorCodes.ALREADY_EXISTS,
-              `Space "${name}" already exists`,
-              SERVICE_NAME
-            )
-          );
-        }
-
+      // Run the host-activation ceremony (registers the space owner-side and
+      // activates the current session on it). Re-running on an existing space
+      // is safe — the owner delegation dedupes server-side.
+      const hosted = await this.hostSpaceFn(spaceId);
+      if (!hosted.ok) {
         return err(
           serviceError(
             SpaceErrorCodes.CREATION_FAILED,
-            `Failed to create space: ${response.status} - ${errorText}`,
+            hosted.error.message,
             SERVICE_NAME,
-            { meta: { status: response.status } }
-          )
-        );
-      }
-
-      const rawData = await response.json();
-
-      // Validate server response
-      const validationResult = validateServerCreateSpaceResponse(rawData);
-      if (!validationResult.ok) {
-        return err(
-          serviceError(
-            SpaceErrorCodes.CREATION_FAILED,
-            validationResult.error.message,
-            SERVICE_NAME,
-            { meta: validationResult.error.meta }
+            { meta: hosted.error.meta }
           )
         );
       }
 
       const spaceInfo: SpaceInfo = {
-        id: validationResult.data.id,
-        name: validationResult.data.name || name,
-        owner: validationResult.data.owner || this.userDid || "",
+        id: spaceId,
+        name,
+        owner: this.userDid ?? "",
         type: "owned",
         permissions: ["*"],
       };

--- a/packages/sdk-core/src/spaces/index.ts
+++ b/packages/sdk-core/src/spaces/index.ts
@@ -31,6 +31,8 @@ export {
   // Delegation creation types
   SpaceDelegationParams,
   CreateDelegationFunction,
+  // Space hosting type
+  HostSpaceFunction,
 } from "./SpaceService";
 
 // Validation schemas and types

--- a/packages/sdk-services/src/sql/SQLService.test.ts
+++ b/packages/sdk-services/src/sql/SQLService.test.ts
@@ -4,6 +4,7 @@ import type {
   FetchResponse,
   IServiceContext,
 } from "../types";
+import { ErrorCodes } from "../types";
 import { SQLService } from "./SQLService";
 import { SQLAction } from "./types";
 
@@ -416,6 +417,27 @@ describe("SQLService permissions", () => {
       expect(result.error.message).toBe("SQL execute failed: upstream request timed out. Please retry.");
       expect(result.error.message).not.toContain("<!DOCTYPE html>");
       expect(result.error.meta?.responseSnippet).toContain("<!DOCTYPE html>");
+    }
+  });
+
+  test("maps 402 quota responses to SQL_QUOTA_EXCEEDED (not NETWORK_ERROR)", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async () => response(false, 402,
+        "Storage quota exceeded. Used: 134060 bytes, Limit: 131072 bytes",
+        "Payment Required",
+      ), invokeCalls),
+    );
+
+    const result = await service.execute("CREATE TABLE IF NOT EXISTS notes (body TEXT)");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Node returns a plain-text 402 for a storage-quota write; apps switch on
+      // code, so it must map to the quota code (parity with KV), not NETWORK_ERROR.
+      expect(result.error.code).toBe(ErrorCodes.SQL_QUOTA_EXCEEDED);
     }
   });
 });

--- a/packages/sdk-services/src/sql/SQLService.ts
+++ b/packages/sdk-services/src/sql/SQLService.ts
@@ -529,6 +529,8 @@ export class SQLService extends BaseService implements ISQLService {
         return ErrorCodes.SQL_DATABASE_NOT_FOUND;
       case 413:
         return ErrorCodes.SQL_RESPONSE_TOO_LARGE;
+      case 402:
+        return ErrorCodes.SQL_QUOTA_EXCEEDED;
       case 429:
         return ErrorCodes.SQL_QUOTA_EXCEEDED;
       default:

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -121,6 +121,9 @@ export interface Config extends ClientConfig {
   /** Whether to auto-create space on sign-in (default: true) */
   autoCreateSpace?: boolean;
 
+  /** Whether to auto-bootstrap the account after sign-in (default: true) */
+  autoBootstrapAccount?: boolean;
+
   /** Space creation handler (default: ModalSpaceCreationHandler) */
   spaceCreationHandler?: ISpaceCreationHandler;
 
@@ -356,6 +359,7 @@ export class TinyCloudWeb {
       domain: this.config.domain ?? (typeof window !== 'undefined' ? window.location.hostname : 'app.tinycloud.xyz'),
       prefix: this.config.spacePrefix,
       autoCreateSpace: this.config.autoCreateSpace ?? true,
+      autoBootstrapAccount: this.config.autoBootstrapAccount,
       sessionExpirationMs: this.config.sessionExpirationMs,
       sessionStorage: this.sessionStorage,
       notificationHandler: this.notificationHandler,


### PR DESCRIPTION
Rebases the two open fix PRs onto 2.5.0/#302 and completes the registry-durability work that unpinning the billing app requires. Seven commits, reviewable independently:

1. **63964af** — #303 rebased: wire `invokeAny` into space-scoped service contexts.
2. **d30df4d** — #304 rebased: run the host-activation ceremony in `spaces.create()`. Conflicts with #302 in `TinyCloudNode.ts` hand-resolved preserving both `isInteractiveSigner`/`bootstrapStatus` semantics and the fix.
3. **ca7d1e0** — forward `autoBootstrapAccount` through the web-sdk `Config` → node-sdk (gap#5; belt-and-braces on 2.5.x since #302 already skips bootstrap for interactive signers — live-verified: 3 signature prompts, no loop).
4. **b7a3495** — awaited account-registry sync inside `signIn()` with non-fatal `registryStatus {synced, reason}`; de-swallows the three silent registry-write sites; hosts the account space before writing. signIn never hard-fails on a registry 402/404.
5. **35b7f2d** — durable flush: every registration site keeps its record pending until a `register()` call confirms `{ok:true}` (service failures are `{ok:false}` Results, invisible to `.catch()`); the sync flushes pending records awaited + result-checked.
6. **726d170** — reconciliation: the sync derives expected owned spaces (primary + account + manifest resources) and registers missing records — heals accounts bricked by the legacy fire-and-forget writes (their spaces already exist, so no registration site ever fires for them).
7. **efc354c** — sdk-services: map SQL 402 → `SQL_QUOTA_EXCEEDED` (was falling to `NETWORK_ERROR`).

**Verification** (local rig: quota-enforcing node #89+#90 + billing sidecar + account app on this build): fresh-passkey first sign-in renders Overview/Spaces populated (the gap#6 scenario); a pre-bricked account self-heals on its next sign-in; KV/SQL writes move the meter byte-exact; at-cap writes 402 with correct codes while reads pass; zero epoch errors/500s. Full evidence: `docs/specs/sdk-25-rig-verification-results.md` in the development repo. Tests: sdk-core 610, node-sdk 140 (10 new), sdk-services 165, webpack build clean. Changesets included (prerelease mode untouched).

**Supersedes #303 and #304** (same fixes, rebased through #302 — those PRs can be closed when this merges).

Known cosmetic nit: `syncAccessible()` re-registers records as `discovered` after reconciliation writes them as `owned` (last-write-wins in the KV record; the UI reads the index and shows `owned`). Follow-up candidate: `register()` should not downgrade an existing `owned` record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)