### PR TITLE
Fix bootstrap root permissions: empty path instead of "/"

### DIFF
--- a/.changeset/tidy-bootstrap-root-paths.md
+++ b/.changeset/tidy-bootstrap-root-paths.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/bootstrap": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+---
+
+Fix bootstrap space manifests granting unusable root capabilities. The default, applications, and public space manifests declared kv/sql permissions with `path: "/"`, which the recap encoder joined into resources like `applications/sql//` (double slash). The node's byte-prefix resource matching can never extend such a resource, so every invocation riding a bootstrap session delegation was rejected with "Unauthorized Action" — this is what broke Listen's first conversations query after OpenKey auto-sign bootstrap. Root permissions now use `path: ""`, which encodes as `applications/sql` and correctly covers all paths under the service.

--- a/packages/bootstrap/src/index.ts
+++ b/packages/bootstrap/src/index.ts
@@ -94,13 +94,16 @@ export const TINYCLOUD_DEFAULT_SPACE_MANIFEST: Manifest = {
     {
       service: "tinycloud.kv",
       space: BOOTSTRAP_DEFAULT_SPACE,
-      path: "/",
+      // Empty path = whole service on this space. Do NOT use "/": the recap
+      // encoder joins it as `<space>/<service>//`, which the node's byte-prefix
+      // resource matching can never extend (real paths start `<service>/x…`).
+      path: "",
       actions: ["get", "put", "del", "list", "metadata"],
     },
     {
       service: "tinycloud.sql",
       space: BOOTSTRAP_DEFAULT_SPACE,
-      path: "/",
+      path: "",
       actions: ["read", "write"],
     },
   ],
@@ -117,13 +120,16 @@ export const TINYCLOUD_APPLICATIONS_SPACE_MANIFEST: Manifest = {
     {
       service: "tinycloud.kv",
       space: DEFAULT_MANIFEST_SPACE,
-      path: "/",
+      // Empty path = whole service on this space. Do NOT use "/": the recap
+      // encoder joins it as `<space>/<service>//`, which the node's byte-prefix
+      // resource matching can never extend (real paths start `<service>/x…`).
+      path: "",
       actions: ["get", "put", "del", "list", "metadata"],
     },
     {
       service: "tinycloud.sql",
       space: DEFAULT_MANIFEST_SPACE,
-      path: "/",
+      path: "",
       actions: ["read", "write"],
     },
   ],
@@ -215,7 +221,7 @@ export const TINYCLOUD_PUBLIC_SPACE_MANIFEST: Manifest = {
     {
       service: "tinycloud.kv",
       space: BOOTSTRAP_PUBLIC_SPACE,
-      path: "/",
+      path: "",
       actions: ["get", "list", "metadata"],
     },
   ],


### PR DESCRIPTION
## Problem

Listen failed to load after OpenKey sign-in with:

```
Unauthorized Action: tinycloud:pkh:eip155:1:0x…:applications/sql/xyz.tinycloud.listen/conversations / tinycloud.sql/read
```

The bootstrap space manifests (`TINYCLOUD_DEFAULT_SPACE_MANIFEST`, `TINYCLOUD_APPLICATIONS_SPACE_MANIFEST`, `TINYCLOUD_PUBLIC_SPACE_MANIFEST`) declare kv/sql root permissions with `path: "/"`. The recap encoder joins these into resources with a **double slash**:

```
tinycloud:pkh:eip155:1:0x…:applications/sql//
```

The node's `ResourceId::extends` is a byte-prefix check — `applications/sql/xyz.app/db` does **not** start with `applications/sql//`, so a bootstrap session delegation can never authorize a real invocation. Since TC-86 (#302 + Listen PR 80) runs account bootstrap silently via OpenKey auto-sign, `registerBootstrapRuntimeGrant` registers grants that claim path-`/` coverage and outrank the valid primary session in `selectInvocationSession` — so the app's first SQL query rides the unusable delegation and 401s.

## Fix

Root permissions now use `path: ""`, which encodes as `applications/sql` and covers all paths under the service via the node's next-byte-is-`/` rule.

**Verified against the production node** with a managed test key:
- recap `applications/sql//` (old) → `401 Unauthorized Action` (byte-identical to the outage error)
- recap `applications/sql` (new) → query authorized (reaches SQLite)

## Rollout note

The OpenKey auto-sign allowlist (`evaluateBootstrapSessionScope`) derives from these same constants. Once OpenKey bumps to this version, old clients' `"/"` bootstrap sign requests are denied → the SDK degrades bootstrap to skipped → apps fall back to their primary session delegation, which works. So deploying OpenKey with this fix immediately unbreaks currently-deployed Listen; redeploying Listen with this version then restores healthy bootstrap.

## Tests
- `packages/bootstrap` tests pass; `node-sdk` signInManifest + bootstrapGate suites pass.
- `tinycloud-web-sdk-example-app#test` failure pre-exists on master (missing `build` script).