### PR TITLE
fix(node-sdk): normalize session DID for delegation

### DIFF
--- a/.changeset/calm-keys-delegate.md
+++ b/.changeset/calm-keys-delegate.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/node-sdk": patch
+---
+
+Normalize session verification-method DID URLs to principal DIDs at the WASM delegation boundary so session-key delegations accept persisted `did:key:...#key-id` identities.

--- a/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
@@ -146,6 +146,7 @@ function installFakeSession(
     spaceId?: string;
     address?: string;
     chainId?: number;
+    verificationMethod?: string;
   },
 ): void {
   const fakeSession = {
@@ -155,7 +156,7 @@ function installFakeSession(
     spaceId: opts.spaceId ?? "space://test",
     delegationCid: "bafyparent",
     delegationHeader: { Authorization: "Bearer parent" },
-    verificationMethod: "did:key:z6MkTestSession",
+    verificationMethod: opts.verificationMethod ?? "did:key:z6MkTestSession",
     jwk: { kty: "OKP", crv: "Ed25519", x: "test" },
     siwe: opts.siwe,
     signature: "0xfake",
@@ -263,7 +264,10 @@ describe("TinyCloudNode.delegateTo", () => {
     });
 
     const node = new TinyCloudNode({ wasmBindings: wasm });
-    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+    installFakeSession(node, {
+      siwe: buildSiwe(futureExpiry),
+      verificationMethod: "did:key:z6MkTestSession#z6MkTestSession",
+    });
 
     const result = await node.delegateTo(BOB_DID, [
       {
@@ -278,6 +282,9 @@ describe("TinyCloudNode.delegateTo", () => {
     expect(result.delegation.delegateDID).toBe(BOB_DID);
     // WASM path was used.
     expect(createDelegationSpy).toHaveBeenCalledTimes(1);
+    expect((createDelegationSpy as any).mock.calls[0][0].verificationMethod).toBe(
+      "did:key:z6MkTestSession",
+    );
     // Wallet path was NOT used.
     expect(prepareSessionSpy).not.toHaveBeenCalled();
   });

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -2661,7 +2661,10 @@ export class TinyCloudNode {
       delegationCid: params.session.delegationCid,
       jwk: params.session.jwk,
       spaceId: params.session.spaceId,
-      verificationMethod: params.session.verificationMethod,
+      // Session storage carries the verification method as a DID URL
+      // (`did:key:...#key-id`). The Rust UCAN builder expects the principal
+      // DID here and rejects the fragment as an invalid audience DID.
+      verificationMethod: params.session.verificationMethod.split("#", 1)[0],
     };
 
     const result = this.wasmBindings.createDelegation(


### PR DESCRIPTION
## Summary
- normalize persisted session verification-method DID URLs at the WASM delegation boundary
- keep the stored DID URL intact elsewhere
- cover fragment-bearing session keys in the wallet-prompt-free delegateTo path

## Verification
- bun run --cwd packages/node-sdk test (141 passed)
- bunx turbo build --filter=@tinycloud/node-sdk...