### PR TITLE
fix(node-sdk): primary session out-ranks covering runtime grants (TC-111)

### DIFF
--- a/.changeset/tc-111-primary-session-grant.md
+++ b/.changeset/tc-111-primary-session-grant.md
@@ -1,0 +1,20 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-core": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/sdk-services": patch
+---
+
+Fix runtime permission selection so the primary session's own recap always
+out-ranks any other covering runtime grant (TC-111).
+
+Previously `selectInvocationSession`/`invokeAnyWithRuntimePermissions` picked the
+first covering grant in insertion order, so a broad — possibly broken —
+bootstrap or delegated grant could hijack an operation the primary session
+itself already authorized and 401. The primary session is now registered as a
+synthetic highest-trust (`provenance: "primary"`) runtime grant built from the
+raw SIWE recap (full owner-scoped space URIs, so owners can never be conflated),
+and grant selection filters covering grants then prefers the primary. Spaces the
+node skipped activating this sign-in are excluded from the synthetic grant so it
+can never out-rank a working grant. The synthetic primary grant is never exposed
+through `getRuntimePermissionDelegations`/`hasRuntimePermissions`.

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -1222,3 +1222,424 @@ describe("TinyCloudNode runtime permission delegations", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// TC-111: the primary session's own recap must out-rank any other covering
+// runtime grant so a broad/broken bootstrap or delegated grant can never
+// hijack an operation the primary session itself already authorizes.
+// ---------------------------------------------------------------------------
+describe("TinyCloudNode primary-session grant precedence (TC-111)", () => {
+  const ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+
+  // The TinyCloudSession the harness installs on `node.auth`. Full-URI space,
+  // matching what `parseRecapFromSiwe` emits for the primary recap.
+  function primarySession(node: TinyCloudNode) {
+    return (node as any).auth.tinyCloudSession;
+  }
+
+  // Install a broad hijacking grant (path "" covers everything on the space)
+  // that a broken bootstrap/delegated flow might have registered. We push
+  // directly to mirror an already-installed grant without going through the
+  // activation machinery.
+  function installBroadGrant(
+    node: TinyCloudNode,
+    spaceId: string,
+    service: string,
+    action: string,
+    provenance: "bootstrap" | "delegated" | "runtime" = "bootstrap",
+  ): void {
+    (node as any).runtimePermissionGrants.push({
+      session: {
+        delegationHeader: { Authorization: "hijack-token" },
+        delegationCid: "hijack-cid",
+        spaceId,
+        verificationMethod: "did:key:hijack",
+        jwk: { kty: "OKP" },
+      },
+      delegation: {
+        cid: "hijack-cid",
+        delegationHeader: { Authorization: "hijack-token" },
+        delegateDID: "did:key:hijack",
+        delegatorDID: node.did,
+        spaceId,
+        path: "",
+        actions: [action],
+        expiry: new Date(Date.now() + 3600_000),
+        allowSubDelegation: true,
+        ownerAddress: ADDRESS,
+        chainId: 1,
+        host: "https://tinycloud.test",
+      },
+      operations: [{ spaceId, service, path: "", action }],
+      expiresAt: new Date(Date.now() + 3600_000),
+      provenance,
+    });
+  }
+
+  test("primary session wins over a broad covering grant (hijack regression)", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const defaultSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+
+    // Broken bootstrap grant registered FIRST — under insertion-order `.find`
+    // it would have been selected and hijacked the operation.
+    installBroadGrant(node, defaultSpaceId, "kv", "tinycloud.kv/put");
+
+    // The primary session's own recap covers this native op.
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "kv",
+        space: defaultSpaceId,
+        path: "vault/",
+        actions: ["tinycloud.kv/put"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: defaultSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "vault/foo",
+      "tinycloud.kv/put",
+    );
+    // Must mint with the PRIMARY (base) session, not the hijacking grant.
+    expect(invoke.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "base-token",
+    );
+  });
+
+  test("primary session wins over a broad covering grant via invokeAny", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const defaultSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+
+    installBroadGrant(node, defaultSpaceId, "sql", "tinycloud.sql/write");
+
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "sql",
+        space: defaultSpaceId,
+        path: "default",
+        actions: ["tinycloud.sql/write"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: defaultSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeAnyWithRuntimePermissions(
+      fallback,
+      [
+        {
+          spaceId: defaultSpaceId,
+          service: "sql",
+          path: "default",
+          action: "tinycloud.sql/write",
+        },
+      ],
+      [{}],
+    );
+
+    const invokeAny = (node as any).wasmBindings.invokeAny;
+    expect(invokeAny.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "base-token",
+    );
+  });
+
+  test("grant is still selected when the primary recap does not cover the op", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const defaultSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+    const secretsSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:secrets`;
+
+    // Real grant covers the SECRETS space.
+    installBroadGrant(node, secretsSpaceId, "kv", "tinycloud.kv/put", "delegated");
+
+    // Primary recap only covers the DEFAULT space — so the op on `secrets`
+    // is not covered by the synthetic primary and the grant must win.
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "kv",
+        space: defaultSpaceId,
+        path: "vault/",
+        actions: ["tinycloud.kv/put"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: secretsSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "vault/secrets/X",
+      "tinycloud.kv/put",
+    );
+    expect(invoke.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "hijack-token",
+    );
+  });
+
+  test("primary recap for owner B never covers an op on owner A's space", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const aliceSpaceId = "tinycloud:pkh:eip155:1:0xAAAA000000000000000000000000000000000000:default";
+    const bobSpaceId = "tinycloud:pkh:eip155:1:0xBBBB000000000000000000000000000000000000:default";
+
+    // A grant covers Alice's space.
+    installBroadGrant(node, aliceSpaceId, "kv", "tinycloud.kv/put", "delegated");
+
+    // Primary recap claims Bob's identically-named "default" space. Because we
+    // build primary ops from the RAW full URI, the owner is preserved and the
+    // synthetic primary must NOT cover an op on Alice's space.
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "kv",
+        space: bobSpaceId,
+        path: "",
+        actions: ["tinycloud.kv/put"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: aliceSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "vault/x",
+      "tinycloud.kv/put",
+    );
+    // The Alice-space grant wins; the Bob-space primary recap must not.
+    expect(invoke.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "hijack-token",
+    );
+  });
+
+  test("skipped-activation space is excluded from the synthetic primary grant", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const defaultSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+
+    // A bootstrap grant that actually works covers the space.
+    installBroadGrant(node, defaultSpaceId, "kv", "tinycloud.kv/put", "bootstrap");
+
+    // The node REFUSED to activate this space this sign-in, so even though the
+    // recap claims it, the synthetic primary must NOT include it — otherwise
+    // the (non-working) primary would out-rank the working bootstrap grant.
+    (node as any).auth.lastActivationSkippedSpaceIds = [defaultSpaceId];
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "kv",
+        space: defaultSpaceId,
+        path: "",
+        actions: ["tinycloud.kv/put"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    // No primary grant should have been registered (only the bootstrap grant).
+    const grants = (node as any).runtimePermissionGrants;
+    expect(grants.some((g: any) => g.provenance === "primary")).toBe(false);
+
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: defaultSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      fallback,
+      "kv",
+      "vault/x",
+      "tinycloud.kv/put",
+    );
+    // The working bootstrap grant wins.
+    expect(invoke.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "hijack-token",
+    );
+  });
+
+  test("invokeAny: primary wins when it covers all entries, grant when it doesn't", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const defaultSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+    const secretsSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:secrets`;
+
+    // A single delegated grant that covers BOTH spaces (two operations), so a
+    // multi-space batch can be satisfied by one grant.
+    (node as any).runtimePermissionGrants.push({
+      session: {
+        delegationHeader: { Authorization: "hijack-token" },
+        delegationCid: "hijack-cid",
+        spaceId: defaultSpaceId,
+        verificationMethod: "did:key:hijack",
+        jwk: { kty: "OKP" },
+      },
+      delegation: {
+        cid: "hijack-cid",
+        delegationHeader: { Authorization: "hijack-token" },
+        delegateDID: "did:key:hijack",
+        delegatorDID: node.did,
+        spaceId: defaultSpaceId,
+        path: "",
+        actions: ["tinycloud.sql/write"],
+        expiry: new Date(Date.now() + 3600_000),
+        allowSubDelegation: true,
+        ownerAddress: ADDRESS,
+        chainId: 1,
+        host: "https://tinycloud.test",
+      },
+      operations: [
+        { spaceId: defaultSpaceId, service: "sql", path: "", action: "tinycloud.sql/write" },
+        { spaceId: secretsSpaceId, service: "sql", path: "", action: "tinycloud.sql/write" },
+      ],
+      expiresAt: new Date(Date.now() + 3600_000),
+      provenance: "delegated",
+    });
+
+    // Primary recap only covers the DEFAULT space.
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "sql",
+        space: defaultSpaceId,
+        path: "default",
+        actions: ["tinycloud.sql/write"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    const fallback = {
+      delegationHeader: { Authorization: "base-token" },
+      delegationCid: "base-cid",
+      spaceId: defaultSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    // All entries covered by primary -> primary wins.
+    (node as any).invokeAnyWithRuntimePermissions(
+      fallback,
+      [
+        {
+          spaceId: defaultSpaceId,
+          service: "sql",
+          path: "default",
+          action: "tinycloud.sql/write",
+        },
+      ],
+      [{}],
+    );
+    const invokeAny = (node as any).wasmBindings.invokeAny;
+    expect(invokeAny.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "base-token",
+    );
+
+    // One entry only covered by a grant (secrets space) -> grant wins.
+    (node as any).invokeAnyWithRuntimePermissions(
+      fallback,
+      [
+        {
+          spaceId: defaultSpaceId,
+          service: "sql",
+          path: "default",
+          action: "tinycloud.sql/write",
+        },
+        {
+          spaceId: secretsSpaceId,
+          service: "sql",
+          path: "default",
+          action: "tinycloud.sql/write",
+        },
+      ],
+      [{}, {}],
+    );
+    expect(invokeAny.mock.calls[1][0].delegationHeader.Authorization).toBe(
+      "hijack-token",
+    );
+  });
+
+  test("getRuntimePermissionDelegations never returns the synthetic primary grant", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const defaultSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+
+    // One real delegated grant plus the synthetic primary.
+    installBroadGrant(node, defaultSpaceId, "kv", "tinycloud.kv/put", "delegated");
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "kv",
+        space: defaultSpaceId,
+        path: "",
+        actions: ["tinycloud.kv/put"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    // Sanity: the synthetic primary IS registered.
+    expect(
+      (node as any).runtimePermissionGrants.some(
+        (g: any) => g.provenance === "primary",
+      ),
+    ).toBe(true);
+
+    // Unfiltered public listing must exclude it (only the delegated grant).
+    const delegations = node.getRuntimePermissionDelegations();
+    expect(delegations).toHaveLength(1);
+    expect(delegations[0].cid).toBe("hijack-cid");
+
+    // Permission-filtered public listing must also exclude it: even though the
+    // primary recap covers this op, only the delegated grant is returned.
+    const filtered = node.getRuntimePermissionDelegations([
+      {
+        service: "tinycloud.kv",
+        space: "default",
+        path: "vault/x",
+        actions: ["tinycloud.kv/put"],
+      },
+    ]);
+    expect(filtered.every((d) => d.cid !== "base-cid")).toBe(true);
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -334,6 +334,15 @@ interface RuntimePermissionGrant {
   delegation: PortableDelegation;
   operations: RuntimePermissionOperation[];
   expiresAt: Date;
+  /**
+   * Where this grant came from. Drives precedence in
+   * {@link TinyCloudNode.findGrantForOperations} (a `"primary"` grant — the
+   * synthetic representation of the base session's own recap — always
+   * out-ranks other covering grants) and gates the public-surface guardrails
+   * that must never surface the synthetic primary grant. Optional so existing
+   * test constructors and older call sites remain valid.
+   */
+  provenance?: "primary" | "bootstrap" | "delegated" | "runtime";
 }
 
 type CanonicalizableEncryptionJson = CanonicalJson;
@@ -493,6 +502,12 @@ export class TinyCloudNode {
   private _delegationManager?: DelegationManager;
   private _spaceService?: SpaceService;
   private runtimePermissionGrants: RuntimePermissionGrant[] = [];
+  /**
+   * Memoized `recapOperationsFromSession` result, keyed by the exact SIWE it
+   * was parsed from. The primary session is stable for the life of a sign-in,
+   * so this avoids re-parsing the recap on every registration.
+   */
+  private _recapOperationsCache?: { siwe: string; operations: RuntimePermissionOperation[] };
 
   /**
    * TinyCloudSession captured by {@link restoreSession} when there's no
@@ -936,6 +951,18 @@ export class TinyCloudNode {
     // Initialize service context with session
     this.initializeServices();
 
+    // Register the primary session's own recap as the highest-trust
+    // (`provenance: "primary"`) runtime grant so it always wins invocation
+    // selection over broader bootstrap/delegated grants (TC-111). Must run
+    // after the primary session is established and after grants were cleared
+    // above, so no dupes. `lastActivationSkippedSpaceIds` was already
+    // populated by the auth layer's session activation inside `tc.signIn`
+    // above, so the skipped-activation exclusion sees the real skip set here.
+    const primarySession = this.currentTinyCloudSession();
+    if (primarySession) {
+      this.registerPrimarySessionGrant(primarySession);
+    }
+
     const bootstrapped = await this.bootstrapAccountIfNeeded();
 
     await this.ensureRequestedEncryptionNetworks();
@@ -1238,6 +1265,117 @@ export class TinyCloudNode {
       },
       operations,
       expiresAt,
+      provenance: "bootstrap",
+    });
+  }
+
+  /**
+   * Map the base session's OWN recap into runtime permission operations.
+   *
+   * Uses the RAW `parseRecapFromSiwe` binding — NOT `parseRecapCapabilities`,
+   * whose `normalizeSpace` collapses `tinycloud:pkh:...:<owner>:<space>` to a
+   * bare short name and would conflate two owners' identically-named spaces.
+   * We must keep the full owner-scoped URI so a synthetic primary grant can
+   * never cover an operation on a different owner's space.
+   *
+   * Mirrors {@link operationsFromDelegation}'s op shape: encryption network
+   * entries (`urn:tinycloud:encryption:` paths) become `resource` ops; every
+   * other entry becomes a `spaceId` op carrying the raw recap `space` URI.
+   * One op per action.
+   *
+   * Returns `[]` for session-only / restored-without-siwe modes and for any
+   * unparseable SIWE — the primary grant is simply not registered in that case.
+   */
+  private recapOperationsFromSession(
+    session: TinyCloudSession,
+  ): RuntimePermissionOperation[] {
+    const siwe = session.siwe;
+    if (!siwe) {
+      return [];
+    }
+    if (this._recapOperationsCache?.siwe === siwe) {
+      return this._recapOperationsCache.operations;
+    }
+    let operations: RuntimePermissionOperation[] = [];
+    try {
+      const entries = this.wasmBindings.parseRecapFromSiwe(siwe);
+      if (Array.isArray(entries)) {
+        operations = entries.flatMap((entry) => {
+          const service = this.invocationServiceName(entry.service);
+          return entry.actions.map((action) => ({
+            ...(this.isEncryptionNetworkOperation(service, entry.path)
+              ? { resource: entry.path }
+              : { spaceId: entry.space }),
+            service,
+            path: entry.path,
+            action,
+          }));
+        });
+      }
+    } catch {
+      operations = [];
+    }
+    this._recapOperationsCache = { siwe, operations };
+    return operations;
+  }
+
+  /**
+   * Register the base (primary) session's own recap as a synthetic runtime
+   * grant tagged `provenance: "primary"` so it always out-ranks other covering
+   * grants in {@link findGrantForOperations}. This closes the selection-design
+   * hazard where a broad — possibly broken — bootstrap/delegated grant could
+   * hijack an operation the primary session itself already authorized (TC-111).
+   *
+   * Two safety exclusions:
+   *  - Ops whose space is in `lastActivationSkippedSpaceIds` are dropped: the
+   *    node refused to activate those spaces this sign-in even though the recap
+   *    claims them. Including them would let the synthetic primary out-rank a
+   *    working grant and 401 (the "skipped-activation inverted hijack").
+   *  - Encryption `resource` ops are kept as-is (space-independent).
+   *
+   * No-ops when nothing remains after exclusion. Callers (`signIn`,
+   * `restoreSession`) clear `runtimePermissionGrants` first, so no dupes.
+   */
+  private registerPrimarySessionGrant(session: TinyCloudSession): void {
+    const skipped = this.auth
+      ? (this.auth as NodeUserAuthorization).lastActivationSkippedSpaceIds ?? []
+      : [];
+    const operations = this.recapOperationsFromSession(session).filter(
+      (operation) =>
+        operation.spaceId === undefined ||
+        !skipped.some((spaceId) => this.spaceIdsEqual(spaceId, operation.spaceId!)),
+    );
+    if (operations.length === 0) {
+      return;
+    }
+
+    const expiresAt = extractSiweExpiration(session.siwe) ?? this.getSessionExpiry();
+    const actions = [...new Set(operations.map((operation) => operation.action))];
+    this.runtimePermissionGrants.push({
+      session: {
+        delegationHeader: session.delegationHeader,
+        delegationCid: session.delegationCid,
+        spaceId: session.spaceId,
+        verificationMethod: session.verificationMethod,
+        jwk: session.jwk,
+      },
+      delegation: {
+        cid: session.delegationCid,
+        delegationHeader: session.delegationHeader,
+        delegateDID: session.verificationMethod,
+        delegatorDID: this.did,
+        spaceId: session.spaceId,
+        path: "",
+        actions,
+        expiry: expiresAt,
+        allowSubDelegation: true,
+        ownerAddress: session.address,
+        chainId: session.chainId,
+        host: this.config.host,
+      },
+      operations,
+      expiresAt,
+      provenance: "primary",
     });
   }
 
@@ -1709,6 +1847,11 @@ export class TinyCloudNode {
       } else {
         this._restoredTcSession = tcSession;
       }
+
+      // Register the restored primary session's own recap as the highest-trust
+      // runtime grant, mirroring signIn() (TC-111). Grants were cleared above,
+      // so no dupes. Only runs when the restored session carries a `siwe`.
+      this.registerPrimarySessionGrant(tcSession);
     }
   }
 
@@ -2960,7 +3103,12 @@ export class TinyCloudNode {
   ): PortableDelegation[] {
     this.pruneExpiredRuntimePermissionGrants();
     if (permissions === undefined) {
-      return this.runtimePermissionGrants.map((grant) => grant.delegation);
+      // Exclude the synthetic primary grant: it represents the base session's
+      // own recap, not an installed runtime delegation. Per this method's
+      // contract, base-session manifest permissions are not represented here.
+      return this.runtimePermissionGrants
+        .filter((grant) => grant.provenance !== "primary")
+        .map((grant) => grant.delegation);
     }
 
     const session = this.currentTinyCloudSession();
@@ -3134,6 +3282,7 @@ export class TinyCloudNode {
         delegation,
         operations: this.permissionOperations(delegatedEntries, spaceId),
         expiresAt,
+        provenance: "runtime",
       });
       delegations.push(delegation);
     }
@@ -3590,6 +3739,10 @@ export class TinyCloudNode {
     const { subset, missing } = isCapabilitySubset(expandedEntries, granted);
 
     if (!subset) {
+      // This branch only runs when the session recap is NOT a superset of the
+      // requested entries. The synthetic primary grant is built from that same
+      // recap, so it can never cover an entry the recap itself doesn't — it can
+      // never be selected here. No `excludePrimary` guard is needed.
       const runtimeGrant = this.findGrantForOperations(
         this.permissionEntriesToOperations(expandedEntries, session),
       );
@@ -4001,7 +4154,12 @@ export class TinyCloudNode {
     }
 
     for (const operation of operations) {
-      const grant = this.findGrantForOperation(operation);
+      // Public surface: never surface the synthetic primary grant. It exists
+      // only to win runtime invocation selection; the base session's own recap
+      // is not an installed runtime delegation, so excluding it keeps the
+      // `getRuntimePermissionDelegations` contract (base-session manifest
+      // permissions are not represented here) airtight.
+      const grant = this.findGrantForOperation(operation, { excludePrimary: true });
       if (!grant) {
         return [];
       }
@@ -4056,6 +4214,7 @@ export class TinyCloudNode {
       delegation,
       operations,
       expiresAt: delegation.expiry,
+      provenance: "delegated",
     };
   }
 
@@ -4078,6 +4237,7 @@ export class TinyCloudNode {
       delegation,
       operations,
       expiresAt,
+      provenance: "delegated",
     });
   }
 
@@ -4216,24 +4376,38 @@ export class TinyCloudNode {
 
   private findGrantForOperations(
     operations: RuntimePermissionOperation[],
+    options?: { excludePrimary?: boolean },
   ): RuntimePermissionGrant | undefined {
     if (operations.length === 0) {
       return undefined;
     }
     this.pruneExpiredRuntimePermissionGrants();
-    return this.runtimePermissionGrants.find((grant) => {
+    const covering = this.runtimePermissionGrants.filter((grant) => {
+      if (options?.excludePrimary && grant.provenance === "primary") {
+        return false;
+      }
       return operations.every((operation) =>
         grant.operations.some((granted) =>
           this.operationCovers(granted, operation),
         ),
       );
     });
+    if (covering.length === 0) {
+      return undefined;
+    }
+    // Provenance ranking: the synthetic primary grant (the base session's own
+    // recap) always wins when it covers every op, so a broad bootstrap or
+    // delegated grant can never hijack an operation the primary session itself
+    // authorizes (TC-111). Otherwise fall back to insertion order — the same
+    // semantics as the previous `.find`.
+    return covering.find((grant) => grant.provenance === "primary") ?? covering[0];
   }
 
   private findGrantForOperation(
     operation: RuntimePermissionOperation,
+    options?: { excludePrimary?: boolean },
   ): RuntimePermissionGrant | undefined {
-    return this.findGrantForOperations([operation]);
+    return this.findGrantForOperations([operation], options);
   }
 
   private pruneExpiredRuntimePermissionGrants(): void {


### PR DESCRIPTION
Closes TC-111.

## Problem

`selectInvocationSession` (and `invokeAnyWithRuntimePermissions`) picked the **first covering runtime grant in insertion order**, so a broad — possibly broken — bootstrap/delegated grant could hijack an operation the **primary session itself already authorized**, and 401. This is the selection-design mechanism behind the Listen bootstrap outage (a bootstrap grant asserting `path: ""` shadowed the valid primary session). The double-slash path bug was fixed separately; this closes the latent hazard.

## Fix — primary session as a synthetic highest-trust grant

At `signIn()`/`restoreSession()`, the base session's own signed recap is parsed into a runtime grant tagged `provenance: "primary"`, and `findGrantForOperations` changes from insertion-order `.find` to **filter-covering-then-prefer-primary**. One change fixes both invoke paths; the primary always wins any op it authorizes, while genuine grants (bootstrap-hosted spaces, delegated/shared sessions, encryption networks) still win the ops the primary recap does *not* cover.

Three correctness guards:
- **Owner-safe parse** — raw `wasmBindings.parseRecapFromSiwe` preserving full `tinycloud:pkh:…:<owner>:<space>` URIs; deliberately **not** `parseRecapCapabilities`, whose `normalizeSpace` (sdk-core `capabilities.ts:283`) drops the owner and would conflate Alice's `default` with Bob's.
- **Skipped-activation exclusion** — a recap can *claim* a space the node refused to activate (`lastActivationSkippedSpaceIds`); those ops are excluded from the synthetic primary so it can never out-rank a *working* grant (an inverted-hijack that a naive primary-first rule would have shipped).
- **Public-surface guardrails** — the synthetic primary is filtered out of `getRuntimePermissionDelegations()` and the `hasPermissions`/`findRuntimeGrantsForPermissionEntries` paths (`excludePrimary` option), preserving the documented contract that base-session manifest perms aren't represented there.

## Tests

New `primary-session grant precedence (TC-111)` block: hijack regression (asserts `base-token`, not the grant, for both `invoke` and `invokeAny`), primary-doesn't-cover (grant still wins), owner-B safety, skipped-activation exclusion, invokeAny mixed, and public-surface exclusion. Existing grant-wins tests (secrets, raw decrypt, SQL migration batch) stay green.

- `bun run build`: 13/13.
- `runtimePermissions`: 24 pass (17 pre-existing + 7 new). `sharing`+`bootstrapGate`+`signInManifest`: 23 pass. `delegateTo`: 9 pass.

## Blast radius

`packages/node-sdk/src/TinyCloudNode.ts` only (private members + one optional `provenance` field). No sdk-core changes; web-sdk inherits. Changeset: `patch` for the linked group. When no primary grant exists (session-only / restored-without-siwe), selection reproduces today's `.find` semantics exactly.