### PR TITLE
fix(bootstrap): add .js extensions to ESM relative imports

### DIFF
--- a/.changeset/fix-bootstrap-esm-extensions.md
+++ b/.changeset/fix-bootstrap-esm-extensions.md
@@ -1,0 +1,19 @@
+---
+"@tinycloud/bootstrap": patch
+---
+
+Fix Node-ESM `ERR_MODULE_NOT_FOUND` in `@tinycloud/bootstrap` 2.5.0.
+
+The TC-112 capability-SSOT refactor split a vendored `capabilities` module out
+of the previously-inlined build, but the tsup config uses `bundle: false`, so
+the extensionless source imports (`from "./capabilities"`,
+`from "./generated/capabilities"`) survived verbatim into `dist/index.js` and
+`dist/capabilities.js`. Node's ESM resolver requires explicit file extensions,
+so every Node-ESM consumer (e.g. Listen's vitest suites) got
+`ERR_MODULE_NOT_FOUND` on import; the CJS entry hit the same error via
+require-of-ESM. Bundlers (vite) and Bun tolerate the missing extension, which is
+why builds passed. 2.4.1 was fully inlined and unaffected.
+
+Fix: make the source relative imports extensionful (`./capabilities.js`,
+`./generated/capabilities.js`), which TypeScript's `bundler` module resolution
+accepts and which produces resolvable ESM and CJS output.

--- a/packages/bootstrap/src/capabilities.ts
+++ b/packages/bootstrap/src/capabilities.ts
@@ -28,7 +28,7 @@ import {
   CAPABILITIES as GENERATED_CAPABILITIES,
   type CapabilityEntry,
   type CapabilityStatus,
-} from "./generated/capabilities";
+} from "./generated/capabilities.js";
 
 export type { CapabilityStatus };
 

--- a/packages/bootstrap/src/index.ts
+++ b/packages/bootstrap/src/index.ts
@@ -1,7 +1,7 @@
 import { getAddress, isAddress } from "viem";
-import { KV, SQL, CAPABILITIES, SPACE, ENCRYPTION } from "./capabilities";
+import { KV, SQL, CAPABILITIES, SPACE, ENCRYPTION } from "./capabilities.js";
 
-export * from "./capabilities";
+export * from "./capabilities.js";
 
 export type ManifestDefaults = boolean | "admin" | "all";
 


### PR DESCRIPTION
Fixes Node-ESM `ERR_MODULE_NOT_FOUND` in `@tinycloud/bootstrap@2.5.0`.

The TC-112 capability-SSOT refactor split a vendored `capabilities` module out of the previously-inlined build, but `packages/bootstrap` builds with tsup `bundle: false`, so the extensionless source imports survived verbatim into `dist/index.js`. Node's ESM resolver requires explicit extensions → every Node-ESM consumer breaks on import (found by Listen's vitest suites during the TC-110/111 beta validation: 6 suites failed under 2.5.0; 2.4.1 was fully inlined and unaffected). Bundlers/Bun tolerate it, which is why CI stayed green.

Fix: extensionful source imports (`./capabilities.js`, `./generated/capabilities.js`) — smallest change preserving the multi-entry `bundle:false` layout; fixes ESM, CJS, and d.ts output together.

Verified: Node import smoke on `dist/index.js` and `dist/index.cjs` (fails before → 36 exports after); bootstrap suite 20 pass; repo build 13/13. sdk-core scanned (same vendored registry) — bundles inline, clean; repo-wide dist grep found no other extensionless runtime relative imports.

Note (pre-existing, unchanged): the CJS entry uses require-of-ESM for its sibling, which needs Node 20.19+/22.12+ — same as 2.5.0's shipping posture; making CJS fully self-contained would need `bundle:true` and is deliberately out of scope.

Changeset: `patch` @tinycloud/bootstrap.