### PR TITLE
fix(node-sdk): primary-grant selection returns the caller's scoped session (TC-111 follow-up)

### DIFF
--- a/.changeset/tc-111-fallback-session-fix.md
+++ b/.changeset/tc-111-fallback-session-fix.md
@@ -1,0 +1,26 @@
+---
+"@tinycloud/node-sdk": patch
+"@tinycloud/sdk-core": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/sdk-services": patch
+---
+
+TC-111 follow-up: primary-grant selection now returns the caller's scoped
+session so multi-space recaps mint resources against the correct target space.
+
+TC-111 registers the primary session's own recap as a synthetic
+`provenance: "primary"` runtime grant that wins invocation selection when it
+covers the requested op. The two invocation call sites then used
+`grant.session` — the stored primary `ServiceSession`, whose `spaceId` is the
+PRIMARY space. For scoped ops on OTHER spaces that a multi-space recap also
+covers (e.g. an account-registry write whose fallback session targets the
+`account` space), the invocation was minted against the primary space
+(`applications/kv/...` instead of `account/kv/...`) and the node rejected it
+(observed as 404/40x in prod).
+
+`selectInvocationSession` and `invokeAnyWithRuntimePermissions` now invoke with
+the caller's passed/fallback session — which shares the primary delegation but
+carries the correct target `spaceId` — whenever the winning grant is the
+primary one. Non-primary grants keep using `grant.session`. Ranking semantics in
+`findGrantForOperations` are unchanged. This fixes wrong-space invocations for
+account/secrets ops that were minted against the primary space.

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -1676,6 +1676,13 @@ describe("TinyCloudNode primary-session grant precedence (TC-111)", () => {
       },
     ]);
     (node as any).registerPrimarySessionGrant(primarySession(node));
+    // A broad non-primary grant also covers the op. This makes the three
+    // outcomes distinguishable: "scoped-token" = correct (primary won, caller
+    // session used), "base-token" = call-site regression (primary session
+    // returned), "hijack-token" = ranking regression (primary registration or
+    // coverage silently broken, grant won). Without it, a primary-registration
+    // failure would fall through to the fallback and pass vacuously.
+    installBroadGrant(node, accountSpaceId, "kv", "tinycloud.kv/put", "delegated");
 
     // The caller passes a SCOPED fallback session for the account space: same
     // primary delegation, but the correct target `spaceId` and a distinct token.
@@ -1726,6 +1733,9 @@ describe("TinyCloudNode primary-session grant precedence (TC-111)", () => {
       },
     ]);
     (node as any).registerPrimarySessionGrant(primarySession(node));
+    // Broad non-primary grant covering the op — see the single-invoke test
+    // above for why this keeps the test non-vacuous.
+    installBroadGrant(node, accountSpaceId, "kv", "tinycloud.kv/put", "delegated");
 
     const scopedFallback = {
       delegationHeader: { Authorization: "scoped-token" },

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -1642,4 +1642,116 @@ describe("TinyCloudNode primary-session grant precedence (TC-111)", () => {
     ]);
     expect(filtered.every((d) => d.cid !== "base-cid")).toBe(true);
   });
+
+  // TC-111 follow-up (prod regression): a multi-space primary recap covers ops
+  // on OTHER spaces than the primary session's own `spaceId`. When the primary
+  // grant wins for such an op, the invocation must be minted with the caller's
+  // SCOPED fallback session (correct target `spaceId`), NOT the stored primary
+  // `ServiceSession` (whose `spaceId` is the primary space). Before the fix, the
+  // account-registry write for a scoped `account`-space op was minted against
+  // the primary `applications` space and the node rejected it (404/40x).
+  test("primary wins but mints with the scoped fallback session (wrong-space regression)", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    // Space A: the primary session's own space (as installed by the harness).
+    const applicationsSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+    // Space B: a DIFFERENT space the multi-space recap also covers.
+    const accountSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:account`;
+
+    // Primary recap covers BOTH the primary space AND the account space.
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "kv",
+        space: applicationsSpaceId,
+        path: "",
+        actions: ["tinycloud.kv/put"],
+      },
+      {
+        service: "kv",
+        space: accountSpaceId,
+        path: "applications/",
+        actions: ["tinycloud.kv/put"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    // The caller passes a SCOPED fallback session for the account space: same
+    // primary delegation, but the correct target `spaceId` and a distinct token.
+    const scopedFallback = {
+      delegationHeader: { Authorization: "scoped-token" },
+      delegationCid: "scoped-cid",
+      spaceId: accountSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeWithRuntimePermissions(
+      scopedFallback,
+      "kv",
+      "applications/xyz.tinycloud.listen",
+      "tinycloud.kv/put",
+    );
+
+    // Must mint with the SCOPED fallback (account space), not the primary
+    // session whose spaceId is the applications space.
+    expect(invoke.mock.calls[0][0].spaceId).toBe(accountSpaceId);
+    expect(invoke.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "scoped-token",
+    );
+  });
+
+  // invokeAny analog of the wrong-space regression above.
+  test("invokeAny: primary wins but mints with the scoped fallback session", () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const applicationsSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:default`;
+    const accountSpaceId = `tinycloud:pkh:eip155:1:${ADDRESS}:account`;
+
+    (node as any).wasmBindings.parseRecapFromSiwe = mock(() => [
+      {
+        service: "kv",
+        space: applicationsSpaceId,
+        path: "",
+        actions: ["tinycloud.kv/put"],
+      },
+      {
+        service: "kv",
+        space: accountSpaceId,
+        path: "applications/",
+        actions: ["tinycloud.kv/put"],
+      },
+    ]);
+    (node as any).registerPrimarySessionGrant(primarySession(node));
+
+    const scopedFallback = {
+      delegationHeader: { Authorization: "scoped-token" },
+      delegationCid: "scoped-cid",
+      spaceId: accountSpaceId,
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP" },
+    };
+
+    (node as any).invokeAnyWithRuntimePermissions(
+      scopedFallback,
+      [
+        {
+          spaceId: accountSpaceId,
+          service: "kv",
+          path: "applications/xyz.tinycloud.listen",
+          action: "tinycloud.kv/put",
+        },
+      ],
+      [{}],
+    );
+
+    const invokeAny = (node as any).wasmBindings.invokeAny;
+    expect(invokeAny.mock.calls[0][0].spaceId).toBe(accountSpaceId);
+    expect(invokeAny.mock.calls[0][0].delegationHeader.Authorization).toBe(
+      "scoped-token",
+    );
+  });
 });

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -3788,10 +3788,16 @@ export class TinyCloudNode {
     if (!subset) {
       // This branch only runs when the session recap is NOT a superset of the
       // requested entries. The synthetic primary grant is built from that same
-      // recap, so it can never cover an entry the recap itself doesn't — it can
-      // never be selected here. No `excludePrimary` guard is needed.
+      // recap, so it should never cover an entry the recap itself doesn't —
+      // but `operationCovers` is strictly more permissive than
+      // `isCapabilitySubset` (action `/*` and path `/*`/`/**` wildcards), so a
+      // wildcard-bearing recap could slip through and mint a delegation with
+      // the primary session's spaceId (the wrong-space class). Exclude the
+      // primary explicitly; failure then degrades to
+      // PermissionNotInManifestError instead of a wrong-space delegation.
       const runtimeGrant = this.findGrantForOperations(
         this.permissionEntriesToOperations(expandedEntries, session),
+        { excludePrimary: true },
       );
       if (runtimeGrant) {
         const marginMs = TinyCloudNode.SESSION_EXPIRY_SAFETY_MARGIN_MS;

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -613,7 +613,12 @@ export class TinyCloudNode {
         return operation ? [operation] : [];
       }),
     );
-    return this.wasmBindings.invokeAny(grant?.session ?? session, entries, facts);
+    // When the primary grant wins, invoke with the PASSED session (its scoped
+    // target `spaceId`), not the stored primary `ServiceSession` — see
+    // `selectInvocationSession` for the wrong-space rationale (TC-111 follow-up).
+    const invocationSession =
+      !grant || grant.provenance === "primary" ? session : grant.session;
+    return this.wasmBindings.invokeAny(invocationSession, entries, facts);
   };
 
   /**
@@ -4413,7 +4418,17 @@ export class TinyCloudNode {
       path,
       action,
     });
-    return grant?.session ?? fallback;
+    if (!grant) {
+      return fallback;
+    }
+    // "Primary wins" means the caller's own session already authorizes the op:
+    // use the PASSED session, not the stored primary `ServiceSession`. The stored
+    // primary carries the primary space's `spaceId`, but a multi-space recap can
+    // cover scoped ops on OTHER spaces whose fallback session carries the correct
+    // target `spaceId`. Returning `grant.session` there would mint the invocation
+    // against the wrong space (TC-111 follow-up). Non-primary grants keep their
+    // own session.
+    return grant.provenance === "primary" ? fallback : grant.session;
   }
 
   private findGrantForOperations(


### PR DESCRIPTION
Fixes the production regression that forced the Listen 2.6.1 rollback.

## Regression

When TC-111's synthetic primary grant won selection, both invocation call sites used `grant.session` — the stored primary `ServiceSession`. The WASM `invoke()` builds the att resource from `session.spaceId`, so scoped ops on OTHER spaces covered by a multi-space recap were minted against the wrong space (observed in prod via decoded invoke JWTs: the account-registry write became `applications/kv/applications/xyz.tinycloud.listen` instead of `account/kv/…`). Broke account-registry writes, secrets vault reads, and schema seeding under the 2.6.1 Listen frontend; primary-space ops were unaffected.

## Fix

Primary-wins now returns the **caller's fallback/passed session** (same delegation for scoped sessions, correct target `spaceId`) in `selectInvocationSession` and `invokeAnyWithRuntimePermissions`. Ranking, synthetic-grant registration, skipped-activation exclusion, and public-surface filtering unchanged. Strictly safe: pre-TC-111 behavior for these ops was "no grant matched → fallback", so returning the fallback is never worse.

Review hardening (independent adversarial pass, verdict SHIP): `delegateTo`'s grant lookup now passes `excludePrimary` (closes a latent wildcard path to the same wrong-space class via `createDelegationViaRuntimeGrant`), and the two new regression tests carry a broad non-primary grant so correct / call-site-revert / ranking-broken outcomes are three-way distinguishable.

## Verification

- Wrong-space test proven to fail on unfixed code (att spaceId `…:default` vs expected `…:account`), passes after.
- invokeAny analog; per-entry resource construction verified in sdk-rs (session contributes only the proof there).
- Full node-sdk suite green (runtimePermissions, sharing, bootstrapGate, signInManifest, accountRegistrySync, delegateTo); build 13/13.

Changeset: patch across the linked group.