### PR TITLE
chore: bump tinycloud-node pin to v1.4.5 + re-vendor capability registry (TC-119/TC-121)

### DIFF
--- a/.changeset/tc-119-node-v1.4.5-pin.md
+++ b/.changeset/tc-119-node-v1.4.5-pin.md
@@ -1,0 +1,29 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-services": patch
+---
+
+Bump the tinycloud-node WASM-build pin to the v1.4.5 release tag and re-vendor
+the capability registry artifact (TC-119 / TC-121).
+
+`packages/sdk-rs/Cargo.toml` now pins `tinycloud-sdk-rs`/`tinycloud-sdk-wasm` to
+`tag = "v1.4.5"` (was `v1.4.2`). v1.4.5 is the first release that both contains
+the TC-112 capability registry AND wires it into the live `/invoke`//`/delegate`
+chain-containment paths (TC-119: alias/implication-aware delegation and
+invocation models). Unlike the v1.4.2 pin — where the registry was decoupled and
+the compiled WASM was unaffected — the WASM compiled from this pin genuinely
+changes (the `tinycloud-auth` crate it links in gained the W1 UCAN revocation
+handling shipped across v1.4.3–v1.4.5), so the published `web-sdk-wasm`/
+`node-sdk-wasm` binaries move.
+
+The vendored `@tinycloud/bootstrap` registry
+(`src/generated/capabilities.ts`) is re-vendored byte-identical from
+tinycloud-node@v1.4.5; the registry CONTENT (`REGISTRY_SOURCE_SHA256`,
+`CAPABILITIES`, `ALIASES`, `IMPLICATIONS`) is unchanged — only the new
+TC-121 `REGISTRY_SOURCE_REPO`/`REGISTRY_SOURCE_GIT_SHA` header exports and their
+doc comments are added. The capabilities-sync CI now anchors its fetch-and-diff
+to the explicit release-tag commit (`ANCHOR_NODE_REV`) rather than the header
+sha (which, for a locally-generated artifact, names the generation parent and
+would fetch the wrong artifact).

--- a/.github/workflows/capabilities-sync.yml
+++ b/.github/workflows/capabilities-sync.yml
@@ -6,11 +6,20 @@
 # from and fails on any diff, so the SDK's single source of truth can never
 # silently drift from the enforcer. It fetches-and-diffs; it does NOT regenerate.
 #
-# The rev is read FROM the vendored file itself (`REGISTRY_SOURCE_GIT_SHA`), so
-# this check is anchored to the registry, NOT to the WASM-build pin in
-# packages/sdk-rs/Cargo.toml. A separate warn-only step flags when the two
-# diverge — that is the signal to bump the Cargo pin through the normal release
-# flow once a tinycloud-node release ships the registry.
+# ANCHOR (TC-121): the diff is anchored to ANCHOR_NODE_REV — the EXACT
+# tinycloud-node commit the vendored copy was taken from (the release-tag commit
+# it was re-vendored at). This is the single authoritative source rev, kept in
+# lockstep with the identity test's EXPECTED_NODE_REV and the sdk-rs Cargo pin's
+# release tag.
+#
+# Why NOT the header's REGISTRY_SOURCE_GIT_SHA: the generated file carries a
+# REGISTRY_SOURCE_GIT_SHA export, but when the artifact is generated locally that
+# value is the PARENT of the commit that ends up containing it (a documented
+# chicken-egg — the sha is stamped before the artifact is committed). The value
+# embedded in the currently-vendored file is that generation parent, NOT the
+# commit the file actually lives at, so fetching `generated/capabilities.ts` at
+# the header sha would pull the WRONG (older) artifact. The header sha is
+# therefore a WARN-ONLY cross-check below, never the diff anchor.
 name: capabilities-sync
 
 on:
@@ -34,12 +43,13 @@ env:
   NODE_REPO: tinycloudlabs/tinycloud-node
   VENDORED: packages/bootstrap/src/generated/capabilities.ts
   UPSTREAM_PATH: generated/capabilities.ts
-  # Fallback rev used only until the codegen header carries a
-  # REGISTRY_SOURCE_GIT_SHA export (requested from caps-node-dev, tinycloud-node
-  # codegen). Once present, the "Resolve source rev" step reads it from the
-  # vendored file and this value is ignored.
-  # TODO(tc-112): drop once REGISTRY_SOURCE_GIT_SHA is emitted by codegen.
-  FALLBACK_NODE_REV: e9be8963aef608b2e7cd61df500c84a6104df62a
+  # Authoritative diff anchor: the exact tinycloud-node commit the vendored
+  # registry was taken from. This is the release-tag commit for v1.4.5
+  # (git tag v1.4.5 == a20b48f14ccb56eb849c60529a28b5657765faef). Bump this in
+  # lockstep with a re-vendor + the identity test's EXPECTED_NODE_REV + the
+  # sdk-rs Cargo pin tag. Do NOT derive it from the header's
+  # REGISTRY_SOURCE_GIT_SHA (see the header note above).
+  ANCHOR_NODE_REV: a20b48f14ccb56eb849c60529a28b5657765faef
 
 jobs:
   diff:
@@ -47,25 +57,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve source rev from the vendored file
-        id: rev
+      - name: Fetch upstream generated/capabilities.ts at the anchor rev
         run: |
           set -euo pipefail
-          # Prefer the git source sha embedded in the generated header; fall back
-          # to FALLBACK_NODE_REV until codegen emits it.
-          SHA="$(grep -oE 'REGISTRY_SOURCE_GIT_SHA[^"]*"[0-9a-f]{40}"' "$VENDORED" \
-                   | grep -oE '[0-9a-f]{40}' || true)"
-          if [ -z "$SHA" ]; then
-            echo "REGISTRY_SOURCE_GIT_SHA not found in $VENDORED; using FALLBACK_NODE_REV."
-            SHA="$FALLBACK_NODE_REV"
-          fi
-          echo "Resolved tinycloud-node rev: $SHA"
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-
-      - name: Fetch upstream generated/capabilities.ts at that rev
-        run: |
-          set -euo pipefail
-          URL="https://raw.githubusercontent.com/${NODE_REPO}/${{ steps.rev.outputs.sha }}/${UPSTREAM_PATH}"
+          URL="https://raw.githubusercontent.com/${NODE_REPO}/${ANCHOR_NODE_REV}/${UPSTREAM_PATH}"
           echo "Fetching $URL"
           curl -fsSL "$URL" -o upstream-capabilities.ts
 
@@ -74,24 +69,61 @@ jobs:
           set -euo pipefail
           if ! diff -u upstream-capabilities.ts "$VENDORED"; then
             echo "::error::Vendored capability registry ($VENDORED) is out of sync"
-            echo "::error::with ${NODE_REPO}@${{ steps.rev.outputs.sha }} ($UPSTREAM_PATH)."
+            echo "::error::with ${NODE_REPO}@${ANCHOR_NODE_REV} ($UPSTREAM_PATH)."
             echo "::error::Re-vendor the generated file byte-identical from that rev."
             exit 1
           fi
-          echo "Vendored registry matches ${NODE_REPO}@${{ steps.rev.outputs.sha }}."
+          echo "Vendored registry matches ${NODE_REPO}@${ANCHOR_NODE_REV}."
 
-      - name: Warn if the sdk-rs Cargo pin diverges from the registry rev
+      - name: Cross-check the header REGISTRY_SOURCE_GIT_SHA (warn only)
         run: |
           set -euo pipefail
-          # The Cargo pin governs the WASM build and may lag the registry rev
-          # (e.g. it tracks a release tag). Divergence is expected between a
-          # registry bump and the next tinycloud-node release; warn, do not fail.
-          PIN="$(grep -oE 'tinycloud-sdk-rs = \{[^}]*\}' packages/sdk-rs/Cargo.toml || true)"
-          REGISTRY_REV="${{ steps.rev.outputs.sha }}"
-          if echo "$PIN" | grep -q "$REGISTRY_REV"; then
-            echo "sdk-rs Cargo pin matches the registry rev ($REGISTRY_REV)."
+          # The header sha is the artifact's GENERATION PARENT when generated
+          # locally, not necessarily the commit it lives at, so it is NOT the
+          # diff anchor. Surface it for humans and warn if it happens to equal
+          # the anchor (that only holds for CI-generated artifacts) — never fail.
+          HEADER_SHA="$(grep -oE 'REGISTRY_SOURCE_GIT_SHA[^"]*"[0-9a-f]{40}"' "$VENDORED" \
+                         | grep -oE '[0-9a-f]{40}' || true)"
+          if [ -z "$HEADER_SHA" ]; then
+            echo "::warning::No REGISTRY_SOURCE_GIT_SHA found in $VENDORED (older artifact?)."
+          elif [ "$HEADER_SHA" = "$ANCHOR_NODE_REV" ]; then
+            echo "Header REGISTRY_SOURCE_GIT_SHA equals the anchor rev (CI-generated artifact)."
           else
-            echo "::warning::sdk-rs Cargo pin does not reference the registry rev ${REGISTRY_REV}."
+            echo "::warning::Header REGISTRY_SOURCE_GIT_SHA ($HEADER_SHA) != anchor rev ${ANCHOR_NODE_REV}."
+            echo "::warning::Expected for a locally-generated artifact: the header sha is the"
+            echo "::warning::generation PARENT, not the commit the artifact lives at. The diff is"
+            echo "::warning::anchored to ANCHOR_NODE_REV, so this is informational only."
+          fi
+
+      - name: Warn if the sdk-rs Cargo pin diverges from the anchor rev
+        run: |
+          set -euo pipefail
+          # The Cargo pin governs the WASM build. With the registry now shipped
+          # on a release tag, the pin and the anchor should point at the SAME
+          # tinycloud-node commit. The pin references a release TAG (e.g.
+          # v1.4.5) while the anchor is that tag's COMMIT sha, so resolve the tag
+          # via ls-remote (dereferencing annotated tags) before comparing.
+          # Warn-only: divergence is a signal to re-align the pin, never a hard
+          # failure (a re-vendor may briefly precede the release-tag bump).
+          PIN="$(grep -oE 'tinycloud-sdk-rs = \{[^}]*\}' packages/sdk-rs/Cargo.toml || true)"
+          PIN_TAG="$(echo "$PIN" | grep -oE 'tag = "[^"]*"' | sed -E 's/.*"([^"]*)".*/\1/' || true)"
+          PIN_REV="$(echo "$PIN" | grep -oE 'rev = "[0-9a-f]{7,40}"' | grep -oE '[0-9a-f]{7,40}' || true)"
+          RESOLVED=""
+          if [ -n "$PIN_TAG" ]; then
+            # Prefer the dereferenced tag (^{}) so annotated tags resolve to the
+            # underlying commit, matching what Cargo checks out.
+            RESOLVED="$(git ls-remote "https://github.com/${NODE_REPO}.git" "refs/tags/${PIN_TAG}^{}" 2>/dev/null | awk '{print $1}' || true)"
+            if [ -z "$RESOLVED" ]; then
+              RESOLVED="$(git ls-remote "https://github.com/${NODE_REPO}.git" "refs/tags/${PIN_TAG}" 2>/dev/null | awk '{print $1}' || true)"
+            fi
+          elif [ -n "$PIN_REV" ]; then
+            RESOLVED="$PIN_REV"
+          fi
+          PIN_DESC="${PIN_TAG:-${PIN_REV:-unknown}}"
+          if [ -n "$RESOLVED" ] && [ "$RESOLVED" = "$ANCHOR_NODE_REV" ]; then
+            echo "sdk-rs Cargo pin (${PIN_DESC}) resolves to the anchor rev (${ANCHOR_NODE_REV})."
+          else
+            echo "::warning::sdk-rs Cargo pin (${PIN_DESC}) resolves to '${RESOLVED:-unresolved}', not the anchor rev ${ANCHOR_NODE_REV}."
             echo "::warning::Pin: ${PIN}"
-            echo "::warning::Expected once tinycloud-node ships a release containing the registry — bump the pin through the normal release flow."
+            echo "::warning::Re-align the pin's release tag with the re-vendor anchor through the normal release flow."
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "cacaos"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.5#a20b48f14ccb56eb849c60529a28b5657765faef"
 dependencies = [
  "async-trait",
  "hex",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.5#a20b48f14ccb56eb849c60529a28b5657765faef"
 dependencies = [
  "hex",
  "http 1.4.0",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "siwe-recap"
 version = "1.0.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.5#a20b48f14ccb56eb849c60529a28b5657765faef"
 dependencies = [
  "base64 0.22.1",
  "ipld-core",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-auth"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.5#a20b48f14ccb56eb849c60529a28b5657765faef"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4928,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-rs"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.5#a20b48f14ccb56eb849c60529a28b5657765faef"
 dependencies = [
  "async-trait",
  "hex",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "tinycloud-sdk-wasm"
 version = "1.3.0"
-source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.2#e2f95778b7265406bf69a4d56d5805c1e846ddd0"
+source = "git+https://github.com/tinycloudlabs/tinycloud-node.git?tag=v1.4.5#a20b48f14ccb56eb849c60529a28b5657765faef"
 dependencies = [
  "aes-gcm",
  "chrono",

--- a/packages/bootstrap/src/generated/capabilities.identity.test.ts
+++ b/packages/bootstrap/src/generated/capabilities.identity.test.ts
@@ -3,18 +3,26 @@ import { join } from "node:path";
 
 import { expect, test } from "bun:test";
 
-import { REGISTRY_SOURCE_SHA256, REGISTRY_VERSION } from "./capabilities";
+import {
+  REGISTRY_SOURCE_GIT_SHA,
+  REGISTRY_SOURCE_REPO,
+  REGISTRY_SOURCE_SHA256,
+  REGISTRY_VERSION,
+} from "./capabilities";
 
 // Pins the identity of the vendored tinycloud-node registry (TC-112). If the
 // generated file is re-vendored from a different node rev, these constants
 // change and this test fails — forcing a deliberate update here AND in the
-// capabilities-sync workflow's FALLBACK_NODE_REV, so the two can't silently
-// diverge. Once codegen emits REGISTRY_SOURCE_GIT_SHA, the workflow reads the
-// rev straight from the header and the FALLBACK_NODE_REV coupling below can go.
+// capabilities-sync workflow's ANCHOR_NODE_REV, so the two can't silently
+// diverge. ANCHOR_NODE_REV is the authoritative diff anchor (the commit the
+// artifact was vendored at); the header's REGISTRY_SOURCE_GIT_SHA is NOT used as
+// the anchor because, for a locally-generated artifact, it names the generation
+// parent rather than the commit the file lives at (see the workflow comments).
 const EXPECTED_VERSION = 1;
 const EXPECTED_SOURCE_SHA256 =
   "3850f17a9771600b4a0f7bfa38ccaed8464f3ee391342f5d5b627276e614a8ff";
-const EXPECTED_NODE_REV = "e9be8963aef608b2e7cd61df500c84a6104df62a";
+// tinycloud-node release tag v1.4.5.
+const EXPECTED_NODE_REV = "a20b48f14ccb56eb849c60529a28b5657765faef";
 
 const WORKFLOW = join(
   import.meta.dir,
@@ -26,9 +34,17 @@ test("vendored registry identity is pinned", () => {
   expect(REGISTRY_SOURCE_SHA256).toBe(EXPECTED_SOURCE_SHA256);
 });
 
-test("capabilities-sync FALLBACK_NODE_REV matches the pinned node rev", () => {
+test("vendored registry carries TC-121 source headers", () => {
+  expect(REGISTRY_SOURCE_REPO).toBe("TinyCloudLabs/tinycloud-node");
+  // The git sha is the artifact's generation source; its exact value is not
+  // pinned here (locally-generated artifacts stamp the generation parent), only
+  // that a well-formed 40-hex commit sha is present.
+  expect(REGISTRY_SOURCE_GIT_SHA).toMatch(/^[0-9a-f]{40}$/);
+});
+
+test("capabilities-sync ANCHOR_NODE_REV matches the pinned node rev", () => {
   const yaml = readFileSync(WORKFLOW, "utf8");
-  const match = yaml.match(/FALLBACK_NODE_REV:\s*([0-9a-f]{40})/);
+  const match = yaml.match(/ANCHOR_NODE_REV:\s*([0-9a-f]{40})/);
   expect(match).not.toBeNull();
   expect(match![1]).toBe(EXPECTED_NODE_REV);
 });

--- a/packages/bootstrap/src/generated/capabilities.ts
+++ b/packages/bootstrap/src/generated/capabilities.ts
@@ -7,6 +7,15 @@
 export const REGISTRY_VERSION = 1 as const;
 export const REGISTRY_SOURCE_SHA256 = "3850f17a9771600b4a0f7bfa38ccaed8464f3ee391342f5d5b627276e614a8ff" as const;
 
+/** GitHub repository the registry lives in (TC-121; js-sdk sync anchor). */
+export const REGISTRY_SOURCE_REPO = "TinyCloudLabs/tinycloud-node" as const;
+/**
+ * Git commit the artifact was generated from. Authoritative when generated
+ * in CI (GITHUB_SHA); approximate when generated locally, where it names
+ * the parent of the commit that will contain this artifact.
+ */
+export const REGISTRY_SOURCE_GIT_SHA = "e9be8963aef608b2e7cd61df500c84a6104df62a" as const;
+
 export type CapabilityStatus = "active" | "deprecated-alias" | "reserved";
 
 export interface CapabilityEntry {

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -22,19 +22,24 @@ console_error_panic_hook = "0.1"
 hex = "0.4.3"
 iri-string = "0.7.12"
 js-sys = "0.3.59"
-# Includes TinyCloudLabs/tinycloud-node#71 via the v1.4.2 release.
+# WASM-build pin. Tracks tinycloud-node RELEASE TAGS (never unreleased revs).
 #
-# TC-112: this WASM-build pin intentionally stays on the v1.4.2 RELEASE TAG and
-# is deliberately decoupled from the capability-registry rev. The registry sync
-# is anchored elsewhere (the vendored packages/bootstrap/src/generated/
-# capabilities.ts + capabilities-sync CI fetch-and-diff + FALLBACK_NODE_REV +
-# the identity test), so the build pin need not move to an unreleased rev.
-# MERGE GATE: do NOT merge this branch until tinycloud-node#98 is merged. Swap
-# this pin to a release tag as a follow-up once the node cuts a release that
-# contains the registry (that release-flow bump + re-vendor is tracked in the
-# TC-112 PR body; TC-121 covers the codegen source-sha upgrade).
-tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", tag = "v1.4.2" }
-tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", tag = "v1.4.2" }
+# v1.4.5 is the first release tag that both CONTAINS the TC-112 capability
+# registry AND wires it into the live /invoke//delegate chain-containment paths
+# (TC-119: alias/implication-aware models/delegation.rs + models/invocation.rs).
+# So unlike the v1.4.2 pin — where the registry was decoupled and the compiled
+# WASM was unaffected — bumping to v1.4.5 can genuinely change the compiled WASM,
+# and that is intended. tinycloud-node#98 (the registry) is merged and released.
+#
+# The capability registry sync stays anchored to the vendored
+# packages/bootstrap/src/generated/capabilities.ts + the capabilities-sync CI
+# fetch-and-diff (anchored to the release-tag rev) + the identity test. The pin
+# and that anchor now point at the SAME release, but the anchor — not this pin —
+# remains the authoritative registry source. Bump this pin only to newer node
+# release tags, in lockstep with the re-vendor + anchor update (TC-121 covers the
+# codegen source-sha headers those steps rely on).
+tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", tag = "v1.4.5" }
+tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", tag = "v1.4.5" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.150"
 serde-wasm-bindgen = "0.6.5"


### PR DESCRIPTION
## What's in tinycloud-node v1.4.5 (tag commit `a20b48f`)

- **TC-112** capability registry + policy-contract aliasing (already vendored at v1.4.2 time).
- **TC-119**: the registry is now wired into the LIVE `/invoke`//`/delegate` chain-containment paths — `models/delegation.rs` + `models/invocation.rs` are alias/implication-aware.
- **TC-121**: generated artifacts carry `REGISTRY_SOURCE_GIT_SHA` + `REGISTRY_SOURCE_REPO`.
- **TC-120**: w5 harness fix (no SDK impact).

## Changes

1. **Pin bump** (`packages/sdk-rs/Cargo.toml` + `Cargo.lock`): `tinycloud-sdk-rs` / `tinycloud-sdk-wasm` `tag = "v1.4.2"` → `"v1.4.5"`. The old TC-112-era merge-gate comment ("do NOT merge until tinycloud-node#98") is replaced — #98 is merged and released — with a note that the pin now tracks a registry-carrying release tag while the vendored artifact + CI anchor remain the authoritative registry source.
2. **Re-vendor** `packages/bootstrap/src/generated/capabilities.ts` **byte-identical** from node@`a20b48f`. The registry CONTENT is unchanged — `REGISTRY_SOURCE_SHA256` stays `3850f17a…`, and `CAPABILITIES` / `ALIASES` / `IMPLICATIONS` are identical. The only delta is the two new TC-121 header exports (`REGISTRY_SOURCE_REPO`, `REGISTRY_SOURCE_GIT_SHA`) + their doc comments (+9 lines).
3. **Sync workflow rework** (`.github/workflows/capabilities-sync.yml`): the fetch-and-diff is now anchored to an explicit release-tag commit `ANCHOR_NODE_REV = a20b48f…` (renamed from `FALLBACK_NODE_REV`), which is authoritative. The header's `REGISTRY_SOURCE_GIT_SHA` is demoted to a **warn-only** cross-check.
   - **Parent-sha caveat**: the artifact committed on node `main` embeds `e9be896` (its *generation parent* — a documented chicken-egg), NOT the commit that contains it. Fetching the upstream artifact at the header sha would pull the wrong (older) file, so the header sha must never be the diff anchor.
   - The warn-only Cargo-pin divergence step now resolves the pin's release tag via `git ls-remote refs/tags/v1.4.5^{}` and compares to the anchor — reporting **no divergence** (tag `v1.4.5` == anchor `a20b48f`).
4. **Identity test**: `EXPECTED_NODE_REV` → `a20b48f…`; `REGISTRY_VERSION` / `REGISTRY_SOURCE_SHA256` assertions hold unchanged; extended to assert `REGISTRY_SOURCE_REPO == "TinyCloudLabs/tinycloud-node"` and that `REGISTRY_SOURCE_GIT_SHA` is 40-hex (its exact value is intentionally NOT pinned — it's the generation parent).
5. **Changeset**: `patch` for the linked group (`sdk-core` / `web-sdk` / `node-sdk` / `sdk-services`).

## Did the WASM actually change? Yes.

Unlike the v1.4.2 pin, the compiled WASM genuinely moves. Verified by building the release web target at **both** pins and comparing byte-for-byte:

| pin | `tinycloud_web_sdk_rs_bg.wasm` sha256 | size |
|-----|----------------------------------------|------|
| v1.4.2 (`e2f95778`) | `7c446d6fc2561ccda128bdf6c1d27125a40a6401c22cfbab1af95d07294cffda` | 1,283,295 |
| v1.4.5 (`a20b48f`)  | `76763cdf296a632109f1a3531e44fc55ca1f42d433f52f61f1ef250e7f4a729f` | 1,283,279 |

The driver reachable from the WASM compilation is `tinycloud-auth/src/authorization.rs` (the `TinyCloudRevocation` enum gained a boxed `Ucan` variant + W1 revocation handling across v1.4.3–v1.4.5); `tinycloud-auth` is a direct dependency of the WASM crates. The TC-119 alias/implication containment itself lives in `tinycloud-core` (server-side), outside the WASM dependency tree — so the WASM change is real but comes via `tinycloud-auth`, not the core containment code.

## Test results

- `cargo check` (workspace root) ✅
- Full `turbo build` ✅ (13/13; both WASM targets)
- `@tinycloud/bootstrap` 20 pass ✅ (incl. updated identity test)
- `@tinycloud/sdk-core` 608 pass ✅
- `@tinycloud/sdk-services` 168 pass ✅
- `@tinycloud/node-sdk` 130 pass ✅
- capabilities-sync workflow logic validated locally against the real raw URL at `a20b48f`: fetch OK, byte-diff matches, header cross-check warns (`e9be896` ≠ anchor, as designed), Cargo-pin tag resolves to the anchor (no divergence).

## Links

- TC-112 (registry SSOT) · TC-119 (live alias/implication enforcement) · TC-121 (source-sha headers)