### PR TITLE
fix(cli): classify missing signer keys as auth errors

### DIFF
--- a/.changeset/cli-private-jwk-auth-error.md
+++ b/.changeset/cli-private-jwk-auth-error.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/cli": patch
+---
+
+Reject unrecoverable public-only profile sessions before SDK restore and report missing private JWK material as an authentication problem with a sign-in hint instead of a network failure.

--- a/packages/cli/src/lib/sdk.test.ts
+++ b/packages/cli/src/lib/sdk.test.ts
@@ -194,4 +194,18 @@ describe("ensureAuthenticated restoreSession uses full keypair from key.json", (
     expect(restoreCalls).toHaveLength(1);
     expect(restoreCalls[0]!.jwk).toBe(FULL_KEY_JWK);
   });
+
+  test("an unrecoverable public-only session is rejected as auth state before restore", async () => {
+    profile = { authMethod: "openkey", did: "did:key:zSession" };
+    session = { ...sessionShell, jwk: PUBLIC_ONLY_SESSION_JWK };
+    key = { kty: "OKP", crv: "Ed25519", x: "key-public" };
+
+    const error = await ensureAuthenticated(ctx).catch((cause) => cause as CLIError);
+    expect(error.code).toBe("AUTH_REQUIRED");
+    expect(error.exitCode).toBe(3);
+    expect(error.metadata?.hint).toBe(
+      "Sign in again with: tc --profile tc-sdk-test-headless auth login --method openkey",
+    );
+    expect(restoreCalls).toHaveLength(0);
+  });
 });

--- a/packages/cli/src/lib/sdk.ts
+++ b/packages/cli/src/lib/sdk.ts
@@ -35,6 +35,26 @@ export function selectSignerJwk(
   return key ?? undefined;
 }
 
+function signerJwkForProfile(
+  profileName: string,
+  sessionJwk: unknown,
+  key: object | null,
+): object {
+  const jwk = selectSignerJwk(sessionJwk, key);
+  if (jwkHasPrivateParameter(jwk)) {
+    return jwk;
+  }
+
+  throw new CLIError(
+    "AUTH_REQUIRED",
+    `Profile "${profileName}" cannot restore its session because its private key material is missing.`,
+    ExitCode.AUTH_REQUIRED,
+    {
+      hint: `Sign in again with: tc --profile ${profileName} auth login --method openkey`,
+    },
+  );
+}
+
 /**
  * Create a TinyCloudNode instance from the current CLI context.
  * Uses the profile's persisted session and key.
@@ -79,7 +99,7 @@ export async function createSDKInstance(
         delegationHeader: session.delegationHeader as { Authorization: string },
         delegationCid: session.delegationCid as string,
         spaceId: session.spaceId as string,
-        jwk: selectSignerJwk(session.jwk, key),
+        jwk: signerJwkForProfile(ctx.profile, session.jwk, key),
         verificationMethod: (session.verificationMethod as string) ?? profile?.sessionDid ?? profile?.did,
         address: session.address as string | undefined,
         chainId: session.chainId as number | undefined,
@@ -108,7 +128,7 @@ export async function createSDKInstance(
       delegationHeader: session.delegationHeader as { Authorization: string },
       delegationCid: session.delegationCid as string,
       spaceId: session.spaceId as string,
-      jwk: selectSignerJwk(session.jwk, key),
+      jwk: signerJwkForProfile(ctx.profile, session.jwk, key),
       verificationMethod: (session.verificationMethod as string) ?? profile?.did,
       address: session.address as string | undefined,
       chainId: session.chainId as number | undefined,

--- a/packages/cli/src/output/errors.test.ts
+++ b/packages/cli/src/output/errors.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { CLIError, setActiveProfileName, wrapError } from "./errors.js";
+
+afterEach(() => {
+  delete process.env.TC_PROFILE;
+});
+
+describe("wrapError", () => {
+  test("classifies missing private JWK material as auth state, not network", () => {
+    setActiveProfileName("feed-migration-owner");
+
+    const error = wrapError(
+      new CLIError(
+        "NETWORK_ERROR",
+        "Missing private key parameter in JWK",
+        6,
+      ),
+    );
+
+    expect(error.code).toBe("AUTH_REQUIRED");
+    expect(error.exitCode).toBe(3);
+    expect(error.metadata?.hint).toBe(
+      "Sign in again with: tc --profile feed-migration-owner auth login --method openkey",
+    );
+    expect(error.message).not.toContain("NETWORK");
+  });
+});

--- a/packages/cli/src/output/errors.ts
+++ b/packages/cli/src/output/errors.ts
@@ -23,9 +23,25 @@ export class CLIError extends Error {
 }
 
 export function wrapError(error: unknown): CLIError {
-  if (error instanceof CLIError) return error;
-
   const message = error instanceof Error ? error.message : String(error);
+
+  // A signer cannot make a request without private key material. Some SDK
+  // service paths historically wrapped that local restore/signing failure as
+  // NETWORK_ERROR, which led the CLI to suggest switching hosts. Classify the
+  // underlying auth-state problem before preserving an existing CLIError.
+  if (message.includes("Missing private key parameter in JWK")) {
+    const profileName = activeProfileName ?? process.env.TC_PROFILE ?? DEFAULT_PROFILE;
+    return new CLIError(
+      "AUTH_REQUIRED",
+      `Profile "${profileName}" cannot restore its session because its private key material is missing.`,
+      ExitCode.AUTH_REQUIRED,
+      {
+        hint: `Sign in again with: tc --profile ${profileName} auth login --method openkey`,
+      },
+    );
+  }
+
+  if (error instanceof CLIError) return error;
 
   // Map known error patterns to exit codes
   if (message.includes("Not signed in") || message.includes("AUTH_EXPIRED") || message.includes("Session expired")) {


### PR DESCRIPTION
## Summary

- reject persisted sessions before SDK restore when neither `session.json.jwk` nor `key.json` contains private signing material
- classify the legacy `Missing private key parameter in JWK` failure as `AUTH_REQUIRED`, even when an SDK service wrapped it as `NETWORK_ERROR`
- show a profile-specific OpenKey sign-in recovery command instead of the unrelated host-switch hint

The normal public-only OpenKey session case is already rehydrated from the private profile key by #295. This follow-up makes an unrecoverable/corrupt profile state explicit and actionable.

## Verification

- `bun test packages/cli/src/lib/sdk.test.ts packages/cli/src/output/errors.test.ts` — 16 passed
- `bun run --cwd packages/cli build` — passed
- `bun test packages/cli` — unrelated pre-existing cross-file Bun mock pollution prevents the aggregate invocation; focused changed-area tests pass independently
