### PR TITLE
fix(sdk-services): mint dispatchable abilities for execute/export/describe (TC-114)

### DIFF
--- a/.changeset/tc-114-dispatchable-abilities.md
+++ b/.changeset/tc-114-dispatchable-abilities.md
@@ -1,0 +1,26 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-services": patch
+---
+
+Mint the ability the node actually dispatches for SQL/DuckDB
+`execute`/`export`/`describe` (TC-114).
+
+`SQLService.executeStatementOnDb`/`exportDb` and
+`DuckDbService.executeStatementOnDb`/`describeDb` were sending the literal method
+name as the invocation ability (`tinycloud.sql/execute`,
+`tinycloud.sql/export`, `tinycloud.duckdb/execute`, `tinycloud.duckdb/describe`).
+The node has no such capabilities — it routes these requests by request-body
+kind gated by read/write/admin — so under chain containment a narrowly-delegated
+session (read+write, no `sql/*`/`duckdb/*` wildcard) 401s on these calls. They
+worked previously only because real grants carry the service wildcard.
+
+Each method now mints the dispatchable ability grounded in the node's routing:
+`export`/`describe` are authorized as reads (`tinycloud.{sql,duckdb}/read`) and
+named-statement execution as a write (`tinycloud.{sql,duckdb}/write`, which the
+SQL parser accepts for both read-only and mutating statements). Public method
+signatures and the exported `SQLAction`/`DuckDbAction` request-kind constants are
+unchanged. Narrowly-delegated sessions with no service wildcard now get working
+`export`, `executeStatement`, and `describe`.

--- a/packages/sdk-services/src/duckdb/DuckDbService.test.ts
+++ b/packages/sdk-services/src/duckdb/DuckDbService.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  FetchRequestInit,
+  FetchResponse,
+  IServiceContext,
+} from "../types";
+import { DuckDbService } from "./DuckDbService";
+import { DuckDbAction } from "./types";
+
+function response(
+  ok: boolean,
+  status: number,
+  body: unknown,
+  statusText = ok ? "OK" : "Error",
+): FetchResponse {
+  return {
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: () => null,
+    },
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    arrayBuffer: async () =>
+      new TextEncoder().encode(
+        typeof body === "string" ? body : JSON.stringify(body),
+      ).buffer as ArrayBuffer,
+    blob: async () =>
+      new Blob([typeof body === "string" ? body : JSON.stringify(body)]),
+  };
+}
+
+function createContext(
+  fetchImpl: IServiceContext["fetch"],
+  invokeCalls: Array<{ service: string; path: string; action: string }>,
+): IServiceContext {
+  return {
+    session: {
+      delegationHeader: { Authorization: "Bearer test" },
+      delegationCid: "bafybeitest",
+      spaceId: "tinycloud:pkh:eip155:1:0xabc:default",
+      verificationMethod: "did:key:test",
+      jwk: {},
+    },
+    isAuthenticated: true,
+    invoke: (_session, service, path, action) => {
+      invokeCalls.push({ service, path, action });
+      return {
+        Authorization: "Bearer signed-invocation",
+      };
+    },
+    invokeAny: (_session, entries) => {
+      return {
+        Authorization: "Bearer signed-multi-invocation",
+      };
+    },
+    fetch: fetchImpl,
+    hosts: ["https://node.tinycloud.xyz"],
+    getService: () => undefined,
+    emit: () => undefined,
+    on: () => () => undefined,
+    abortSignal: new AbortController().signal,
+    retryPolicy: {
+      maxAttempts: 3,
+      backoff: "exponential",
+      baseDelayMs: 1000,
+      maxDelayMs: 10000,
+      retryableErrors: [],
+    },
+  };
+}
+
+// TC-114: the client must mint the ability the node actually dispatches, not
+// the literal method name. `describe` is authorized as a read and
+// `executeStatement` as a write (see DuckDbService for node file:line
+// grounding), so a narrowly-delegated read+write session works.
+describe("DuckDbService permissions (TC-114)", () => {
+  test("describe signs with read permission", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    let requestInit: FetchRequestInit | undefined;
+
+    const service = new DuckDbService();
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, { tables: [] });
+      }, invokeCalls),
+    );
+
+    const result = await service.describeDb("default");
+
+    expect(result.ok).toBe(true);
+    expect(invokeCalls).toEqual([
+      { service: "duckdb", path: "default", action: DuckDbAction.READ },
+    ]);
+    expect(JSON.parse(requestInit?.body as string)).toEqual({
+      action: "describe",
+    });
+  });
+
+  test("executeStatement signs with write permission", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    let requestInit: FetchRequestInit | undefined;
+
+    const service = new DuckDbService();
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, { columns: [], rows: [], rowCount: 0 });
+      }, invokeCalls),
+    );
+
+    const result = await service.executeStatementOnDb("default", "insert_row", [
+      "hello",
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(invokeCalls).toEqual([
+      { service: "duckdb", path: "default", action: DuckDbAction.WRITE },
+    ]);
+    expect(JSON.parse(requestInit?.body as string)).toEqual({
+      action: "executeStatement",
+      name: "insert_row",
+      params: ["hello"],
+    });
+  });
+});

--- a/packages/sdk-services/src/duckdb/DuckDbService.ts
+++ b/packages/sdk-services/src/duckdb/DuckDbService.ts
@@ -264,9 +264,17 @@ export class DuckDbService extends BaseService implements IDuckDbService {
       }
 
       try {
+        // TC-114: mint the dispatchable ability, not the literal method name.
+        // The node has no `tinycloud.duckdb/execute` capability — it routes an
+        // `executeStatement` request by body kind and classifies write-class
+        // from the RESOLVED named statement's SQL
+        // (tinycloud-node-server/src/routes/mod.rs:1698-1701). Mirroring the SQL
+        // path, `write` is the ability that works for both read-only and
+        // mutating named statements and is contained in a normal read+write
+        // delegation.
         const response = await this.invokeDuckDb(
           dbName,
-          DuckDbAction.EXECUTE,
+          DuckDbAction.WRITE,
           { action: "executeStatement", name, params: params ?? [] },
           options?.signal
         );
@@ -295,9 +303,14 @@ export class DuckDbService extends BaseService implements IDuckDbService {
       }
 
       try {
+        // TC-114: mint the dispatchable ability, not the literal method name.
+        // The node has no `tinycloud.duckdb/describe` capability — it routes a
+        // `describe` request by body kind and authorizes it as a READ
+        // (`DuckDbRequest::Describe` is non-write:
+        // tinycloud-node-server/src/routes/mod.rs:1705, see comment :1680).
         const response = await this.invokeDuckDb(
           dbName,
-          DuckDbAction.DESCRIBE,
+          DuckDbAction.READ,
           { action: "describe" },
           options?.signal
         );

--- a/packages/sdk-services/src/sql/SQLService.test.ts
+++ b/packages/sdk-services/src/sql/SQLService.test.ts
@@ -398,6 +398,60 @@ describe("SQLService permissions", () => {
     expect(bodies.map((body) => body.action)).toEqual(["batch", "query"]);
   });
 
+  // TC-114: the client must mint the ability the node actually dispatches, not
+  // the literal method name. `export` is authorized as a read and
+  // `execute_statement` as a write (see SQLService for node file:line
+  // grounding), so a narrowly-delegated read+write session works.
+  test("export signs with read permission (TC-114)", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    let requestInit: FetchRequestInit | undefined;
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, "sqlite-bytes");
+      }, invokeCalls),
+    );
+
+    const result = await service.exportDb("default");
+
+    expect(result.ok).toBe(true);
+    expect(invokeCalls).toEqual([
+      { service: "sql", path: "default", action: SQLAction.READ },
+    ]);
+    expect(JSON.parse(requestInit?.body as string)).toEqual({
+      action: "export",
+    });
+  });
+
+  test("executeStatement signs with write permission (TC-114)", async () => {
+    const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
+    let requestInit: FetchRequestInit | undefined;
+
+    const service = new SQLService();
+    service.initialize(
+      createContext(async (_url, init) => {
+        requestInit = init;
+        return response(true, 200, { columns: [], rows: [], rowCount: 0 });
+      }, invokeCalls),
+    );
+
+    const result = await service.executeStatementOnDb("default", "insert_note", [
+      "hello",
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(invokeCalls).toEqual([
+      { service: "sql", path: "default", action: SQLAction.WRITE },
+    ]);
+    expect(JSON.parse(requestInit?.body as string)).toEqual({
+      action: "execute_statement",
+      name: "insert_note",
+      params: ["hello"],
+    });
+  });
+
   test("SQL errors sanitize proxy HTML pages", async () => {
     const invokeCalls: Array<{ service: string; path: string; action: string }> = [];
 

--- a/packages/sdk-services/src/sql/SQLService.ts
+++ b/packages/sdk-services/src/sql/SQLService.ts
@@ -260,9 +260,19 @@ export class SQLService extends BaseService implements ISQLService {
       }
 
       try {
+        // TC-114: mint the dispatchable ability, not the literal method name.
+        // The node has no `tinycloud.sql/execute` capability — it routes an
+        // `execute_statement` request by body kind and classifies write-class
+        // from the RESOLVED named statement's SQL
+        // (tinycloud-node-server/src/routes/mod.rs:1168-1171). A named statement
+        // may mutate, and the SQL parser rejects writes under a read/select
+        // ability (tinycloud-core/src/sql/parser.rs:135) while permitting reads
+        // under write (write ⊇ read), so `write` is the ability that works for
+        // both read-only and mutating statements and is contained in a normal
+        // read+write delegation.
         const response = await this.invokeSQL(
           dbName,
-          SQLAction.EXECUTE,
+          SQLAction.WRITE,
           { action: "execute_statement", name, params: params ?? [] },
           options?.signal
         );
@@ -291,9 +301,14 @@ export class SQLService extends BaseService implements ISQLService {
       }
 
       try {
+        // TC-114: mint the dispatchable ability, not the literal method name.
+        // The node has no `tinycloud.sql/export` capability — it routes an
+        // `export` request by body kind and authorizes it as a READ
+        // (`SqlRequest::Export` is non-write:
+        // tinycloud-node-server/src/routes/mod.rs:1172, see comment :1155).
         const response = await this.invokeSQL(
           dbName,
-          SQLAction.EXPORT,
+          SQLAction.READ,
           { action: "export" },
           options?.signal
         );


### PR DESCRIPTION
## Summary

The SQL/DuckDB service clients minted the **literal method name** as the
invocation ability, but the node has **no such capabilities**. It routes these
requests by request-body `action` kind, gated by read/write/admin. Under chain
containment a **narrowly-delegated** session (e.g. `read`+`write`, no service
wildcard) `401`s on `export`/`executeStatement`/`describe` — the minted ability
(`tinycloud.sql/execute`, etc.) is not covered by the delegated chain. These
calls work today only because real grants carry the `sql/*` / `duckdb/*`
wildcard, which happens to contain the bogus ability.

This maps each method to the ability the node actually dispatches, grounded in
node code.

## Per-method mapping (grounded in `tinycloud-node` @ `origin/main`, e9be896)

| SDK method | Request kind | Node gating | Minted ability | Node grounding (`tinycloud-node-server/src/routes/mod.rs`) |
|---|---|---|---|---|
| `SQLService.exportDb` | `SqlRequest::Export` | read (non-write) | `tinycloud.sql/read` | `sql_request_is_write` → `false` at `:1172` (doc comment `:1155` "Export is a read"); export handler `:1243`-`:1252` |
| `SQLService.executeStatementOnDb` | `SqlRequest::ExecuteStatement` | write-class if the resolved named statement mutates | `tinycloud.sql/write` | `sql_request_is_write` `:1168`-`:1171`; parser rejects writes under read/select (`tinycloud-core/src/sql/parser.rs:135`), permits reads under write (write ⊇ read) |
| `DuckDbService.describeDb` | `DuckDbRequest::Describe` | read (non-write) | `tinycloud.duckdb/read` | `duckdb_request_is_write` → `false` at `:1705` (doc comment `:1680` "Describe and Export are reads") |
| `DuckDbService.executeStatementOnDb` | `DuckDbRequest::ExecuteStatement` | write-class if the resolved named statement mutates | `tinycloud.duckdb/write` | `duckdb_request_is_write` `:1698`-`:1701` |

### Why `write` for `executeStatement` (not `read`)

A named statement may be a `SELECT` or a mutation; the SDK only holds the
statement **name** at mint time. The node's SQL parser rejects a write under a
`read`/`select` ability (`parser.rs:135`) but accepts a read under `write`
(write is a superset), so `write` is the single ability that works for both
read-only and mutating named statements — and is contained in a normal
`read`+`write` delegation. This mirrors `executeOnDb`, which already mints
`write` for raw execute. The node re-derives the effective ability via
`preferred_database_ability` (`:2102`-`:2132`, ordered write → schema → admin →
`*` → read → select), so a single-`write` invocation selects `write` cleanly.

## What is NOT changed

- Public method signatures — unchanged.
- Exported `SQLAction` / `DuckDbAction` constants (`EXECUTE`/`EXPORT`/`DESCRIBE`)
  — kept as documented request-kind artifacts; the TC-112 capability registry in
  `@tinycloud/bootstrap` is untouched.

## Test coverage

- `SQLService.test.ts`: new assertions that `exportDb` mints `SQLAction.READ`
  and `executeStatementOnDb` mints `SQLAction.WRITE` (and body kinds unchanged).
- `DuckDbService.test.ts` (new file): `describeDb` mints `DuckDbAction.READ`,
  `executeStatementOnDb` mints `DuckDbAction.WRITE`.
- Suites green: bootstrap (19), sdk-services (168), sdk-core (608),
  node-sdk (130). Full turbo build (13/13) green.

## Impact

Narrowly-delegated sessions (no `sql/*` / `duckdb/*` wildcard) now get working
`export`, `executeStatement`, and `describe`.

Refs TC-114, TC-112
