### PR TITLE
fix(node-sdk): keep active session key across sign-ins

### DIFF
--- a/.changeset/fuzzy-feeds-share-session-key.md
+++ b/.changeset/fuzzy-feeds-share-session-key.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/node-sdk": patch
+---
+
+Keep TinyCloudNode session-key accessors synchronized with the active key and make repeated sign-in rotate that key safely, so delegation flows do not reference the removed default key.

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -58,12 +58,12 @@ function makeFakeSessionManager(): ISessionManager {
       return id;
     },
     renameSessionKeyId(oldId: string, newId: string): void {
-      if (keys.has(oldId)) {
-        keys.delete(oldId);
-        keys.add(newId);
-      }
+      if (!keys.has(oldId)) throw new Error(`Key ${oldId} does not exist.`);
+      keys.delete(oldId);
+      keys.add(newId);
     },
     getDID(keyId: string): string {
+      if (!keys.has(keyId)) throw new Error(`Key ${keyId} does not exist.`);
       return `did:key:z6MkTest-${keyId}`;
     },
     jwk(keyId: string): string | undefined {
@@ -190,6 +190,71 @@ function stubAuthNetworkCalls(node: TinyCloudNode): void {
 // ---------------------------------------------------------------------------
 
 describe("TinyCloudNode.signIn — manifest-driven recap", () => {
+  test("sessionDid follows the active key across repeated signIn calls", async () => {
+    const node = makeNodeWithSigner(makeFakeWasmBindings(), {
+      autoBootstrapAccount: false,
+      includeAccountRegistryPermissions: false,
+      manifest: {
+        app_id: "xyz.tinycloud.feed.host",
+        name: "Feed Host",
+        defaults: false,
+        permissions: [],
+      },
+    });
+
+    await withFetchResponses(
+      [
+        new Response(
+          JSON.stringify({
+            protocol: 1,
+            version: "test",
+            features: [],
+            nodeId: "did:key:z6MkNode",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        new Response(JSON.stringify({ activated: ["space://test"], skipped: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ],
+      async () => {
+        await node.signIn();
+      },
+    );
+
+    const firstKeyId = node.session?.sessionKey;
+    expect(firstKeyId).toStartWith("session-");
+    expect(node.sessionDid).toBe(`did:key:z6MkTest-${firstKeyId}`);
+
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await withFetchResponses(
+      [
+        new Response(
+          JSON.stringify({
+            protocol: 1,
+            version: "test",
+            features: [],
+            nodeId: "did:key:z6MkNode",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        new Response(JSON.stringify({ activated: ["space://test"], skipped: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ],
+      async () => {
+        await node.signIn();
+      },
+    );
+
+    const secondKeyId = node.session?.sessionKey;
+    expect(secondKeyId).toStartWith("session-");
+    expect(secondKeyId).not.toBe(firstKeyId);
+    expect(node.sessionDid).toBe(`did:key:z6MkTest-${secondKeyId}`);
+  });
+
   test("no manifest → uses defaultActions (legacy fallback)", async () => {
     const prepareSessionSpy = mock((cfg: any) => ({
       siwe: "fake-siwe",

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -751,6 +751,7 @@ export class TinyCloudNode {
       signer: this.signer!,
       signStrategy: config.signStrategy ?? { type: "auto-sign" },
       wasmBindings: this.wasmBindings,
+      sessionManager: this.sessionManager,
       sessionStorage: config.sessionStorage ?? new MemorySessionStorage(),
       domain: this.siweDomain,
       spacePrefix: config.prefix,
@@ -981,6 +982,15 @@ export class TinyCloudNode {
 
     await this.tc.signIn(options);
     this.syncResolvedHostFromAuth();
+
+    // NodeUserAuthorization renames the constructor's "default" key when it
+    // creates the signed-in session. Keep node-level key accessors in sync so
+    // sessionDid and delegation flows use the active key instead of the old ID.
+    const signedInSession = this.currentTinyCloudSession();
+    if (signedInSession) {
+      this.sessionKeyId = signedInSession.sessionKey;
+      this.sessionKeyJwk = signedInSession.jwk;
+    }
 
     // Initialize service context with session
     this.initializeServices();
@@ -2034,6 +2044,7 @@ export class TinyCloudNode {
       signer: this.signer,
       signStrategy: this.config.signStrategy ?? { type: "auto-sign" },
       wasmBindings: this.wasmBindings,
+      sessionManager: this.sessionManager,
       sessionStorage: options?.sessionStorage ?? this.config.sessionStorage ?? new MemorySessionStorage(),
       domain: this.siweDomain,
       spacePrefix: prefix,
@@ -2095,6 +2106,7 @@ export class TinyCloudNode {
       signer: this.signer,
       signStrategy: this.config.signStrategy ?? { type: "auto-sign" },
       wasmBindings: this.wasmBindings,
+      sessionManager: this.sessionManager,
       sessionStorage: options?.sessionStorage ?? this.config.sessionStorage ?? new MemorySessionStorage(),
       domain: this.siweDomain,
       spacePrefix: prefix,

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -110,6 +110,8 @@ export interface NodeUserAuthorizationConfig {
   enablePublicSpace?: boolean;
   /** WASM bindings for cryptographic operations. Required. */
   wasmBindings: IWasmBindings;
+  /** Existing session manager to share with a higher-level SDK client. */
+  sessionManager?: ISessionManager;
   /**
    * SIWE nonce override. If omitted, the WASM layer generates a random nonce.
    * If `siweConfig.nonce` is also provided, `siweConfig.nonce` wins.
@@ -209,6 +211,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
   private readonly includeAccountRegistryPermissions: boolean;
 
   private sessionManager: ISessionManager;
+  private activeSessionKeyId = "default";
   private extensions: Extension[] = [];
   private _session?: ClientSession;
   private _tinyCloudSession?: TinyCloudSession;
@@ -266,8 +269,9 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this._manifest = config.manifest;
     this._capabilityRequest = config.capabilityRequest;
 
-    // Initialize session manager via WASM bindings
-    this.sessionManager = this.wasm.createSessionManager();
+    // Reuse the caller's manager when authorization is owned by a higher-level
+    // client so both layers address the same session keys.
+    this.sessionManager = config.sessionManager ?? this.wasm.createSessionManager();
   }
 
   /**
@@ -914,7 +918,8 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
     // Create a session key
     const keyId = `session-${Date.now()}`;
-    this.sessionManager.renameSessionKeyId("default", keyId);
+    this.sessionManager.renameSessionKeyId(this.activeSessionKeyId, keyId);
+    this.activeSessionKeyId = keyId;
 
     // Get JWK for session key
     const jwkString = this.sessionManager.jwk(keyId);
@@ -1128,7 +1133,8 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
     // Create a session key
     const keyId = `session-${Date.now()}`;
-    this.sessionManager.renameSessionKeyId("default", keyId);
+    this.sessionManager.renameSessionKeyId(this.activeSessionKeyId, keyId);
+    this.activeSessionKeyId = keyId;
 
     // Get JWK for session key
     const jwkString = this.sessionManager.jwk(keyId);


### PR DESCRIPTION
## Summary
- share one session manager between `TinyCloudNode` and its authorization layer
- keep node-level session key accessors synchronized after sign-in
- rotate from the currently active key on repeated sign-in instead of trying to rename the removed `default` key

## Why
Feed Host signs in at startup and its persistent delegation store verifies sign-in again before writing. The second call previously failed with `Key default does not exist.`, which surfaced in Feed as a generic setup failure.

## Verification
- `bun test packages/node-sdk/src` (141 passed)
- `bun run --cwd packages/node-sdk build`
- Feed OpenKey flow with injected Ethereum wallet and stable-key Feed Host (passed end to end; automatic delegation, persistence, and first artifact)