### PR TITLE
feat(node-sdk): restore delegated sessions safely

### DIFF
--- a/.changeset/tc-193-restore-session-key.md
+++ b/.changeset/tc-193-restore-session-key.md
@@ -1,9 +1,10 @@
 ---
 "@tinycloud/sdk-core": patch
+"@tinycloud/sdk-services": minor
 "@tinycloud/node-sdk": patch
 "@tinycloud/web-sdk": patch
 "@tinycloud/node-sdk-wasm": patch
 "@tinycloud/web-sdk-wasm": patch
 ---
 
-Restore persisted sessions with their original private Ed25519 signer. Verify the signed SIWE, ReCap, Cacao header/CID, address, chain, session DID, and expiry before installing authority; atomically replace the auth/core/service host context while retaining every live secondary signer. Browser restore now preserves spaces and policy expiry, and rejected restores leave persisted storage untouched.
+Restore persisted sessions with their original private Ed25519 signer. Verify the signed SIWE, ReCap, Cacao header/CID, address, chain, session DID, and expiry before installing authority; atomically replace the auth/core/service host context while retaining every live secondary signer. Retired service graphs abort outstanding work and cannot reuse old encryption authority. Browser restore now preserves spaces and policy expiry, and rejected restores leave persisted storage untouched.

--- a/.changeset/tc-193-restore-session-key.md
+++ b/.changeset/tc-193-restore-session-key.md
@@ -6,4 +6,4 @@
 "@tinycloud/web-sdk-wasm": patch
 ---
 
-Restore persisted sessions with their original private Ed25519 signer, validating that the JWK and verification method identify the same principal before runtime delegation activation.
+Restore persisted sessions with their original private Ed25519 signer. Verify the signed SIWE, ReCap, Cacao header/CID, address, chain, session DID, and expiry before installing authority; atomically replace the auth/core/service host context while retaining every live secondary signer. Browser restore now preserves spaces and policy expiry, and rejected restores leave persisted storage untouched.

--- a/.changeset/tc-193-restore-session-key.md
+++ b/.changeset/tc-193-restore-session-key.md
@@ -1,0 +1,9 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/node-sdk-wasm": patch
+"@tinycloud/web-sdk-wasm": patch
+---
+
+Restore persisted sessions with their original private Ed25519 signer, validating that the JWK and verification method identify the same principal before runtime delegation activation.

--- a/.changeset/tc-193-validated-runtime-delegation.md
+++ b/.changeset/tc-193-validated-runtime-delegation.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/node-sdk": patch
+---
+
+Add a CID-bound `activateValidatedRuntimeDelegation` helper that validates and installs compact UCAN runtime delegations.

--- a/.changeset/tidy-ops-artifacts.md
+++ b/.changeset/tidy-ops-artifacts.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/operations": minor
+---
+
+Add the public `@tinycloud/operations/artifacts` authority and v1 permission-artifact APIs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4984,6 +4984,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.7",
  "console_error_panic_hook",
+ "ed25519-dalek",
  "getrandom 0.2.17",
  "hex",
  "iri-string",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4995,6 +4995,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha3",
+ "time",
  "tinycloud-sdk-rs",
  "tinycloud-sdk-wasm",
  "tokio",

--- a/packages/node-sdk/src/NodeWasmBindings.ts
+++ b/packages/node-sdk/src/NodeWasmBindings.ts
@@ -60,10 +60,7 @@ export class NodeWasmBindings implements IWasmBindings {
   prepareSession = prepareSession;
   completeSessionSetup = completeSessionSetup;
   validatePersistedSession(proof: PersistedSessionProof) {
-    return validatePersistedSession({
-      ...proof,
-      now: new Date().toISOString(),
-    });
+    return validatePersistedSession(proof);
   }
   ensureEip55 = ensureEip55;
   makeSpaceId = makeSpaceId;

--- a/packages/node-sdk/src/NodeWasmBindings.ts
+++ b/packages/node-sdk/src/NodeWasmBindings.ts
@@ -13,6 +13,7 @@ import {
   computeCid,
   prepareSession,
   completeSessionSetup,
+  validatePersistedSession,
   ensureEip55,
   makeSpaceId,
   createDelegation,
@@ -30,7 +31,11 @@ import {
   vault_random_bytes,
   vault_sha256,
 } from "@tinycloud/node-sdk-wasm";
-import type { IWasmBindings, ISessionManager } from "@tinycloud/sdk-core";
+import type {
+  IWasmBindings,
+  ISessionManager,
+  PersistedSessionProof,
+} from "@tinycloud/sdk-core";
 
 /**
  * Node.js WASM bindings using @tinycloud/node-sdk-wasm.
@@ -54,6 +59,12 @@ export class NodeWasmBindings implements IWasmBindings {
   computeCid = computeCid;
   prepareSession = prepareSession;
   completeSessionSetup = completeSessionSetup;
+  validatePersistedSession(proof: PersistedSessionProof) {
+    return validatePersistedSession({
+      ...proof,
+      now: new Date().toISOString(),
+    });
+  }
   ensureEip55 = ensureEip55;
   makeSpaceId = makeSpaceId;
   createDelegation = createDelegation;

--- a/packages/node-sdk/src/NodeWasmBindings.ts
+++ b/packages/node-sdk/src/NodeWasmBindings.ts
@@ -18,6 +18,7 @@ import {
   makeSpaceId,
   createDelegation,
   parseRecapFromSiwe,
+  parseVerifiedRecapFromSiwe,
   generateHostSIWEMessage,
   siweToDelegationHeaders,
   protocolVersion,
@@ -66,6 +67,7 @@ export class NodeWasmBindings implements IWasmBindings {
   makeSpaceId = makeSpaceId;
   createDelegation = createDelegation;
   parseRecapFromSiwe = parseRecapFromSiwe;
+  parseVerifiedRecapFromSiwe = parseVerifiedRecapFromSiwe;
   generateHostSIWEMessage = generateHostSIWEMessage;
   siweToDelegationHeaders = siweToDelegationHeaders;
   protocolVersion = protocolVersion;

--- a/packages/node-sdk/src/TinyCloudNode.accountRegistrySync.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.accountRegistrySync.test.ts
@@ -58,6 +58,7 @@ function warnedWith(warnSpy: ReturnType<typeof mock>, needle: string): boolean {
 function makeFakeSessionManager(): ISessionManager {
   return {
     createSessionKey: (id: string) => id,
+    replaceSessionKey: (_jwk: object, keyId: string) => keyId,
     renameSessionKeyId: () => {},
     getDID: (keyId: string) => `did:key:${keyId}`,
     jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),

--- a/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
@@ -37,6 +37,10 @@ function makeFakeSessionManager(): ISessionManager {
       keys.add(id);
       return id;
     },
+    replaceSessionKey(_jwk: object, keyId: string): string {
+      keys.add(keyId);
+      return keyId;
+    },
     renameSessionKeyId(oldId: string, newId: string): void {
       if (keys.has(oldId)) {
         keys.delete(oldId);

--- a/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
@@ -67,6 +67,10 @@ function makeFakeSessionManager(): ISessionManager {
       keys.add(id);
       return id;
     },
+    replaceSessionKey(_jwk: object, keyId: string): string {
+      keys.add(keyId);
+      return keyId;
+    },
     renameSessionKeyId(oldId: string, newId: string): void {
       if (keys.has(oldId)) {
         keys.delete(oldId);

--- a/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
@@ -11,6 +11,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  CaveatedDelegationUnsupportedError,
   PermissionNotInManifestError,
   SessionExpiredError,
   type PermissionEntry,
@@ -328,6 +329,35 @@ describe("TinyCloudNode.delegateTo", () => {
 
     expect(createDelegationSpy).not.toHaveBeenCalled();
     expect(prepareSessionSpy).not.toHaveBeenCalled();
+  });
+
+  test("fails closed rather than serializing exact caveat branches as action-only authority", async () => {
+    const caveats = [{ tenant: "alpha", nested: { region: "us-east-1" } }];
+    const createDelegationSpy = mock(() => ({}));
+    const wasm = makeFakeWasmBindings({
+      parseRecapFromSiwe: mock(() => [{
+        service: "kv",
+        space: "default",
+        path: "items/",
+        actions: ["tinycloud.kv/get"],
+        caveats,
+      }]) as any,
+      createDelegation: createDelegationSpy as any,
+    });
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    installFakeSession(node, { siwe: buildSiwe(futureExpiry) });
+
+    const result = node.delegateTo(BOB_DID, [{
+      service: "tinycloud.kv",
+      space: "default",
+      path: "items/",
+      actions: ["tinycloud.kv/get"],
+      caveats,
+    }]);
+
+    await expect(result).rejects.toBeInstanceOf(CaveatedDelegationUnsupportedError);
+    await expect(result).rejects.toMatchObject({ entries: [{ caveats }] });
+    expect(createDelegationSpy).not.toHaveBeenCalled();
   });
 
   test("multi-entry input → ONE UCAN with merged abilities map", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.ensureOwnedSpaceHosted.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ensureOwnedSpaceHosted.test.ts
@@ -10,6 +10,7 @@ const SECRETS = `tinycloud:pkh:eip155:1:${ADDRESS}:secrets`;
 function makeSessionManager(): ISessionManager {
   return {
     createSessionKey: (id: string) => id,
+    replaceSessionKey: (_jwk: object, keyId: string) => keyId,
     renameSessionKeyId: () => {},
     getDID: (keyId: string) => `did:key:${keyId}`,
     jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),

--- a/packages/node-sdk/src/TinyCloudNode.hostOwnedSpace.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.hostOwnedSpace.test.ts
@@ -9,6 +9,7 @@ const ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
 function makeSessionManager(): ISessionManager {
   return {
     createSessionKey: (id: string) => id,
+    replaceSessionKey: (_jwk: object, keyId: string) => keyId,
     renameSessionKeyId: () => {},
     getDID: (keyId: string) => `did:key:${keyId}`,
     jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),

--- a/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
@@ -374,6 +374,45 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
     }
   });
 
+  test("rejects a captured encryption discovery that resolves after restore retires its graph", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestSignal: AbortSignal | undefined;
+    let releaseResponse!: (response: Response) => void;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => { markStarted = resolve; });
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => new Promise<Response>((resolve) => {
+      requestSignal = init?.signal;
+      releaseResponse = resolve;
+      markStarted();
+    })) as typeof fetch;
+
+    try {
+      const proof = await signedRestorableSession();
+      const node = new TinyCloudNode({
+        signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
+        wasmBindings: new NodeWasmBindings(),
+      });
+      await node.restoreSession({ ...proof, tinycloudHosts: ["https://one.example"] });
+
+      const captured = node.encryption;
+      const inFlight = captured.discoverNetwork(
+        "urn:tinycloud:encryption:did:key:zTest:network",
+      );
+      await started;
+
+      await node.restoreSession({ ...proof, tinycloudHosts: ["https://two.example"] });
+      expect(requestSignal?.aborted).toBe(true);
+      releaseResponse(new Response(null, { status: 404 }));
+
+      await expect(inFlight).rejects.toThrow("Service graph has been retired");
+      await expect(captured.discoverNetwork(
+        "urn:tinycloud:encryption:did:key:zTest:network",
+      )).rejects.toThrow("Service graph has been retired");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("does not turn an empty ReCap into delegation or sharing authority", async () => {
     const proof = await signedRestorableSession({ expirationless: true });
     const node = new TinyCloudNode({ wasmBindings: new NodeWasmBindings() });

--- a/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
-import { principalDidEquals, type ISessionManager, type IWasmBindings } from "@tinycloud/sdk-core";
+import {
+  principalDidEquals,
+  type Delegation,
+  type ISessionManager,
+  type IWasmBindings,
+  type ServiceContext,
+} from "@tinycloud/sdk-core";
 
 import { activateValidatedRuntimeDelegation } from "./delegation";
 import { NodeWasmBindings } from "./NodeWasmBindings";
@@ -13,7 +19,10 @@ const PROOF_PRIVATE_KEY = "4f3edf983ac636a65a842ce7c78d9aa706d3b113bce036f4d9c5c
 
 async function signedRestorableSession(options?: {
   expirationless?: boolean;
+  expired?: boolean;
   spaces?: Record<string, string>;
+  signedSpaces?: Record<string, string>;
+  abilities?: Record<string, Record<string, string[]>>;
 }) {
   const wasm = new NodeWasmBindings();
   const signer = new PrivateKeySigner(PROOF_PRIVATE_KEY);
@@ -23,6 +32,12 @@ async function signedRestorableSession(options?: {
   const chainId = await signer.getChainId();
   const spaceId = wasm.makeSpaceId(address, chainId, "default");
   const now = new Date();
+  const issuedAt = options?.expired
+    ? new Date(now.getTime() - 2 * 60 * 60_000)
+    : now;
+  const expirationTime = options?.expired
+    ? new Date(now.getTime() - 60 * 60_000)
+    : new Date(now.getTime() + 60 * 60_000);
   const verificationMethod = manager.getDID("default");
   const prepared = options?.expirationless
     ? {
@@ -33,24 +48,25 @@ async function signedRestorableSession(options?: {
         address,
         chainId,
         domain: "restore.test",
-        issuedAt: now.toISOString(),
+        issuedAt: issuedAt.toISOString(),
       }, "default"),
     }
     : wasm.prepareSession({
-      abilities: { kv: { "": ["tinycloud.kv/get"] } },
+      abilities: options?.abilities ?? { kv: { "": ["tinycloud.kv/get"] } },
       address,
       chainId,
       domain: "restore.test",
-      issuedAt: now.toISOString(),
-      expirationTime: new Date(now.getTime() + 60 * 60_000).toISOString(),
+      issuedAt: issuedAt.toISOString(),
+      expirationTime: expirationTime.toISOString(),
       spaceId,
+      additionalSpaces: options?.signedSpaces ?? options?.spaces,
       jwk,
     });
   const signature = await signer.signMessage(prepared.siwe);
   const session = wasm.completeSessionSetup({ ...prepared, signature });
   const expiresAt = options?.expirationless
     ? new Date(now.getTime() + 30 * 60_000).toISOString()
-    : new Date(now.getTime() + 60 * 60_000).toISOString();
+    : expirationTime.toISOString();
   return {
     delegationHeader: session.delegationHeader,
     delegationCid: session.delegationCid,
@@ -98,6 +114,13 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
     const proof = await signedRestorableSession();
     const wasm = new NodeWasmBindings();
     expect(() => wasm.validatePersistedSession!(proof)).not.toThrow();
+    const unrelatedJwk = JSON.parse(wasm.createSessionManager().jwk("default")!);
+    expect(() => wasm.validatePersistedSession!({ ...proof, jwk: unrelatedJwk })).toThrow();
+    const expired = await signedRestorableSession({ expired: true });
+    expect(() => wasm.validatePersistedSession!({
+      ...expired,
+      now: new Date(expired.expiresAt).toISOString(),
+    } as any)).toThrow();
     const node = new TinyCloudNode({
       host: RESTORE_HOST,
       signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
@@ -160,8 +183,132 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
     const sessionKey = registry.getAllKeys()[0];
     expect(registry.getDelegationsForKey(sessionKey.id).some((delegation: { spaceId: string }) =>
       delegation.spaceId === proof.spaces!.public
-    )).toBe(false);
+    )).toBe(true);
     expect(((node as any).sessionManager as ISessionManager).listSessionKeys!()).toContain("secondary");
+  });
+
+  test("reconstructs every verified narrow ReCap entry without unsigned metadata authority", async () => {
+    const proof = await signedRestorableSession({
+      spaces: {
+        public: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:public",
+        unsigned: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:unsigned",
+      },
+      signedSpaces: {
+        public: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:public",
+      },
+      abilities: {
+        kv: { "narrow/": ["tinycloud.kv/get"] },
+        sql: { "records/": ["tinycloud.sql/read"] },
+      },
+    });
+    const wasm = new NodeWasmBindings();
+    const verified = wasm.validatePersistedSession!(proof);
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://recap.example"] });
+
+    const registry = (node as any)._capabilityRegistry;
+    const key = registry.getAllKeys()[0];
+    const actual = registry.getDelegationsForKey(key.id).map((delegation: Delegation) => ({
+      space: delegation.spaceId,
+      path: delegation.path,
+      actions: delegation.actions,
+    })).sort((left: { space: string; path: string }, right: { space: string; path: string }) =>
+      `${left.space}|${left.path}`.localeCompare(`${right.space}|${right.path}`),
+    );
+    const expected = verified.recap.map((entry) => ({
+      space: entry.space,
+      path: entry.path,
+      actions: entry.actions,
+    })).sort((left, right) =>
+      `${left.space}|${left.path}`.localeCompare(`${right.space}|${right.path}`),
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual.some((entry: { space: string }) => entry.space === proof.spaces!.unsigned)).toBe(false);
+    expect(actual.flatMap((entry: { actions: string[] }) => entry.actions)).toEqual(
+      expect.arrayContaining(["tinycloud.kv/get", "tinycloud.sql/read"]),
+    );
+    expect(actual.flatMap((entry: { actions: string[] }) => entry.actions)).not.toContain("tinycloud.kv/put");
+  });
+
+  test("retires captured services and aborts in-flight requests after each successful restore", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestSignal: AbortSignal | undefined;
+    let requestStarted!: () => void;
+    const started = new Promise<void>((resolve) => { requestStarted = resolve; });
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      requestSignal = init?.signal ?? undefined;
+      requestStarted();
+      requestSignal?.addEventListener("abort", () => {
+        reject(new DOMException("retired", "AbortError"));
+      }, { once: true });
+    })) as typeof fetch;
+
+    try {
+      const proof = await signedRestorableSession({
+        abilities: { kv: { "": ["tinycloud.kv/get", "tinycloud.kv/metadata"] } },
+      });
+      const node = new TinyCloudNode({
+        signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
+        wasmBindings: new NodeWasmBindings(),
+      });
+      await node.restoreSession({ ...proof, tinycloudHosts: ["https://one.example"] });
+
+      const captured = {
+        context: (node as any)._serviceContext as ServiceContext,
+        core: (node as any).tc,
+        kv: node.kv,
+        publicKV: node.publicKV,
+        sql: node.sql,
+        duckdb: node.duckdb,
+        hooks: node.hooks,
+        vault: node.vault,
+        encryption: node.encryption,
+        sharing: node.sharing,
+        delegations: node.delegationManager,
+        spaces: node.spaces,
+      };
+      const inFlight = captured.kv.get("in-flight");
+      await started;
+
+      await node.restoreSession({ ...proof, tinycloudHosts: ["https://two.example"] });
+
+      expect(requestSignal?.aborted).toBe(true);
+      await expect(inFlight).resolves.toMatchObject({ ok: false });
+      expect(captured.context.session).toBeNull();
+      expect(captured.context.abortSignal.aborted).toBe(true);
+      expect(() => captured.core.kv).toThrow("Services not initialized");
+      await expect(captured.publicKV.get("after")).resolves.toMatchObject({ ok: false });
+      await expect(captured.delegations.list()).resolves.toMatchObject({ ok: false });
+      await expect(captured.sharing.generate({ path: "after", actions: ["tinycloud.kv/get"] }))
+        .resolves.toMatchObject({ ok: false });
+      expect(node.hosts).toEqual(["https://two.example"]);
+
+      await node.restoreSession({ ...proof, tinycloudHosts: ["https://three.example"] });
+      expect(node.hosts).toEqual(["https://three.example"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("does not turn an empty ReCap into delegation or sharing authority", async () => {
+    const proof = await signedRestorableSession({ expirationless: true });
+    const node = new TinyCloudNode({ wasmBindings: new NodeWasmBindings() });
+
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://empty-recap.example"] });
+
+    expect(node.capabilityRegistry.getAllKeys()).toEqual([]);
+    await expect(node.delegateTo("did:key:zEmpty", [{
+      service: "tinycloud.kv",
+      space: proof.spaceId,
+      path: "",
+      actions: ["tinycloud.kv/get"],
+    }])).rejects.toThrow();
+    await expect(node.sharing.generate({
+      path: "cannot-share",
+      actions: ["tinycloud.kv/get"],
+    })).resolves.toMatchObject({ ok: false });
   });
 
   test("does not inherit wallet metadata or activation skips from a previous live session", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { principalDidEquals } from "@tinycloud/sdk-core";
+import { principalDidEquals, type ISessionManager, type IWasmBindings } from "@tinycloud/sdk-core";
 
 import { activateValidatedRuntimeDelegation } from "./delegation";
 import { NodeWasmBindings } from "./NodeWasmBindings";
@@ -19,52 +19,144 @@ function restorableData(jwk: object, verificationMethod: string) {
   };
 }
 
+function withSiweExpiration(siwe: string, expiresAt: Date): string {
+  const updated = siwe.replace(
+    /^Expiration Time: .+$/m,
+    `Expiration Time: ${expiresAt.toISOString()}`,
+  );
+  if (updated === siwe) throw new Error("test SIWE did not contain an expiration time");
+  return updated;
+}
+
+function legacySessionManager(): ISessionManager {
+  return {
+    createSessionKey: (id) => id,
+    renameSessionKeyId: () => undefined,
+    getDID: (id) => `did:key:${id}#${id}`,
+    jwk: () => JSON.stringify({
+      kty: "OKP", crv: "Ed25519",
+      x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      d: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    }),
+  };
+}
+
+function legacyBindings(): IWasmBindings {
+  return { createSessionManager: legacySessionManager } as IWasmBindings;
+}
+
 describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
-  test("rejects malformed, public-only, and mismatched persisted keys without replacing the active signer", async () => {
-    const wasm = new NodeWasmBindings();
-    const sourceManager = wasm.createSessionManager();
-    const sourceJwk = JSON.parse(sourceManager.jwk("default")!);
-    const sourceDid = sourceManager.getDID("default");
-    const unrelatedManager = wasm.createSessionManager();
-    const unrelatedDid = unrelatedManager.getDID("default");
-    const node = new TinyCloudNode({ host: RESTORE_HOST, wasmBindings: wasm });
+  test("keeps the live key, auth, host, service graph, and grants after every rejected restore", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const restored = new TinyCloudNode({ wasmBindings: new NodeWasmBindings() });
+      await restored.restoreSession(fixture.restorableSession);
+      const delegation = await fixture.mintDelegation();
+      const activated = await activateValidatedRuntimeDelegation(restored, delegation, { host: fixture.host });
+      await fixture.readAndDecrypt(restored, activated);
+      const sourceJwk = fixture.restorableSession.jwk as Record<string, string>;
+      const sourceDid = fixture.restorableSession.verificationMethod;
+      const unrelatedDid = new NodeWasmBindings().createSessionManager().getDID("default");
+      const publicOnly = { ...sourceJwk };
+      delete publicOnly.d;
+      const previous = {
+        did: restored.sessionDid,
+        host: restored.hosts[0],
+        manager: (restored as any).sessionManager,
+        serviceContext: (restored as any)._serviceContext,
+        kv: (restored as any)._kv,
+        auth: (restored as any).auth,
+        grants: (restored as any).runtimePermissionGrants,
+      };
+      const assertPriorState = async () => {
+        expect(restored.sessionDid).toBe(previous.did);
+        expect(restored.hosts[0]).toBe(previous.host);
+        expect((restored as any).sessionManager).toBe(previous.manager);
+        expect((restored as any)._serviceContext).toBe(previous.serviceContext);
+        expect((restored as any)._kv).toBe(previous.kv);
+        expect((restored as any).auth).toBe(previous.auth);
+        expect((restored as any).runtimePermissionGrants).toEqual(previous.grants);
+        await fixture.readAndDecrypt(restored, activated);
+      };
+      for (const rejected of [
+        restorableData(publicOnly, sourceDid),
+        restorableData({ kty: "OKP", crv: "Ed25519" }, sourceDid),
+        restorableData(sourceJwk, unrelatedDid),
+        restorableData(sourceJwk, `${sourceDid.split("#", 1)[0]}#not-the-key`),
+        restorableData({ ...sourceJwk, alg: "ES256" }, sourceDid),
+        { ...fixture.restorableSession, chainId: -1, tinycloudHosts: undefined },
+      ]) {
+        const error = await restored.restoreSession(rejected).catch((err) => err as Error);
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).not.toContain(sourceJwk.d);
+        await assertPriorState();
+      }
+    } finally {
+      fixture.stop();
+    }
+  });
+
+  test("preserves compatibility with custom managers that do not support key replacement", async () => {
+    const node = new TinyCloudNode({ host: RESTORE_HOST, wasmBindings: legacyBindings() });
     const initialDid = node.sessionDid;
-
-    const publicOnly = { ...sourceJwk };
-    delete publicOnly.d;
-    await expect(
-      node.restoreSession(restorableData(publicOnly, sourceDid)),
-    ).rejects.toThrow(/invalid private Ed25519 session key/);
-    expect(node.sessionDid).toBe(initialDid);
-
-    await expect(
-      node.restoreSession(restorableData({ kty: "OKP", crv: "Ed25519" }, sourceDid)),
-    ).rejects.toThrow(/invalid private Ed25519 session key/);
-    expect(node.sessionDid).toBe(initialDid);
-
-    await expect(
-      node.restoreSession(restorableData(sourceJwk, unrelatedDid)),
-    ).rejects.toThrow(/verification method does not match/);
-    expect(node.sessionDid).toBe(initialDid);
-
-    await expect(
-      node.restoreSession(restorableData(sourceJwk, "not-a-did")),
-    ).rejects.toThrow(/verification method does not match/);
+    const error = await node.restoreSession(restorableData({ d: "private-material-must-not-leak" }, initialDid))
+      .catch((err) => err as Error & { code?: string });
+    expect(error.name).toBe("UnsupportedSessionRestoreError");
+    expect(error.code).toBe("RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED");
+    expect(error.message).not.toContain("private-material-must-not-leak");
     expect(node.sessionDid).toBe(initialDid);
   });
 
-  test("round-trips a real WASM session JWK into a fresh node and activates a narrow signed grant", async () => {
+  test("stages the persisted SIWE expiry into capability and sharing services", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const restored = fixture.createRestoredDelegate();
+      const firstExpiry = new Date(Date.now() + 2 * 60 * 60_000);
+      const restoredExpiry = new Date(Date.now() + 3 * 60 * 60_000);
+
+      await restored.restoreSession({
+        ...fixture.restorableSession,
+        siwe: withSiweExpiration(fixture.restorableSession.siwe, firstExpiry),
+      });
+      await restored.restoreSession({
+        ...fixture.restorableSession,
+        siwe: withSiweExpiration(fixture.restorableSession.siwe, restoredExpiry),
+      });
+
+      const registry = (restored as any)._capabilityRegistry;
+      const sessionKey = registry.getAllKeys()[0];
+      const delegations = registry.getDelegationsForKey(sessionKey.id);
+      expect(delegations).not.toHaveLength(0);
+      expect(delegations.every((delegation: { expiry: Date }) =>
+        delegation.expiry.getTime() === restoredExpiry.getTime()
+      )).toBe(true);
+      expect((restored as any)._sharingService.sessionExpiry.getTime()).toBe(
+        restoredExpiry.getTime(),
+      );
+    } finally {
+      fixture.stop();
+    }
+  });
+
+  test("round-trips a real WASM session JWK, stores the canonical verification method, and cryptographically validates restored-key signing", async () => {
     const fixture = await createHermeticEncryptedNode();
     try {
       const restored = fixture.createRestoredDelegate();
       const defaultDid = restored.sessionDid;
 
-      await restored.restoreSession(fixture.restorableSession);
+      const bareDid = fixture.restorableSession.verificationMethod.split("#", 1)[0]!;
+      await restored.restoreSession({
+        ...fixture.restorableSession,
+        jwk: { ...(fixture.restorableSession.jwk as object), alg: "EdDSA" },
+        verificationMethod: bareDid,
+      });
 
       expect(restored.sessionDid).not.toBe(defaultDid);
-      expect(principalDidEquals(restored.sessionDid, fixture.restorableSession.verificationMethod)).toBe(
-        true,
+      expect(principalDidEquals(restored.sessionDid, bareDid)).toBe(true);
+      expect((restored as any)._serviceContext.session.verificationMethod).toBe(
+        fixture.restorableSession.verificationMethod,
       );
+      expect(restored.restorableSession?.verificationMethod).toBe(fixture.restorableSession.verificationMethod);
 
       const delegation = await fixture.mintDelegation();
       const activated = await activateValidatedRuntimeDelegation(restored, delegation, {
@@ -73,6 +165,8 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
 
       expect(activated.audience).toBe(restored.sessionDid.split("#", 1)[0]);
       expect(restored.getRuntimePermissionDelegations()).toHaveLength(1);
+      await fixture.readAndDecrypt(restored, activated);
+      fixture.assertNarrowDelegatedReadAndDecrypt(activated, restored.sessionDid);
     } finally {
       fixture.stop();
     }

--- a/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
@@ -4,10 +4,67 @@ import { principalDidEquals, type ISessionManager, type IWasmBindings } from "@t
 
 import { activateValidatedRuntimeDelegation } from "./delegation";
 import { NodeWasmBindings } from "./NodeWasmBindings";
+import { PrivateKeySigner } from "./signers/PrivateKeySigner";
 import { TinyCloudNode } from "./TinyCloudNode";
 import { createHermeticEncryptedNode } from "./test-support/hermetic-encrypted-node";
 
 const RESTORE_HOST = "http://127.0.0.1:1";
+const PROOF_PRIVATE_KEY = "4f3edf983ac636a65a842ce7c78d9aa706d3b113bce036f4d9c5c1b5605dce6f";
+
+async function signedRestorableSession(options?: {
+  expirationless?: boolean;
+  spaces?: Record<string, string>;
+}) {
+  const wasm = new NodeWasmBindings();
+  const signer = new PrivateKeySigner(PROOF_PRIVATE_KEY);
+  const manager = wasm.createSessionManager();
+  const jwk = JSON.parse(manager.jwk("default")!);
+  const address = await signer.getAddress();
+  const chainId = await signer.getChainId();
+  const spaceId = wasm.makeSpaceId(address, chainId, "default");
+  const now = new Date();
+  const verificationMethod = manager.getDID("default");
+  const prepared = options?.expirationless
+    ? {
+      jwk,
+      spaceId,
+      verificationMethod,
+      siwe: (manager as any).build({
+        address,
+        chainId,
+        domain: "restore.test",
+        issuedAt: now.toISOString(),
+      }, "default"),
+    }
+    : wasm.prepareSession({
+      abilities: { kv: { "": ["tinycloud.kv/get"] } },
+      address,
+      chainId,
+      domain: "restore.test",
+      issuedAt: now.toISOString(),
+      expirationTime: new Date(now.getTime() + 60 * 60_000).toISOString(),
+      spaceId,
+      jwk,
+    });
+  const signature = await signer.signMessage(prepared.siwe);
+  const session = wasm.completeSessionSetup({ ...prepared, signature });
+  const expiresAt = options?.expirationless
+    ? new Date(now.getTime() + 30 * 60_000).toISOString()
+    : new Date(now.getTime() + 60 * 60_000).toISOString();
+  return {
+    delegationHeader: session.delegationHeader,
+    delegationCid: session.delegationCid,
+    spaceId,
+    spaces: options?.spaces,
+    jwk,
+    verificationMethod,
+    address,
+    chainId,
+    siwe: prepared.siwe,
+    signature,
+    expiresAt,
+  };
+}
 
 function restorableData(jwk: object, verificationMethod: string) {
   return {
@@ -17,15 +74,6 @@ function restorableData(jwk: object, verificationMethod: string) {
     jwk,
     verificationMethod,
   };
-}
-
-function withSiweExpiration(siwe: string, expiresAt: Date): string {
-  const updated = siwe.replace(
-    /^Expiration Time: .+$/m,
-    `Expiration Time: ${expiresAt.toISOString()}`,
-  );
-  if (updated === siwe) throw new Error("test SIWE did not contain an expiration time");
-  return updated;
 }
 
 function legacySessionManager(): ISessionManager {
@@ -46,6 +94,135 @@ function legacyBindings(): IWasmBindings {
 }
 
 describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
+  test("cryptographically binds persisted SIWE authority before trusting its recap, expiry, CID, or header", async () => {
+    const proof = await signedRestorableSession();
+    const wasm = new NodeWasmBindings();
+    expect(() => wasm.validatePersistedSession!(proof)).not.toThrow();
+    const node = new TinyCloudNode({
+      host: RESTORE_HOST,
+      signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
+      wasmBindings: wasm,
+    });
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://valid.example"] });
+    const priorDid = node.sessionDid;
+    const priorHost = node.hosts[0];
+    const priorState = {
+      auth: (node as any).auth,
+      core: (node as any).tc,
+      manager: (node as any).sessionManager,
+      serviceContext: (node as any)._serviceContext,
+    };
+    for (const tampered of [
+      { ...proof, signature: `${proof.signature.slice(0, -1)}0` },
+      { ...proof, siwe: proof.siwe.replace("Chain ID: 1", "Chain ID: 2") },
+      { ...proof, delegationCid: `${proof.delegationCid}x` },
+      { ...proof, delegationHeader: { Authorization: `${proof.delegationHeader.Authorization}x` } },
+      { ...proof, address: "0x0000000000000000000000000000000000000001" },
+      { ...proof, chainId: proof.chainId + 1 },
+    ]) {
+      expect(() => wasm.validatePersistedSession!(tampered)).toThrow();
+      await expect(node.restoreSession({ ...tampered, tinycloudHosts: ["https://tampered.example"] })).rejects.toThrow();
+      expect(node.sessionDid).toBe(priorDid);
+      expect(node.hosts[0]).toBe(priorHost);
+      expect((node as any).auth).toBe(priorState.auth);
+      expect((node as any).tc).toBe(priorState.core);
+      expect((node as any).sessionManager).toBe(priorState.manager);
+      expect((node as any)._serviceContext).toBe(priorState.serviceContext);
+    }
+    await expect(node.restoreSession({
+      ...proof,
+      expiresAt: new Date(Date.now() + 2 * 60 * 60_000).toISOString(),
+    })).rejects.toThrow("does not match its signed SIWE authority");
+  });
+
+  test("replaces auth, host, core publicKV, spaces, and all live keys on repeated cross-host restore", async () => {
+    const proof = await signedRestorableSession({
+      spaces: { public: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:public" },
+    });
+    const node = new TinyCloudNode({
+      signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
+      wasmBindings: new NodeWasmBindings(),
+    });
+    const manager = (node as any).sessionManager as ISessionManager;
+    manager.createSessionKey("secondary");
+
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://one.example"] });
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://two.example"] });
+
+    expect(node.hosts).toEqual(["https://two.example"]);
+    expect((node as any).config.host).toBe("https://two.example");
+    expect((node as any).auth.hosts).toEqual(["https://two.example"]);
+    expect((node as any).tc.isSignedIn).toBe(true);
+    expect(((node as any).tc.serviceContext as { hosts: string[] }).hosts).toEqual(["https://two.example"]);
+    expect(() => node.publicKV).not.toThrow();
+    expect((node.restorableSession?.spaces)).toEqual(proof.spaces);
+    const registry = (node as any)._capabilityRegistry;
+    const sessionKey = registry.getAllKeys()[0];
+    expect(registry.getDelegationsForKey(sessionKey.id).some((delegation: { spaceId: string }) =>
+      delegation.spaceId === proof.spaces!.public
+    )).toBe(false);
+    expect(((node as any).sessionManager as ISessionManager).listSessionKeys!()).toContain("secondary");
+  });
+
+  test("does not inherit wallet metadata or activation skips from a previous live session", async () => {
+    const proof = await signedRestorableSession();
+    const node = new TinyCloudNode({
+      signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
+      wasmBindings: new NodeWasmBindings(),
+    });
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://one.example"] });
+    (node as any).auth._lastActivationSkippedSpaceIds = [proof.spaceId];
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://two.example"] });
+    expect((node as any).runtimePermissionGrants).toHaveLength(1);
+
+    await node.restoreSession({
+      delegationHeader: proof.delegationHeader,
+      delegationCid: proof.delegationCid,
+      spaceId: proof.spaceId,
+      jwk: proof.jwk,
+      verificationMethod: proof.verificationMethod,
+      tinycloudHosts: ["https://three.example"],
+    });
+    expect(node.address).toBeUndefined();
+    expect((node as any).auth.session).toBeUndefined();
+    expect(node.hosts).toEqual(["https://three.example"]);
+  });
+
+  test("uses the persisted expiry for a valid expiration-less proof and rejects a missing policy expiry", async () => {
+    const proof = await signedRestorableSession({ expirationless: true });
+    const node = new TinyCloudNode({
+      signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
+      wasmBindings: new NodeWasmBindings(),
+    });
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://one.example"] });
+    const firstExpiry = (node as any)._sharingService.sessionExpiry;
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://two.example"] });
+    expect((node as any)._sharingService.sessionExpiry.getTime()).toBe(firstExpiry.getTime());
+    await expect(node.restoreSession({ ...proof, expiresAt: undefined })).rejects.toThrow(
+      "must include expiresAt",
+    );
+  });
+
+  test("rejects explicit alg:null and partial key managers without replacing live state", async () => {
+    const proof = await signedRestorableSession();
+    const node = new TinyCloudNode({ wasmBindings: new NodeWasmBindings() });
+    const before = node.sessionDid;
+    await expect(node.restoreSession({ ...proof, jwk: { ...proof.jwk, alg: null } })).rejects.toThrow(
+      "invalid private Ed25519",
+    );
+    expect(node.sessionDid).toBe(before);
+
+    const partial = new TinyCloudNode({ host: RESTORE_HOST, wasmBindings: {
+      createSessionManager: legacySessionManager,
+    } as IWasmBindings });
+    const partialDid = partial.sessionDid;
+    await expect(partial.restoreSession(restorableData(proof.jwk, proof.verificationMethod))).rejects.toMatchObject({
+      name: "UnsupportedSessionRestoreError",
+      code: "RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED",
+    });
+    expect(partial.sessionDid).toBe(partialDid);
+  });
+
   test("keeps the live key, auth, host, service graph, and grants after every rejected restore", async () => {
     const fixture = await createHermeticEncryptedNode();
     try {
@@ -107,35 +284,25 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
     expect(node.sessionDid).toBe(initialDid);
   });
 
-  test("stages the persisted SIWE expiry into capability and sharing services", async () => {
-    const fixture = await createHermeticEncryptedNode();
-    try {
-      const restored = fixture.createRestoredDelegate();
-      const firstExpiry = new Date(Date.now() + 2 * 60 * 60_000);
-      const restoredExpiry = new Date(Date.now() + 3 * 60 * 60_000);
+  test("stages the signed SIWE expiry into capability and sharing services", async () => {
+    const proof = await signedRestorableSession();
+    const restored = new TinyCloudNode({
+      host: RESTORE_HOST,
+      signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
+      wasmBindings: new NodeWasmBindings(),
+    });
 
-      await restored.restoreSession({
-        ...fixture.restorableSession,
-        siwe: withSiweExpiration(fixture.restorableSession.siwe, firstExpiry),
-      });
-      await restored.restoreSession({
-        ...fixture.restorableSession,
-        siwe: withSiweExpiration(fixture.restorableSession.siwe, restoredExpiry),
-      });
+    await restored.restoreSession(proof);
 
-      const registry = (restored as any)._capabilityRegistry;
-      const sessionKey = registry.getAllKeys()[0];
-      const delegations = registry.getDelegationsForKey(sessionKey.id);
-      expect(delegations).not.toHaveLength(0);
-      expect(delegations.every((delegation: { expiry: Date }) =>
-        delegation.expiry.getTime() === restoredExpiry.getTime()
-      )).toBe(true);
-      expect((restored as any)._sharingService.sessionExpiry.getTime()).toBe(
-        restoredExpiry.getTime(),
-      );
-    } finally {
-      fixture.stop();
-    }
+    const expectedExpiry = new Date(proof.expiresAt).getTime();
+    const registry = (restored as any)._capabilityRegistry;
+    const sessionKey = registry.getAllKeys()[0];
+    const delegations = registry.getDelegationsForKey(sessionKey.id);
+    expect(delegations).not.toHaveLength(0);
+    expect(delegations.every((delegation: { expiry: Date }) =>
+      delegation.expiry.getTime() === expectedExpiry
+    )).toBe(true);
+    expect((restored as any)._sharingService.sessionExpiry.getTime()).toBe(expectedExpiry);
   });
 
   test("round-trips a real WASM session JWK, stores the canonical verification method, and cryptographically validates restored-key signing", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
@@ -6,6 +6,7 @@ import {
   type ISessionManager,
   type IWasmBindings,
   type ServiceContext,
+  type ValidatedPersistedSessionProof,
 } from "@tinycloud/sdk-core";
 
 import { activateValidatedRuntimeDelegation } from "./delegation";
@@ -232,13 +233,71 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
     expect(actual.flatMap((entry: { actions: string[] }) => entry.actions)).not.toContain("tinycloud.kv/put");
   });
 
+  test("keeps caveated same-CID scopes distinct through restore, invocation, and revocation", async () => {
+    const proof = await signedRestorableSession();
+    const caveats = [
+      { tenant: "alpha", nested: { region: "us-east-1" } },
+      { tenant: "bravo", nested: { region: "eu-west-1" } },
+    ];
+    const wasm = new NodeWasmBindings();
+    const validate = wasm.validatePersistedSession.bind(wasm);
+    (wasm as any).validatePersistedSession = (input: Parameters<typeof validate>[0]) => {
+      const verified = validate(input);
+      const scope = verified.verifiedRecap![0]!;
+      return {
+        ...verified,
+        verifiedRecap: caveats.map((caveat) => ({
+          ...scope,
+          actions: ["tinycloud.kv/get"],
+          caveats: [caveat],
+        })),
+      };
+    };
+    const invokeAny = wasm.invokeAny;
+    const invocations: unknown[][] = [];
+    (wasm as any).invokeAny = (session: unknown, entries: unknown[], facts?: unknown) => {
+      invocations.push(entries);
+      return invokeAny(session as any, entries as any, facts as any);
+    };
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+
+    await node.restoreSession(proof);
+
+    const registry = node.capabilityRegistry;
+    const key = registry.getAllKeys()[0]!;
+    const restored = registry.getDelegationsForKey(key.id);
+    expect(restored).toHaveLength(2);
+    expect(restored.map((delegation) => delegation.caveats)).toEqual(
+      caveats.map((caveat) => [caveat]),
+    );
+
+    const session = (node as any)._serviceContext.session;
+    (node as any).invokeAnyWithRuntimePermissions(session, [{
+      spaceId: proof.spaceId,
+      service: "kv",
+      path: "narrow",
+      action: "tinycloud.kv/get",
+    }]);
+    expect(invocations.at(-1)).toEqual([{
+      spaceId: proof.spaceId,
+      service: "kv",
+      path: "narrow",
+      action: "tinycloud.kv/get",
+      caveats: [caveats[0]],
+    }]);
+
+    expect(registry.revokeDelegation(proof.delegationCid).ok).toBe(true);
+    expect(registry.getDelegationsForKey(key.id).every((delegation) => delegation.isRevoked)).toBe(true);
+  });
+
   test("retires captured services and aborts in-flight requests after each successful restore", async () => {
     const originalFetch = globalThis.fetch;
-    let requestSignal: AbortSignal | undefined;
+    const requestSignals: AbortSignal[] = [];
     let requestStarted!: () => void;
     const started = new Promise<void>((resolve) => { requestStarted = resolve; });
     globalThis.fetch = mock((_url: string, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
-      requestSignal = init?.signal ?? undefined;
+      const requestSignal = init?.signal;
+      if (requestSignal) requestSignals.push(requestSignal);
       requestStarted();
       requestSignal?.addEventListener("abort", () => {
         reject(new DOMException("retired", "AbortError"));
@@ -270,12 +329,26 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
         spaces: node.spaces,
       };
       const inFlight = captured.kv.get("in-flight");
+      const encryptionInFlight = (captured.encryption as any).config.node.fetchByNetworkId(
+        "urn:tinycloud:encryption:did:key:zTest:network",
+      );
+      const encryptionFailure = encryptionInFlight.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
       await started;
+      // `postDecrypt` is async; let it reach the graph-bound fetch before
+      // replacing the graph so this exercises its in-flight cancellation.
+      await Promise.resolve();
 
       await node.restoreSession({ ...proof, tinycloudHosts: ["https://two.example"] });
 
-      expect(requestSignal?.aborted).toBe(true);
+      // Both the ordinary service call and captured encryption discovery are
+      // in flight on the retired graph, and both receive its abort signal.
+      expect(requestSignals).toHaveLength(2);
+      expect(requestSignals.every((signal) => signal.aborted)).toBe(true);
       await expect(inFlight).resolves.toMatchObject({ ok: false });
+      expect(await encryptionFailure).toBeInstanceOf(DOMException);
       expect(captured.context.session).toBeNull();
       expect(captured.context.abortSignal.aborted).toBe(true);
       expect(() => captured.core.kv).toThrow("Services not initialized");
@@ -283,6 +356,15 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
       await expect(captured.delegations.list()).resolves.toMatchObject({ ok: false });
       await expect(captured.sharing.generate({ path: "after", actions: ["tinycloud.kv/get"] }))
         .resolves.toMatchObject({ ok: false });
+      await expect((captured.encryption as any).config.node.fetchByNetworkId(
+        "urn:tinycloud:encryption:did:key:zTest:network",
+      )).rejects.toThrow("Service graph has been retired");
+      await expect((captured.encryption as any).config.signer.signDecryptInvocation({
+        targetNode: "https://one.example",
+        networkId: "urn:tinycloud:encryption:test",
+        body: {},
+        facts: [],
+      })).rejects.toThrow("Service graph has been retired");
       expect(node.hosts).toEqual(["https://two.example"]);
 
       await node.restoreSession({ ...proof, tinycloudHosts: ["https://three.example"] });
@@ -368,6 +450,51 @@ describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
       code: "RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED",
     });
     expect(partial.sessionDid).toBe(partialDid);
+  });
+
+  test("rejects authenticated legacy verifier output without breaking its TypeScript contract", async () => {
+    const proof = await signedRestorableSession();
+    const legacyOutput: ValidatedPersistedSessionProof = {
+      expiresAt: proof.expiresAt,
+    };
+    expect(legacyOutput.verifiedRecap).toBeUndefined();
+    const wasm = new NodeWasmBindings();
+    const validate = wasm.validatePersistedSession.bind(wasm);
+    (wasm as any).validatePersistedSession = (input: Parameters<typeof validate>[0]) => {
+      const { verifiedRecap: _ignored, ...legacy } = validate(input);
+      return legacy;
+    };
+    const node = new TinyCloudNode({ wasmBindings: wasm });
+    const before = node.sessionDid;
+
+    await expect(node.restoreSession(proof)).rejects.toMatchObject({
+      name: "UnsupportedSessionRestoreError",
+      code: "RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED",
+    });
+    expect(node.sessionDid).toBe(before);
+  });
+
+  test("commits a restore even when a custom retired service throws during sign-out", async () => {
+    const proof = await signedRestorableSession();
+    const node = new TinyCloudNode({ wasmBindings: new NodeWasmBindings() });
+    await node.restoreSession({ ...proof, tinycloudHosts: ["https://one.example"] });
+    const oldContext = (node as any)._serviceContext as ServiceContext;
+    oldContext.registerService("throws-on-sign-out", {
+      config: {},
+      initialize: () => undefined,
+      onSessionChange: () => undefined,
+      onSignOut: () => { throw new Error("custom cleanup failed"); },
+    });
+    const originalError = console.error;
+    console.error = mock(() => undefined);
+    try {
+      await expect(node.restoreSession({ ...proof, tinycloudHosts: ["https://two.example"] })).resolves.toBeUndefined();
+    } finally {
+      console.error = originalError;
+    }
+    expect(node.hosts).toEqual(["https://two.example"]);
+    expect((node as any)._serviceContext).not.toBe(oldContext);
+    expect(oldContext.abortSignal.aborted).toBe(true);
   });
 
   test("keeps the live key, auth, host, service graph, and grants after every rejected restore", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import { principalDidEquals } from "@tinycloud/sdk-core";
+
+import { activateValidatedRuntimeDelegation } from "./delegation";
+import { NodeWasmBindings } from "./NodeWasmBindings";
+import { TinyCloudNode } from "./TinyCloudNode";
+import { createHermeticEncryptedNode } from "./test-support/hermetic-encrypted-node";
+
+const RESTORE_HOST = "http://127.0.0.1:1";
+
+function restorableData(jwk: object, verificationMethod: string) {
+  return {
+    delegationHeader: { Authorization: "Bearer restore-test" },
+    delegationCid: "bafy-restore-test",
+    spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+    jwk,
+    verificationMethod,
+  };
+}
+
+describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
+  test("rejects malformed, public-only, and mismatched persisted keys without replacing the active signer", async () => {
+    const wasm = new NodeWasmBindings();
+    const sourceManager = wasm.createSessionManager();
+    const sourceJwk = JSON.parse(sourceManager.jwk("default")!);
+    const sourceDid = sourceManager.getDID("default");
+    const unrelatedManager = wasm.createSessionManager();
+    const unrelatedDid = unrelatedManager.getDID("default");
+    const node = new TinyCloudNode({ host: RESTORE_HOST, wasmBindings: wasm });
+    const initialDid = node.sessionDid;
+
+    const publicOnly = { ...sourceJwk };
+    delete publicOnly.d;
+    await expect(
+      node.restoreSession(restorableData(publicOnly, sourceDid)),
+    ).rejects.toThrow(/invalid private Ed25519 session key/);
+    expect(node.sessionDid).toBe(initialDid);
+
+    await expect(
+      node.restoreSession(restorableData({ kty: "OKP", crv: "Ed25519" }, sourceDid)),
+    ).rejects.toThrow(/invalid private Ed25519 session key/);
+    expect(node.sessionDid).toBe(initialDid);
+
+    await expect(
+      node.restoreSession(restorableData(sourceJwk, unrelatedDid)),
+    ).rejects.toThrow(/verification method does not match/);
+    expect(node.sessionDid).toBe(initialDid);
+
+    await expect(
+      node.restoreSession(restorableData(sourceJwk, "not-a-did")),
+    ).rejects.toThrow(/verification method does not match/);
+    expect(node.sessionDid).toBe(initialDid);
+  });
+
+  test("round-trips a real WASM session JWK into a fresh node and activates a narrow signed grant", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const restored = fixture.createRestoredDelegate();
+      const defaultDid = restored.sessionDid;
+
+      await restored.restoreSession(fixture.restorableSession);
+
+      expect(restored.sessionDid).not.toBe(defaultDid);
+      expect(principalDidEquals(restored.sessionDid, fixture.restorableSession.verificationMethod)).toBe(
+        true,
+      );
+
+      const delegation = await fixture.mintDelegation();
+      const activated = await activateValidatedRuntimeDelegation(restored, delegation, {
+        host: fixture.host,
+      });
+
+      expect(activated.audience).toBe(restored.sessionDid.split("#", 1)[0]);
+      expect(restored.getRuntimePermissionDelegations()).toHaveLength(1);
+    } finally {
+      fixture.stop();
+    }
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import {
+  CaveatedDelegationUnsupportedError,
   canonicalHashHex,
   hexEncode,
   encryptionBase64Decode,
@@ -523,6 +524,75 @@ describe("TinyCloudNode runtime permission delegations", () => {
     expect(createDelegation.mock.calls[0][0].delegationHeader.Authorization).toBe(
       "runtime-token",
     );
+  });
+
+  test("fails closed when a caveated runtime grant would cross the action-only WASM boundary", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const spaceId = `tinycloud:pkh:eip155:1:${address}:secrets`;
+    const caveats = [{ tenant: "alpha", nested: { region: "us-east-1" } }];
+    const permission: PermissionEntry = {
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "vault/secrets/ANTHROPIC_API_KEY",
+      actions: ["tinycloud.kv/put"],
+      caveats,
+    };
+    (node as any).runtimePermissionGrants = [{
+      session: {
+        delegationHeader: { Authorization: "runtime-token" },
+        delegationCid: "runtime-cid",
+        spaceId,
+        verificationMethod: "did:key:default",
+        jwk: { kty: "OKP" },
+      },
+      delegation: {
+        cid: "runtime-cid",
+        delegationHeader: { Authorization: "runtime-token" },
+        spaceId,
+        path: permission.path,
+        actions: permission.actions,
+        caveats,
+        expiry: new Date(Date.now() + 3_600_000),
+        delegateDID: "did:key:default",
+        ownerAddress: address,
+        chainId: 1,
+      },
+      operations: [{
+        spaceId,
+        service: "kv",
+        path: permission.path,
+        action: "tinycloud.kv/put",
+        caveats,
+      }],
+      expiresAt: new Date(Date.now() + 3_600_000),
+      provenance: "delegated",
+    }];
+
+    await expect(node.delegateTo("did:key:backend", [permission]))
+      .rejects.toBeInstanceOf(CaveatedDelegationUnsupportedError);
+    expect((node as any).wasmBindings.createDelegation).not.toHaveBeenCalled();
+  });
+
+  test("rejects caveated runtime grants before preparing an action-only session", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const permission: PermissionEntry = {
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "vault/secrets/ANTHROPIC_API_KEY",
+      actions: ["tinycloud.kv/put"],
+      caveats: [{ tenant: "alpha" }],
+    };
+
+    await expect(node.grantRuntimePermissions([permission]))
+      .rejects.toBeInstanceOf(CaveatedDelegationUnsupportedError);
+    expect((node as any).wasmBindings.prepareSession).not.toHaveBeenCalled();
   });
 
   test("can reinstall a portable runtime delegation", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -577,6 +577,79 @@ describe("TinyCloudNode runtime permission delegations", () => {
     expect((node as any).wasmBindings.createDelegation).not.toHaveBeenCalled();
   });
 
+  test("rejects an uncaveated public request selected against a caveated runtime grant", async () => {
+    const invoke = mock((session: any) => ({
+      Authorization: session.delegationHeader.Authorization,
+    })) as any;
+    const node = makeNode(invoke);
+    const address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const spaceId = `tinycloud:pkh:eip155:1:${address}:default`;
+    const caveats = [{ tenant: "alpha", nested: { region: "us-east-1" } }];
+    const operation = {
+      spaceId,
+      service: "kv",
+      path: "vault/secrets/ANTHROPIC_API_KEY",
+      action: "tinycloud.kv/put",
+      caveats,
+    };
+    const grant = {
+      session: {
+        delegationHeader: { Authorization: "runtime-token" },
+        delegationCid: "runtime-cid",
+        spaceId,
+        verificationMethod: "did:key:default",
+        jwk: { kty: "OKP" },
+      },
+      delegation: {
+        cid: "runtime-cid",
+        delegationHeader: { Authorization: "runtime-token" },
+        spaceId,
+        path: operation.path,
+        actions: [operation.action],
+        caveats,
+        expiry: new Date(Date.now() + 3_600_000),
+        delegateDID: "did:key:default",
+        ownerAddress: address,
+        chainId: 1,
+      },
+      operations: [operation],
+      expiresAt: new Date(Date.now() + 3_600_000),
+      provenance: "delegated" as const,
+    };
+    (node as any).runtimePermissionGrants = [grant];
+    const selectGrant = mock((operations: unknown[], options: unknown) =>
+      (node as any).__selectRuntimeGrant(operations, options),
+    );
+    (node as any).__selectRuntimeGrant = (node as any).findGrantForOperations.bind(node);
+    (node as any).findGrantForOperations = selectGrant;
+
+    const result = node.createDelegation({
+      path: operation.path,
+      actions: [operation.action],
+      delegateDID: "did:key:backend",
+    });
+
+    await expect(result).rejects.toMatchObject({
+      name: "CaveatedDelegationUnsupportedError",
+      code: "CAVEATED_DELEGATION_UNSUPPORTED",
+      entries: [{ caveats }],
+    });
+    expect(selectGrant).toHaveBeenCalledTimes(1);
+    const [selectedOperations, selectedOptions] = selectGrant.mock.calls[0] as [
+      Array<Record<string, unknown>>,
+      { excludePrimary: boolean },
+    ];
+    expect(selectedOperations).toEqual([expect.objectContaining({
+      spaceId: operation.spaceId,
+      service: operation.service,
+      path: operation.path,
+      action: operation.action,
+    })]);
+    expect(selectedOperations[0]?.caveats).toBeUndefined();
+    expect(selectedOptions).toEqual({ excludePrimary: true });
+    expect((node as any).wasmBindings.createDelegation).not.toHaveBeenCalled();
+  });
+
   test("rejects caveated runtime grants before preparing an action-only session", async () => {
     const invoke = mock((session: any) => ({
       Authorization: session.delegationHeader.Authorization,

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -20,6 +20,7 @@ import { TinyCloudNode } from "./TinyCloudNode";
 function makeFakeSessionManager(): ISessionManager {
   return {
     createSessionKey: (id: string) => id,
+    replaceSessionKey: (_jwk: object, keyId: string) => keyId,
     renameSessionKeyId: () => {},
     getDID: (keyId: string) => `did:key:${keyId}`,
     jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),

--- a/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import type { EncodedShareData, ISessionManager, IWasmBindings } from "@tinycloud/sdk-core";
+import {
+  CapabilityKeyRegistry,
+  CaveatedDelegationUnsupportedError,
+  type EncodedShareData,
+  type ISessionManager,
+  type IWasmBindings,
+} from "@tinycloud/sdk-core";
 import { Wallet } from "ethers";
 
 import { TinyCloudNode } from "./TinyCloudNode";
@@ -8,6 +14,8 @@ import { NodeWasmBindings } from "./NodeWasmBindings";
 import { deserializeDelegation, serializeDelegation } from "./delegation";
 
 const originalFetch = globalThis.fetch;
+const OWNER = "0xD559CCd9EB87c530A9a349262669386dE93cf412";
+const SPACE = `tinycloud:pkh:eip155:1:${OWNER}:applications`;
 
 function makeFakeSessionManager(): ISessionManager {
   return {
@@ -15,7 +23,7 @@ function makeFakeSessionManager(): ISessionManager {
     replaceSessionKey: (_jwk: object, keyId: string) => keyId,
     renameSessionKeyId: () => {},
     getDID: (keyId: string) => `did:key:${keyId}`,
-    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test", d: "test" }),
   };
 }
 
@@ -76,6 +84,118 @@ describe("TinyCloudNode sharing", () => {
         "xyz.tinycloud.tinychat/threads": ["tinycloud.sql/read"],
       },
     });
+  });
+
+  test("rejects every meaningful parent caveat branch before sub-delegation signing", async () => {
+    const wasmBindings = makeWasmBindings();
+    const signer = { signMessage: mock(async () => "signature") };
+    const node = new TinyCloudNode({
+      host: "https://node.example",
+      signer: signer as any,
+      wasmBindings,
+    });
+    (node as any)._address = OWNER;
+    (node as any)._chainId = 1;
+    const parent = {
+      cid: "parent-cid",
+      delegationHeader: { Authorization: "parent.header.signature" },
+      spaceId: SPACE,
+      path: "shared",
+      actions: ["tinycloud.kv/get"],
+      expiry: new Date(Date.now() + 60 * 60_000),
+      delegateDID: "did:key:z6MkReceiver",
+      ownerAddress: OWNER,
+      chainId: 1,
+    };
+    const cases = [
+      { caveats: [{ tenant: "alpha" }] },
+      { caveats: [{}, { tenant: "alpha" }] },
+      {
+        resources: [{
+          service: "kv",
+          space: SPACE,
+          path: "shared",
+          actions: ["tinycloud.kv/get"],
+          caveats: [{ tenant: "alpha" }],
+        }],
+      },
+    ];
+
+    for (const parentCaveats of cases) {
+      const result = node.createSubDelegation(
+        { ...parent, ...parentCaveats },
+        {
+          path: "shared",
+          actions: ["tinycloud.kv/get"],
+          delegateDID: "did:key:z6MkChild",
+        },
+      );
+      await expect(result).rejects.toBeInstanceOf(CaveatedDelegationUnsupportedError);
+      await expect(result).rejects.toMatchObject({
+        code: "CAVEATED_DELEGATION_UNSUPPORTED",
+      });
+    }
+
+    expect(wasmBindings.prepareSession).not.toHaveBeenCalled();
+    expect(signer.signMessage).not.toHaveBeenCalled();
+  });
+
+  test("does not activate a root share after its owner-signer graph retires", async () => {
+    const wasmBindings = makeWasmBindings();
+    let releaseSignature!: () => void;
+    let markSigningStarted!: () => void;
+    const signingStarted = new Promise<void>((resolve) => {
+      markSigningStarted = resolve;
+    });
+    const signer = {
+      signMessage: mock(async () => {
+        markSigningStarted();
+        await new Promise<void>((resolve) => {
+          releaseSignature = resolve;
+        });
+        return "signature";
+      }),
+    };
+    const node = new TinyCloudNode({
+      host: "https://node.example",
+      signer: signer as any,
+      wasmBindings,
+    });
+    const session = {
+      address: OWNER,
+      chainId: 1,
+      sessionKey: "default",
+      spaceId: SPACE,
+      delegationCid: "parent-cid",
+      delegationHeader: { Authorization: "parent.header.signature" },
+      verificationMethod: "did:key:default",
+      jwk: { kty: "OKP", crv: "Ed25519", x: "test", d: "test" },
+      siwe: "signed session",
+      signature: "signature",
+    };
+    (node as any).auth = { tinyCloudSession: session };
+    (node as any)._address = OWNER;
+    (node as any)._chainId = 1;
+    (node as any).initializeV2Services({
+      delegationHeader: session.delegationHeader,
+      delegationCid: session.delegationCid,
+      spaceId: session.spaceId,
+      verificationMethod: session.verificationMethod,
+      jwk: session.jwk,
+    });
+    (node.sharing as any).registry = new CapabilityKeyRegistry();
+    globalThis.fetch = mock(async () => new Response(null, { status: 200 })) as typeof fetch;
+
+    const result = node.sharing.generate({
+      path: "outside-the-session-recap",
+      actions: ["tinycloud.kv/get"],
+    });
+    await signingStarted;
+    (node as any)._serviceGraph.retire();
+    releaseSignature();
+
+    await expect(result).resolves.toMatchObject({ ok: false });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   test("real WASM attenuates a received share and the child survives transport/useDelegation", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
@@ -12,6 +12,7 @@ const originalFetch = globalThis.fetch;
 function makeFakeSessionManager(): ISessionManager {
   return {
     createSessionKey: (id: string) => id,
+    replaceSessionKey: (_jwk: object, keyId: string) => keyId,
     renameSessionKeyId: () => {},
     getDID: (keyId: string) => `did:key:${keyId}`,
     jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),

--- a/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
@@ -198,6 +198,50 @@ describe("TinyCloudNode sharing", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  test("public owner delegation does not activate after its captured graph retires during wallet signing", async () => {
+    const wasmBindings = makeWasmBindings();
+    let releaseSignature!: () => void;
+    let markSigningStarted!: () => void;
+    const signingStarted = new Promise<void>((resolve) => {
+      markSigningStarted = resolve;
+    });
+    const signer = {
+      signMessage: mock(async () => {
+        markSigningStarted();
+        await new Promise<void>((resolve) => {
+          releaseSignature = resolve;
+        });
+        return "signature";
+      }),
+    };
+    globalThis.fetch = mock(async () => new Response(null, { status: 200 })) as typeof fetch;
+    const node = new TinyCloudNode({
+      host: "https://node.example",
+      signer: signer as any,
+      wasmBindings,
+    });
+    (node as any)._restoredTcSession = {
+      address: OWNER,
+      chainId: 1,
+      spaceId: SPACE,
+    };
+
+    const result = node.createOwnerDelegation({
+      delegateDid: "did:key:z6MkExternalCaller",
+      spaceId: SPACE,
+      path: "xyz.tinycloud.listen/conversations",
+      actions: ["tinycloud.sql/read"],
+      expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+    });
+    await signingStarted;
+    (node as any)._serviceGraph.retire();
+    releaseSignature();
+
+    await expect(result).rejects.toThrow("Service graph has been retired");
+    expect(signer.signMessage).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   test("real WASM attenuates a received share and the child survives transport/useDelegation", async () => {
     const wasmBindings = new NodeWasmBindings();
     globalThis.fetch = mock(async () => new Response(

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -269,6 +269,67 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     })).rejects.toThrow("Service graph has been retired");
   });
 
+  test("rejects captured encryption discovery after a later wallet sign-in retires its graph", async () => {
+    const originalFetch = globalThis.fetch;
+    let discoveryRequested = false;
+    let requestSignal: AbortSignal | undefined;
+    let releaseDiscovery!: (response: Response) => void;
+    let markDiscoveryStarted!: () => void;
+    const discoveryStarted = new Promise<void>((resolve) => { markDiscoveryStarted = resolve; });
+    const info = () => new Response(JSON.stringify({
+      protocol: 1,
+      version: "test",
+      features: [],
+      nodeId: "did:key:z6MkNode",
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+    const activation = () => new Response(JSON.stringify({
+      activated: ["space://test"],
+      skipped: [],
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+    globalThis.fetch = mock((url: string, init?: RequestInit) => {
+      if (url.includes("/encryption/networks/")) {
+        if (discoveryRequested) return Promise.resolve(new Response(null, { status: 404 }));
+        discoveryRequested = true;
+        requestSignal = init?.signal;
+        markDiscoveryStarted();
+        return new Promise<Response>((resolve) => { releaseDiscovery = resolve; });
+      }
+      if (url.includes("/info")) return Promise.resolve(info());
+      return Promise.resolve(activation());
+    }) as typeof fetch;
+
+    try {
+      const node = makeNodeWithSigner(makeFakeWasmBindings(), {
+        autoBootstrapAccount: false,
+        includeAccountRegistryPermissions: false,
+        manifest: {
+          app_id: "xyz.tinycloud.feed.host",
+          name: "Feed Host",
+          defaults: false,
+          permissions: [],
+        },
+      });
+      await node.signIn();
+
+      const captured = node.encryption;
+      const inFlight = captured.discoverNetwork(
+        "urn:tinycloud:encryption:did:key:zTest:network",
+      );
+      await discoveryStarted;
+
+      await node.signIn();
+      expect(requestSignal?.aborted).toBe(true);
+      releaseDiscovery(new Response(null, { status: 404 }));
+
+      await expect(inFlight).rejects.toThrow("Service graph has been retired");
+      await expect(captured.discoverNetwork(
+        "urn:tinycloud:encryption:did:key:zTest:network",
+      )).rejects.toThrow("Service graph has been retired");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("no manifest → uses defaultActions (legacy fallback)", async () => {
     const prepareSessionSpy = mock((cfg: any) => ({
       siwe: "fake-siwe",

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -57,6 +57,10 @@ function makeFakeSessionManager(): ISessionManager {
       keys.add(id);
       return id;
     },
+    replaceSessionKey(_jwk: object, keyId: string): string {
+      keys.add(keyId);
+      return keyId;
+    },
     renameSessionKeyId(oldId: string, newId: string): void {
       if (!keys.has(oldId)) throw new Error(`Key ${oldId} does not exist.`);
       keys.delete(oldId);

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -230,6 +230,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     const firstKeyId = node.session?.sessionKey;
     expect(firstKeyId).toStartWith("session-");
     expect(node.sessionDid).toBe(`did:key:z6MkTest-${firstKeyId}`);
+    const capturedEncryption = node.encryption;
 
     await new Promise((resolve) => setTimeout(resolve, 2));
     await withFetchResponses(
@@ -257,6 +258,15 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     expect(secondKeyId).toStartWith("session-");
     expect(secondKeyId).not.toBe(firstKeyId);
     expect(node.sessionDid).toBe(`did:key:z6MkTest-${secondKeyId}`);
+    await expect((capturedEncryption as any).config.node.fetchByNetworkId(
+      "urn:tinycloud:encryption:did:key:z6MkTest:default",
+    )).rejects.toThrow("Service graph has been retired");
+    await expect((capturedEncryption as any).config.signer.signDecryptInvocation({
+      targetNode: "did:key:z6MkNode",
+      networkId: "urn:tinycloud:encryption:did:key:z6MkTest:default",
+      body: {},
+      facts: [],
+    })).rejects.toThrow("Service graph has been retired");
   });
 
   test("no manifest → uses defaultActions (legacy fallback)", async () => {

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -164,6 +164,31 @@ async function withFetchResponses(
   }
 }
 
+async function withActivationResponses(
+  responses: Response[],
+  fn: (fetchMock: any) => Promise<void>,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (!url.endsWith("/delegate") || init?.method !== "POST") {
+      throw new Error(`unexpected activation fetch: ${url}`);
+    }
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("unexpected activation fetch");
+    }
+    return response;
+  });
+
+  globalThis.fetch = fetchMock as any;
+  try {
+    await fn(fetchMock);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
 /**
  * Stub out the post-prepareSession network calls so signIn can complete
  * without contacting a real server. We monkey-patch the inner auth
@@ -704,7 +729,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     };
     auth.hostOwnedSpace = mock(async () => true);
 
-    await withFetchResponses(
+    await withActivationResponses(
       [
         new Response(JSON.stringify({ activated: [], skipped: [accountSpaceId] }), {
           status: 200,

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -169,8 +169,13 @@ async function withActivationResponses(
   fn: (fetchMock: any) => Promise<void>,
 ): Promise<void> {
   const originalFetch = globalThis.fetch;
+  const expectedAuthorization = "Bearer manifest-activation-fixture";
   const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
+    const authorization = new Headers(init?.headers).get("authorization");
+    if (authorization !== expectedAuthorization) {
+      return originalFetch(input, init);
+    }
     if (!url.endsWith("/delegate") || init?.method !== "POST") {
       throw new Error(`unexpected activation fetch: ${url}`);
     }
@@ -725,7 +730,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     const node = makeNodeWithSigner(makeFakeWasmBindings());
     const auth = (node as any).auth;
     auth._tinyCloudSession = {
-      delegationHeader: { Authorization: "Bearer fake" },
+      delegationHeader: { Authorization: "Bearer manifest-activation-fixture" },
     };
     auth.hostOwnedSpace = mock(async () => true);
 

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -2533,7 +2533,12 @@ export class TinyCloudNode {
       },
       onRootDelegationNeeded: this.signer ? async (params) => {
         graph.assertActive();
-        return this.createRootDelegationForSharing(params);
+        const delegation = await this.createRootDelegationForSharing(
+          params,
+          () => graph.assertActive(),
+        );
+        graph.assertActive();
+        return delegation;
       } : undefined,
     });
     const spaceService = new SpaceService({
@@ -3417,7 +3422,12 @@ export class TinyCloudNode {
       onRootDelegationNeeded: this.signer
         ? async (params) => {
           graph.assertActive();
-          return this.createRootDelegationForSharing(params);
+          const delegation = await this.createRootDelegationForSharing(
+            params,
+            () => graph.assertActive(),
+          );
+          graph.assertActive();
+          return delegation;
         }
         : undefined,
     });
@@ -3495,7 +3505,11 @@ export class TinyCloudNode {
    * with expiry longer than the current session.
    * @internal
    */
-  async createOwnerDelegation(params: CreateOwnerDelegationParams): Promise<OwnerDelegationReceipt> {
+  async createOwnerDelegation(
+    params: CreateOwnerDelegationParams,
+    assertActive?: () => void,
+  ): Promise<OwnerDelegationReceipt> {
+    assertActive?.();
     if (!params.delegateDid.startsWith("did:key:") || params.actions.length === 0 || params.path.length === 0) {
       throw new Error("Owner delegation requires an external did:key audience and bounded capabilities");
     }
@@ -3521,8 +3535,10 @@ export class TinyCloudNode {
       delegateUri: params.delegateDid,
     });
     const signature = await this.signer.signMessage(prepared.siwe);
+    assertActive?.();
     const delegationSession = this.wasmBindings.completeSessionSetup({ ...prepared, signature });
     const activation = await activateSessionWithHost(host, delegationSession.delegationHeader);
+    assertActive?.();
     if (!activation.success) {
       throw new Error(`Owner delegation import failed: ${activation.status} ${activation.error ?? ""}`.trim());
     }
@@ -3557,7 +3573,7 @@ export class TinyCloudNode {
     path: string;
     actions: string[];
     requestedExpiry: Date;
-  }): Promise<Delegation | undefined> {
+  }, assertActive?: () => void): Promise<Delegation | undefined> {
     try {
       return (await this.createOwnerDelegation({
         delegateDid: params.shareKeyDID,
@@ -3565,8 +3581,9 @@ export class TinyCloudNode {
         path: params.path,
         actions: params.actions,
         expiresAt: params.requestedExpiry,
-      })).delegation;
+      }, assertActive)).delegation;
     } catch {
+      assertActive?.();
       return undefined;
     }
   }
@@ -4627,8 +4644,9 @@ export class TinyCloudNode {
       // the primary session's spaceId (the wrong-space class). Exclude the
       // primary explicitly; failure then degrades to
       // PermissionNotInManifestError instead of a wrong-space delegation.
+      const runtimeOperations = this.permissionEntriesToOperations(expandedEntries, session);
       const runtimeGrant = this.findGrantForOperations(
-        this.permissionEntriesToOperations(expandedEntries, session),
+        runtimeOperations,
         { excludePrimary: true },
       );
       if (runtimeGrant) {
@@ -4645,6 +4663,7 @@ export class TinyCloudNode {
           expandedEntries,
           runtimeExpiration,
           runtimeGrant,
+          runtimeOperations,
         );
         return { delegation, prompted: false };
       }
@@ -4861,7 +4880,9 @@ export class TinyCloudNode {
     entries: PermissionEntry[],
     expirationTime: Date,
     grant: RuntimePermissionGrant,
+    requestedOperations: RuntimePermissionOperation[],
   ): Promise<PortableDelegation> {
+    this.assertRuntimeGrantCaveatsPreservable(entries, requestedOperations, grant);
     this.assertDelegationCaveatsPreservable(entries);
     const result = this.createDelegationWrapper({
       session: grant.session,
@@ -4936,6 +4957,78 @@ export class TinyCloudNode {
     );
     if (caveated.length > 0) {
       throw new CaveatedDelegationUnsupportedError(caveated);
+    }
+  }
+
+  /**
+   * Runtime grant selection intentionally allows an uncaveated operation to
+   * select a caveated grant so invocation can restore the signed caveat before
+   * crossing the caveat-aware WASM boundary. Child delegation cannot do that:
+   * it only accepts action maps, so reject the selected constrained branch.
+   */
+  private assertRuntimeGrantCaveatsPreservable(
+    entries: PermissionEntry[],
+    requestedOperations: RuntimePermissionOperation[],
+    grant: RuntimePermissionGrant,
+  ): void {
+    let operationIndex = 0;
+    const caveated: PermissionEntry[] = [];
+    for (const entry of entries) {
+      for (const action of entry.actions) {
+        const requested = requestedOperations[operationIndex++];
+        if (!requested) continue;
+        const constrained = grant.operations.find((granted) =>
+          this.operationCovers(granted, requested) &&
+          !recapCaveatsEqual(granted.caveats, undefined),
+        );
+        if (constrained) {
+          caveated.push({
+            ...entry,
+            actions: [action],
+            caveats: cloneRecapCaveats(constrained.caveats),
+          });
+        }
+      }
+    }
+    if (caveated.length > 0) {
+      throw new CaveatedDelegationUnsupportedError(caveated);
+    }
+  }
+
+  /** Reject caveated parent branches before action-only child signing. */
+  private assertPortableDelegationCaveatsPreservable(
+    delegation: PortableDelegation,
+  ): void {
+    const entries: PermissionEntry[] = [];
+    const add = (
+      service: string,
+      space: string,
+      path: string,
+      actions: string[],
+      caveats: readonly Record<string, unknown>[] | undefined,
+    ): void => {
+      if (recapCaveatsEqual(caveats, undefined)) return;
+      entries.push({
+        service: service.startsWith("tinycloud.") ? service : `tinycloud.${service}`,
+        space,
+        path,
+        actions: [...actions],
+        caveats: cloneRecapCaveats(caveats),
+      });
+    };
+
+    add(
+      delegation.actions[0]?.split("/", 1)[0] ?? "tinycloud.unknown",
+      delegation.spaceId,
+      delegation.path,
+      delegation.actions,
+      delegation.caveats,
+    );
+    for (const resource of delegation.resources ?? []) {
+      add(resource.service, resource.space, resource.path, resource.actions, resource.caveats);
+    }
+    if (entries.length > 0) {
+      throw new CaveatedDelegationUnsupportedError(entries);
     }
   }
 
@@ -5930,6 +6023,8 @@ export class TinyCloudNode {
       expiryMs?: number;
     }
   ): Promise<PortableDelegation> {
+    this.assertPortableDelegationCaveatsPreservable(parentDelegation);
+
     if (!this.signer) {
       throw new Error("Cannot createSubDelegation() in session-only mode. Requires wallet mode.");
     }

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -101,8 +101,10 @@ import {
   // Capability-chain delegation
   type PermissionEntry,
   ENCRYPTION_PERMISSION_SERVICE,
+  CaveatedDelegationUnsupportedError,
   PermissionNotInManifestError,
   SessionExpiredError,
+  recapCaveatsEqual,
   expandPermissionEntries as expandPermissionEntriesCore,
   isCapabilitySubset,
   parseRecapCapabilities,
@@ -315,25 +317,6 @@ function cloneRecapCaveats(
   } catch {
     throw new Error("Verified persisted session ReCap contains invalid caveats.");
   }
-}
-
-function canonicalRecapCaveats(
-  caveats: readonly Record<string, unknown>[] | undefined,
-): string {
-  const canonicalize = (value: unknown): string => {
-    if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
-      return JSON.stringify(value);
-    }
-    if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
-    if (typeof value === "object") {
-      const object = value as Record<string, unknown>;
-      return `{${Object.keys(object).sort().map((key) =>
-        `${JSON.stringify(key)}:${canonicalize(object[key])}`
-      ).join(",")}}`;
-    }
-    throw new Error("ReCap caveats must be JSON values.");
-  };
-  return canonicalize(cloneRecapCaveats(caveats));
 }
 
 /** One replaceable set of services bound to a single host/session authority. */
@@ -883,7 +866,7 @@ export class TinyCloudNode {
           return entry;
         }
         if (entry.caveats !== undefined &&
-          canonicalRecapCaveats(entry.caveats) !== canonicalRecapCaveats(granted.caveats)) {
+          !recapCaveatsEqual(entry.caveats, granted.caveats)) {
           throw new Error("Invocation caveats do not match signed ReCap authority.");
         }
         return { ...entry, caveats: cloneRecapCaveats(granted.caveats) };
@@ -972,12 +955,13 @@ export class TinyCloudNode {
     // Initialize SharingService for receive-only access (no session required)
     // This allows session-only users to receive sharing links without signIn()
     // Full capabilities (generate) are added after signIn()
+    const receiveOnlyGraph = this._serviceGraph;
     this._sharingService = new SharingService({
       hosts: [this.config.host!],
       // session: undefined - not needed for receive()
-      invoke: this._serviceGraph.invoke,
-      fetch: this._serviceGraph.fetch,
-      assertActive: this._serviceGraph.assertActive,
+      invoke: receiveOnlyGraph.invoke,
+      fetch: receiveOnlyGraph.fetch,
+      assertActive: () => receiveOnlyGraph.assertActive(),
       keyProvider: this._keyProvider,
       registry: this._capabilityRegistry,
       createDelegationWasm: (params) => this.createDelegationWrapper(params),
@@ -992,7 +976,7 @@ export class TinyCloudNode {
         const prefix = config.pathPrefix?.replace(/\/$/, '');
         const kvService = new KVService({ prefix });
         // Create a new service context for the KV service
-        const kvContext = this._serviceGraph.track(new ServiceContext({
+        const kvContext = receiveOnlyGraph.track(new ServiceContext({
           invoke: config.invoke,
           fetch: config.fetch ?? globalThis.fetch.bind(globalThis),
           hosts: config.hosts,
@@ -2518,7 +2502,7 @@ export class TinyCloudNode {
       hosts: [input.host],
       invoke: graph.invoke,
       fetch: graph.fetch,
-      assertActive: graph.assertActive,
+      assertActive: () => graph.assertActive(),
       keyProvider,
       registry: capabilityRegistry,
       createDelegationWasm: (params) => this.createDelegationWrapper(params),
@@ -3181,7 +3165,7 @@ export class TinyCloudNode {
             : (body as NetworkDescriptor);
         },
       },
-      assertActive: graph.assertActive,
+      assertActive: () => graph.assertActive(),
     });
   }
 
@@ -3396,19 +3380,40 @@ export class TinyCloudNode {
       },
     });
 
-    // Update SharingService with full capabilities (session + createDelegation)
-    // SharingService was initialized in constructor for receive-only access
-    this._sharingService.updateConfig({
+    // A SharingService retains its invoke/fetch functions and lifetime guard.
+    // Recreate it for this graph instead of updating the receive-only instance
+    // from the graph that was just retired during a subsequent sign-in.
+    this._sharingService = new SharingService({
+      hosts: [this.config.host!],
       session: serviceSession,
+      invoke: graph.invoke,
+      fetch: graph.fetch,
+      assertActive: () => graph.assertActive(),
+      keyProvider: this._keyProvider,
+      registry: this._capabilityRegistry,
       delegationManager: this._delegationManager,
       sessionExpiry: this.getSessionExpiry(),
-      // WASM-based delegation creation (preferred - no server roundtrip)
       createDelegationWasm: (params) => {
         graph.assertActive();
         return this.createDelegationWrapper(params);
       },
-      // Root delegation for long-lived share links (bypasses session expiry)
-      // In node-sdk we have direct signer access, so no popup needed
+      computeCid: (data, codec) => {
+        if (!this.wasmBindings.computeCid) throw new Error("computeCid is unavailable");
+        return this.wasmBindings.computeCid(data, codec);
+      },
+      createKVService: (config) => {
+        graph.assertActive();
+        const service = new KVService({ prefix: config.pathPrefix?.replace(/\/$/, "") });
+        const context = graph.track(new ServiceContext({
+          invoke: config.invoke,
+          fetch: config.fetch ?? graph.fetch,
+          hosts: config.hosts,
+          telemetry: this.config.telemetry,
+        }));
+        context.setSession(config.session);
+        service.initialize(context);
+        return service;
+      },
       onRootDelegationNeeded: this.signer
         ? async (params) => {
           graph.assertActive();
@@ -4058,6 +4063,7 @@ export class TinyCloudNode {
         "grantRuntimePermissions requires wallet mode with a signer or privateKey.",
       );
     }
+    this.assertDelegationCaveatsPreservable(expanded);
 
     const rawEntries = expanded.filter((entry) =>
       this.isEncryptionPermissionEntry(entry)
@@ -4584,6 +4590,7 @@ export class TinyCloudNode {
             "createDelegation method.",
         );
       }
+      this.assertDelegationCaveatsPreservable(expandedEntries);
       const delegation = await this.createDelegationLegacyWalletPath(
         did,
         expandedEntries[0],
@@ -4727,6 +4734,7 @@ export class TinyCloudNode {
         "createDelegationViaWasmPath requires a non-empty entries array",
       );
     }
+    this.assertDelegationCaveatsPreservable(entries);
 
     // Translate non-raw manifest `space` fields into the server-side
     // spaceId. Encryption entries target raw network URNs, not spaces.
@@ -4854,6 +4862,7 @@ export class TinyCloudNode {
     expirationTime: Date,
     grant: RuntimePermissionGrant,
   ): Promise<PortableDelegation> {
+    this.assertDelegationCaveatsPreservable(entries);
     const result = this.createDelegationWrapper({
       session: grant.session,
       delegateDID: did,
@@ -4915,6 +4924,19 @@ export class TinyCloudNode {
     permissions: PermissionEntry[],
   ): PermissionEntry[] {
     return expandPermissionEntriesCore(permissions);
+  }
+
+  /**
+   * The current WASM child-delegation APIs accept action-only maps. Refuse any
+   * constrained branch rather than signing a broader action-only child UCAN.
+   */
+  private assertDelegationCaveatsPreservable(entries: PermissionEntry[]): void {
+    const caveated = entries.filter((entry) =>
+      !recapCaveatsEqual(entry.caveats, undefined)
+    );
+    if (caveated.length > 0) {
+      throw new CaveatedDelegationUnsupportedError(caveated);
+    }
   }
 
   private shortServiceName(service: string): string {
@@ -5324,7 +5346,7 @@ export class TinyCloudNode {
     // same signed attenuation.  An uncaveated request is decorated with the
     // grant's caveat immediately before WASM signs it.
     if (requested.caveats !== undefined &&
-      canonicalRecapCaveats(granted.caveats) !== canonicalRecapCaveats(requested.caveats)
+      !recapCaveatsEqual(granted.caveats, requested.caveats)
     ) {
       return false;
     }

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -284,6 +284,58 @@ function clonePersistedSessionJwk(jwk: unknown): object {
   }
 }
 
+function cloneRecapCaveats(
+  caveats: readonly Record<string, unknown>[] | undefined,
+): Record<string, unknown>[] {
+  if (!caveats) return [];
+  const cloneJson = (value: unknown): unknown => {
+    if (value === null || typeof value === "boolean" || typeof value === "string") {
+      return value;
+    }
+    if (typeof value === "number") {
+      if (Number.isFinite(value)) return value;
+      throw new Error("ReCap caveats must contain only JSON values.");
+    }
+    if (Array.isArray(value)) return value.map(cloneJson);
+    if (typeof value === "object") {
+      const prototype = Object.getPrototypeOf(value);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new Error("ReCap caveats must contain only JSON values.");
+      }
+      const copy: Record<string, unknown> = Object.create(null);
+      for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+        copy[key] = cloneJson(nested);
+      }
+      return copy;
+    }
+    throw new Error("ReCap caveats must contain only JSON values.");
+  };
+  try {
+    return JSON.parse(JSON.stringify(caveats.map(cloneJson))) as Record<string, unknown>[];
+  } catch {
+    throw new Error("Verified persisted session ReCap contains invalid caveats.");
+  }
+}
+
+function canonicalRecapCaveats(
+  caveats: readonly Record<string, unknown>[] | undefined,
+): string {
+  const canonicalize = (value: unknown): string => {
+    if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+      return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+    if (typeof value === "object") {
+      const object = value as Record<string, unknown>;
+      return `{${Object.keys(object).sort().map((key) =>
+        `${JSON.stringify(key)}:${canonicalize(object[key])}`
+      ).join(",")}}`;
+    }
+    throw new Error("ReCap caveats must be JSON values.");
+  };
+  return canonicalize(cloneRecapCaveats(caveats));
+}
+
 /** One replaceable set of services bound to a single host/session authority. */
 class ServiceGraphLifetime {
   private readonly abortController = new AbortController();
@@ -324,12 +376,22 @@ class ServiceGraphLifetime {
     if (this.retired) return;
     this.retired = true;
     this.abortController.abort();
-    for (const context of this.contexts) {
-      const retire = (context as ServiceContext & { retire?: () => void }).retire;
-      if (retire) retire.call(context);
-      else context.abort();
+    try {
+      for (const context of this.contexts) {
+        try {
+          const retire = (context as ServiceContext & { retire?: () => void }).retire;
+          if (retire) retire.call(context);
+          else context.abort();
+        } catch (error) {
+          // Graph replacement is committed before retirement. A custom
+          // service's best-effort cleanup must not roll that replacement back
+          // or leave later contexts active.
+          console.error("Error retiring service graph context:", error);
+        }
+      }
+    } finally {
+      this.contexts.clear();
     }
-    this.contexts.clear();
   }
 
   assertActive(): void {
@@ -523,6 +585,8 @@ interface RuntimePermissionOperation {
   service: string;
   path: string;
   action: string;
+  /** Exact signed ReCap attenuation for this action, if any. */
+  caveats?: Record<string, unknown>[];
 }
 
 interface RuntimePermissionGrant {
@@ -758,13 +822,37 @@ export class TinyCloudNode {
     action,
     facts,
   ) => {
-    return this.wasmBindings.invoke(
-      this.selectInvocationSession(session, service, path, action),
-      service,
+    const operation: RuntimePermissionOperation = {
+      spaceId: session.spaceId,
+      service: this.invocationServiceName(service),
       path,
       action,
-      facts,
+    };
+    const grant = this.findGrantForOperation(operation);
+    const grantedOperation = grant?.operations.find((candidate) =>
+      this.operationCovers(candidate, operation),
     );
+    const invocationSession = !grant || grant.provenance === "primary"
+      ? session
+      : grant.session;
+
+    // The legacy single-capability binding has no caveat parameter.  Calling
+    // it for a restored caveated grant would silently broaden the authority,
+    // so mint the equivalent one-entry aggregate invocation instead.
+    if ((grantedOperation?.caveats?.length ?? 0) > 0) {
+      if (!this.wasmBindings.invokeAny) {
+        throw new Error("WASM binding does not support caveat-preserving invocation");
+      }
+      return this.wasmBindings.invokeAny(invocationSession, [{
+        spaceId: invocationSession.spaceId,
+        service,
+        path,
+        action,
+        caveats: cloneRecapCaveats(grantedOperation!.caveats),
+      }], facts);
+    }
+
+    return this.wasmBindings.invoke(invocationSession, service, path, action, facts);
   };
 
   private readonly invokeAnyWithRuntimePermissions: InvokeAnyFunction = (
@@ -775,18 +863,33 @@ export class TinyCloudNode {
     if (!this.wasmBindings.invokeAny) {
       throw new Error("WASM binding does not support invokeAny");
     }
-    const grant = this.findGrantForOperations(
-      entries.flatMap((entry) => {
-        const operation = this.operationFromInvokeAnyEntry(entry);
-        return operation ? [operation] : [];
-      }),
-    );
+    const operations = entries.flatMap((entry) => {
+      const operation = this.operationFromInvokeAnyEntry(entry);
+      return operation ? [operation] : [];
+    });
+    const grant = this.findGrantForOperations(operations);
     // When the primary grant wins, invoke with the PASSED session (its scoped
     // target `spaceId`), not the stored primary `ServiceSession` — see
     // `selectInvocationSession` for the wrong-space rationale (TC-111 follow-up).
     const invocationSession =
       !grant || grant.provenance === "primary" ? session : grant.session;
-    return this.wasmBindings.invokeAny(invocationSession, entries, facts);
+    const caveatPreservingEntries = grant
+      ? entries.map((entry) => {
+        const requested = this.operationFromInvokeAnyEntry(entry);
+        const granted = requested && grant.operations.find((candidate) =>
+          this.operationCovers(candidate, requested),
+        );
+        if (!granted?.caveats?.length) {
+          return entry;
+        }
+        if (entry.caveats !== undefined &&
+          canonicalRecapCaveats(entry.caveats) !== canonicalRecapCaveats(granted.caveats)) {
+          throw new Error("Invocation caveats do not match signed ReCap authority.");
+        }
+        return { ...entry, caveats: cloneRecapCaveats(granted.caveats) };
+      })
+      : entries;
+    return this.wasmBindings.invokeAny(invocationSession, caveatPreservingEntries, facts);
   };
 
   /**
@@ -969,7 +1072,10 @@ export class TinyCloudNode {
     return new ServiceGraphLifetime(
       this.invokeWithRuntimePermissions,
       this.invokeAnyWithRuntimePermissions,
-      globalThis.fetch.bind(globalThis),
+      // Resolve fetch at request time. This keeps the graph-owned lifetime
+      // signal while preserving the SDK's existing injectable global fetch
+      // behavior (including adapters that install it after construction).
+      (url, init) => globalThis.fetch(url, init),
     );
   }
 
@@ -1535,7 +1641,7 @@ export class TinyCloudNode {
     }
     let operations: RuntimePermissionOperation[] = [];
     try {
-      const entries = this.wasmBindings.parseRecapFromSiwe(siwe);
+      const entries = this.parseRecapWithCaveats(siwe);
       if (Array.isArray(entries)) {
         operations = entries.flatMap((entry) => {
           const service = this.invocationServiceName(entry.service);
@@ -1546,6 +1652,7 @@ export class TinyCloudNode {
             service,
             path: entry.path,
             action,
+            caveats: cloneRecapCaveats(entry.caveats),
           }));
         });
       }
@@ -2110,20 +2217,27 @@ export class TinyCloudNode {
         siwe: sessionData.siwe!,
         signature: sessionData.signature!,
       });
-      if (!Array.isArray(verified.recap) || !verified.recap.every((entry) =>
+      const exactRecap = verified.verifiedRecap;
+      if (!Array.isArray(exactRecap) || !exactRecap.every((entry) =>
         entry !== null && typeof entry === "object" &&
         typeof entry.service === "string" &&
         typeof entry.space === "string" &&
         typeof entry.path === "string" &&
-        Array.isArray(entry.actions) && entry.actions.every((action) => typeof action === "string")
+        Array.isArray(entry.actions) && entry.actions.every((action) => typeof action === "string") &&
+        Array.isArray(entry.caveats) && entry.caveats.every((caveat) =>
+          caveat !== null && typeof caveat === "object" && !Array.isArray(caveat)
+        )
       )) {
-        throw new Error("Verified persisted session ReCap could not be reconstructed.");
+        throw new UnsupportedSessionRestoreError(
+          "it cannot reconstruct caveat-preserving persisted ReCap authority",
+        );
       }
-      stagedRecap = verified.recap.map((entry) => ({
+      stagedRecap = exactRecap.map((entry) => ({
         service: entry.service,
         space: entry.space,
         path: entry.path,
         actions: [...entry.actions],
+        caveats: cloneRecapCaveats(entry.caveats),
       }));
       const signedExpiry = verified.expiresAt === undefined
         ? undefined
@@ -2244,6 +2358,7 @@ export class TinyCloudNode {
         service,
         path: entry.path,
         action,
+        caveats: cloneRecapCaveats(entry.caveats),
       }));
     });
     const cache = { siwe: session.siwe, operations };
@@ -2344,7 +2459,14 @@ export class TinyCloudNode {
     hooks.initialize(serviceContext);
     serviceContext.registerService('hooks', hooks);
     serviceContext.setSession(input.serviceSession);
-    const encryption = this.createEncryptionService();
+    const encryption = this.createEncryptionService({
+      graph,
+      host: input.host,
+      session: input.serviceSession,
+      did: input.nodeDid,
+      address: input.address,
+      chainId: input.chainId,
+    });
     encryption.initialize(serviceContext);
     serviceContext.registerService('encryption', encryption);
     const vault = this.createVaultService(input.serviceSession.spaceId, kv, encryption, {
@@ -2369,6 +2491,7 @@ export class TinyCloudNode {
           spaceId: entry.space,
           path: entry.path,
           actions: [...entry.actions],
+          caveats: cloneRecapCaveats(entry.caveats),
           expiry: input.sessionExpiry,
           isRevoked: false,
           allowSubDelegation: true,
@@ -2821,6 +2944,19 @@ export class TinyCloudNode {
     return session;
   }
 
+  /**
+   * Runtime-permission helpers can be used from an authenticated Node session
+   * before its public ServiceContext is initialized. They still need the
+   * current signed session, never an optional or stale authority object.
+   */
+  private requireEncryptionSession(): ServiceSession {
+    const session = this._serviceContext?.session ?? this.auth?.tinyCloudSession;
+    if (!session) {
+      throw new Error("Not signed in. Call signIn() first.");
+    }
+    return session;
+  }
+
   private createEncryptionCrypto(): EncryptionCrypto {
     const wasm = this.wasmBindings;
     const columnEncrypt = (key: Uint8Array, plaintext: Uint8Array): Uint8Array => {
@@ -2885,14 +3021,18 @@ export class TinyCloudNode {
     networkId: string;
     action: string;
     facts: NetworkInvocationFact;
+  }, binding?: {
+    graph: ServiceGraphLifetime;
+    session: ServiceSession;
   }): Promise<{ authorization: string; invocationCid: string }> {
+    binding?.graph.assertActive();
     if (!this.wasmBindings.invokeAny) {
       throw new Error("WASM binding does not support raw-resource invokeAny");
     }
     if (!this.wasmBindings.computeCid) {
       throw new Error("WASM binding does not support invocation CID computation");
     }
-    const session = this.requireServiceSession();
+    const session = binding?.session ?? this.requireEncryptionSession();
     const headers = this.invokeAnyWithRuntimePermissions(
       session,
       [
@@ -2911,6 +3051,7 @@ export class TinyCloudNode {
       input.targetNode,
       session.jwk,
     );
+    binding?.graph.assertActive();
     return {
       authorization: audienceBound,
       invocationCid: this.wasmBindings.computeCid(
@@ -2920,12 +3061,51 @@ export class TinyCloudNode {
     };
   }
 
-  private createEncryptionService(): EncryptionService {
+  private async fetchEncryptionNetworkAt(
+    host: string,
+    networkId: string,
+    fetchFn: FetchFunction,
+  ): Promise<NetworkDescriptor | null> {
+    const response = await fetchFn(
+      `${host}/encryption/networks/${encodeURIComponent(networkId)}`,
+    );
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch encryption network ${networkId}: HTTP ${response.status} ${await response.text()}`,
+      );
+    }
+    const body = (await response.json()) as {
+      descriptor?: NetworkDescriptor;
+    } | NetworkDescriptor;
+    return "descriptor" in body && body.descriptor ? body.descriptor : body as NetworkDescriptor;
+  }
+
+  private createEncryptionService(binding?: {
+    graph: ServiceGraphLifetime;
+    host: string;
+    session: ServiceSession;
+    did: string;
+    address: string | undefined;
+    chainId: number;
+  }): EncryptionService {
+    const graph = binding?.graph ?? this._serviceGraph;
+    const host = binding?.host ?? this.config.host!;
+    // The public service path always has a ServiceContext. Keep the auth-session
+    // fallback for the internal runtime-permission helpers, which construct an
+    // encryption service before a ServiceContext is installed. Both paths bind
+    // the resulting service to this graph, so a later graph replacement still
+    // retires the captured service permanently.
+    const session = binding?.session ?? this.requireEncryptionSession();
+    const did = binding?.did ?? this.did;
+    const address = binding?.address ?? this._address;
+    const chainId = binding?.chainId ?? this._chainId;
     const crypto = this.createEncryptionCrypto();
     const transport: DecryptTransport = {
-      postDecrypt: async ({ networkId, authorization, canonicalBody }) => {
-        const response = await fetch(
-          `${this.config.host}/encryption/networks/${encodeURIComponent(networkId)}/decrypt`,
+      postDecrypt: async ({ networkId, authorization, canonicalBody, signal }) => {
+        graph.assertActive();
+        const response = await graph.fetch(
+          `${host}/encryption/networks/${encodeURIComponent(networkId)}/decrypt`,
           {
             method: "POST",
             headers: {
@@ -2933,8 +3113,10 @@ export class TinyCloudNode {
               "Content-Type": "application/json",
             },
             body: canonicalBody,
+            signal,
           },
         );
+        graph.assertActive();
         if (!response.ok) {
           throw new Error(
             `decrypt failed ${response.status}: ${await response.text()}`,
@@ -2949,12 +3131,14 @@ export class TinyCloudNode {
         signDecryptInvocation: async (
           input: BuildDecryptInvocationInput,
         ): Promise<BuiltDecryptInvocation> => {
+          graph.assertActive();
           const signed = await this.signRawNetworkAuthorization({
             targetNode: input.targetNode,
             networkId: input.networkId,
             action: DECRYPT_ACTION,
             facts: input.facts,
-          });
+          }, { graph, session });
+          graph.assertActive();
           return {
             ...signed,
             canonicalBody: canonicalizeEncryptionJson(
@@ -2965,31 +3149,39 @@ export class TinyCloudNode {
       },
       transport,
       node: {
-        fetchByNetworkId: (networkId) => this.getEncryptionNetwork(networkId),
+        fetchByNetworkId: async (networkId) => {
+          graph.assertActive();
+          const descriptor = await this.fetchEncryptionNetworkAt(host, networkId, graph.fetch);
+          graph.assertActive();
+          return descriptor;
+        },
       },
       wellKnown: {
         fetchWellKnown: async (principal, discoveryKey) => {
-          if (!this._address || !didPrincipalMatches(principal, this.did)) {
+          graph.assertActive();
+          if (!address || !didPrincipalMatches(principal, did)) {
             return null;
           }
-          if (!this.config.host) {
+          const publicSpaceId = makePublicSpaceId(address, chainId);
+          const encodedKey = discoveryKey.split("/").map(encodeURIComponent).join("/");
+          const response = await graph.fetch(
+            `${host}/public/${encodeURIComponent(publicSpaceId)}/kv/${encodedKey}`,
+            { method: "GET" },
+          );
+          graph.assertActive();
+          if (!response.ok) {
             return null;
           }
-          const publicSpaceId = makePublicSpaceId(this._address, this._chainId);
-          const result = await TinyCloud.readPublicSpace<
-            NetworkDescriptor | { descriptor?: NetworkDescriptor }
-          >(this.config.host, publicSpaceId, discoveryKey);
-          if (!result.ok) {
-            return null;
-          }
-          const body = result.data as
+          const body = await response.json() as
             | NetworkDescriptor
             | { descriptor?: NetworkDescriptor };
+          graph.assertActive();
           return "descriptor" in body && body.descriptor
             ? body.descriptor
             : (body as NetworkDescriptor);
         },
       },
+      assertActive: graph.assertActive,
     });
   }
 
@@ -3531,21 +3723,11 @@ export class TinyCloudNode {
     const networkId = nameOrNetworkId.startsWith("urn:tinycloud:encryption:")
       ? nameOrNetworkId
       : this.getDefaultEncryptionNetworkId(nameOrNetworkId);
-    const response = await fetch(
-      `${this.config.host}/encryption/networks/${encodeURIComponent(networkId)}`,
+    return this.fetchEncryptionNetworkAt(
+      this.config.host!,
+      networkId,
+      globalThis.fetch.bind(globalThis),
     );
-    if (response.status === 404) {
-      return null;
-    }
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch encryption network ${networkId}: HTTP ${response.status} ${await response.text()}`,
-      );
-    }
-    const body = (await response.json()) as {
-      descriptor?: NetworkDescriptor;
-    } | NetworkDescriptor;
-    return "descriptor" in body && body.descriptor ? body.descriptor : body as NetworkDescriptor;
   }
 
   async createEncryptionNetwork(
@@ -4423,7 +4605,7 @@ export class TinyCloudNode {
     //    surface a clear TypeError rather than silently falling
     //    through.
     const granted = parseRecapCapabilities(
-      (siwe: string) => this.wasmBindings.parseRecapFromSiwe(siwe),
+      (siwe: string) => this.parseRecapWithCaveats(siwe),
       session.siwe,
     );
     const { subset, missing } = isCapabilitySubset(expandedEntries, granted);
@@ -4802,6 +4984,7 @@ export class TinyCloudNode {
         service,
         path: entry.path,
         action,
+        ...(entry.caveats === undefined ? {} : { caveats: cloneRecapCaveats(entry.caveats) }),
       }));
     });
   }
@@ -4812,7 +4995,7 @@ export class TinyCloudNode {
   ): boolean {
     try {
       const granted = parseRecapCapabilities(
-        (siwe: string) => this.wasmBindings.parseRecapFromSiwe(siwe),
+        (siwe: string) => this.parseRecapWithCaveats(siwe),
         session.siwe,
       );
       return isCapabilitySubset(entries, granted).subset;
@@ -4835,6 +5018,7 @@ export class TinyCloudNode {
         service,
         path: entry.path,
         action,
+        ...(entry.caveats === undefined ? {} : { caveats: cloneRecapCaveats(entry.caveats) }),
       }));
     });
   }
@@ -4946,6 +5130,7 @@ export class TinyCloudNode {
       space: this.isEncryptionPermissionEntry(entry) ? "encryption" : spaceId,
       path: entry.path,
       actions: [...entry.actions],
+      ...(entry.caveats === undefined ? {} : { caveats: cloneRecapCaveats(entry.caveats) }),
     }));
   }
 
@@ -4966,6 +5151,7 @@ export class TinyCloudNode {
         service,
         path: resource.path,
         action,
+        caveats: cloneRecapCaveats(resource.caveats),
       }));
     });
   }
@@ -4985,6 +5171,7 @@ export class TinyCloudNode {
       space: delegation.spaceId,
       path: delegation.path,
       actions,
+      ...(delegation.caveats === undefined ? {} : { caveats: cloneRecapCaveats(delegation.caveats) }),
     }));
   }
 
@@ -5133,6 +5320,15 @@ export class TinyCloudNode {
       return false;
     }
 
+    // A caller that already carries a caveat can only be covered by the exact
+    // same signed attenuation.  An uncaveated request is decorated with the
+    // grant's caveat immediately before WASM signs it.
+    if (requested.caveats !== undefined &&
+      canonicalRecapCaveats(granted.caveats) !== canonicalRecapCaveats(requested.caveats)
+    ) {
+      return false;
+    }
+
     if (granted.resource !== undefined || requested.resource !== undefined) {
       return granted.resource !== undefined &&
         requested.resource !== undefined &&
@@ -5181,6 +5377,12 @@ export class TinyCloudNode {
       : service;
   }
 
+  /** Prefer the v2 caveat-preserving parser while retaining old custom WASM. */
+  private parseRecapWithCaveats(siwe: string): WasmRecapEntry[] {
+    return this.wasmBindings.parseVerifiedRecapFromSiwe?.(siwe)
+      ?? this.wasmBindings.parseRecapFromSiwe(siwe);
+  }
+
   private isEncryptionNetworkOperation(service: string, path: string): boolean {
     return service === "encryption" &&
       path.startsWith("urn:tinycloud:encryption:");
@@ -5192,6 +5394,7 @@ export class TinyCloudNode {
     service: string;
     path: string;
     action: string;
+    caveats?: Record<string, unknown>[];
   }): RuntimePermissionOperation | undefined {
     const service = this.invocationServiceName(entry.service);
     if (typeof entry.resource === "string") {
@@ -5200,6 +5403,7 @@ export class TinyCloudNode {
         service,
         path: entry.path,
         action: entry.action,
+        ...(entry.caveats === undefined ? {} : { caveats: cloneRecapCaveats(entry.caveats) }),
       };
     }
     if (this.isEncryptionNetworkOperation(service, entry.path)) {
@@ -5208,6 +5412,7 @@ export class TinyCloudNode {
         service,
         path: entry.path,
         action: entry.action,
+        ...(entry.caveats === undefined ? {} : { caveats: cloneRecapCaveats(entry.caveats) }),
       };
     }
     if (typeof entry.spaceId === "string") {
@@ -5216,6 +5421,7 @@ export class TinyCloudNode {
         service,
         path: entry.path,
         action: entry.action,
+        ...(entry.caveats === undefined ? {} : { caveats: cloneRecapCaveats(entry.caveats) }),
       };
     }
     return undefined;

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -57,11 +57,13 @@ import {
   ISigner,
   type InvokeAnyFunction,
   type InvokeFunction,
+  type FetchFunction,
   INotificationHandler,
   SilentNotificationHandler,
   IENSResolver,
   IWasmBindings,
   ISessionManager,
+  type WasmRecapEntry,
   ISpaceCreationHandler,
   SignInOptions,
   // v2 services
@@ -279,6 +281,74 @@ function clonePersistedSessionJwk(jwk: unknown): object {
     return cloned;
   } catch {
     throw new Error("Persisted session has an invalid private Ed25519 session key.");
+  }
+}
+
+/** One replaceable set of services bound to a single host/session authority. */
+class ServiceGraphLifetime {
+  private readonly abortController = new AbortController();
+  private readonly contexts = new Set<ServiceContext>();
+  private retired = false;
+
+  constructor(
+    private readonly invokeFn: InvokeFunction,
+    private readonly invokeAnyFn: InvokeAnyFunction,
+    private readonly fetchFn: FetchFunction,
+  ) {}
+
+  readonly invoke: InvokeFunction = (session, service, path, action, facts) => {
+    this.assertActive();
+    return this.invokeFn(session, service, path, action, facts);
+  };
+
+  readonly invokeAny: InvokeAnyFunction = (session, entries, facts) => {
+    this.assertActive();
+    return this.invokeAnyFn(session, entries, facts);
+  };
+
+  readonly fetch: FetchFunction = (url, init) => {
+    this.assertActive();
+    return this.fetchFn(url, {
+      ...init,
+      signal: this.combineSignals(init?.signal),
+    });
+  };
+
+  track(context: ServiceContext): ServiceContext {
+    this.assertActive();
+    this.contexts.add(context);
+    return context;
+  }
+
+  retire(): void {
+    if (this.retired) return;
+    this.retired = true;
+    this.abortController.abort();
+    for (const context of this.contexts) {
+      const retire = (context as ServiceContext & { retire?: () => void }).retire;
+      if (retire) retire.call(context);
+      else context.abort();
+    }
+    this.contexts.clear();
+  }
+
+  assertActive(): void {
+    if (this.retired) {
+      throw new Error("Service graph has been retired by session replacement.");
+    }
+  }
+
+  private combineSignals(signal?: AbortSignal): AbortSignal {
+    if (!signal) return this.abortController.signal;
+    const combined = new AbortController();
+    const abort = () => combined.abort();
+    if (signal.aborted || this.abortController.signal.aborted) {
+      abort();
+    } else {
+      signal.addEventListener("abort", abort, { once: true });
+      this.abortController.signal.addEventListener("abort", abort, { once: true });
+    }
+    return combined.signal;
   }
 }
 
@@ -599,6 +669,7 @@ export class TinyCloudNode {
   private _chainId: number = 1;
   private wasmBindings: IWasmBindings;
   private sessionManager: ISessionManager;
+  private _serviceGraph!: ServiceGraphLifetime;
   private _serviceContext?: ServiceContext;
   private _kv?: KVService;
   private _sql?: SQLService;
@@ -782,6 +853,8 @@ export class TinyCloudNode {
     }
     this.sessionKeyJwk = JSON.parse(jwkStr);
 
+    this._serviceGraph = this.createServiceGraphLifetime();
+
     // Initialize capability registry for all users (needed for tracking received delegations)
     this._capabilityRegistry = new CapabilityKeyRegistry();
 
@@ -799,8 +872,9 @@ export class TinyCloudNode {
     this._sharingService = new SharingService({
       hosts: [this.config.host!],
       // session: undefined - not needed for receive()
-      invoke: this.invokeWithRuntimePermissions,
-      fetch: globalThis.fetch.bind(globalThis),
+      invoke: this._serviceGraph.invoke,
+      fetch: this._serviceGraph.fetch,
+      assertActive: this._serviceGraph.assertActive,
       keyProvider: this._keyProvider,
       registry: this._capabilityRegistry,
       createDelegationWasm: (params) => this.createDelegationWrapper(params),
@@ -815,12 +889,12 @@ export class TinyCloudNode {
         const prefix = config.pathPrefix?.replace(/\/$/, '');
         const kvService = new KVService({ prefix });
         // Create a new service context for the KV service
-        const kvContext = new ServiceContext({
+        const kvContext = this._serviceGraph.track(new ServiceContext({
           invoke: config.invoke,
           fetch: config.fetch ?? globalThis.fetch.bind(globalThis),
           hosts: config.hosts,
           telemetry: this.config.telemetry,
-        });
+        }));
         kvContext.setSession(config.session);
         kvService.initialize(kvContext);
         return kvService;
@@ -889,6 +963,14 @@ export class TinyCloudNode {
       config.capabilityRequest === undefined &&
       (config.prefix ?? "default") === "default" &&
       isOpenKeyAutoSignStrategy(config.signStrategy);
+  }
+
+  private createServiceGraphLifetime(): ServiceGraphLifetime {
+    return new ServiceGraphLifetime(
+      this.invokeWithRuntimePermissions,
+      this.invokeAnyWithRuntimePermissions,
+      globalThis.fetch.bind(globalThis),
+    );
   }
 
   private syncResolvedHostFromAuth(): void {
@@ -1084,6 +1166,15 @@ export class TinyCloudNode {
 
     await this.tc.signIn(options);
     this.syncResolvedHostFromAuth();
+
+    // Bind the replacement services to the runtime dependencies active for
+    // this sign-in and permanently retire anything captured from the previous
+    // session. The authorization flow above remains transactional: a rejected
+    // sign-in leaves the existing graph untouched.
+    const oldGraph = this._serviceGraph;
+    this._serviceGraph = this.createServiceGraphLifetime();
+    oldGraph.retire();
+    this.tc.retireServices();
 
     // NodeUserAuthorization renames the constructor's "default" key when it
     // creates the signed-in session. Keep node-level key accessors in sync so
@@ -2004,6 +2095,7 @@ export class TinyCloudNode {
       ? canonicalizeAddress(sessionData.address!)
       : undefined;
     let stagedSessionExpiry = new Date(0);
+    let stagedRecap: WasmRecapEntry[] = [];
     if (hasPersistedProof) {
       if (typeof this.wasmBindings.validatePersistedSession !== "function") {
         throw new UnsupportedSessionRestoreError("it cannot verify persisted SIWE authority");
@@ -2012,14 +2104,27 @@ export class TinyCloudNode {
         delegationHeader: sessionData.delegationHeader,
         delegationCid: sessionData.delegationCid,
         spaceId: sessionData.spaceId,
-        spaces: sessionData.spaces,
         jwk: stagedJwk,
-        verificationMethod: canonicalVerificationMethod,
         address: restoredAddress!,
         chainId: sessionData.chainId!,
         siwe: sessionData.siwe!,
         signature: sessionData.signature!,
       });
+      if (!Array.isArray(verified.recap) || !verified.recap.every((entry) =>
+        entry !== null && typeof entry === "object" &&
+        typeof entry.service === "string" &&
+        typeof entry.space === "string" &&
+        typeof entry.path === "string" &&
+        Array.isArray(entry.actions) && entry.actions.every((action) => typeof action === "string")
+      )) {
+        throw new Error("Verified persisted session ReCap could not be reconstructed.");
+      }
+      stagedRecap = verified.recap.map((entry) => ({
+        service: entry.service,
+        space: entry.space,
+        path: entry.path,
+        actions: [...entry.actions],
+      }));
       const signedExpiry = verified.expiresAt === undefined
         ? undefined
         : persistedExpiry(verified.expiresAt);
@@ -2069,6 +2174,7 @@ export class TinyCloudNode {
       stagedNodeDid,
       stagedHost,
       stagedSessionExpiry,
+      stagedRecap,
     );
     const stagedGraph = this.stageRestoredServiceGraph({
       host: stagedHost,
@@ -2080,9 +2186,12 @@ export class TinyCloudNode {
       chainId: stagedChainId,
       tinyCloudSession: stagedTcSession,
       sessionExpiry: stagedSessionExpiry,
+      recap: stagedRecap,
     });
 
     // Every operation below is a non-throwing pointer/value swap.
+    const oldGraph = this._serviceGraph;
+    const oldCore = this.tc;
     this.sessionManager = stagedManager;
     this.sessionKeyId = stagedKeyId;
     this.sessionKeyJwk = stagedJwk;
@@ -2101,6 +2210,7 @@ export class TinyCloudNode {
     this._sharingService = stagedGraph.sharingService;
     this._delegationManager = stagedGraph.delegationManager;
     this._spaceService = stagedGraph.spaceService;
+    this._serviceGraph = stagedGraph.graph;
     this._baseSecrets = new Map();
     this._secrets = new Map();
     this._publicKV = undefined;
@@ -2114,6 +2224,8 @@ export class TinyCloudNode {
     } else {
       this._restoredTcSession = stagedTcSession;
     }
+    oldGraph.retire();
+    (oldCore as { retireServices?: () => void } | null)?.retireServices?.();
   }
 
   private stagePrimarySessionState(
@@ -2121,25 +2233,19 @@ export class TinyCloudNode {
     verificationMethod: string,
     host: string,
     sessionExpiry: Date,
+    recap: WasmRecapEntry[],
   ): { cache: { siwe: string; operations: RuntimePermissionOperation[] } | undefined; grants: RuntimePermissionGrant[] } {
     if (!session?.siwe) return { cache: undefined, grants: [] };
     let operations: RuntimePermissionOperation[] = [];
-    try {
-      const entries = this.wasmBindings.parseRecapFromSiwe(session.siwe);
-      if (Array.isArray(entries)) {
-        operations = entries.flatMap((entry) => {
-          const service = this.invocationServiceName(entry.service);
-          return entry.actions.map((action) => ({
-            ...(this.isEncryptionNetworkOperation(service, entry.path) ? { resource: entry.path } : { spaceId: entry.space }),
-            service,
-            path: entry.path,
-            action,
-          }));
-        });
-      }
-    } catch {
-      operations = [];
-    }
+    operations = recap.flatMap((entry) => {
+      const service = this.invocationServiceName(entry.service);
+      return entry.actions.map((action) => ({
+        ...(this.isEncryptionNetworkOperation(service, entry.path) ? { resource: entry.path } : { spaceId: entry.space }),
+        service,
+        path: entry.path,
+        action,
+      }));
+    });
     const cache = { siwe: session.siwe, operations };
     // Restored authority has no host-activation result yet. Importing a skip
     // list from an unrelated prior session would erase valid restored grants.
@@ -2186,8 +2292,10 @@ export class TinyCloudNode {
     chainId: number;
     tinyCloudSession: TinyCloudSession | undefined;
     sessionExpiry: Date;
+    recap: WasmRecapEntry[];
   }): {
     core: TinyCloud | null;
+    graph: ServiceGraphLifetime;
     serviceContext: ServiceContext;
     kv: KVService;
     sql: SQLService;
@@ -2204,23 +2312,25 @@ export class TinyCloudNode {
     // TinyCloud owns the public-KV service graph. Stage a replacement core
     // context alongside the node graph so repeated cross-host restores cannot
     // leave publicKV pointed at a stale or uninitialized context.
+    const graph = this.createServiceGraphLifetime();
     const core = this.auth
       ? new TinyCloud(this.auth, {
-        invokeAny: this.invokeAnyWithRuntimePermissions,
+        invokeAny: graph.invokeAny,
         telemetry: this.config.telemetry,
       })
       : null;
     if (core) {
-      core.initializeServices(this.invokeWithRuntimePermissions, [input.host]);
-      (core.serviceContext as ServiceContext).setSession(input.serviceSession);
+      core.initializeServices(graph.invoke, [input.host], graph.fetch);
+      const coreContext = graph.track(core.serviceContext as ServiceContext);
+      coreContext.setSession(input.serviceSession);
     }
-    const serviceContext = new ServiceContext({
-      invoke: this.invokeWithRuntimePermissions,
-      invokeAny: this.invokeAnyWithRuntimePermissions,
-      fetch: globalThis.fetch.bind(globalThis),
+    const serviceContext = graph.track(new ServiceContext({
+      invoke: graph.invoke,
+      invokeAny: graph.invokeAny,
+      fetch: graph.fetch,
       hosts: [input.host],
       telemetry: this.config.telemetry,
-    });
+    }));
     const kv = new KVService({});
     kv.initialize(serviceContext);
     serviceContext.registerService('kv', kv);
@@ -2242,6 +2352,7 @@ export class TinyCloudNode {
       did: input.nodeDid,
       address: input.address,
       chainId: input.chainId,
+      serviceGraph: graph,
     });
     vault.initialize(serviceContext);
     serviceContext.registerService('vault', vault);
@@ -2249,41 +2360,19 @@ export class TinyCloudNode {
     const capabilityRegistry = new CapabilityKeyRegistry();
     if (input.tinyCloudSession) {
       const session = input.tinyCloudSession;
-      // Extra space names are persisted session metadata. Only space IDs that
-      // occur in the now-verified ReCap may participate in the capability
-      // registry; e.g. a lazily-created public-space label cannot mint a
-      // primary-session grant by itself.
-      const recapSpaces = new Set<string>();
-      try {
-        for (const entry of this.wasmBindings.parseRecapFromSiwe(session.siwe)) {
-          recapSpaces.add(entry.space);
-        }
-      } catch {
-        throw new Error("Verified persisted session ReCap could not be reconstructed.");
-      }
-      const delegations: Delegation[] = recapSpaces.has(session.spaceId) ? [{
-        cid: session.delegationCid,
-        delegateDID: session.verificationMethod,
-        spaceId: session.spaceId,
-        path: "",
-        actions: [...ROOT_DELEGATION_ACTIONS],
-        expiry: input.sessionExpiry,
-        isRevoked: false,
-        allowSubDelegation: true,
-      }] : [];
-      for (const spaceId of Object.values(session.spaces ?? {})) {
-        if (!recapSpaces.has(spaceId)) continue;
-        delegations.push({
+      // ReCap entries are returned by the verifier that authenticated this
+      // SIWE. Persisted space metadata is only a routing hint and cannot add
+      // an unsigned space, path, or action to the registry.
+      const delegations: Delegation[] = input.recap.map((entry) => ({
           cid: session.delegationCid,
           delegateDID: session.verificationMethod,
-          spaceId,
-          path: "",
-          actions: [...ROOT_DELEGATION_ACTIONS],
+          spaceId: entry.space,
+          path: entry.path,
+          actions: [...entry.actions],
           expiry: input.sessionExpiry,
           isRevoked: false,
           allowSubDelegation: true,
-        });
-      }
+        }));
       if (delegations.length > 0) {
         capabilityRegistry.registerKey({
           id: session.sessionKey,
@@ -2297,15 +2386,16 @@ export class TinyCloudNode {
     const delegationManager = new DelegationManager({
       hosts: [input.host],
       session: input.serviceSession,
-      invoke: this.invokeWithRuntimePermissions,
-      invokeAny: this.invokeAnyWithRuntimePermissions,
-      fetch: globalThis.fetch.bind(globalThis),
+      invoke: graph.invoke,
+      invokeAny: graph.invokeAny,
+      fetch: graph.fetch,
     });
     const keyProvider = new WasmKeyProvider({ sessionManager: input.manager });
     const sharingService = new SharingService({
       hosts: [input.host],
-      invoke: this.invokeWithRuntimePermissions,
-      fetch: globalThis.fetch.bind(globalThis),
+      invoke: graph.invoke,
+      fetch: graph.fetch,
+      assertActive: graph.assertActive,
       keyProvider,
       registry: capabilityRegistry,
       createDelegationWasm: (params) => this.createDelegationWrapper(params),
@@ -2315,12 +2405,12 @@ export class TinyCloudNode {
       },
       createKVService: (config) => {
         const service = new KVService({ prefix: config.pathPrefix?.replace(/\/$/, '') });
-        const context = new ServiceContext({
+        const context = graph.track(new ServiceContext({
           invoke: config.invoke,
           fetch: config.fetch ?? globalThis.fetch.bind(globalThis),
           hosts: config.hosts,
           telemetry: this.config.telemetry,
-        });
+        }));
         context.setSession(config.session);
         service.initialize(context);
         return service;
@@ -2330,25 +2420,64 @@ export class TinyCloudNode {
       session: input.serviceSession,
       delegationManager,
       sessionExpiry: input.sessionExpiry,
-      createDelegationWasm: (params) => this.createDelegationWrapper(params),
-      onRootDelegationNeeded: this.signer ? async (params) => this.createRootDelegationForSharing(params) : undefined,
+      createDelegationWasm: (params) => {
+        graph.assertActive();
+        return this.createDelegationWrapper(params);
+      },
+      onRootDelegationNeeded: this.signer ? async (params) => {
+        graph.assertActive();
+        return this.createRootDelegationForSharing(params);
+      } : undefined,
     });
     const spaceService = new SpaceService({
       hosts: [input.host],
       session: input.serviceSession,
-      invoke: this.wasmBindings.invoke,
-      fetch: globalThis.fetch.bind(globalThis),
+      invoke: graph.invoke,
+      fetch: graph.fetch,
       capabilityRegistry,
       userDid: input.nodeDid,
-      createKVService: (spaceId) => this.createSpaceScopedKVService(spaceId),
+      createKVService: (spaceId) => {
+        graph.assertActive();
+        const scopedKv = new KVService({});
+        const context = graph.track(new ServiceContext({
+          invoke: graph.invoke,
+          invokeAny: graph.invokeAny,
+          fetch: graph.fetch,
+          hosts: [input.host],
+          telemetry: this.config.telemetry,
+        }));
+        context.setSession({ ...input.serviceSession, spaceId });
+        scopedKv.initialize(context);
+        return scopedKv;
+      },
       createVaultService: (spaceId) => {
-        const scopedKv = this.createSpaceScopedKVService(spaceId);
-        const scopedVault = this.createVaultService(spaceId, scopedKv);
-        if (this._serviceContext) scopedVault.initialize(this._serviceContext);
+        graph.assertActive();
+        const scopedKv = new KVService({});
+        const context = graph.track(new ServiceContext({
+          invoke: graph.invoke,
+          invokeAny: graph.invokeAny,
+          fetch: graph.fetch,
+          hosts: [input.host],
+          telemetry: this.config.telemetry,
+        }));
+        context.setSession({ ...input.serviceSession, spaceId });
+        scopedKv.initialize(context);
+        const scopedVault = this.createVaultService(spaceId, scopedKv, encryption, {
+          host: input.host,
+          did: input.nodeDid,
+          address: input.address,
+          chainId: input.chainId,
+          serviceGraph: graph,
+        });
+        scopedVault.initialize(context);
         return scopedVault;
       },
-      createSecretsService: (spaceId) => this.secretsForSpace(spaceId),
+      createSecretsService: (spaceId) => {
+        graph.assertActive();
+        return this.secretsForSpace(spaceId);
+      },
       createDelegation: async (params) => {
+        graph.assertActive();
         try {
           const portableDelegation = await this.createDelegation({
             delegateDID: params.delegateDID,
@@ -2378,10 +2507,13 @@ export class TinyCloudNode {
           }};
         }
       },
-      onSpaceRegistered: async (space) => { await this.account.spaces.register(space); },
+      onSpaceRegistered: async (space) => {
+        graph.assertActive();
+        await this.account.spaces.register(space);
+      },
     });
     spaceService.updateConfig({ sharingService });
-    return { core, serviceContext, kv, sql, duckdb, hooks, vault, encryption, capabilityRegistry, keyProvider, sharingService, delegationManager, spaceService };
+    return { core, graph, serviceContext, kv, sql, duckdb, hooks, vault, encryption, capabilityRegistry, keyProvider, sharingService, delegationManager, spaceService };
   }
 
   /**
@@ -2580,16 +2712,21 @@ export class TinyCloudNode {
     }
 
     // Initialize TinyCloud core services (needed for publicKV, ensurePublicSpace)
-    this.tc!.initializeServices(this.invokeWithRuntimePermissions, [this.config.host!]);
+    this.tc!.initializeServices(
+      this._serviceGraph.invoke,
+      [this.config.host!],
+      this._serviceGraph.fetch,
+    );
+    this._serviceGraph.track(this.tc!.serviceContext as ServiceContext);
 
     // Create service context
-    this._serviceContext = new ServiceContext({
-      invoke: this.invokeWithRuntimePermissions,
-      invokeAny: this.invokeAnyWithRuntimePermissions,
-      fetch: globalThis.fetch.bind(globalThis),
+    this._serviceContext = this._serviceGraph.track(new ServiceContext({
+      invoke: this._serviceGraph.invoke,
+      invokeAny: this._serviceGraph.invokeAny,
+      fetch: this._serviceGraph.fetch,
       hosts: [this.config.host!],
       telemetry: this.config.telemetry,
-    });
+    }));
 
     // Create and register KV service
     this._kv = new KVService({});
@@ -2638,12 +2775,12 @@ export class TinyCloudNode {
   private createSpaceScopedKVService(spaceId: string): KVService {
     const kvService = new KVService({});
     if (this._serviceContext) {
-      const spaceScopedContext = new ServiceContext({
+      const spaceScopedContext = this._serviceGraph.track(new ServiceContext({
         invoke: this._serviceContext.invoke,
         fetch: this._serviceContext.fetch,
         hosts: this._serviceContext.hosts,
         telemetry: this.config.telemetry,
-      });
+      }));
       const session = this._serviceContext.session;
       if (session) {
         spaceScopedContext.setSession({ ...session, spaceId });
@@ -2877,9 +3014,11 @@ export class TinyCloudNode {
       did: string;
       address: string | undefined;
       chainId: number;
+      serviceGraph?: ServiceGraphLifetime;
     },
   ): DataVaultService {
     const wasm = this.wasmBindings;
+    const serviceGraph = nodeContext?.serviceGraph ?? this._serviceGraph;
     const vaultCrypto = createVaultCrypto({
       vault_encrypt: wasm.vault_encrypt, vault_decrypt: wasm.vault_decrypt, vault_derive_key: wasm.vault_derive_key,
       vault_x25519_from_seed: wasm.vault_x25519_from_seed, vault_x25519_dh: wasm.vault_x25519_dh,
@@ -2905,13 +3044,17 @@ export class TinyCloudNode {
         kv,
         ensurePublicSpace: async () => {
           try {
+            serviceGraph.assertActive();
             await self.ensurePublicSpace();
             return { ok: true as const, data: undefined };
           } catch (error) {
             return { ok: false as const, error: { code: "STORAGE_ERROR", message: error instanceof Error ? error.message : String(error), service: "vault" } };
           }
         },
-        get publicKV() { return self._publicKV ?? self.tc!.publicKV; },
+        get publicKV() {
+          serviceGraph.assertActive();
+          return self._publicKV ?? self.tc!.publicKV;
+        },
         readPublicSpace: <T>(host: string, targetSpaceId: string, key: string) =>
           TinyCloud.readPublicSpace<T>(host, targetSpaceId, key),
         makePublicSpaceId: TinyCloud.makePublicSpaceId,
@@ -2928,6 +3071,8 @@ export class TinyCloudNode {
    * @internal
    */
   private initializeV2Services(serviceSession: ServiceSession): void {
+    const graph = this._serviceGraph;
+
     // Initialize CapabilityKeyRegistry
     this._capabilityRegistry = new CapabilityKeyRegistry();
 
@@ -2981,23 +3126,25 @@ export class TinyCloudNode {
     this._delegationManager = new DelegationManager({
       hosts: [this.config.host!],
       session: serviceSession,
-      invoke: this.invokeWithRuntimePermissions,
-      invokeAny: this.invokeAnyWithRuntimePermissions,
-      fetch: globalThis.fetch.bind(globalThis),
+      invoke: graph.invoke,
+      invokeAny: graph.invokeAny,
+      fetch: graph.fetch,
     });
 
     // Initialize SpaceService
     this._spaceService = new SpaceService({
       hosts: [this.config.host!],
       session: serviceSession,
-      invoke: this.wasmBindings.invoke,
-      fetch: globalThis.fetch.bind(globalThis),
+      invoke: graph.invoke,
+      fetch: graph.fetch,
       capabilityRegistry: this._capabilityRegistry,
       userDid: this.did,
       createKVService: (spaceId: string) => {
+        graph.assertActive();
         return this.createSpaceScopedKVService(spaceId);
       },
       createVaultService: (spaceId: string) => {
+        graph.assertActive();
         const kvService = this.createSpaceScopedKVService(spaceId);
         const vaultService = this.createVaultService(spaceId, kvService);
         if (this._serviceContext) {
@@ -3006,11 +3153,13 @@ export class TinyCloudNode {
         return vaultService;
       },
       createSecretsService: (spaceId: string) => {
+        graph.assertActive();
         return this.secretsForSpace(spaceId);
       },
       // Enable space.delegations.create() via SIWE-based delegation
       createDelegation: async (params) => {
         try {
+          graph.assertActive();
           // Use the existing createDelegation method which calls /delegate with SIWE
           const portableDelegation = await this.createDelegation({
             delegateDID: params.delegateDID,
@@ -3050,6 +3199,7 @@ export class TinyCloudNode {
         }
       },
       onSpaceRegistered: async (space) => {
+        graph.assertActive();
         await this.account.spaces.register(space);
       },
     });
@@ -3061,11 +3211,17 @@ export class TinyCloudNode {
       delegationManager: this._delegationManager,
       sessionExpiry: this.getSessionExpiry(),
       // WASM-based delegation creation (preferred - no server roundtrip)
-      createDelegationWasm: (params) => this.createDelegationWrapper(params),
+      createDelegationWasm: (params) => {
+        graph.assertActive();
+        return this.createDelegationWrapper(params);
+      },
       // Root delegation for long-lived share links (bypasses session expiry)
       // In node-sdk we have direct signer access, so no popup needed
       onRootDelegationNeeded: this.signer
-        ? async (params) => this.createRootDelegationForSharing(params)
+        ? async (params) => {
+          graph.assertActive();
+          return this.createRootDelegationForSharing(params);
+        }
         : undefined,
     });
 
@@ -3294,13 +3450,13 @@ export class TinyCloudNode {
     }
 
     const sql = new SQLService({});
-    const spaceScopedContext = new ServiceContext({
+    const spaceScopedContext = this._serviceGraph.track(new ServiceContext({
       invoke: this._serviceContext.invoke,
       invokeAny: this._serviceContext.invokeAny,
       fetch: this._serviceContext.fetch,
       hosts: this._serviceContext.hosts,
       telemetry: this.config.telemetry,
-    });
+    }));
     spaceScopedContext.setSession({ ...this._serviceContext.session, spaceId });
     sql.initialize(spaceScopedContext);
     return sql;
@@ -3326,12 +3482,12 @@ export class TinyCloudNode {
     }
 
     const kv = new KVService({});
-    const spaceScopedContext = new ServiceContext({
+    const spaceScopedContext = this._serviceGraph.track(new ServiceContext({
       invoke: this._serviceContext.invoke,
       invokeAny: this._serviceContext.invokeAny,
       fetch: this._serviceContext.fetch,
       hosts: this._serviceContext.hosts,
-    });
+    }));
     spaceScopedContext.setSession({ ...this._serviceContext.session, spaceId });
     kv.initialize(spaceScopedContext);
     return kv;
@@ -4022,12 +4178,12 @@ export class TinyCloudNode {
     // Cache a properly authorized public KV service using the new delegation
     if (this._serviceContext) {
       const publicKV = new KVService({ prefix: "" });
-      const publicContext = new ServiceContext({
-        invoke: this.invokeWithRuntimePermissions,
-        fetch: this._serviceContext.fetch,
+      const publicContext = this._serviceGraph.track(new ServiceContext({
+        invoke: this._serviceGraph.invoke,
+        fetch: this._serviceGraph.fetch,
         hosts: this._serviceContext.hosts,
         telemetry: this.config.telemetry,
-      });
+      }));
       publicContext.setSession({
         delegationHeader: delegationSession.delegationHeader,
         delegationCid: delegationSession.delegationCid,

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -265,6 +265,32 @@ function didPrincipalMatches(actual: string, expected: string): boolean {
   }
 }
 
+function clonePersistedSessionJwk(jwk: unknown): object {
+  if (jwk === null || typeof jwk !== "object" || Array.isArray(jwk)) {
+    throw new Error("Persisted session has an invalid private Ed25519 session key.");
+  }
+
+  try {
+    const serialized = JSON.stringify(jwk);
+    const cloned = serialized === undefined ? undefined : JSON.parse(serialized);
+    if (cloned === null || typeof cloned !== "object" || Array.isArray(cloned)) {
+      throw new Error("invalid JWK object");
+    }
+    return cloned;
+  } catch {
+    throw new Error("Persisted session has an invalid private Ed25519 session key.");
+  }
+}
+
+function restoredSessionDidMatches(actual: string, expected: unknown): boolean {
+  if (typeof expected !== "string") return false;
+  try {
+    return principalDidEquals(actual, expected);
+  } catch {
+    return false;
+  }
+}
+
 function sharingActionsToAbilities(path: string, actions: string[]): AbilitiesMap | undefined {
   const abilities: AbilitiesMap = {};
 
@@ -1874,6 +1900,64 @@ export class TinyCloudNode {
     // Ensure WASM is ready (critical for browser where WASM loads asynchronously)
     await this.wasmBindings.ensureInitialized?.();
 
+    // Preflight the persisted signer before resetting any service state. A
+    // fresh TinyCloudNode always starts with a generated default key, so merely
+    // restoring delegation metadata would leave `sessionDid` pointed at the
+    // wrong principal. A disposable manager validates the private Ed25519 JWK
+    // without changing this node; the verification method is then checked
+    // against the DID derived by that exact key (fragments are intentionally
+    // ignored because either DID or DID URL is valid persisted input).
+    const restoredJwk = clonePersistedSessionJwk(sessionData.jwk);
+    const stagedManager = this.wasmBindings.createSessionManager();
+    let stagedKeyId: string;
+    let stagedDid: string;
+    try {
+      stagedKeyId = stagedManager.replaceSessionKey(restoredJwk, "restore-validation");
+      stagedDid = stagedManager.getDID(stagedKeyId);
+    } catch {
+      throw new Error("Persisted session has an invalid private Ed25519 session key.");
+    }
+    if (!restoredSessionDidMatches(stagedDid, sessionData.verificationMethod)) {
+      throw new Error(
+        "Persisted session verification method does not match its private Ed25519 session key.",
+      );
+    }
+
+    const restoredAddress = sessionData.address
+      ? canonicalizeAddress(sessionData.address)
+      : undefined;
+    const resolvedHost = await this.resolveRestoredHost(
+      sessionData.tinycloudHosts,
+      restoredAddress,
+      sessionData.chainId,
+    );
+
+    // The actual replacement is also validated by the shared WASM manager and
+    // happens only after all persisted-key and host preflight above succeeds.
+    // Read back the imported key rather than retaining raw input so the
+    // node-level signer state exactly mirrors the manager used by all SDK
+    // services and delegation flows.
+    let installedKeyId: string;
+    let installedJwk: object;
+    try {
+      installedKeyId = this.sessionManager.replaceSessionKey(restoredJwk, this.sessionKeyId);
+      const installedJwkJson = this.sessionManager.jwk(installedKeyId);
+      if (!installedJwkJson) {
+        throw new Error("missing restored session key");
+      }
+      installedJwk = clonePersistedSessionJwk(JSON.parse(installedJwkJson));
+      if (!restoredSessionDidMatches(
+        this.sessionManager.getDID(installedKeyId),
+        sessionData.verificationMethod,
+      )) {
+        throw new Error("restored session key DID mismatch");
+      }
+    } catch {
+      throw new Error("Persisted session could not install its private Ed25519 session key.");
+    }
+    this.sessionKeyId = installedKeyId;
+    this.sessionKeyJwk = installedJwk;
+
     // Reset services so they get recreated with new session
     this._kv = undefined;
     this._sql = undefined;
@@ -1887,9 +1971,6 @@ export class TinyCloudNode {
     this._serviceContext = undefined;
     this.runtimePermissionGrants = [];
 
-    const restoredAddress = sessionData.address
-      ? canonicalizeAddress(sessionData.address)
-      : undefined;
     if (restoredAddress) {
       this._address = restoredAddress;
     }
@@ -1905,11 +1986,6 @@ export class TinyCloudNode {
     //      persisted tinycloudHosts field
     // Without this, the ServiceContext below (and every service call) would
     // silently target the default host instead of the user's actual node.
-    const resolvedHost = await this.resolveRestoredHost(
-      sessionData.tinycloudHosts,
-      restoredAddress,
-      sessionData.chainId,
-    );
     if (resolvedHost) {
       this.config.host = resolvedHost;
     }
@@ -1948,7 +2024,7 @@ export class TinyCloudNode {
       delegationCid: sessionData.delegationCid,
       spaceId: sessionData.spaceId,
       verificationMethod: sessionData.verificationMethod,
-      jwk: sessionData.jwk,
+      jwk: installedJwk,
     };
     this._serviceContext.setSession(serviceSession);
 
@@ -1973,12 +2049,12 @@ export class TinyCloudNode {
       const tcSession: TinyCloudSession = {
         address: restoredAddress,
         chainId: sessionData.chainId,
-        sessionKey: JSON.stringify(sessionData.jwk),
+        sessionKey: JSON.stringify(installedJwk),
         spaceId: sessionData.spaceId,
         delegationCid: sessionData.delegationCid,
         delegationHeader: sessionData.delegationHeader,
         verificationMethod: sessionData.verificationMethod,
-        jwk: sessionData.jwk as { [k: string]: unknown },
+        jwk: installedJwk as { [k: string]: unknown },
         siwe: sessionData.siwe,
         signature: sessionData.signature ?? "",
       };

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -282,13 +282,25 @@ function clonePersistedSessionJwk(jwk: unknown): object {
   }
 }
 
-function restoredSessionDidMatches(actual: string, expected: unknown): boolean {
-  if (typeof expected !== "string") return false;
-  try {
-    return principalDidEquals(actual, expected);
-  } catch {
-    return false;
+export class UnsupportedSessionRestoreError extends Error {
+  readonly code = "RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED" as const;
+
+  constructor() {
+    super("Persisted session restore is unsupported by this WASM binding because it cannot replace the session signer.");
+    this.name = "UnsupportedSessionRestoreError";
   }
+}
+
+function canonicalRestoredVerificationMethod(
+  canonicalVerificationMethod: string,
+  persistedVerificationMethod: unknown,
+): string | undefined {
+  if (typeof persistedVerificationMethod !== "string") return undefined;
+  const principal = canonicalVerificationMethod.split("#", 1)[0];
+  return persistedVerificationMethod === principal ||
+    persistedVerificationMethod === canonicalVerificationMethod
+    ? canonicalVerificationMethod
+    : undefined;
 }
 
 function sharingActionsToAbilities(path: string, actions: string[]): AbilitiesMap | undefined {
@@ -1900,24 +1912,49 @@ export class TinyCloudNode {
     // Ensure WASM is ready (critical for browser where WASM loads asynchronously)
     await this.wasmBindings.ensureInitialized?.();
 
-    // Preflight the persisted signer before resetting any service state. A
-    // fresh TinyCloudNode always starts with a generated default key, so merely
-    // restoring delegation metadata would leave `sessionDid` pointed at the
-    // wrong principal. A disposable manager validates the private Ed25519 JWK
-    // without changing this node; the verification method is then checked
-    // against the DID derived by that exact key (fragments are intentionally
-    // ignored because either DID or DID URL is valid persisted input).
+    // Build every part of the restored state against a disposable manager.
+    // Nothing live is touched until the commit below.
     const restoredJwk = clonePersistedSessionJwk(sessionData.jwk);
+    if (
+      sessionData.chainId !== undefined &&
+      (!Number.isSafeInteger(sessionData.chainId) || sessionData.chainId <= 0)
+    ) {
+      throw new Error("Persisted session chain ID must be a positive safe integer.");
+    }
     const stagedManager = this.wasmBindings.createSessionManager();
+    const stagedReplace = stagedManager.replaceSessionKey;
+    if (typeof stagedReplace !== "function" || typeof this.sessionManager.replaceSessionKey !== "function") {
+      throw new UnsupportedSessionRestoreError();
+    }
     let stagedKeyId: string;
-    let stagedDid: string;
+    let stagedJwk: object;
+    let canonicalVerificationMethod: string;
     try {
-      stagedKeyId = stagedManager.replaceSessionKey(restoredJwk, "restore-validation");
-      stagedDid = stagedManager.getDID(stagedKeyId);
+      const liveManager = this.sessionManager as ISessionManager & {
+        listSessionKeys?(): string[];
+      };
+      // A successful restore replaces only the primary signer; preserve any
+      // share keys that the concrete WASM manager exposes. Older custom
+      // managers need not implement listing and remain supported.
+      for (const keyId of liveManager.listSessionKeys?.() ?? []) {
+        if (keyId === this.sessionKeyId) continue;
+        const jwk = liveManager.jwk(keyId);
+        if (!jwk) throw new Error("missing live session key");
+        stagedReplace.call(stagedManager, clonePersistedSessionJwk(JSON.parse(jwk)), keyId);
+      }
+      stagedKeyId = stagedReplace.call(stagedManager, restoredJwk, this.sessionKeyId);
+      const stagedJwkJson = stagedManager.jwk(stagedKeyId);
+      if (!stagedJwkJson) throw new Error("missing restored session key");
+      stagedJwk = clonePersistedSessionJwk(JSON.parse(stagedJwkJson));
+      canonicalVerificationMethod = stagedManager.getDID(stagedKeyId);
     } catch {
       throw new Error("Persisted session has an invalid private Ed25519 session key.");
     }
-    if (!restoredSessionDidMatches(stagedDid, sessionData.verificationMethod)) {
+    const restoredVerificationMethod = canonicalRestoredVerificationMethod(
+      canonicalVerificationMethod,
+      sessionData.verificationMethod,
+    );
+    if (!restoredVerificationMethod) {
       throw new Error(
         "Persisted session verification method does not match its private Ed25519 session key.",
       );
@@ -1931,150 +1968,328 @@ export class TinyCloudNode {
       restoredAddress,
       sessionData.chainId,
     );
-
-    // The actual replacement is also validated by the shared WASM manager and
-    // happens only after all persisted-key and host preflight above succeeds.
-    // Read back the imported key rather than retaining raw input so the
-    // node-level signer state exactly mirrors the manager used by all SDK
-    // services and delegation flows.
-    let installedKeyId: string;
-    let installedJwk: object;
-    try {
-      installedKeyId = this.sessionManager.replaceSessionKey(restoredJwk, this.sessionKeyId);
-      const installedJwkJson = this.sessionManager.jwk(installedKeyId);
-      if (!installedJwkJson) {
-        throw new Error("missing restored session key");
-      }
-      installedJwk = clonePersistedSessionJwk(JSON.parse(installedJwkJson));
-      if (!restoredSessionDidMatches(
-        this.sessionManager.getDID(installedKeyId),
-        sessionData.verificationMethod,
-      )) {
-        throw new Error("restored session key DID mismatch");
-      }
-    } catch {
-      throw new Error("Persisted session could not install its private Ed25519 session key.");
-    }
-    this.sessionKeyId = installedKeyId;
-    this.sessionKeyJwk = installedJwk;
-
-    // Reset services so they get recreated with new session
-    this._kv = undefined;
-    this._sql = undefined;
-    this._duckdb = undefined;
-    this._hooks = undefined;
-    this._vault = undefined;
-    this._encryption = undefined;
-    this._baseSecrets.clear();
-    this._secrets.clear();
-    this._spaceService = undefined;
-    this._serviceContext = undefined;
-    this.runtimePermissionGrants = [];
-
-    if (restoredAddress) {
-      this._address = restoredAddress;
-    }
-    if (sessionData.chainId) {
-      this._chainId = sessionData.chainId;
-    }
-
-    // Resolve the host the restored session should target, mirroring what a
-    // fresh signIn() would have done. Priority:
-    //   1. explicitHost   — local dev / pinned node, never override
-    //   2. persisted hosts — the node this session was created against
-    //   3. registry/fallback resolution — old sessions that predate the
-    //      persisted tinycloudHosts field
-    // Without this, the ServiceContext below (and every service call) would
-    // silently target the default host instead of the user's actual node.
-    if (resolvedHost) {
-      this.config.host = resolvedHost;
-    }
-
-    // Create service context
-    this._serviceContext = new ServiceContext({
-      invoke: this.invokeWithRuntimePermissions,
-      invokeAny: this.invokeAnyWithRuntimePermissions,
-      fetch: globalThis.fetch.bind(globalThis),
-      hosts: [this.config.host!],
-      telemetry: this.config.telemetry,
-    });
-
-    // Create and register KV service
-    this._kv = new KVService({});
-    this._kv.initialize(this._serviceContext);
-    this._serviceContext.registerService('kv', this._kv);
-
-    // Create and register SQL service
-    this._sql = new SQLService({});
-    this._sql.initialize(this._serviceContext);
-    this._serviceContext.registerService('sql', this._sql);
-
-    // Create and register DuckDB service
-    this._duckdb = new DuckDbService({});
-    this._duckdb.initialize(this._serviceContext);
-    this._serviceContext.registerService('duckdb', this._duckdb);
-
-    this._hooks = new HooksService({});
-    this._hooks.initialize(this._serviceContext);
-    this._serviceContext.registerService('hooks', this._hooks);
-
-    // Set session on context
+    const stagedHost = resolvedHost ?? this.config.host!;
+    const stagedAddress = restoredAddress ?? this._address;
+    const stagedChainId = sessionData.chainId ?? this._chainId;
+    const stagedNodeDid = stagedAddress
+      ? pkhDid(stagedAddress, stagedChainId)
+      : canonicalVerificationMethod;
     const serviceSession: ServiceSession = {
       delegationHeader: sessionData.delegationHeader,
       delegationCid: sessionData.delegationCid,
       spaceId: sessionData.spaceId,
-      verificationMethod: sessionData.verificationMethod,
-      jwk: installedJwk,
+      verificationMethod: restoredVerificationMethod,
+      jwk: stagedJwk,
     };
-    this._serviceContext.setSession(serviceSession);
-
-    // Create and register Vault service (matches initializeServices behavior)
-    this._vault = this.createVaultService(sessionData.spaceId, this._kv!);
-    this._vault.initialize(this._serviceContext);
-    this._serviceContext.registerService('vault', this._vault);
-
-    // Initialize v2 services
-    this.initializeV2Services(serviceSession);
-
-    // Rehydrate a TinyCloudSession on whatever surface is available. In
-    // wallet mode the auth layer holds it; in session-only mode (OpenKey,
-    // public-space restore, …) `this.auth` is null and we fall back to
-    // `_restoredTcSession` on the node itself. Both surfaces are read by
-    // {@link currentTinyCloudSession} so callers don't have to care.
-    //
-    // Required for `useRuntimeDelegation` / `hasRuntimePermissions` /
-    // `getRuntimePermissionDelegations` to work after a session restore —
-    // without this they bail with `SessionExpiredError(new Date(0))`.
-    if (sessionData.siwe && restoredAddress && sessionData.chainId) {
-      const tcSession: TinyCloudSession = {
+    const stagedTcSession: TinyCloudSession | undefined =
+      sessionData.siwe && restoredAddress && sessionData.chainId ? {
         address: restoredAddress,
         chainId: sessionData.chainId,
-        sessionKey: JSON.stringify(installedJwk),
+        sessionKey: JSON.stringify(stagedJwk),
         spaceId: sessionData.spaceId,
         delegationCid: sessionData.delegationCid,
         delegationHeader: sessionData.delegationHeader,
-        verificationMethod: sessionData.verificationMethod,
-        jwk: installedJwk as { [k: string]: unknown },
+        verificationMethod: restoredVerificationMethod,
+        jwk: stagedJwk as { [k: string]: unknown },
         siwe: sessionData.siwe,
         signature: sessionData.signature ?? "",
-      };
-      if (this.auth) {
-        // Pass the now-resolved host so the auth layer's host-needing
-        // methods (ensureSpaceExists/hostSpace) don't throw "hosts have
-        // not been resolved" on a restored session.
-        this.auth.setRestoredTinyCloudSession(
-          tcSession,
-          this.config.host ? [this.config.host] : undefined,
-        );
-      } else {
-        this._restoredTcSession = tcSession;
-      }
+      } : undefined;
+    // The service graph is staged before the session is committed. Derive its
+    // expiry from that staged session once, so capability and sharing state
+    // cannot accidentally inherit a prior session's lifetime.
+    const stagedSessionExpiry = stagedTcSession
+      ? extractSiweExpiration(stagedTcSession.siwe) ?? this.getSessionExpiry()
+      : this.getSessionExpiry();
+    const stagedPrimary = this.stagePrimarySessionState(
+      stagedTcSession,
+      stagedNodeDid,
+      stagedHost,
+      stagedSessionExpiry,
+    );
+    const stagedGraph = this.stageRestoredServiceGraph({
+      host: stagedHost,
+      manager: stagedManager,
+      serviceSession,
+      verificationMethod: canonicalVerificationMethod,
+      nodeDid: stagedNodeDid,
+      address: stagedAddress,
+      chainId: stagedChainId,
+      tinyCloudSession: stagedTcSession,
+      sessionExpiry: stagedSessionExpiry,
+    });
 
-      // Register the restored primary session's own recap as the highest-trust
-      // runtime grant, mirroring signIn() (TC-111). Grants were cleared above,
-      // so no dupes. Only runs when the restored session carries a `siwe`.
-      this.registerPrimarySessionGrant(tcSession);
+    // Every operation below is a non-throwing pointer/value swap.
+    this.sessionManager = stagedManager;
+    this.sessionKeyId = stagedKeyId;
+    this.sessionKeyJwk = stagedJwk;
+    if (resolvedHost) this.config.host = resolvedHost;
+    if (restoredAddress) this._address = restoredAddress;
+    if (sessionData.chainId !== undefined) this._chainId = sessionData.chainId;
+    this._serviceContext = stagedGraph.serviceContext;
+    this._kv = stagedGraph.kv;
+    this._sql = stagedGraph.sql;
+    this._duckdb = stagedGraph.duckdb;
+    this._hooks = stagedGraph.hooks;
+    this._vault = stagedGraph.vault;
+    this._encryption = stagedGraph.encryption;
+    this._capabilityRegistry = stagedGraph.capabilityRegistry;
+    this._keyProvider = stagedGraph.keyProvider;
+    this._sharingService = stagedGraph.sharingService;
+    this._delegationManager = stagedGraph.delegationManager;
+    this._spaceService = stagedGraph.spaceService;
+    this._baseSecrets = new Map();
+    this._secrets = new Map();
+    this._publicKV = undefined;
+    this._account = undefined;
+    this._recapOperationsCache = stagedPrimary.cache;
+    this.runtimePermissionGrants = stagedPrimary.grants;
+    if (this.auth) {
+      this.auth.installRestoredSession(stagedManager, stagedTcSession, this.config.host ? [this.config.host] : undefined);
+      this._restoredTcSession = undefined;
+    } else {
+      this._restoredTcSession = stagedTcSession;
     }
+  }
+
+  private stagePrimarySessionState(
+    session: TinyCloudSession | undefined,
+    verificationMethod: string,
+    host: string,
+    sessionExpiry: Date,
+  ): { cache: { siwe: string; operations: RuntimePermissionOperation[] } | undefined; grants: RuntimePermissionGrant[] } {
+    if (!session?.siwe) return { cache: undefined, grants: [] };
+    let operations: RuntimePermissionOperation[] = [];
+    try {
+      const entries = this.wasmBindings.parseRecapFromSiwe(session.siwe);
+      if (Array.isArray(entries)) {
+        operations = entries.flatMap((entry) => {
+          const service = this.invocationServiceName(entry.service);
+          return entry.actions.map((action) => ({
+            ...(this.isEncryptionNetworkOperation(service, entry.path) ? { resource: entry.path } : { spaceId: entry.space }),
+            service,
+            path: entry.path,
+            action,
+          }));
+        });
+      }
+    } catch {
+      operations = [];
+    }
+    const cache = { siwe: session.siwe, operations };
+    const skipped = this.auth?.lastActivationSkippedSpaceIds ?? [];
+    const acceptedOperations = operations.filter((operation) =>
+      operation.spaceId === undefined || !skipped.some((spaceId) => this.spaceIdsEqual(spaceId, operation.spaceId!)),
+    );
+    if (acceptedOperations.length === 0) return { cache, grants: [] };
+    const expiresAt = extractSiweExpiration(session.siwe) ?? sessionExpiry;
+    return {
+      cache,
+      grants: [{
+        session: {
+          delegationHeader: session.delegationHeader,
+          delegationCid: session.delegationCid,
+          spaceId: session.spaceId,
+          verificationMethod: session.verificationMethod,
+          jwk: session.jwk,
+        },
+        delegation: {
+          cid: session.delegationCid,
+          delegationHeader: session.delegationHeader,
+          delegateDID: session.verificationMethod,
+          delegatorDID: verificationMethod,
+          spaceId: session.spaceId,
+          path: "",
+          actions: [...new Set(acceptedOperations.map((operation) => operation.action))],
+          expiry: expiresAt,
+          allowSubDelegation: true,
+          ownerAddress: session.address,
+          chainId: session.chainId,
+          host,
+        },
+        operations: acceptedOperations,
+        expiresAt,
+        provenance: "primary",
+      }],
+    };
+  }
+
+  private stageRestoredServiceGraph(input: {
+    host: string;
+    manager: ISessionManager;
+    serviceSession: ServiceSession;
+    verificationMethod: string;
+    nodeDid: string;
+    address: string | undefined;
+    chainId: number;
+    tinyCloudSession: TinyCloudSession | undefined;
+    sessionExpiry: Date;
+  }): {
+    serviceContext: ServiceContext;
+    kv: KVService;
+    sql: SQLService;
+    duckdb: DuckDbService;
+    hooks: HooksService;
+    vault: DataVaultService;
+    encryption: EncryptionService;
+    capabilityRegistry: CapabilityKeyRegistry;
+    keyProvider: WasmKeyProvider;
+    sharingService: SharingService;
+    delegationManager: DelegationManager;
+    spaceService: SpaceService;
+  } {
+    const serviceContext = new ServiceContext({
+      invoke: this.invokeWithRuntimePermissions,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
+      fetch: globalThis.fetch.bind(globalThis),
+      hosts: [input.host],
+      telemetry: this.config.telemetry,
+    });
+    const kv = new KVService({});
+    kv.initialize(serviceContext);
+    serviceContext.registerService('kv', kv);
+    const sql = new SQLService({});
+    sql.initialize(serviceContext);
+    serviceContext.registerService('sql', sql);
+    const duckdb = new DuckDbService({});
+    duckdb.initialize(serviceContext);
+    serviceContext.registerService('duckdb', duckdb);
+    const hooks = new HooksService({});
+    hooks.initialize(serviceContext);
+    serviceContext.registerService('hooks', hooks);
+    serviceContext.setSession(input.serviceSession);
+    const encryption = this.createEncryptionService();
+    encryption.initialize(serviceContext);
+    serviceContext.registerService('encryption', encryption);
+    const vault = this.createVaultService(input.serviceSession.spaceId, kv, encryption, {
+      host: input.host,
+      did: input.nodeDid,
+      address: input.address,
+      chainId: input.chainId,
+    });
+    vault.initialize(serviceContext);
+    serviceContext.registerService('vault', vault);
+
+    const capabilityRegistry = new CapabilityKeyRegistry();
+    if (input.tinyCloudSession) {
+      const session = input.tinyCloudSession;
+      const delegations: Delegation[] = [{
+        cid: session.delegationCid,
+        delegateDID: session.verificationMethod,
+        spaceId: session.spaceId,
+        path: "",
+        actions: [...ROOT_DELEGATION_ACTIONS],
+        expiry: input.sessionExpiry,
+        isRevoked: false,
+        allowSubDelegation: true,
+      }];
+      for (const spaceId of Object.values(session.spaces ?? {})) {
+        delegations.push({
+          cid: session.delegationCid,
+          delegateDID: session.verificationMethod,
+          spaceId,
+          path: "",
+          actions: [...ROOT_DELEGATION_ACTIONS],
+          expiry: input.sessionExpiry,
+          isRevoked: false,
+          allowSubDelegation: true,
+        });
+      }
+      capabilityRegistry.registerKey({
+        id: session.sessionKey,
+        did: session.verificationMethod,
+        type: "session",
+        jwk: session.jwk as JWK,
+        priority: 0,
+      }, delegations);
+    }
+    const delegationManager = new DelegationManager({
+      hosts: [input.host],
+      session: input.serviceSession,
+      invoke: this.invokeWithRuntimePermissions,
+      invokeAny: this.invokeAnyWithRuntimePermissions,
+      fetch: globalThis.fetch.bind(globalThis),
+    });
+    const keyProvider = new WasmKeyProvider({ sessionManager: input.manager });
+    const sharingService = new SharingService({
+      hosts: [input.host],
+      invoke: this.invokeWithRuntimePermissions,
+      fetch: globalThis.fetch.bind(globalThis),
+      keyProvider,
+      registry: capabilityRegistry,
+      createDelegationWasm: (params) => this.createDelegationWrapper(params),
+      computeCid: (data, codec) => {
+        if (!this.wasmBindings.computeCid) throw new Error("computeCid is unavailable");
+        return this.wasmBindings.computeCid(data, codec);
+      },
+      createKVService: (config) => {
+        const service = new KVService({ prefix: config.pathPrefix?.replace(/\/$/, '') });
+        const context = new ServiceContext({
+          invoke: config.invoke,
+          fetch: config.fetch ?? globalThis.fetch.bind(globalThis),
+          hosts: config.hosts,
+          telemetry: this.config.telemetry,
+        });
+        context.setSession(config.session);
+        service.initialize(context);
+        return service;
+      },
+    });
+    sharingService.updateConfig({
+      session: input.serviceSession,
+      delegationManager,
+      sessionExpiry: input.sessionExpiry,
+      createDelegationWasm: (params) => this.createDelegationWrapper(params),
+      onRootDelegationNeeded: this.signer ? async (params) => this.createRootDelegationForSharing(params) : undefined,
+    });
+    const spaceService = new SpaceService({
+      hosts: [input.host],
+      session: input.serviceSession,
+      invoke: this.wasmBindings.invoke,
+      fetch: globalThis.fetch.bind(globalThis),
+      capabilityRegistry,
+      userDid: input.nodeDid,
+      createKVService: (spaceId) => this.createSpaceScopedKVService(spaceId),
+      createVaultService: (spaceId) => {
+        const scopedKv = this.createSpaceScopedKVService(spaceId);
+        const scopedVault = this.createVaultService(spaceId, scopedKv);
+        if (this._serviceContext) scopedVault.initialize(this._serviceContext);
+        return scopedVault;
+      },
+      createSecretsService: (spaceId) => this.secretsForSpace(spaceId),
+      createDelegation: async (params) => {
+        try {
+          const portableDelegation = await this.createDelegation({
+            delegateDID: params.delegateDID,
+            path: params.path,
+            actions: params.actions,
+            disableSubDelegation: params.disableSubDelegation,
+            expiryMs: params.expiry ? params.expiry.getTime() - Date.now() : undefined,
+          });
+          return { ok: true as const, data: {
+            cid: portableDelegation.cid,
+            delegateDID: portableDelegation.delegateDID,
+            delegatorDID: this.did,
+            spaceId: portableDelegation.spaceId,
+            path: portableDelegation.path,
+            actions: portableDelegation.actions,
+            expiry: portableDelegation.expiry,
+            isRevoked: false,
+            allowSubDelegation: !portableDelegation.disableSubDelegation,
+            createdAt: new Date(),
+            authHeader: portableDelegation.delegationHeader.Authorization,
+          }};
+        } catch (error) {
+          return { ok: false as const, error: {
+            code: "CREATION_FAILED",
+            message: error instanceof Error ? error.message : String(error),
+            service: "delegation",
+          }};
+        }
+      },
+      onSpaceRegistered: async (space) => { await this.account.spaces.register(space); },
+    });
+    spaceService.updateConfig({ sharingService });
+    return { serviceContext, kv, sql, duckdb, hooks, vault, encryption, capabilityRegistry, keyProvider, sharingService, delegationManager, spaceService };
   }
 
   /**
@@ -2561,7 +2776,17 @@ export class TinyCloudNode {
     return this._encryption;
   }
 
-  private createVaultService(spaceId: string, kv: IKVService): DataVaultService {
+  private createVaultService(
+    spaceId: string,
+    kv: IKVService,
+    encryptionService = this.getEncryptionService(),
+    nodeContext?: {
+      host: string;
+      did: string;
+      address: string | undefined;
+      chainId: number;
+    },
+  ): DataVaultService {
     const wasm = this.wasmBindings;
     const vaultCrypto = createVaultCrypto({
       vault_encrypt: wasm.vault_encrypt, vault_decrypt: wasm.vault_decrypt, vault_derive_key: wasm.vault_derive_key,
@@ -2569,12 +2794,17 @@ export class TinyCloudNode {
       vault_random_bytes: wasm.vault_random_bytes, vault_sha256: wasm.vault_sha256,
     });
     const self = this;
+    const did = nodeContext?.did ?? this.did;
+    const address = nodeContext?.address ?? this._address;
+    const chainId = nodeContext?.chainId ?? this._chainId;
+    const host = nodeContext?.host ?? this.config.host!;
+    const ownerDid = this.ownerDidFromSpaceId(spaceId) ?? did;
     return new DataVaultService({
       spaceId,
       crypto: vaultCrypto,
       encryption: {
-        networkId: this.getEncryptionNetworkIdForSpace(spaceId),
-        service: this.getEncryptionService(),
+        networkId: `urn:tinycloud:encryption:${ownerDid}:${DEFAULT_ENCRYPTION_NETWORK_NAME}`,
+        service: encryptionService,
         decryptCapabilityProof: () => ({
           proofs: [this.requireServiceSession().delegationCid],
         }),
@@ -2593,10 +2823,10 @@ export class TinyCloudNode {
         readPublicSpace: <T>(host: string, targetSpaceId: string, key: string) =>
           TinyCloud.readPublicSpace<T>(host, targetSpaceId, key),
         makePublicSpaceId: TinyCloud.makePublicSpaceId,
-        did: this.did,
-        address: this._address ?? "",
-        chainId: this._chainId,
-        hosts: [this.config.host!],
+        did,
+        address: address ?? "",
+        chainId,
+        hosts: [host],
       },
     });
   }

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -3509,7 +3509,8 @@ export class TinyCloudNode {
     params: CreateOwnerDelegationParams,
     assertActive?: () => void,
   ): Promise<OwnerDelegationReceipt> {
-    assertActive?.();
+    const assertOwnerGraphActive = assertActive ?? this._serviceGraph.assertActive.bind(this._serviceGraph);
+    assertOwnerGraphActive();
     if (!params.delegateDid.startsWith("did:key:") || params.actions.length === 0 || params.path.length === 0) {
       throw new Error("Owner delegation requires an external did:key audience and bounded capabilities");
     }
@@ -3535,10 +3536,10 @@ export class TinyCloudNode {
       delegateUri: params.delegateDid,
     });
     const signature = await this.signer.signMessage(prepared.siwe);
-    assertActive?.();
+    assertOwnerGraphActive();
     const delegationSession = this.wasmBindings.completeSessionSetup({ ...prepared, signature });
     const activation = await activateSessionWithHost(host, delegationSession.delegationHeader);
-    assertActive?.();
+    assertOwnerGraphActive();
     if (!activation.success) {
       throw new Error(`Owner delegation import failed: ${activation.status} ${activation.error ?? ""}`.trim());
     }

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -3702,13 +3702,16 @@ export class TinyCloudNode {
     return this.delegationManager.status(cid);
   }
 
-  /** Compute the canonical CID of a compact delegation authorization. */
+  /** Compute the canonical CID of a compact UCAN or DAG-CBOR delegation authorization. */
   computeDelegationCid(authorization: string): string {
     if (!authorization || !this.wasmBindings.computeCid) {
       throw new Error("Delegation CID computation is unavailable");
     }
+    const compact = authorization.replace(/^Bearer /i, "");
     return this.wasmBindings.computeCid(
-      new TextEncoder().encode(authorization),
+      compact.includes(".")
+        ? new TextEncoder().encode(compact)
+        : decodeAuthorizationBytes(authorization),
       0x55n,
     );
   }

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -285,8 +285,8 @@ function clonePersistedSessionJwk(jwk: unknown): object {
 export class UnsupportedSessionRestoreError extends Error {
   readonly code = "RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED" as const;
 
-  constructor() {
-    super("Persisted session restore is unsupported by this WASM binding because it cannot replace the session signer.");
+  constructor(reason = "it cannot replace and enumerate every live session signer") {
+    super(`Persisted session restore is unsupported by this WASM binding because ${reason}.`);
     this.name = "UnsupportedSessionRestoreError";
   }
 }
@@ -301,6 +301,21 @@ function canonicalRestoredVerificationMethod(
     persistedVerificationMethod === canonicalVerificationMethod
     ? canonicalVerificationMethod
     : undefined;
+}
+
+function persistedExpiry(value: unknown): Date {
+  if (typeof value !== "string") {
+    throw new Error("Persisted session without a SIWE expiration must include expiresAt.");
+  }
+  const expiry = new Date(value);
+  if (!Number.isFinite(expiry.getTime()) || expiry.getTime() <= Date.now()) {
+    throw new Error("Persisted session expiry is invalid or expired.");
+  }
+  return expiry;
+}
+
+function sameInstant(left: Date, right: Date): boolean {
+  return left.getTime() === right.getTime();
 }
 
 function sharingActionsToAbilities(path: string, actions: string[]): AbilitiesMap | undefined {
@@ -1879,6 +1894,8 @@ export class TinyCloudNode {
     delegationHeader: { Authorization: string };
     delegationCid: string;
     spaceId: string;
+    /** Additional capability spaces persisted with the primary session. */
+    spaces?: Record<string, string>;
     jwk: object;
     verificationMethod: string;
     address?: string;
@@ -1893,11 +1910,16 @@ export class TinyCloudNode {
      */
     siwe?: string;
     /**
-     * The wallet/OpenKey signature over `siwe`. Optional because the
-     * runtime doesn't re-verify it — it's persisted alongside the SIWE
-     * for callers that need to round-trip the full session shape.
+     * The wallet/OpenKey signature over `siwe`. When any signed-session
+     * metadata is restored, this is required and verified in WASM before
+     * local ReCap or expiry authority is installed.
      */
     signature?: string;
+    /**
+     * Persisted policy expiry. Required when an otherwise valid SIWE omits
+     * `Expiration Time`; restore never invents a new renewable lifetime.
+     */
+    expiresAt?: string;
     /**
      * The TinyCloud hosts this session was created against (from
      * {@link PersistedSessionData.tinycloudHosts}). When present they are
@@ -1923,22 +1945,28 @@ export class TinyCloudNode {
     }
     const stagedManager = this.wasmBindings.createSessionManager();
     const stagedReplace = stagedManager.replaceSessionKey;
-    if (typeof stagedReplace !== "function" || typeof this.sessionManager.replaceSessionKey !== "function") {
+    const liveKeys = this.sessionManager.listSessionKeys;
+    const stagedKeys = stagedManager.listSessionKeys;
+    if (
+      typeof stagedReplace !== "function" ||
+      typeof liveKeys !== "function" ||
+      typeof stagedKeys !== "function"
+    ) {
       throw new UnsupportedSessionRestoreError();
     }
     let stagedKeyId: string;
     let stagedJwk: object;
     let canonicalVerificationMethod: string;
     try {
-      const liveManager = this.sessionManager as ISessionManager & {
-        listSessionKeys?(): string[];
-      };
-      // A successful restore replaces only the primary signer; preserve any
-      // share keys that the concrete WASM manager exposes. Older custom
-      // managers need not implement listing and remain supported.
-      for (const keyId of liveManager.listSessionKeys?.() ?? []) {
+      // Replacing a primary signer without a complete key inventory silently
+      // loses receive/share keys. Require the capability rather than guessing.
+      const keyIds = liveKeys.call(this.sessionManager);
+      if (!Array.isArray(keyIds) || !keyIds.every((keyId) => typeof keyId === "string")) {
+        throw new UnsupportedSessionRestoreError("it cannot reliably enumerate every live session signer");
+      }
+      for (const keyId of keyIds) {
         if (keyId === this.sessionKeyId) continue;
-        const jwk = liveManager.jwk(keyId);
+        const jwk = this.sessionManager.jwk(keyId);
         if (!jwk) throw new Error("missing live session key");
         stagedReplace.call(stagedManager, clonePersistedSessionJwk(JSON.parse(jwk)), keyId);
       }
@@ -1947,7 +1975,8 @@ export class TinyCloudNode {
       if (!stagedJwkJson) throw new Error("missing restored session key");
       stagedJwk = clonePersistedSessionJwk(JSON.parse(stagedJwkJson));
       canonicalVerificationMethod = stagedManager.getDID(stagedKeyId);
-    } catch {
+    } catch (error) {
+      if (error instanceof UnsupportedSessionRestoreError) throw error;
       throw new Error("Persisted session has an invalid private Ed25519 session key.");
     }
     const restoredVerificationMethod = canonicalRestoredVerificationMethod(
@@ -1960,17 +1989,57 @@ export class TinyCloudNode {
       );
     }
 
-    const restoredAddress = sessionData.address
-      ? canonicalizeAddress(sessionData.address)
+    const proofValues = [
+      sessionData.siwe,
+      sessionData.signature,
+      sessionData.address,
+      sessionData.chainId,
+    ];
+    const hasPersistedProof = proofValues.every((value) => value !== undefined);
+    if (!hasPersistedProof && (proofValues.some((value) => value !== undefined) || sessionData.expiresAt !== undefined)) {
+      throw new Error("Persisted session authority metadata is incomplete.");
+    }
+
+    const restoredAddress = hasPersistedProof
+      ? canonicalizeAddress(sessionData.address!)
       : undefined;
+    let stagedSessionExpiry = new Date(0);
+    if (hasPersistedProof) {
+      if (typeof this.wasmBindings.validatePersistedSession !== "function") {
+        throw new UnsupportedSessionRestoreError("it cannot verify persisted SIWE authority");
+      }
+      const verified = this.wasmBindings.validatePersistedSession({
+        delegationHeader: sessionData.delegationHeader,
+        delegationCid: sessionData.delegationCid,
+        spaceId: sessionData.spaceId,
+        spaces: sessionData.spaces,
+        jwk: stagedJwk,
+        verificationMethod: canonicalVerificationMethod,
+        address: restoredAddress!,
+        chainId: sessionData.chainId!,
+        siwe: sessionData.siwe!,
+        signature: sessionData.signature!,
+      });
+      const signedExpiry = verified.expiresAt === undefined
+        ? undefined
+        : persistedExpiry(verified.expiresAt);
+      const persistedPolicyExpiry = sessionData.expiresAt === undefined
+        ? undefined
+        : persistedExpiry(sessionData.expiresAt);
+      if (signedExpiry && persistedPolicyExpiry && !sameInstant(signedExpiry, persistedPolicyExpiry)) {
+        throw new Error("Persisted session expiry does not match its signed SIWE authority.");
+      }
+      stagedSessionExpiry = signedExpiry ?? persistedPolicyExpiry ?? persistedExpiry(undefined);
+    }
     const resolvedHost = await this.resolveRestoredHost(
       sessionData.tinycloudHosts,
       restoredAddress,
       sessionData.chainId,
     );
     const stagedHost = resolvedHost ?? this.config.host!;
-    const stagedAddress = restoredAddress ?? this._address;
-    const stagedChainId = sessionData.chainId ?? this._chainId;
+    // Never blend a metadata-light restore with the prior wallet identity.
+    const stagedAddress = restoredAddress;
+    const stagedChainId = sessionData.chainId ?? 1;
     const stagedNodeDid = stagedAddress
       ? pkhDid(stagedAddress, stagedChainId)
       : canonicalVerificationMethod;
@@ -1982,24 +2051,19 @@ export class TinyCloudNode {
       jwk: stagedJwk,
     };
     const stagedTcSession: TinyCloudSession | undefined =
-      sessionData.siwe && restoredAddress && sessionData.chainId ? {
-        address: restoredAddress,
-        chainId: sessionData.chainId,
+      hasPersistedProof ? {
+        address: restoredAddress!,
+        chainId: sessionData.chainId!,
         sessionKey: JSON.stringify(stagedJwk),
         spaceId: sessionData.spaceId,
+        spaces: sessionData.spaces,
         delegationCid: sessionData.delegationCid,
         delegationHeader: sessionData.delegationHeader,
         verificationMethod: restoredVerificationMethod,
         jwk: stagedJwk as { [k: string]: unknown },
-        siwe: sessionData.siwe,
-        signature: sessionData.signature ?? "",
+        siwe: sessionData.siwe!,
+        signature: sessionData.signature!,
       } : undefined;
-    // The service graph is staged before the session is committed. Derive its
-    // expiry from that staged session once, so capability and sharing state
-    // cannot accidentally inherit a prior session's lifetime.
-    const stagedSessionExpiry = stagedTcSession
-      ? extractSiweExpiration(stagedTcSession.siwe) ?? this.getSessionExpiry()
-      : this.getSessionExpiry();
     const stagedPrimary = this.stagePrimarySessionState(
       stagedTcSession,
       stagedNodeDid,
@@ -2023,8 +2087,8 @@ export class TinyCloudNode {
     this.sessionKeyId = stagedKeyId;
     this.sessionKeyJwk = stagedJwk;
     if (resolvedHost) this.config.host = resolvedHost;
-    if (restoredAddress) this._address = restoredAddress;
-    if (sessionData.chainId !== undefined) this._chainId = sessionData.chainId;
+    this._address = stagedAddress;
+    this._chainId = stagedChainId;
     this._serviceContext = stagedGraph.serviceContext;
     this._kv = stagedGraph.kv;
     this._sql = stagedGraph.sql;
@@ -2041,10 +2105,11 @@ export class TinyCloudNode {
     this._secrets = new Map();
     this._publicKV = undefined;
     this._account = undefined;
+    this.tc = stagedGraph.core;
     this._recapOperationsCache = stagedPrimary.cache;
     this.runtimePermissionGrants = stagedPrimary.grants;
     if (this.auth) {
-      this.auth.installRestoredSession(stagedManager, stagedTcSession, this.config.host ? [this.config.host] : undefined);
+      this.auth.installRestoredSession(stagedManager, stagedTcSession, [stagedHost]);
       this._restoredTcSession = undefined;
     } else {
       this._restoredTcSession = stagedTcSession;
@@ -2076,12 +2141,10 @@ export class TinyCloudNode {
       operations = [];
     }
     const cache = { siwe: session.siwe, operations };
-    const skipped = this.auth?.lastActivationSkippedSpaceIds ?? [];
-    const acceptedOperations = operations.filter((operation) =>
-      operation.spaceId === undefined || !skipped.some((spaceId) => this.spaceIdsEqual(spaceId, operation.spaceId!)),
-    );
-    if (acceptedOperations.length === 0) return { cache, grants: [] };
-    const expiresAt = extractSiweExpiration(session.siwe) ?? sessionExpiry;
+    // Restored authority has no host-activation result yet. Importing a skip
+    // list from an unrelated prior session would erase valid restored grants.
+    if (operations.length === 0) return { cache, grants: [] };
+    const expiresAt = sessionExpiry;
     return {
       cache,
       grants: [{
@@ -2099,14 +2162,14 @@ export class TinyCloudNode {
           delegatorDID: verificationMethod,
           spaceId: session.spaceId,
           path: "",
-          actions: [...new Set(acceptedOperations.map((operation) => operation.action))],
+          actions: [...new Set(operations.map((operation) => operation.action))],
           expiry: expiresAt,
           allowSubDelegation: true,
           ownerAddress: session.address,
           chainId: session.chainId,
           host,
         },
-        operations: acceptedOperations,
+        operations,
         expiresAt,
         provenance: "primary",
       }],
@@ -2124,6 +2187,7 @@ export class TinyCloudNode {
     tinyCloudSession: TinyCloudSession | undefined;
     sessionExpiry: Date;
   }): {
+    core: TinyCloud | null;
     serviceContext: ServiceContext;
     kv: KVService;
     sql: SQLService;
@@ -2137,6 +2201,19 @@ export class TinyCloudNode {
     delegationManager: DelegationManager;
     spaceService: SpaceService;
   } {
+    // TinyCloud owns the public-KV service graph. Stage a replacement core
+    // context alongside the node graph so repeated cross-host restores cannot
+    // leave publicKV pointed at a stale or uninitialized context.
+    const core = this.auth
+      ? new TinyCloud(this.auth, {
+        invokeAny: this.invokeAnyWithRuntimePermissions,
+        telemetry: this.config.telemetry,
+      })
+      : null;
+    if (core) {
+      core.initializeServices(this.invokeWithRuntimePermissions, [input.host]);
+      (core.serviceContext as ServiceContext).setSession(input.serviceSession);
+    }
     const serviceContext = new ServiceContext({
       invoke: this.invokeWithRuntimePermissions,
       invokeAny: this.invokeAnyWithRuntimePermissions,
@@ -2172,7 +2249,19 @@ export class TinyCloudNode {
     const capabilityRegistry = new CapabilityKeyRegistry();
     if (input.tinyCloudSession) {
       const session = input.tinyCloudSession;
-      const delegations: Delegation[] = [{
+      // Extra space names are persisted session metadata. Only space IDs that
+      // occur in the now-verified ReCap may participate in the capability
+      // registry; e.g. a lazily-created public-space label cannot mint a
+      // primary-session grant by itself.
+      const recapSpaces = new Set<string>();
+      try {
+        for (const entry of this.wasmBindings.parseRecapFromSiwe(session.siwe)) {
+          recapSpaces.add(entry.space);
+        }
+      } catch {
+        throw new Error("Verified persisted session ReCap could not be reconstructed.");
+      }
+      const delegations: Delegation[] = recapSpaces.has(session.spaceId) ? [{
         cid: session.delegationCid,
         delegateDID: session.verificationMethod,
         spaceId: session.spaceId,
@@ -2181,8 +2270,9 @@ export class TinyCloudNode {
         expiry: input.sessionExpiry,
         isRevoked: false,
         allowSubDelegation: true,
-      }];
+      }] : [];
       for (const spaceId of Object.values(session.spaces ?? {})) {
+        if (!recapSpaces.has(spaceId)) continue;
         delegations.push({
           cid: session.delegationCid,
           delegateDID: session.verificationMethod,
@@ -2194,13 +2284,15 @@ export class TinyCloudNode {
           allowSubDelegation: true,
         });
       }
-      capabilityRegistry.registerKey({
-        id: session.sessionKey,
-        did: session.verificationMethod,
-        type: "session",
-        jwk: session.jwk as JWK,
-        priority: 0,
-      }, delegations);
+      if (delegations.length > 0) {
+        capabilityRegistry.registerKey({
+          id: session.sessionKey,
+          did: session.verificationMethod,
+          type: "session",
+          jwk: session.jwk as JWK,
+          priority: 0,
+        }, delegations);
+      }
     }
     const delegationManager = new DelegationManager({
       hosts: [input.host],
@@ -2289,7 +2381,7 @@ export class TinyCloudNode {
       onSpaceRegistered: async (space) => { await this.account.spaces.register(space); },
     });
     spaceService.updateConfig({ sharingService });
-    return { serviceContext, kv, sql, duckdb, hooks, vault, encryption, capabilityRegistry, keyProvider, sharingService, delegationManager, spaceService };
+    return { core, serviceContext, kv, sql, duckdb, hooks, vault, encryption, capabilityRegistry, keyProvider, sharingService, delegationManager, spaceService };
   }
 
   /**

--- a/packages/node-sdk/src/TinyCloudNode.validatedDelegation.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.validatedDelegation.test.ts
@@ -56,7 +56,7 @@ describe("activateValidatedRuntimeDelegation", () => {
       expect(activated.expiry.getTime()).toBe(delegation.expiry.getTime());
       expect(activated.delegation).not.toHaveProperty("permissions");
 
-      await fixture.readAndDecrypt(activated);
+      await fixture.readAndDecrypt(fixture.delegate, activated);
       fixture.assertNarrowDelegatedReadAndDecrypt(activated);
     } finally {
       fixture.stop();

--- a/packages/node-sdk/src/TinyCloudNode.validatedDelegation.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.validatedDelegation.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PermissionEntry } from "@tinycloud/sdk-core";
+
+import { activateValidatedRuntimeDelegation } from "./delegation";
+import {
+  activateValidatedRuntimeDelegation as publicActivateValidatedRuntimeDelegation,
+} from "./index";
+import {
+  createHermeticEncryptedNode,
+  type HermeticEncryptedNode,
+} from "./test-support/hermetic-encrypted-node";
+
+function cloneDelegation(
+  delegation: Awaited<ReturnType<HermeticEncryptedNode["mintDelegation"]>>,
+  overrides: Record<string, unknown>,
+) {
+  return {
+    ...delegation,
+    delegationHeader: { ...delegation.delegationHeader },
+    actions: [...delegation.actions],
+    resources: delegation.resources?.map((resource) => ({
+      ...resource,
+      actions: [...resource.actions],
+    })),
+    ...overrides,
+  };
+}
+
+describe("activateValidatedRuntimeDelegation", () => {
+  test("exports the validated activation helper from the node-sdk entrypoint", () => {
+    expect(publicActivateValidatedRuntimeDelegation).toBe(
+      activateValidatedRuntimeDelegation,
+    );
+  });
+
+  test("CID-binds a real WASM delegation, installs it, and exercises narrow encrypted KV read/decrypt", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const delegation = await fixture.mintDelegation();
+      const activated = await activateValidatedRuntimeDelegation(
+        fixture.delegate,
+        delegation,
+        { host: fixture.host },
+      );
+
+      expect(activated.cid).toBe(delegation.cid);
+      expect(activated.delegation).toBe(
+        fixture.delegate
+          .getRuntimePermissionDelegations()
+          .find((installed) => installed.cid === delegation.cid),
+      );
+      expect(activated.audience).toBe(fixture.delegate.sessionDid.split("#", 1)[0]);
+      expect(activated.host).toBe(fixture.host);
+      expect(activated.effectivePermissions).toEqual(fixture.permissions);
+      expect(activated.expiry.getTime()).toBe(delegation.expiry.getTime());
+      expect(activated.delegation).not.toHaveProperty("permissions");
+
+      await fixture.readAndDecrypt(activated);
+      fixture.assertNarrowDelegatedReadAndDecrypt(activated);
+    } finally {
+      fixture.stop();
+    }
+  });
+
+  test("rejects an altered artifact audience, CID, or authorization bytes before activation", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const delegation = await fixture.mintDelegation();
+      await expect(
+        activateValidatedRuntimeDelegation(
+          fixture.delegate,
+          cloneDelegation(delegation, {
+            delegateDID: fixture.unrelatedAudience,
+          }),
+          { host: fixture.host },
+        ),
+      ).rejects.toThrow(/audience does not match signed authority/);
+
+      await expect(
+        activateValidatedRuntimeDelegation(
+          fixture.delegate,
+          cloneDelegation(delegation, { cid: `${delegation.cid}altered` }),
+          { host: fixture.host },
+        ),
+      ).rejects.toThrow(/CID does not match authorization bytes/);
+
+      const authorization = delegation.delegationHeader.Authorization;
+      const replacement = authorization.endsWith("A") ? "B" : "A";
+      await expect(
+        activateValidatedRuntimeDelegation(
+          fixture.delegate,
+          cloneDelegation(delegation, {
+            delegationHeader: {
+              Authorization: `${authorization.slice(0, -1)}${replacement}`,
+            },
+          }),
+          { host: fixture.host },
+        ),
+      ).rejects.toThrow(/CID does not match authorization bytes/);
+    } finally {
+      fixture.stop();
+    }
+  });
+
+  test("rejects wrong signed audience, wrong host, and expiry", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const wrongAudience = await fixture.mintDelegationForAudience(
+        fixture.unrelatedAudience,
+      );
+      await expect(
+        activateValidatedRuntimeDelegation(fixture.delegate, wrongAudience, {
+          host: fixture.host,
+        }),
+      ).rejects.toThrow(/targets .* but this session is/);
+
+      const delegation = await fixture.mintDelegation();
+      await expect(
+        activateValidatedRuntimeDelegation(
+          fixture.delegate,
+          cloneDelegation(delegation, { host: "http://wrong-loopback.invalid" }),
+          { host: fixture.host },
+        ),
+      ).rejects.toThrow(/host .* does not match/);
+
+      await expect(
+        activateValidatedRuntimeDelegation(
+          fixture.delegate,
+          cloneDelegation(delegation, { expiry: new Date(Date.now() - 1) }),
+          { host: fixture.host },
+        ),
+      ).rejects.toThrow(/expired/);
+
+      await expect(
+        activateValidatedRuntimeDelegation(
+          fixture.delegate,
+          cloneDelegation(delegation, {
+            expiry: new Date(delegation.expiry.getTime() - 1_000),
+          }),
+          { host: fixture.host },
+        ),
+      ).rejects.toThrow(/expiry does not match signed authority/);
+    } finally {
+      fixture.stop();
+    }
+  });
+
+  test("rejects a real but transport-unrecognized delegation chain", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const untrusted = await fixture.mintUntrustedDelegation();
+      await expect(
+        activateValidatedRuntimeDelegation(fixture.delegate, untrusted, {
+          host: fixture.host,
+        }),
+      ).rejects.toThrow(/Failed to activate runtime permission delegation/);
+    } finally {
+      fixture.stop();
+    }
+  });
+
+  test("derives signed effective permissions, ignores artifact display permissions, and rejects broadening", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const delegation = await fixture.mintDelegation();
+      const artifactWithBroadDisplayPermissions = {
+        ...delegation,
+        permissions: [
+          {
+            service: "tinycloud.kv",
+            space: delegation.spaceId,
+            path: "",
+            actions: ["tinycloud.kv/*"],
+          },
+        ] satisfies PermissionEntry[],
+      };
+      const activated = await activateValidatedRuntimeDelegation(
+        fixture.delegate,
+        artifactWithBroadDisplayPermissions,
+        { host: fixture.host },
+      );
+      expect(activated.effectivePermissions).toEqual(fixture.permissions);
+
+      const broadened = cloneDelegation(delegation, {
+        resources: delegation.resources?.map((resource) =>
+          resource.service === "kv"
+            ? {
+                ...resource,
+                actions: [...resource.actions, "tinycloud.kv/put"],
+              }
+            : resource,
+        ),
+      });
+      await expect(
+        activateValidatedRuntimeDelegation(fixture.delegate, broadened, {
+          host: fixture.host,
+        }),
+      ).rejects.toThrow(/do not match signed authority/);
+    } finally {
+      fixture.stop();
+    }
+  });
+
+  test("allows idempotent activation only for the same validated CID and contents", async () => {
+    const fixture = await createHermeticEncryptedNode();
+    try {
+      const delegation = await fixture.mintDelegation();
+      const first = await activateValidatedRuntimeDelegation(
+        fixture.delegate,
+        delegation,
+        { host: fixture.host },
+      );
+      const second = await activateValidatedRuntimeDelegation(
+        fixture.delegate,
+        delegation,
+        { host: fixture.host },
+      );
+
+      expect(second).toEqual(first);
+      expect(
+        fixture.delegate
+          .getRuntimePermissionDelegations()
+          .filter((installed) => installed.cid === delegation.cid),
+      ).toHaveLength(1);
+
+      second.delegation.delegationHeader.Authorization = "different-installed-content";
+      await expect(
+        activateValidatedRuntimeDelegation(fixture.delegate, delegation, {
+          host: fixture.host,
+        }),
+      ).rejects.toThrow(/different authorization is already installed/);
+    } finally {
+      fixture.stop();
+    }
+  });
+});

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
@@ -25,6 +25,10 @@ function createSessionManager(): ISessionManager {
     createSessionKey(id: string): string {
       return ensureKey(id);
     },
+    replaceSessionKey(jwk: object, keyId: string): string {
+      keys.set(keyId, JSON.stringify(jwk));
+      return keyId;
+    },
     renameSessionKeyId(oldId: string, newId: string): void {
       const value = keys.get(oldId);
       if (value) {

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -367,20 +367,29 @@ export class NodeUserAuthorization implements IUserAuthorization {
     hosts?: string[],
   ): void {
     this.sessionManager = sessionManager;
+    // Restore is a complete session replacement, not an additive update. In
+    // particular, a second restore may target a different host and must not
+    // retain skip decisions from the previous activation.
+    this.tinycloudHosts = hosts && hosts.length > 0 ? [...hosts] : undefined;
+    this._lastActivationSkippedSpaceIds = [];
     if (!session) {
+      this._session = undefined;
       this._tinyCloudSession = undefined;
+      this._address = undefined;
+      this._chainId = undefined;
       return;
     }
     this._tinyCloudSession = { ...session };
     this._address = session.address;
     this._chainId = session.chainId;
-    if (
-      (!this.tinycloudHosts || this.tinycloudHosts.length === 0) &&
-      hosts &&
-      hosts.length > 0
-    ) {
-      this.tinycloudHosts = [...hosts];
-    }
+    this._session = {
+      address: session.address,
+      walletAddress: session.address,
+      chainId: session.chainId,
+      sessionKey: session.sessionKey,
+      siwe: session.siwe,
+      signature: session.signature,
+    };
   }
 
   /**

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -360,6 +360,29 @@ export class NodeUserAuthorization implements IUserAuthorization {
     }
   }
 
+  /** @internal Atomically adopt the state staged by TinyCloudNode.restoreSession. */
+  installRestoredSession(
+    sessionManager: ISessionManager,
+    session: TinyCloudSession | undefined,
+    hosts?: string[],
+  ): void {
+    this.sessionManager = sessionManager;
+    if (!session) {
+      this._tinyCloudSession = undefined;
+      return;
+    }
+    this._tinyCloudSession = { ...session };
+    this._address = session.address;
+    this._chainId = session.chainId;
+    if (
+      (!this.tinycloudHosts || this.tinycloudHosts.length === 0) &&
+      hosts &&
+      hosts.length > 0
+    ) {
+      this.tinycloudHosts = [...hosts];
+    }
+  }
+
   /**
    * Ensure `tinycloudHosts` are resolved before a host-needing call.
    *

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -108,6 +108,7 @@ export type {
 // High-level API
 export {
   TinyCloudNode,
+  UnsupportedSessionRestoreError,
   type TinyCloudNodeConfig,
   type DelegateToOptions,
   type DelegateToResult,

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -153,6 +153,7 @@ export {
   DEFAULT_MANIFEST_SPACE,
   DEFAULT_MANIFEST_VERSION,
   VAULT_PERMISSION_SERVICE,
+  CaveatedDelegationUnsupportedError,
   PermissionNotInManifestError,
   SessionExpiredError,
   ManifestValidationError,

--- a/packages/node-sdk/src/delegation.ts
+++ b/packages/node-sdk/src/delegation.ts
@@ -1,4 +1,10 @@
-import { Delegation, DelegatedResource, PermissionEntry } from "@tinycloud/sdk-core";
+import {
+  Delegation,
+  DelegatedResource,
+  PermissionEntry,
+  principalDidEquals,
+} from "@tinycloud/sdk-core";
+import type { TinyCloudNode } from "./TinyCloudNode";
 
 /**
  * A portable delegation that can be transported between users.
@@ -91,6 +97,348 @@ export interface DelegationAuthority {
     permissions: PermissionEntry[],
     options?: { expiry?: string | number; forceWalletSign?: boolean },
   ): Promise<{ delegation: PortableDelegation; prompted: boolean }>;
+}
+
+/**
+ * Authority that the validated runtime-delegation activation helper needs.
+ * `TinyCloudNode` implements this surface directly; keeping it structural
+ * makes the helper usable by a compatible Node wrapper without exposing node
+ * internals.
+ */
+export interface RuntimeDelegationActivator {
+  readonly sessionDid: string;
+  computeDelegationCid(authorization: string): string;
+  useRuntimeDelegation(delegation: PortableDelegation): Promise<void>;
+  getRuntimePermissionDelegations(): PortableDelegation[];
+}
+
+/** The installed authority returned by {@link activateValidatedRuntimeDelegation}. */
+export interface ValidatedRuntimeDelegation {
+  /** CID recomputed from the signed authorization bytes. */
+  readonly cid: string;
+  /** The authority object installed by the node runtime. */
+  readonly delegation: PortableDelegation;
+  /** Capabilities read from the signed compact UCAN attenuation. */
+  readonly effectivePermissions: readonly PermissionEntry[];
+  /** Expiry read from the signed compact UCAN payload. */
+  readonly expiry: Date;
+  /** Audience read from the signed compact UCAN payload. */
+  readonly audience: string;
+  /** Host selected for, and used by, the runtime activation. */
+  readonly host: string;
+}
+
+interface SignedRuntimeAuthority {
+  readonly audience: string;
+  readonly expiry: Date;
+  readonly permissions: readonly PermissionEntry[];
+  readonly resources: readonly DelegatedResource[];
+}
+
+const SERVICE_BY_SHORT_NAME: Record<string, string> = {
+  kv: "tinycloud.kv",
+  sql: "tinycloud.sql",
+  duckdb: "tinycloud.duckdb",
+  hooks: "tinycloud.hooks",
+};
+
+function authorizationWithoutBearer(authorization: string): string {
+  return authorization.replace(/^Bearer /i, "");
+}
+
+function normalizedHost(host: string): string {
+  if (typeof host !== "string" || host.length === 0) {
+    throw new Error("Validated runtime delegation requires a non-empty host.");
+  }
+  return host.replace(/\/+$/, "");
+}
+
+function didPrincipalsMatch(left: string, right: string): boolean {
+  try {
+    return principalDidEquals(left, right);
+  } catch {
+    return left === right;
+  }
+}
+
+function compactUcanPayload(authorization: string): Record<string, unknown> {
+  const compact = authorizationWithoutBearer(authorization);
+  const parts = compact.split(".");
+  if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+    throw new Error(
+      "Validated runtime delegation requires a compact UCAN authorization so its signed authority can be derived.",
+    );
+  }
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, "base64url").toString("utf8"),
+    ) as unknown;
+    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("payload is not an object");
+    }
+    return payload as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      "Validated runtime delegation authorization has an invalid compact UCAN payload.",
+    );
+  }
+}
+
+function canonicalPermissionEntries(
+  permissions: PermissionEntry[],
+): PermissionEntry[] {
+  return permissions
+    .map((permission) => ({
+      ...permission,
+      actions: [...permission.actions].sort(),
+    }))
+    .sort((left, right) =>
+      left.service.localeCompare(right.service) ||
+      (left.space ?? "").localeCompare(right.space ?? "") ||
+      left.path.localeCompare(right.path) ||
+      left.actions.join("\u0000").localeCompare(right.actions.join("\u0000")),
+    );
+}
+
+function signedAuthorityFromCompactUcan(
+  authorization: string,
+): SignedRuntimeAuthority {
+  const payload = compactUcanPayload(authorization);
+  if (typeof payload.aud !== "string" || payload.aud.length === 0) {
+    throw new Error("Validated runtime delegation is missing a signed audience.");
+  }
+  if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp)) {
+    throw new Error("Validated runtime delegation is missing a signed expiry.");
+  }
+  const expiry = new Date(payload.exp * 1000);
+  if (Number.isNaN(expiry.getTime())) {
+    throw new Error("Validated runtime delegation has an invalid signed expiry.");
+  }
+  if (payload.att === null || typeof payload.att !== "object" || Array.isArray(payload.att)) {
+    throw new Error("Validated runtime delegation is missing a signed attenuation.");
+  }
+
+  const permissions: PermissionEntry[] = [];
+  for (const [resource, abilities] of Object.entries(payload.att)) {
+    if (abilities === null || typeof abilities !== "object" || Array.isArray(abilities)) {
+      throw new Error("Validated runtime delegation has an invalid signed attenuation.");
+    }
+    const actions = Object.entries(abilities as Record<string, unknown>)
+      .filter(([, caveats]) => Array.isArray(caveats))
+      .map(([action]) => action)
+      .sort();
+    if (actions.length === 0) {
+      throw new Error("Validated runtime delegation has an empty signed capability.");
+    }
+
+    if (resource.startsWith("urn:tinycloud:encryption:")) {
+      permissions.push({
+        service: "tinycloud.encryption",
+        path: resource,
+        actions,
+      });
+      continue;
+    }
+
+    const match = /^(tinycloud:[^/]+)\/(kv|sql|duckdb|hooks)\/(.*)$/.exec(resource);
+    if (!match) {
+      throw new Error(
+        `Validated runtime delegation has an unsupported signed resource '${resource}'.`,
+      );
+    }
+    const [, space, shortService, path] = match;
+    const service = SERVICE_BY_SHORT_NAME[shortService!];
+    if (service === undefined) {
+      throw new Error(
+        `Validated runtime delegation has an unsupported signed service '${shortService}'.`,
+      );
+    }
+    permissions.push({ service, space: space!, path: path!, actions });
+  }
+
+  if (permissions.length === 0) {
+    throw new Error("Validated runtime delegation has no signed capabilities.");
+  }
+  const canonicalPermissions = canonicalPermissionEntries(permissions);
+  const canonicalResources = canonicalPermissions.map((permission) => ({
+    service:
+      permission.service === "tinycloud.encryption"
+        ? "encryption"
+        : permission.service.slice("tinycloud.".length),
+    space:
+      permission.service === "tinycloud.encryption"
+        ? "encryption"
+        : permission.space!,
+    path: permission.path,
+    actions: [...permission.actions],
+  }));
+  return {
+    audience: payload.aud,
+    expiry,
+    permissions: canonicalPermissions,
+    resources: canonicalResources,
+  };
+}
+
+function canonicalResourcesFromPortableDelegation(
+  delegation: PortableDelegation,
+): DelegatedResource[] {
+  if (delegation.resources !== undefined && delegation.resources.length > 0) {
+    return delegation.resources
+      .map((resource) => ({ ...resource, actions: [...resource.actions].sort() }))
+      .sort((left, right) =>
+        left.service.localeCompare(right.service) ||
+        left.space.localeCompare(right.space) ||
+        left.path.localeCompare(right.path) ||
+        left.actions.join("\u0000").localeCompare(right.actions.join("\u0000")),
+      );
+  }
+  const byService = new Map<string, string[]>();
+  for (const action of delegation.actions) {
+    const [service] = action.split("/", 1);
+    const shortService = service!.replace(/^tinycloud\./, "");
+    const values = byService.get(shortService) ?? [];
+    values.push(action);
+    byService.set(shortService, values);
+  }
+  return [...byService.entries()]
+    .map(([service, actions]) => ({
+      service,
+      space: service === "encryption" ? "encryption" : delegation.spaceId,
+      path: delegation.path,
+      actions: [...new Set(actions)].sort(),
+    }))
+    .sort((left, right) =>
+      left.service.localeCompare(right.service) ||
+      left.space.localeCompare(right.space) ||
+      left.path.localeCompare(right.path),
+    );
+}
+
+function resourcesMatch(
+  actual: readonly DelegatedResource[],
+  expected: readonly DelegatedResource[],
+): boolean {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+/**
+ * CID-bind and activate one compact runtime delegation.
+ *
+ * The helper derives audience, expiry, and effective permissions from the
+ * compact UCAN's signed payload, verifies the transport fields agree, then
+ * invokes {@link TinyCloudNode.useRuntimeDelegation}. The node activation call
+ * remains the authority and delegation-chain validation boundary.
+ */
+export async function activateValidatedRuntimeDelegation(
+  node: RuntimeDelegationActivator | TinyCloudNode,
+  delegation: PortableDelegation,
+  options: { host: string },
+): Promise<ValidatedRuntimeDelegation> {
+  const host = normalizedHost(options.host);
+  if (delegation.host !== undefined && normalizedHost(delegation.host) !== host) {
+    throw new Error(
+      `Runtime delegation host '${delegation.host}' does not match expected host '${options.host}'.`,
+    );
+  }
+  if (!(delegation.expiry instanceof Date) || Number.isNaN(delegation.expiry.getTime())) {
+    throw new Error("Runtime delegation has an invalid expiry.");
+  }
+  if (delegation.expiry.getTime() <= Date.now()) {
+    throw new Error("Runtime delegation is expired.");
+  }
+
+  const authorization = delegation.delegationHeader?.Authorization;
+  if (typeof authorization !== "string" || authorization.length === 0) {
+    throw new Error("Runtime delegation is missing authorization bytes.");
+  }
+  const cid = node.computeDelegationCid(authorization);
+  if (cid !== delegation.cid) {
+    throw new Error("Runtime delegation CID does not match authorization bytes.");
+  }
+
+  const signed = signedAuthorityFromCompactUcan(authorization);
+  if (signed.expiry.getTime() <= Date.now()) {
+    throw new Error("Runtime delegation is expired.");
+  }
+  if (delegation.expiry.getTime() !== signed.expiry.getTime()) {
+    throw new Error("Runtime delegation expiry does not match signed authority.");
+  }
+  if (!didPrincipalsMatch(signed.audience, node.sessionDid)) {
+    throw new Error(
+      `Runtime delegation targets ${signed.audience} but this session is ${node.sessionDid}.`,
+    );
+  }
+  if (!didPrincipalsMatch(delegation.delegateDID, signed.audience)) {
+    throw new Error("Runtime delegation audience does not match signed authority.");
+  }
+
+  const declaredResources = canonicalResourcesFromPortableDelegation(delegation);
+  if (!resourcesMatch(declaredResources, signed.resources)) {
+    throw new Error("Runtime delegation resources do not match signed authority.");
+  }
+  const previouslyInstalled = node
+    .getRuntimePermissionDelegations()
+    .find((candidate) => candidate.cid === cid);
+  if (
+    previouslyInstalled !== undefined &&
+    previouslyInstalled.delegationHeader.Authorization !== authorization
+  ) {
+    throw new Error(
+      "A different authorization is already installed for this runtime delegation CID.",
+    );
+  }
+  const primary = signed.resources[0]!;
+  const signedSpace = signed.permissions.find(
+    (permission) => permission.service !== "tinycloud.encryption",
+  )?.space;
+  const installedCandidate: PortableDelegation = {
+    cid,
+    delegationHeader: { Authorization: authorization },
+    ownerAddress: delegation.ownerAddress,
+    chainId: delegation.chainId,
+    spaceId: signedSpace ?? delegation.spaceId,
+    path: primary.path,
+    actions: [...primary.actions],
+    resources: signed.resources.map((resource) => ({
+      ...resource,
+      actions: [...resource.actions],
+    })),
+    expiry: new Date(signed.expiry),
+    delegateDID: signed.audience,
+    host,
+  };
+
+  await node.useRuntimeDelegation(installedCandidate);
+  const installed = node
+    .getRuntimePermissionDelegations()
+    .find((candidate) => candidate.cid === cid);
+  if (!installed) {
+    throw new Error("Runtime delegation activation did not install the validated authority.");
+  }
+  if (
+    installed.delegationHeader.Authorization !== authorization ||
+    !didPrincipalsMatch(installed.delegateDID, signed.audience) ||
+    installed.expiry.getTime() !== signed.expiry.getTime() ||
+    !resourcesMatch(
+      canonicalResourcesFromPortableDelegation(installed),
+      signed.resources,
+    ) ||
+    normalizedHost(installed.host ?? "") !== host
+  ) {
+    throw new Error(
+      "Runtime delegation activation installed authority that differs from the validated authority.",
+    );
+  }
+
+  return {
+    cid,
+    delegation: installed,
+    effectivePermissions: signed.permissions,
+    expiry: new Date(signed.expiry),
+    audience: signed.audience,
+    host: normalizedHost(installed.host ?? host),
+  };
 }
 
 /**

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -135,6 +135,7 @@ export type {
 // High-level API
 export {
   TinyCloudNode,
+  UnsupportedSessionRestoreError,
   type TinyCloudNodeConfig,
   type DelegateToOptions,
   type DelegateToResult,

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -179,6 +179,7 @@ export {
   DEFAULT_MANIFEST_SPACE,
   DEFAULT_MANIFEST_VERSION,
   VAULT_PERMISSION_SERVICE,
+  CaveatedDelegationUnsupportedError,
   PermissionNotInManifestError,
   SessionExpiredError,
   ManifestValidationError,

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -199,12 +199,19 @@ export { NodeWasmBindings } from "./NodeWasmBindings";
 // Delegation
 export { DelegatedAccess } from "./DelegatedAccess";
 export type { RestorableSession } from "./DelegatedAccess";
-export { serializeDelegation, deserializeDelegation, grantAuthRequest } from "./delegation";
+export {
+  serializeDelegation,
+  deserializeDelegation,
+  grantAuthRequest,
+  activateValidatedRuntimeDelegation,
+} from "./delegation";
 export type {
   PortableDelegation,
   AuthRequestArtifact,
   AuthDelegationArtifact,
   DelegationAuthority,
+  RuntimeDelegationActivator,
+  ValidatedRuntimeDelegation,
 } from "./delegation";
 
 // Re-export KV service values

--- a/packages/node-sdk/src/publicExports.test.ts
+++ b/packages/node-sdk/src/publicExports.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+import { CaveatedDelegationUnsupportedError as SdkCoreError } from "@tinycloud/sdk-core";
+
+import { CaveatedDelegationUnsupportedError as CoreError } from "./core";
+import { CaveatedDelegationUnsupportedError as RootError } from "./index";
+
+test("exports CaveatedDelegationUnsupportedError from node root and core", () => {
+  expect(RootError).toBe(SdkCoreError);
+  expect(CoreError).toBe(SdkCoreError);
+});

--- a/packages/node-sdk/src/test-support/hermetic-encrypted-node.ts
+++ b/packages/node-sdk/src/test-support/hermetic-encrypted-node.ts
@@ -1,0 +1,518 @@
+import { ed25519 } from "@noble/curves/ed25519";
+import { bases } from "multiformats/basics";
+import {
+  canonicalHashHex,
+  canonicalizeEncryptionJson,
+  canonicalSignedResponse,
+  type DecryptRequestBody,
+  type DecryptResponseBody,
+  type InlineEncryptedEnvelope,
+  type NetworkDescriptor,
+  type PermissionEntry,
+  type TinyCloudSession,
+} from "@tinycloud/sdk-core";
+
+import { type ValidatedRuntimeDelegation } from "../delegation";
+import { NodeWasmBindings } from "../NodeWasmBindings";
+import { PrivateKeySigner } from "../signers/PrivateKeySigner";
+import { TinyCloudNode } from "../TinyCloudNode";
+
+const OWNER_PRIVATE_KEY = "1".padStart(64, "0");
+const DELEGATE_PRIVATE_KEY = "2".padStart(64, "0");
+const OWNER_CHAIN_ID = 1;
+const SECRET_PATH = "vault/secrets/HERMETIC_DELEGATION_CANARY";
+const PLAINTEXT = "hermetic encrypted delegation proof";
+
+type CompactPayload = {
+  att?: Record<string, Record<string, unknown>>;
+  prf?: string[];
+};
+
+function compactPayload(authorization: string): CompactPayload {
+  const compact = authorization.replace(/^Bearer /i, "");
+  const parts = compact.split(".");
+  if (parts.length !== 3) {
+    throw new Error("loopback expected a compact UCAN authorization");
+  }
+  return JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as CompactPayload;
+}
+
+function base64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function fromBase64(value: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(value, "base64"));
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const length = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+function didKeyFromPublicKey(publicKey: Uint8Array): string {
+  return `did:key:${bases.base58btc.encode(
+    concat(Uint8Array.of(0xed, 0x01), publicKey),
+  )}`;
+}
+
+function hasExactCapability(
+  authorization: string,
+  resource: string,
+  action: string,
+  delegationCid: string,
+): boolean {
+  const payload = compactPayload(authorization);
+  return (
+    payload.att?.[resource]?.[action] !== undefined &&
+    payload.prf?.includes(delegationCid) === true
+  );
+}
+
+class LoopbackEncryptedNode {
+  readonly wasm = new NodeWasmBindings();
+  readonly nodePrivateKey = new Uint8Array(32).fill(17);
+  readonly nodeId = didKeyFromPublicKey(ed25519.getPublicKey(this.nodePrivateKey));
+  readonly networkKeyPair = this.wasm.vault_x25519_from_seed(
+    new Uint8Array(32).fill(23),
+  );
+  readonly activations = new Set<string>();
+  readonly rejectedActivationCids = new Set<string>();
+  readonly observed = {
+    delegatedKvRead: false,
+    delegatedDecrypt: false,
+  };
+
+  private readonly server: ReturnType<typeof Bun.serve>;
+  private envelope?: InlineEncryptedEnvelope;
+  private spaceId?: string;
+  private networkId?: string;
+  private delegationCid?: string;
+
+  constructor() {
+    this.server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => this.handle(request),
+    });
+  }
+
+  get host(): string {
+    return `http://127.0.0.1:${this.server.port}`;
+  }
+
+  configure(input: {
+    spaceId: string;
+    networkId: string;
+    delegationCid: string;
+    envelope: InlineEncryptedEnvelope;
+  }): void {
+    this.spaceId = input.spaceId;
+    this.networkId = input.networkId;
+    this.delegationCid = input.delegationCid;
+    this.envelope = input.envelope;
+  }
+
+  configureNetwork(spaceId: string, networkId: string): void {
+    this.spaceId = spaceId;
+    this.networkId = networkId;
+  }
+
+  rejectActivation(cid: string): void {
+    this.rejectedActivationCids.add(cid);
+  }
+
+  stop(): void {
+    this.server.stop(true);
+  }
+
+  private cidForAuthorization(authorization: string): string {
+    const compact = authorization.replace(/^Bearer /i, "");
+    return this.wasm.computeCid(new TextEncoder().encode(compact), 0x55n);
+  }
+
+  private json(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  private descriptor(): NetworkDescriptor {
+    if (!this.networkId) throw new Error("loopback network is not configured");
+    return {
+      networkId: this.networkId,
+      ownerDid: this.networkId.split(":").slice(3, -1).join(":"),
+      name: "default",
+      members: [{ nodeId: this.nodeId, role: "primary" }],
+      threshold: { n: 1, t: 1 },
+      state: "active",
+      publicEncryptionKey: base64(this.networkKeyPair.publicKey),
+      alg: "x25519-aes256gcm/v1",
+      keyVersion: 1,
+      keyBackend: "local-one-of-one",
+      createdAt: "2026-07-14T00:00:00.000Z",
+      updatedAt: "2026-07-14T00:00:00.000Z",
+    };
+  }
+
+  private assertConfigured(): asserts this is this & {
+    envelope: InlineEncryptedEnvelope;
+    spaceId: string;
+    networkId: string;
+    delegationCid: string;
+  } {
+    if (!this.envelope || !this.spaceId || !this.networkId || !this.delegationCid) {
+      throw new Error("loopback encrypted node is not configured");
+    }
+  }
+
+  private unwrapForNetwork(encryptedSymmetricKey: string): Uint8Array {
+    const sealed = fromBase64(encryptedSymmetricKey);
+    const ephemeralPublicKey = sealed.slice(0, 32);
+    const ciphertext = sealed.slice(32);
+    if (ciphertext[0] !== 0x01) {
+      throw new Error("loopback expected a node-sdk sealed-box ciphertext");
+    }
+    const shared = this.wasm.vault_x25519_dh(
+      this.networkKeyPair.privateKey,
+      ephemeralPublicKey,
+    );
+    return this.wasm.vault_decrypt(shared, ciphertext.slice(1));
+  }
+
+  private wrapForReceiver(
+    receiverPublicKey: Uint8Array,
+    symmetricKey: Uint8Array,
+  ): Uint8Array {
+    const ephemeral = this.wasm.vault_x25519_from_seed(this.wasm.vault_random_bytes(32));
+    const shared = this.wasm.vault_x25519_dh(
+      ephemeral.privateKey,
+      receiverPublicKey,
+    );
+    const ciphertext = this.wasm.vault_encrypt(shared, symmetricKey);
+    return concat(ephemeral.publicKey, Uint8Array.of(0x01), ciphertext);
+  }
+
+  private async handle(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/delegate" && request.method === "POST") {
+      const authorization = request.headers.get("authorization");
+      if (!authorization) return new Response("missing authorization", { status: 401 });
+      const cid = this.cidForAuthorization(authorization);
+      if (this.rejectedActivationCids.has(cid)) {
+        return new Response("delegation chain rejected by loopback transport", { status: 403 });
+      }
+      this.activations.add(cid);
+      return this.json({ activated: [cid], skipped: [] });
+    }
+
+    const descriptorPrefix = "/encryption/networks/";
+    if (
+      url.pathname.startsWith(descriptorPrefix) &&
+      request.method === "GET" &&
+      !url.pathname.endsWith("/decrypt")
+    ) {
+      if (!this.networkId) return new Response("network not found", { status: 404 });
+      return this.json(this.descriptor());
+    }
+
+    this.assertConfigured();
+    if (url.pathname === "/invoke" && request.method === "POST") {
+      const authorization = request.headers.get("authorization");
+      const resource = `${this.spaceId}/kv/${SECRET_PATH}`;
+      if (
+        !authorization ||
+        !hasExactCapability(
+          authorization,
+          resource,
+          "tinycloud.kv/get",
+          this.delegationCid,
+        )
+      ) {
+        return new Response("delegated kv/get proof required", { status: 403 });
+      }
+      this.observed.delegatedKvRead = true;
+      return this.json(this.envelope);
+    }
+
+    if (url.pathname.endsWith("/decrypt") && request.method === "POST") {
+      const authorization = request.headers.get("authorization");
+      if (!authorization) return new Response("missing authorization", { status: 401 });
+      const bodyText = await request.text();
+      const body = JSON.parse(bodyText) as DecryptRequestBody;
+      if (canonicalizeEncryptionJson(body) !== bodyText) {
+        return new Response("non-canonical decrypt body", { status: 400 });
+      }
+      if (
+        body.networkId !== this.networkId ||
+        !hasExactCapability(
+          authorization,
+          this.networkId,
+          "tinycloud.encryption/decrypt",
+          this.delegationCid,
+        )
+      ) {
+        return new Response("delegated decrypt proof required", { status: 403 });
+      }
+      const expectedWrappedKeyHash = canonicalHashHex(
+        (bytes) => this.wasm.vault_sha256(bytes),
+        body.encryptedSymmetricKey,
+      );
+      if (body.encryptedSymmetricKeyHash !== expectedWrappedKeyHash) {
+        return new Response("encrypted key hash mismatch", { status: 400 });
+      }
+
+      const symmetricKey = this.unwrapForNetwork(body.encryptedSymmetricKey);
+      const wrappedKey = this.wrapForReceiver(
+        fromBase64(body.receiverPublicKey),
+        symmetricKey,
+      );
+      const invocationCid = this.cidForAuthorization(authorization);
+      const requestHash = Buffer.from(
+        this.wasm.vault_sha256(
+          new TextEncoder().encode(`${invocationCid}${canonicalHashHex(
+            (bytes) => this.wasm.vault_sha256(bytes),
+            body,
+          )}`),
+        ),
+      ).toString("hex");
+      const response: DecryptResponseBody = {
+        type: "tinycloud.encryption.decrypt-result/v1",
+        targetNode: this.nodeId,
+        networkId: body.networkId,
+        invocationCid,
+        encryptedSymmetricKeyHash: body.encryptedSymmetricKeyHash,
+        receiverPublicKeyHash: body.receiverPublicKeyHash,
+        wrappedKey: base64(wrappedKey),
+        alg: body.alg,
+        keyVersion: body.keyVersion,
+        requestHash,
+        nodeId: this.nodeId,
+        nodeSignature: "",
+      };
+      response.nodeSignature = base64(
+        ed25519.sign(
+          new TextEncoder().encode(canonicalSignedResponse(response)),
+          this.nodePrivateKey,
+        ),
+      );
+      this.observed.delegatedDecrypt = true;
+      return this.json(response);
+    }
+
+    return new Response("not found", { status: 404 });
+  }
+}
+
+function makeNode(host: string, privateKey: string, wasmBindings: NodeWasmBindings): {
+  node: TinyCloudNode;
+  signer: PrivateKeySigner;
+} {
+  const signer = new PrivateKeySigner(privateKey, OWNER_CHAIN_ID);
+  return {
+    signer,
+    node: new TinyCloudNode({ host, signer, wasmBindings }),
+  };
+}
+
+async function makeSession(
+  node: TinyCloudNode,
+  signer: PrivateKeySigner,
+  input: {
+    address: string;
+    spaceId: string;
+    abilities: Record<string, Record<string, string[]>>;
+    rawAbilities?: Record<string, string[]>;
+  },
+): Promise<TinyCloudSession> {
+  const wasm = (node as unknown as { wasmBindings: NodeWasmBindings }).wasmBindings;
+  const jwk = (node as unknown as { sessionKeyJwk: object }).sessionKeyJwk;
+  const issuedAt = new Date();
+  const prepared = wasm.prepareSession({
+    abilities: input.abilities,
+    ...(input.rawAbilities ? { rawAbilities: input.rawAbilities } : {}),
+    address: wasm.ensureEip55(input.address),
+    chainId: OWNER_CHAIN_ID,
+    domain: "127.0.0.1",
+    issuedAt: issuedAt.toISOString(),
+    expirationTime: new Date(issuedAt.getTime() + 60 * 60_000).toISOString(),
+    spaceId: input.spaceId,
+    jwk,
+  });
+  const signature = await signer.signMessage(prepared.siwe);
+  const session = wasm.completeSessionSetup({ ...prepared, signature });
+  return {
+    address: input.address,
+    chainId: OWNER_CHAIN_ID,
+    sessionKey: "default",
+    spaceId: input.spaceId,
+    delegationCid: session.delegationCid,
+    delegationHeader: session.delegationHeader,
+    verificationMethod: node.sessionDid,
+    jwk: jwk as TinyCloudSession["jwk"],
+    siwe: prepared.siwe,
+    signature,
+  };
+}
+
+function installSession(node: TinyCloudNode, session: TinyCloudSession): void {
+  const internals = node as unknown as {
+    auth: { setRestoredTinyCloudSession(session: TinyCloudSession, hosts: string[]): void };
+    _address: string;
+    _chainId: number;
+    initializeServices(): void;
+  };
+  internals.auth.setRestoredTinyCloudSession(session, [node.hosts[0]!]);
+  internals._address = session.address;
+  internals._chainId = session.chainId;
+  internals.initializeServices();
+}
+
+export interface HermeticEncryptedNode {
+  readonly host: string;
+  readonly delegate: TinyCloudNode;
+  readonly permissions: readonly PermissionEntry[];
+  readonly unrelatedAudience: string;
+  mintDelegation(): Promise<Awaited<ReturnType<TinyCloudNode["delegateTo"]>>["delegation"]>;
+  mintDelegationForAudience(
+    audience: string,
+  ): Promise<Awaited<ReturnType<TinyCloudNode["delegateTo"]>>["delegation"]>;
+  mintUntrustedDelegation(): Promise<Awaited<ReturnType<TinyCloudNode["delegateTo"]>>["delegation"]>;
+  readAndDecrypt(delegation: ValidatedRuntimeDelegation): Promise<void>;
+  assertNarrowDelegatedReadAndDecrypt(delegation: ValidatedRuntimeDelegation): void;
+  stop(): void;
+}
+
+/**
+ * Build a loopback encrypted-node fixture for delegation tests.
+ *
+ * The owner and delegate use real NodeWasmBindings to create base sessions,
+ * mint the compact UCAN, CID-bind it, install it, and sign KV/decrypt
+ * invocations. The HTTP server is deliberately minimal: it validates the
+ * received invocation shape/proof and performs real X25519 + authenticated
+ * symmetric encryption through the same WASM crypto methods. It emulates only
+ * host-side UCAN chain/revocation storage and request authorization.
+ */
+export async function createHermeticEncryptedNode(): Promise<HermeticEncryptedNode> {
+  const transport = new LoopbackEncryptedNode();
+  const ownerRuntime = makeNode(transport.host, OWNER_PRIVATE_KEY, transport.wasm);
+  const delegateRuntime = makeNode(transport.host, DELEGATE_PRIVATE_KEY, transport.wasm);
+  const ownerAddress = await ownerRuntime.signer.getAddress();
+  const spaceId = transport.wasm.makeSpaceId(ownerAddress, OWNER_CHAIN_ID, "secrets");
+  const ownerDid = `did:pkh:eip155:${OWNER_CHAIN_ID}:${transport.wasm.ensureEip55(ownerAddress)}`;
+  const networkId = `urn:tinycloud:encryption:${ownerDid}:default`;
+  const permissions: PermissionEntry[] = [
+    {
+      service: "tinycloud.encryption",
+      path: networkId,
+      actions: ["tinycloud.encryption/decrypt"],
+    },
+    {
+      service: "tinycloud.kv",
+      space: spaceId,
+      path: SECRET_PATH,
+      actions: ["tinycloud.kv/get"],
+    },
+  ];
+  transport.configureNetwork(spaceId, networkId);
+
+  const ownerSession = await makeSession(ownerRuntime.node, ownerRuntime.signer, {
+    address: ownerAddress,
+    spaceId,
+    abilities: { kv: { [SECRET_PATH]: ["tinycloud.kv/get"] } },
+    rawAbilities: { [networkId]: ["tinycloud.encryption/decrypt"] },
+  });
+  installSession(ownerRuntime.node, ownerSession);
+
+  const delegateAddress = await delegateRuntime.signer.getAddress();
+  const delegateSession = await makeSession(delegateRuntime.node, delegateRuntime.signer, {
+    address: delegateAddress,
+    spaceId,
+    abilities: {},
+  });
+  installSession(delegateRuntime.node, delegateSession);
+
+  const descriptor: NetworkDescriptor = {
+    networkId,
+    ownerDid,
+    name: "default",
+    members: [{ nodeId: transport.nodeId, role: "primary" }],
+    threshold: { n: 1, t: 1 },
+    state: "active",
+    publicEncryptionKey: base64(transport.networkKeyPair.publicKey),
+    alg: "x25519-aes256gcm/v1",
+    keyVersion: 1,
+    keyBackend: "local-one-of-one",
+    createdAt: "2026-07-14T00:00:00.000Z",
+    updatedAt: "2026-07-14T00:00:00.000Z",
+  };
+  const encrypted = await delegateRuntime.node.encryption.encryptToNetwork(
+    networkId,
+    new TextEncoder().encode(PLAINTEXT),
+    { descriptor },
+  );
+  if (!encrypted.ok) {
+    transport.stop();
+    throw new Error(`failed to prepare encrypted fixture: ${encrypted.error.message}`);
+  }
+
+  const mint = async (audience: string) => {
+    const minted = await ownerRuntime.node.delegateTo(audience, permissions);
+    transport.configure({
+      spaceId,
+      networkId,
+      delegationCid: minted.delegation.cid,
+      envelope: encrypted.data,
+    });
+    return minted.delegation;
+  };
+
+  const unrelatedManager = transport.wasm.createSessionManager();
+  const unrelatedAudience = unrelatedManager
+    .getDID(unrelatedManager.createSessionKey("unrelated"))
+    .split("#", 1)[0]!;
+  const delegateAudience = delegateRuntime.node.sessionDid.split("#", 1)[0]!;
+
+  return {
+    host: transport.host,
+    delegate: delegateRuntime.node,
+    permissions,
+    unrelatedAudience,
+    mintDelegation: () => mint(delegateAudience),
+    mintDelegationForAudience: mint,
+    async mintUntrustedDelegation() {
+      const delegation = await mint(delegateAudience);
+      transport.rejectActivation(delegation.cid);
+      return delegation;
+    },
+    async readAndDecrypt(delegation) {
+      const read = await delegateRuntime.node.kv.get<InlineEncryptedEnvelope>(SECRET_PATH);
+      if (!read.ok || !read.data.data) {
+        throw new Error("loopback delegated KV read failed");
+      }
+      const decrypted = await delegateRuntime.node.encryption.decryptEnvelope(
+        read.data.data,
+        { proofs: [delegation.cid] },
+      );
+      if (!decrypted.ok || new TextDecoder().decode(decrypted.data) !== PLAINTEXT) {
+        throw new Error("loopback delegated decrypt failed");
+      }
+    },
+    assertNarrowDelegatedReadAndDecrypt(delegation) {
+      if (!transport.observed.delegatedKvRead || !transport.observed.delegatedDecrypt) {
+        throw new Error("loopback did not observe both delegated KV read and decrypt");
+      }
+      if (!transport.activations.has(delegation.cid)) {
+        throw new Error("loopback did not observe the validated delegation activation");
+      }
+    },
+    stop: () => transport.stop(),
+  };
+}

--- a/packages/node-sdk/src/test-support/hermetic-encrypted-node.ts
+++ b/packages/node-sdk/src/test-support/hermetic-encrypted-node.ts
@@ -378,8 +378,21 @@ function installSession(node: TinyCloudNode, session: TinyCloudSession): void {
 export interface HermeticEncryptedNode {
   readonly host: string;
   readonly delegate: TinyCloudNode;
+  readonly restorableSession: {
+    delegationHeader: { Authorization: string };
+    delegationCid: string;
+    spaceId: string;
+    jwk: object;
+    verificationMethod: string;
+    address: string;
+    chainId: number;
+    siwe: string;
+    signature: string;
+    tinycloudHosts: string[];
+  };
   readonly permissions: readonly PermissionEntry[];
   readonly unrelatedAudience: string;
+  createRestoredDelegate(): TinyCloudNode;
   mintDelegation(): Promise<Awaited<ReturnType<TinyCloudNode["delegateTo"]>>["delegation"]>;
   mintDelegationForAudience(
     audience: string,
@@ -483,8 +496,22 @@ export async function createHermeticEncryptedNode(): Promise<HermeticEncryptedNo
   return {
     host: transport.host,
     delegate: delegateRuntime.node,
+    restorableSession: {
+      delegationHeader: delegateSession.delegationHeader,
+      delegationCid: delegateSession.delegationCid,
+      spaceId: delegateSession.spaceId,
+      jwk: delegateSession.jwk,
+      verificationMethod: delegateSession.verificationMethod,
+      address: delegateSession.address,
+      chainId: delegateSession.chainId,
+      siwe: delegateSession.siwe,
+      signature: delegateSession.signature,
+      tinycloudHosts: [transport.host],
+    },
     permissions,
     unrelatedAudience,
+    createRestoredDelegate: () =>
+      new TinyCloudNode({ host: transport.host, wasmBindings: transport.wasm }),
     mintDelegation: () => mint(delegateAudience),
     mintDelegationForAudience: mint,
     async mintUntrustedDelegation() {

--- a/packages/node-sdk/src/test-support/hermetic-encrypted-node.ts
+++ b/packages/node-sdk/src/test-support/hermetic-encrypted-node.ts
@@ -4,6 +4,8 @@ import {
   canonicalHashHex,
   canonicalizeEncryptionJson,
   canonicalSignedResponse,
+  principalDidEquals,
+  verifyDidKeyEd25519Signature,
   type DecryptRequestBody,
   type DecryptResponseBody,
   type InlineEncryptedEnvelope,
@@ -24,17 +26,28 @@ const SECRET_PATH = "vault/secrets/HERMETIC_DELEGATION_CANARY";
 const PLAINTEXT = "hermetic encrypted delegation proof";
 
 type CompactPayload = {
+  iss?: string;
   att?: Record<string, Record<string, unknown>>;
   prf?: string[];
 };
 
-function compactPayload(authorization: string): CompactPayload {
+function verifiedCompactPayload(authorization: string): CompactPayload {
   const compact = authorization.replace(/^Bearer /i, "");
   const parts = compact.split(".");
   if (parts.length !== 3) {
     throw new Error("loopback expected a compact UCAN authorization");
   }
-  return JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as CompactPayload;
+  const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as CompactPayload;
+  const issuer = payload.iss?.split("#", 1)[0];
+  if (!issuer?.startsWith("did:key:")) throw new Error("loopback expected a did:key invocation issuer");
+  if (!verifyDidKeyEd25519Signature(
+    issuer,
+    new TextEncoder().encode(`${parts[0]}.${parts[1]}`),
+    Uint8Array.from(Buffer.from(parts[2]!, "base64url")),
+  )) {
+    throw new Error("loopback rejected an invalid UCAN signature");
+  }
+  return payload;
 }
 
 function base64(bytes: Uint8Array): string {
@@ -63,12 +76,11 @@ function didKeyFromPublicKey(publicKey: Uint8Array): string {
 }
 
 function hasExactCapability(
-  authorization: string,
+  payload: CompactPayload,
   resource: string,
   action: string,
   delegationCid: string,
 ): boolean {
-  const payload = compactPayload(authorization);
   return (
     payload.att?.[resource]?.[action] !== undefined &&
     payload.prf?.includes(delegationCid) === true
@@ -85,6 +97,9 @@ class LoopbackEncryptedNode {
   readonly activations = new Set<string>();
   readonly rejectedActivationCids = new Set<string>();
   readonly observed = {
+    signingIssuers: [] as string[],
+    signedDelegation: false,
+    signedInvocation: false,
     delegatedKvRead: false,
     delegatedDecrypt: false,
   };
@@ -205,10 +220,13 @@ class LoopbackEncryptedNode {
     if (url.pathname === "/delegate" && request.method === "POST") {
       const authorization = request.headers.get("authorization");
       if (!authorization) return new Response("missing authorization", { status: 401 });
+      const payload = verifiedCompactPayload(authorization);
+      if (payload.iss) this.observed.signingIssuers.push(payload.iss);
       const cid = this.cidForAuthorization(authorization);
       if (this.rejectedActivationCids.has(cid)) {
         return new Response("delegation chain rejected by loopback transport", { status: 403 });
       }
+      this.observed.signedDelegation = true;
       this.activations.add(cid);
       return this.json({ activated: [cid], skipped: [] });
     }
@@ -226,11 +244,13 @@ class LoopbackEncryptedNode {
     this.assertConfigured();
     if (url.pathname === "/invoke" && request.method === "POST") {
       const authorization = request.headers.get("authorization");
+      if (!authorization) return new Response("missing authorization", { status: 401 });
+      const payload = verifiedCompactPayload(authorization);
+      if (payload.iss) this.observed.signingIssuers.push(payload.iss);
       const resource = `${this.spaceId}/kv/${SECRET_PATH}`;
       if (
-        !authorization ||
         !hasExactCapability(
-          authorization,
+          payload,
           resource,
           "tinycloud.kv/get",
           this.delegationCid,
@@ -238,6 +258,7 @@ class LoopbackEncryptedNode {
       ) {
         return new Response("delegated kv/get proof required", { status: 403 });
       }
+      this.observed.signedInvocation = true;
       this.observed.delegatedKvRead = true;
       return this.json(this.envelope);
     }
@@ -245,6 +266,8 @@ class LoopbackEncryptedNode {
     if (url.pathname.endsWith("/decrypt") && request.method === "POST") {
       const authorization = request.headers.get("authorization");
       if (!authorization) return new Response("missing authorization", { status: 401 });
+      const payload = verifiedCompactPayload(authorization);
+      if (payload.iss) this.observed.signingIssuers.push(payload.iss);
       const bodyText = await request.text();
       const body = JSON.parse(bodyText) as DecryptRequestBody;
       if (canonicalizeEncryptionJson(body) !== bodyText) {
@@ -253,7 +276,7 @@ class LoopbackEncryptedNode {
       if (
         body.networkId !== this.networkId ||
         !hasExactCapability(
-          authorization,
+          payload,
           this.networkId,
           "tinycloud.encryption/decrypt",
           this.delegationCid,
@@ -398,8 +421,11 @@ export interface HermeticEncryptedNode {
     audience: string,
   ): Promise<Awaited<ReturnType<TinyCloudNode["delegateTo"]>>["delegation"]>;
   mintUntrustedDelegation(): Promise<Awaited<ReturnType<TinyCloudNode["delegateTo"]>>["delegation"]>;
-  readAndDecrypt(delegation: ValidatedRuntimeDelegation): Promise<void>;
-  assertNarrowDelegatedReadAndDecrypt(delegation: ValidatedRuntimeDelegation): void;
+  readAndDecrypt(node: TinyCloudNode, delegation: ValidatedRuntimeDelegation): Promise<void>;
+  assertNarrowDelegatedReadAndDecrypt(
+    delegation: ValidatedRuntimeDelegation,
+    expectedSigningIssuer?: string,
+  ): void;
   stop(): void;
 }
 
@@ -519,12 +545,12 @@ export async function createHermeticEncryptedNode(): Promise<HermeticEncryptedNo
       transport.rejectActivation(delegation.cid);
       return delegation;
     },
-    async readAndDecrypt(delegation) {
-      const read = await delegateRuntime.node.kv.get<InlineEncryptedEnvelope>(SECRET_PATH);
+    async readAndDecrypt(node, delegation) {
+      const read = await node.kv.get<InlineEncryptedEnvelope>(SECRET_PATH);
       if (!read.ok || !read.data.data) {
         throw new Error("loopback delegated KV read failed");
       }
-      const decrypted = await delegateRuntime.node.encryption.decryptEnvelope(
+      const decrypted = await node.encryption.decryptEnvelope(
         read.data.data,
         { proofs: [delegation.cid] },
       );
@@ -532,12 +558,18 @@ export async function createHermeticEncryptedNode(): Promise<HermeticEncryptedNo
         throw new Error("loopback delegated decrypt failed");
       }
     },
-    assertNarrowDelegatedReadAndDecrypt(delegation) {
-      if (!transport.observed.delegatedKvRead || !transport.observed.delegatedDecrypt) {
-        throw new Error("loopback did not observe both delegated KV read and decrypt");
+    assertNarrowDelegatedReadAndDecrypt(delegation, expectedSigningIssuer) {
+      if (!transport.observed.signedDelegation || !transport.observed.signedInvocation ||
+        !transport.observed.delegatedKvRead || !transport.observed.delegatedDecrypt) {
+        throw new Error("loopback did not validate signed delegation and invocation traffic");
       }
       if (!transport.activations.has(delegation.cid)) {
         throw new Error("loopback did not observe the validated delegation activation");
+      }
+      if (expectedSigningIssuer && !transport.observed.signingIssuers.some((issuer) =>
+        principalDidEquals(issuer, expectedSigningIssuer)
+      )) {
+        throw new Error("loopback did not observe a signature from the expected restored session key");
       }
     },
     stop: () => transport.stop(),

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -19,6 +19,11 @@
       "import": "./dist/state.js",
       "require": "./dist/state.cjs"
     },
+    "./artifacts": {
+      "types": "./dist/artifacts.d.ts",
+      "import": "./dist/artifacts.js",
+      "require": "./dist/artifacts.cjs"
+    },
     "./operations.json": "./generated/operations.json"
   },
   "engines": {
@@ -29,7 +34,7 @@
     "generated/operations.json"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup --entry src/index.ts --entry src/state.ts --entry src/artifacts.ts",
     "clean": "rm -rf dist",
     "test": "bun test",
     "typecheck": "tsc -p tsconfig.typecheck.json",

--- a/packages/operations/src/artifacts-store.test.ts
+++ b/packages/operations/src/artifacts-store.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createOrReusePermissionRequest,
+  findPermissionRequest,
+  listPermissionRequests,
+} from "./artifacts.js";
+import {
+  authRequestsPath,
+  profilePath,
+  profileStoreMetadataPath,
+} from "./state.js";
+import {
+  signalProfileLockProtocol,
+  waitForProfileLockProtocol,
+} from "../test-support/profile-lock-protocol.js";
+
+const homes: string[] = [];
+const children: ReturnType<typeof Bun.spawn>[] = [];
+const originalTcHome = process.env.TC_HOME;
+const originalHome = process.env.HOME;
+const now = new Date("2026-07-14T12:00:00.000Z");
+
+afterEach(async () => {
+  if (originalTcHome === undefined) delete process.env.TC_HOME;
+  else process.env.TC_HOME = originalTcHome;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  await Promise.all(children.splice(0).map(async (child) => {
+    if (child.exitCode === null) child.kill("SIGTERM");
+    await child.exited;
+  }));
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+async function isolatedHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), "tinycloud-operations-artifacts-"));
+  homes.push(home);
+  process.env.TC_HOME = home;
+  process.env.HOME = homedir();
+  return home;
+}
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    profile: "delegate",
+    posture: "delegate-session" as const,
+    operatorType: "agent" as const,
+    host: "https://node.tinycloud.test",
+    sessionDid: "did:key:session",
+    ...overrides,
+  };
+}
+
+function capability(action = "tinycloud.kv/get") {
+  return {
+    service: "tinycloud.kv",
+    space: "secrets",
+    path: "vault/secrets/API_KEY",
+    actions: [action],
+  };
+}
+
+function requestInput(overrides: Record<string, unknown> = {}) {
+  return {
+    ...context(),
+    missing: [capability()],
+    granted: [],
+    now: () => now,
+    createRequestId: () => "req_one",
+    ...overrides,
+  };
+}
+
+test("reuses an unresolved exact request and explicitly replaces it when requested", async () => {
+  await isolatedHome();
+  const first = await createOrReusePermissionRequest(requestInput());
+  const reused = await createOrReusePermissionRequest(requestInput({ createRequestId: () => "req_two" }));
+
+  expect(first).toMatchObject({ reused: false, request: { requestId: "req_one" } });
+  expect(reused).toMatchObject({ reused: true, request: { requestId: "req_one" } });
+
+  const replacement = await createOrReusePermissionRequest(requestInput({
+    replace: true,
+    createRequestId: () => "req_three",
+  }));
+  expect(replacement).toMatchObject({ reused: false, request: { requestId: "req_three" } });
+  expect((await listPermissionRequests("delegate")).map((item) => item.requestId)).toEqual(["req_three"]);
+});
+
+test("does not reuse a stale-session request and prunes it while holding the format-1 store lock", async () => {
+  await isolatedHome();
+  await createOrReusePermissionRequest(requestInput());
+  expect(await findPermissionRequest("delegate", "req_one", {
+    sessionDid: "did:key:rotated",
+    host: "https://node.tinycloud.test",
+  })).toBeNull();
+
+  const rotated = await createOrReusePermissionRequest(requestInput({
+    ...context({ sessionDid: "did:key:rotated" }),
+    createRequestId: () => "req_rotated",
+  }));
+
+  expect(rotated).toMatchObject({ reused: false, request: { requestId: "req_rotated" } });
+  expect(await findPermissionRequest("delegate", "req_one", {
+    sessionDid: "did:key:rotated",
+    host: "https://node.tinycloud.test",
+  })).toBeNull();
+  expect((await listPermissionRequests("delegate")).map((item) => item.requestId)).toEqual(["req_rotated"]);
+});
+
+test("supersedes a partially granted request with its exact remaining subset", async () => {
+  await isolatedHome();
+  await createOrReusePermissionRequest(requestInput({
+    missing: [capability("tinycloud.kv/get"), capability("tinycloud.kv/put")],
+    createRequestId: () => "req_full",
+  }));
+
+  const remaining = await createOrReusePermissionRequest(requestInput({
+    missing: [capability("tinycloud.kv/put")],
+    granted: [capability("tinycloud.kv/get")],
+    createRequestId: () => "req_remaining",
+  }));
+
+  expect(remaining).toMatchObject({ reused: false, request: { requestId: "req_remaining" } });
+  expect((await listPermissionRequests("delegate")).map((item) => item.requestId)).toEqual(["req_remaining"]);
+});
+
+test("does not persist an empty request when the required capability is already granted", async () => {
+  await isolatedHome();
+  const result = await createOrReusePermissionRequest(requestInput({
+    granted: [capability()],
+  }));
+
+  expect(result).toEqual({ status: "satisfied", reused: false });
+  expect(await listPermissionRequests("delegate")).toEqual([]);
+});
+
+test("prunes only records strictly older than 30 days and removes covered records", async () => {
+  await isolatedHome();
+  const cutoff = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1_000);
+  await createOrReusePermissionRequest(requestInput({
+    now: () => new Date(cutoff.getTime() - 1),
+    createRequestId: () => "req_expired_retention",
+  }));
+  await createOrReusePermissionRequest(requestInput({
+    now: () => cutoff,
+    createRequestId: () => "req_at_retention_boundary",
+    missing: [capability("tinycloud.kv/put")],
+  }));
+  await createOrReusePermissionRequest(requestInput({
+    missing: [capability("tinycloud.kv/del")],
+    createRequestId: () => "req_covered",
+  }));
+
+  await createOrReusePermissionRequest(requestInput({
+    missing: [capability("tinycloud.kv/list")],
+    granted: [capability("tinycloud.kv/del")],
+    createRequestId: () => "req_live",
+  }));
+
+  expect((await listPermissionRequests("delegate")).map((item) => item.requestId)).toEqual([
+    "req_at_retention_boundary",
+    "req_live",
+  ]);
+});
+
+test("preserves the CLI's v1 array layout and refuses an unsupported store format", async () => {
+  await isolatedHome();
+  await mkdir(profilePath("delegate"), { recursive: true });
+  const legacy = {
+    kind: "tinycloud.auth.request",
+    version: 1,
+    requestId: "req_legacy",
+    createdAt: now.toISOString(),
+    profile: "delegate",
+    posture: "delegate-session",
+    operatorType: "agent",
+    host: "https://node.tinycloud.test",
+    sessionDid: "did:key:session",
+    requested: [capability("tinycloud.kv/put")],
+  };
+  await writeFile(authRequestsPath("delegate"), `${JSON.stringify([legacy], null, 2)}\n`);
+
+  await createOrReusePermissionRequest(requestInput({ createRequestId: () => "req_new" }));
+  const text = await readFile(authRequestsPath("delegate"), "utf8");
+  expect(text).toBe(`${JSON.stringify([
+    legacy,
+    {
+      kind: "tinycloud.auth.request",
+      version: 1,
+      requestId: "req_new",
+      createdAt: now.toISOString(),
+      profile: "delegate",
+      posture: "delegate-session",
+      operatorType: "agent",
+      host: "https://node.tinycloud.test",
+      sessionDid: "did:key:session",
+      requested: [capability()],
+    },
+  ], null, 2)}\n`);
+  expect(await readFile(profileStoreMetadataPath("delegate", "auth-requests"), "utf8")).toBe(
+    '{\n  "formatVersion": 1\n}\n',
+  );
+
+  await writeFile(profileStoreMetadataPath("delegate", "auth-requests"), '{"formatVersion":2}\n');
+  await expect(createOrReusePermissionRequest(requestInput({ createRequestId: () => "req_rejected" })))
+    .rejects.toThrow('Unsupported store format for "auth-requests".');
+});
+
+test("separate artifact writers contend on the existing deterministic lock hook without losing either request", async () => {
+  const home = await isolatedHome();
+  const profile = "delegate";
+  const protocolDirectory = join(home, "protocol");
+  const readyPath = join(protocolDirectory, "holder-ready");
+  const releasePath = join(protocolDirectory, "release-holder");
+  const contendedPath = join(protocolDirectory, "artifact-contended");
+  const holder = new URL("../test-support/hold-profile-store-writer.ts", import.meta.url).pathname;
+  const writer = new URL("../test-support/create-artifact-request.ts", import.meta.url).pathname;
+  await mkdir(protocolDirectory, { recursive: true });
+
+  const held = requestRecord("req_held", now);
+  const env = { ...process.env, TC_HOME: home, HOME: homedir(), NODE_ENV: "test" };
+  const holderChild = Bun.spawn([
+    process.execPath,
+    holder,
+    profile,
+    "auth-requests",
+    held.requestId,
+    JSON.stringify(held),
+    readyPath,
+    releasePath,
+  ], { env, stdout: "pipe", stderr: "pipe" });
+  children.push(holderChild);
+  await waitForProfileLockProtocol(readyPath, "the store holder to acquire the profile lock");
+
+  const writerChild = Bun.spawn([
+    process.execPath,
+    writer,
+    profile,
+    "req_writer",
+    now.toISOString(),
+  ], {
+    env: { ...env, TC_TEST_PROFILE_LOCK_CONTENTION_SIGNAL_PATH: contendedPath },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  children.push(writerChild);
+
+  await waitForProfileLockProtocol(contendedPath, "the artifact writer to contend on the profile lock");
+  expect(writerChild.exitCode).toBeNull();
+  await signalProfileLockProtocol(releasePath);
+
+  const [holderExit, writerExit, holderError, writerError] = await Promise.all([
+    holderChild.exited,
+    writerChild.exited,
+    new Response(holderChild.stderr).text(),
+    new Response(writerChild.stderr).text(),
+  ]);
+  expect(holderExit, holderError).toBe(0);
+  expect(writerExit, writerError).toBe(0);
+  expect((await listPermissionRequests(profile)).map((item) => item.requestId).sort()).toEqual([
+    "req_held",
+    "req_writer",
+  ]);
+});
+
+function requestRecord(requestId: string, createdAt: Date) {
+  return {
+    kind: "tinycloud.auth.request" as const,
+    version: 1 as const,
+    requestId,
+    createdAt: createdAt.toISOString(),
+    profile: "delegate",
+    posture: "delegate-session" as const,
+    operatorType: "agent" as const,
+    host: "https://node.tinycloud.test",
+    sessionDid: "did:key:session",
+    requested: [capability()],
+  };
+}

--- a/packages/operations/src/artifacts.test.ts
+++ b/packages/operations/src/artifacts.test.ts
@@ -1,0 +1,180 @@
+import { expect, test } from "bun:test";
+import { grantAuthRequest, type PortableDelegation } from "@tinycloud/node-sdk";
+
+import {
+  DelegationImportArtifactSchema,
+  PermissionRequestArtifactSchema,
+  buildPermissionRequestArtifact,
+  createPermissionRequestIdentity,
+  validateDelegationImportArtifact,
+  validatePermissionRequestArtifact,
+} from "./artifacts.js";
+
+const now = new Date("2026-07-14T12:00:00.000Z");
+
+const required = [
+  {
+    service: "tinycloud.kv",
+    space: "secrets",
+    path: "vault/secrets/API_KEY",
+    actions: ["tinycloud.kv/get"],
+  },
+  {
+    service: "tinycloud.encryption",
+    space: "encryption",
+    path: "urn:tinycloud:encryption:did:pkh:owner:default",
+    actions: ["tinycloud.encryption/decrypt"],
+  },
+];
+
+function request(overrides: Record<string, unknown> = {}) {
+  return buildPermissionRequestArtifact({
+    profile: "delegate",
+    posture: "delegate-session",
+    operatorType: "agent",
+    host: "https://node.tinycloud.test",
+    sessionDid: "did:key:session",
+    ownerDid: "did:pkh:owner",
+    missing: required,
+    now: () => now,
+    createRequestId: () => "req_test",
+    ...overrides,
+  });
+}
+
+test("builds and validates the canonical v1 request artifact with optional command", () => {
+  const mcpRequest = request();
+  expect(mcpRequest).toEqual({
+    kind: "tinycloud.auth.request",
+    version: 1,
+    requestId: "req_test",
+    createdAt: now.toISOString(),
+    profile: "delegate",
+    posture: "delegate-session",
+    operatorType: "agent",
+    host: "https://node.tinycloud.test",
+    sessionDid: "did:key:session",
+    ownerDid: "did:pkh:owner",
+    requested: [required[1]!, required[0]!],
+  });
+  expect(validatePermissionRequestArtifact(mcpRequest)).toEqual(mcpRequest);
+
+  const cliRequest = request({ command: { argv: ["secrets", "get", "API_KEY"], cwd: "/workspace" } });
+  expect(cliRequest.command).toEqual({ argv: ["secrets", "get", "API_KEY"], cwd: "/workspace" });
+  expect(PermissionRequestArtifactSchema.safeParse(cliRequest).success).toBe(true);
+});
+
+test("uses a sorted exact missing-capability set in a request identity bound to profile, session, and host", () => {
+  const identity = createPermissionRequestIdentity({
+    profile: "delegate",
+    sessionDid: "did:key:session",
+    host: "https://node.tinycloud.test",
+    missing: required,
+  });
+
+  expect(identity).toBe(createPermissionRequestIdentity({
+    profile: "delegate",
+    sessionDid: "did:key:session",
+    host: "https://node.tinycloud.test",
+    missing: [...required].reverse(),
+  }));
+  expect(identity).not.toBe(createPermissionRequestIdentity({
+    profile: "other-profile",
+    sessionDid: "did:key:session",
+    host: "https://node.tinycloud.test",
+    missing: required,
+  }));
+  expect(identity).not.toBe(createPermissionRequestIdentity({
+    profile: "delegate",
+    sessionDid: "did:key:rotated-session",
+    host: "https://node.tinycloud.test",
+    missing: required,
+  }));
+  expect(identity).not.toBe(createPermissionRequestIdentity({
+    profile: "delegate",
+    sessionDid: "did:key:session",
+    host: "https://other.tinycloud.test",
+    missing: required,
+  }));
+});
+
+test("an MCP request without command is accepted by the owner grant primitive used by the existing CLI", async () => {
+  const artifact = request();
+  const delegation = portableDelegation();
+  const grant = await grantAuthRequest({
+    delegateTo: async (did, permissions) => {
+      expect(did).toBe(artifact.sessionDid);
+      expect(permissions).toEqual(artifact.requested);
+      return { delegation, prompted: false };
+    },
+  }, artifact);
+
+  expect(grant).toMatchObject({
+    kind: "tinycloud.auth.delegation",
+    version: 1,
+    requestId: artifact.requestId,
+    permissions: artifact.requested,
+  });
+});
+
+test("refuses malformed and unsupported v1 artifacts", () => {
+  expect(() => validatePermissionRequestArtifact({ kind: "tinycloud.auth.request", version: 2 }))
+    .toThrow();
+  expect(PermissionRequestArtifactSchema.safeParse({
+    ...request(),
+    requested: [{ ...required[0], actions: [] }],
+  }).success).toBe(false);
+
+  expect(() => validateDelegationImportArtifact({
+    kind: "tinycloud.auth.delegation",
+    version: 2,
+    requestId: "req_test",
+    delegation: portableDelegation(),
+  })).toThrow();
+  expect(DelegationImportArtifactSchema.safeParse({
+    kind: "tinycloud.auth.delegation",
+    version: 1,
+    requestId: "req_test",
+    delegation: { cid: "not-a-portable-delegation" },
+  }).success).toBe(false);
+});
+
+test("validates the v1 delegation-import shape but does not turn display permissions into authority", () => {
+  const importArtifact = validateDelegationImportArtifact({
+    kind: "tinycloud.auth.delegation",
+    version: 1,
+    requestId: "req_test",
+    delegation: portableDelegation(),
+    permissions: [{
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "/",
+      actions: ["tinycloud.kv/*"],
+    }],
+  });
+
+  expect(importArtifact.permissions).toEqual([{
+    service: "tinycloud.kv",
+    space: "secrets",
+    path: "/",
+    actions: ["tinycloud.kv/*"],
+  }]);
+  // The importer in the next increment must obtain effective authority from
+  // validated delegation bytes; this canonical artifact surface only retains
+  // optional display metadata and exposes no authority derivation API.
+  expect("effectivePermissions" in importArtifact).toBe(false);
+});
+
+function portableDelegation(): PortableDelegation {
+  return {
+    cid: "bafy-test-delegation",
+    spaceId: "tinycloud:pkh:eip155:1:0xowner:secrets",
+    path: "vault/secrets/API_KEY",
+    actions: ["tinycloud.kv/get"],
+    delegateDID: "did:key:session",
+    ownerAddress: "0xowner",
+    chainId: 1,
+    expiry: new Date("2099-01-01T00:00:00.000Z"),
+    delegationHeader: { Authorization: "Bearer test" },
+  };
+}

--- a/packages/operations/src/artifacts.ts
+++ b/packages/operations/src/artifacts.ts
@@ -1,0 +1,306 @@
+import { randomUUID } from "node:crypto";
+
+import type { PermissionEntry } from "@tinycloud/sdk-core";
+import { z } from "zod";
+
+import {
+  canonicalizeCapabilities,
+  evaluateAuthority,
+} from "./authority.js";
+import type {
+  OperationOperatorType,
+  TinyCloudPosture,
+} from "./contract.js";
+import { readAuthRequests, updateProfileStore } from "./state.js";
+
+export { evaluateAuthority } from "./authority.js";
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1_000;
+
+const PermissionEntrySchema = z.object({
+  service: z.string().min(1),
+  space: z.string().min(1).optional(),
+  path: z.string(),
+  actions: z.array(z.string().min(1)).min(1),
+  skipPrefix: z.boolean().optional(),
+  expiry: z.string().min(1).optional(),
+  description: z.string().optional(),
+}).strict();
+
+const CommandSchema = z.object({
+  argv: z.array(z.string()).min(1),
+  cwd: z.string().min(1),
+}).strict();
+
+const PortableDelegationSchema: z.ZodType<Record<string, unknown>> = z.lazy(() => z.object({
+  cid: z.string().min(1),
+  spaceId: z.string().min(1),
+  path: z.string(),
+  actions: z.array(z.string().min(1)).min(1),
+  delegateDID: z.string().min(1),
+  ownerAddress: z.string().min(1),
+  chainId: z.number().int().positive(),
+  expiry: z.union([z.string().datetime({ offset: true }), z.date()]),
+  delegationHeader: z.object({ Authorization: z.string().min(1) }).strict(),
+  host: z.string().min(1).optional(),
+  disableSubDelegation: z.boolean().optional(),
+  publicDelegation: PortableDelegationSchema.optional(),
+  resources: z.array(PermissionEntrySchema).optional(),
+}).passthrough());
+
+/** Canonical wire-format v1 request retained for CLI and OpenKey compatibility. */
+export const PermissionRequestArtifactSchema = z.object({
+  kind: z.literal("tinycloud.auth.request"),
+  version: z.literal(1),
+  requestId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+  profile: z.string().min(1),
+  posture: z.enum(["owner-openkey", "delegate-session", "local-owner-key", "unauthenticated"]),
+  operatorType: z.enum(["human", "agent"]),
+  host: z.string().min(1),
+  sessionDid: z.string().min(1),
+  ownerDid: z.string().min(1).optional(),
+  spaceId: z.string().min(1).optional(),
+  requestedExpiry: z.union([z.string().min(1), z.number().finite()]).optional(),
+  requested: z.array(PermissionEntrySchema).min(1),
+  command: CommandSchema.optional(),
+}).strict();
+
+/** Canonical structured v1 delegation import accepted by the auth operation. */
+export const DelegationImportArtifactSchema = z.object({
+  kind: z.literal("tinycloud.auth.delegation"),
+  version: z.literal(1),
+  requestId: z.string().min(1),
+  delegationCid: z.string().min(1).optional(),
+  delegation: PortableDelegationSchema,
+  // This field is presentation metadata only. A later import operation obtains
+  // effective permissions from validated, installed delegation authority.
+  permissions: z.array(PermissionEntrySchema).optional(),
+  expiry: z.string().datetime({ offset: true }).optional(),
+  prompted: z.boolean().optional(),
+}).strict();
+
+export type PermissionRequestArtifact = z.infer<typeof PermissionRequestArtifactSchema>;
+export type DelegationImportArtifact = z.infer<typeof DelegationImportArtifactSchema>;
+export type ArtifactClock = () => Date;
+export type RequestIdSource = () => string;
+
+export interface PermissionRequestIdentityInput {
+  readonly profile: string;
+  readonly sessionDid: string;
+  readonly host: string;
+  readonly missing: readonly PermissionEntry[];
+}
+
+export interface BuildPermissionRequestArtifactInput extends PermissionRequestIdentityInput {
+  readonly posture: TinyCloudPosture;
+  readonly operatorType: OperationOperatorType;
+  readonly ownerDid?: string;
+  readonly spaceId?: string;
+  readonly requestedExpiry?: string | number;
+  readonly command?: { readonly argv: readonly string[]; readonly cwd: string };
+  readonly now?: ArtifactClock;
+  readonly createRequestId?: RequestIdSource;
+}
+
+export interface CreateOrReusePermissionRequestInput extends BuildPermissionRequestArtifactInput {
+  readonly granted: readonly PermissionEntry[];
+  readonly replace?: boolean;
+}
+
+export type PermissionRequestResolution =
+  | Readonly<{ status: "satisfied"; reused: false }>
+  | Readonly<{ status: "created"; reused: boolean; request: PermissionRequestArtifact }>;
+
+/** Parses a request artifact without accepting a newer wire format as v1. */
+export function validatePermissionRequestArtifact(value: unknown): PermissionRequestArtifact {
+  return PermissionRequestArtifactSchema.parse(value);
+}
+
+/** Parses a structured active-session import artifact without accepting a newer wire format as v1. */
+export function validateDelegationImportArtifact(value: unknown): DelegationImportArtifact {
+  return DelegationImportArtifactSchema.parse(value);
+}
+
+export function isPermissionRequestArtifact(value: unknown): value is PermissionRequestArtifact {
+  return PermissionRequestArtifactSchema.safeParse(value).success;
+}
+
+export function isDelegationImportArtifact(value: unknown): value is DelegationImportArtifact {
+  return DelegationImportArtifactSchema.safeParse(value).success;
+}
+
+/**
+ * Stable exact identity used only for request reuse. It binds a request to its
+ * selected profile, active session DID, host, and canonical missing subset.
+ */
+export function createPermissionRequestIdentity(input: PermissionRequestIdentityInput): string {
+  return JSON.stringify({
+    profile: input.profile,
+    sessionDid: input.sessionDid,
+    host: input.host,
+    missing: canonicalizeCapabilities(input.missing),
+  });
+}
+
+/** Builds an on-disk-compatible v1 record. Omitted values stay omitted. */
+export function buildPermissionRequestArtifact(
+  input: BuildPermissionRequestArtifactInput,
+): PermissionRequestArtifact {
+  const now = input.now ?? (() => new Date());
+  const createdAt = now();
+  if (Number.isNaN(createdAt.getTime())) throw new TypeError("The artifact clock returned an invalid date.");
+  const requested = canonicalizeCapabilities(input.missing);
+  if (requested.length === 0) throw new TypeError("Permission requests require at least one missing capability.");
+
+  return validatePermissionRequestArtifact({
+    kind: "tinycloud.auth.request",
+    version: 1,
+    requestId: input.createRequestId?.() ?? defaultRequestId(createdAt),
+    createdAt: createdAt.toISOString(),
+    profile: input.profile,
+    posture: input.posture,
+    operatorType: input.operatorType,
+    host: input.host,
+    sessionDid: input.sessionDid,
+    ...(input.ownerDid !== undefined ? { ownerDid: input.ownerDid } : {}),
+    ...(input.spaceId !== undefined ? { spaceId: input.spaceId } : {}),
+    ...(input.requestedExpiry !== undefined ? { requestedExpiry: input.requestedExpiry } : {}),
+    requested,
+    ...(input.command !== undefined
+      ? { command: { argv: [...input.command.argv], cwd: input.command.cwd } }
+      : {}),
+  });
+}
+
+/** Reads only valid canonical v1 records and refuses malformed stored artifacts. */
+export async function listPermissionRequests(profile: string): Promise<PermissionRequestArtifact[]> {
+  return (await readAuthRequests<unknown>(profile)).map(validatePermissionRequestArtifact);
+}
+
+export async function findPermissionRequest(
+  profile: string,
+  requestId: string,
+  identity: Pick<PermissionRequestIdentityInput, "sessionDid" | "host">,
+): Promise<PermissionRequestArtifact | null> {
+  const records = await listPermissionRequests(profile);
+  return records.find((record) =>
+    record.requestId === requestId &&
+    record.sessionDid === identity.sessionDid &&
+    record.host === identity.host,
+  ) ?? null;
+}
+
+/**
+ * Atomically returns the newest identical unresolved request, or writes a new
+ * v1 record. Retention, stale-session pruning, covered-record pruning, and
+ * partial-grant supersession all happen in the same existing profile lock.
+ */
+export async function createOrReusePermissionRequest(
+  input: CreateOrReusePermissionRequestInput,
+): Promise<PermissionRequestResolution> {
+  const missing = evaluateAuthority(input.granted, input.missing).missing;
+  const now = input.now ?? (() => new Date());
+  const observedNow = now();
+  if (Number.isNaN(observedNow.getTime())) throw new TypeError("The artifact clock returned an invalid date.");
+
+  return updateProfileStore<unknown, PermissionRequestResolution>(
+    input.profile,
+    "auth-requests",
+    (rawRecords) => {
+      const records = rawRecords.map(validatePermissionRequestArtifact);
+      const retained = prunePermissionRequests(records, {
+        profile: input.profile,
+        sessionDid: input.sessionDid,
+        granted: input.granted,
+        now: observedNow,
+      });
+
+      if (missing.length === 0) {
+        return { records: retained, result: { status: "satisfied", reused: false } };
+      }
+
+      const identity = createPermissionRequestIdentity({ ...input, missing });
+      const withoutSuperseded = retained.filter((record) => !isSupersededBy(record, input, missing));
+      const equivalent = newestEquivalentRequest(withoutSuperseded, identity);
+      if (equivalent !== undefined && input.replace !== true) {
+        return { records: withoutSuperseded, result: { status: "created", reused: true, request: equivalent } };
+      }
+
+      const next = withoutSuperseded.filter((record) =>
+        input.replace !== true || permissionRequestArtifactIdentity(record) !== identity,
+      );
+      const request = buildPermissionRequestArtifact({ ...input, missing, now: () => observedNow });
+      return {
+        records: [...next, request],
+        result: { status: "created", reused: false, request },
+      };
+    },
+  );
+}
+
+export interface PrunePermissionRequestsInput {
+  readonly profile: string;
+  readonly sessionDid: string;
+  readonly granted: readonly PermissionEntry[];
+  readonly now: Date;
+}
+
+/** Pure retention policy used by the locked persistence operation. */
+export function prunePermissionRequests(
+  records: readonly PermissionRequestArtifact[],
+  input: PrunePermissionRequestsInput,
+): PermissionRequestArtifact[] {
+  const cutoff = input.now.getTime() - THIRTY_DAYS_MS;
+  return records.filter((record) => {
+    const createdAt = Date.parse(record.createdAt);
+    if (!Number.isFinite(createdAt) || createdAt < cutoff) return false;
+    if (record.profile === input.profile && record.sessionDid !== input.sessionDid) return false;
+    return !evaluateAuthority(input.granted, record.requested).satisfied;
+  });
+}
+
+function newestEquivalentRequest(
+  records: readonly PermissionRequestArtifact[],
+  identity: string,
+): PermissionRequestArtifact | undefined {
+  let newest: PermissionRequestArtifact | undefined;
+  for (const record of records) {
+    if (permissionRequestArtifactIdentity(record) !== identity) continue;
+    if (newest === undefined || record.createdAt >= newest.createdAt) newest = record;
+  }
+  return newest;
+}
+
+function isSupersededBy(
+  record: PermissionRequestArtifact,
+  input: CreateOrReusePermissionRequestInput,
+  missing: readonly PermissionEntry[],
+): boolean {
+  if (
+    record.profile !== input.profile ||
+    record.sessionDid !== input.sessionDid ||
+    record.host !== input.host
+  ) {
+    return false;
+  }
+  const remaining = evaluateAuthority(input.granted, record.requested).missing;
+  return remaining.length > 0 &&
+    permissionRequestArtifactIdentity(record) !==
+      createPermissionRequestIdentity({ ...input, missing }) &&
+    createPermissionRequestIdentity({ ...input, missing: remaining }) ===
+      createPermissionRequestIdentity({ ...input, missing });
+}
+
+function permissionRequestArtifactIdentity(record: PermissionRequestArtifact): string {
+  return createPermissionRequestIdentity({
+    profile: record.profile,
+    sessionDid: record.sessionDid,
+    host: record.host,
+    missing: record.requested,
+  });
+}
+
+function defaultRequestId(now: Date): string {
+  return `req_${now.getTime().toString(36)}_${randomUUID().replace(/-/g, "")}`;
+}

--- a/packages/operations/src/authority.test.ts
+++ b/packages/operations/src/authority.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test";
+
+import {
+  canonicalizeCapabilities,
+  evaluateAuthority,
+  permissionIdentity,
+} from "./authority.js";
+
+const keyGet = {
+  service: "tinycloud.kv",
+  space: "secrets",
+  path: "vault/secrets/API_KEY",
+  actions: ["tinycloud.kv/get"],
+};
+
+const keyPut = {
+  ...keyGet,
+  actions: ["tinycloud.kv/put"],
+};
+
+test("evaluates only the exact missing subset with the SDK's public containment semantics", () => {
+  const result = evaluateAuthority(
+    [{
+      service: "tinycloud.kv",
+      space: "secrets",
+      path: "vault/secrets/",
+      actions: ["tinycloud.kv/*"],
+    }],
+    [keyPut, keyGet],
+  );
+
+  expect(result).toEqual({
+    satisfied: true,
+    missing: [],
+  });
+
+  const missing = evaluateAuthority([keyGet], [keyPut, keyGet]);
+  expect(missing).toEqual({
+    satisfied: false,
+    missing: [keyPut],
+  });
+});
+
+test("canonicalizes, sorts, and deduplicates exact capability identities without broadening them", () => {
+  const required = [
+    {
+      ...keyGet,
+      actions: ["tinycloud.kv/put", "tinycloud.kv/get", "tinycloud.kv/get"],
+    },
+    {
+      ...keyGet,
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+    },
+    {
+      service: "tinycloud.kv",
+      space: "other-space",
+      path: "vault/secrets/API_KEY",
+      actions: ["tinycloud.kv/get"],
+    },
+  ];
+
+  expect(canonicalizeCapabilities(required)).toEqual([
+    {
+      service: "tinycloud.kv",
+      space: "other-space",
+      path: "vault/secrets/API_KEY",
+      actions: ["tinycloud.kv/get"],
+    },
+    {
+      ...keyGet,
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+    },
+  ]);
+
+  const result = evaluateAuthority([], required);
+  expect(result.missing).toEqual(canonicalizeCapabilities(required));
+  expect(result.missing.some((entry) => entry.actions.some((action) => action.includes("*")))).toBe(false);
+});
+
+test("keeps resource scopes in the exact canonical identity", () => {
+  expect(permissionIdentity(keyGet)).not.toBe(permissionIdentity({ ...keyGet, space: "other-space" }));
+  expect(permissionIdentity(keyGet)).not.toBe(permissionIdentity({ ...keyGet, path: "vault/secrets/" }));
+  expect(permissionIdentity(keyGet)).not.toBe(permissionIdentity(keyPut));
+});

--- a/packages/operations/src/authority.ts
+++ b/packages/operations/src/authority.ts
@@ -1,0 +1,87 @@
+import {
+  isCapabilitySubset,
+  type PermissionEntry,
+} from "@tinycloud/sdk-core";
+
+/**
+ * A capability in the canonical form persisted in a v1 request artifact.
+ *
+ * The SDK remains the semantic authority for containment. This module only
+ * establishes deterministic exact identity for persistence and display.
+ */
+export type CanonicalPermissionEntry = Readonly<PermissionEntry>;
+
+export interface AuthorityEvaluation {
+  readonly satisfied: boolean;
+  readonly missing: readonly CanonicalPermissionEntry[];
+}
+
+/**
+ * Evaluates required authority with the SDK's public subset primitive.
+ *
+ * In particular, this intentionally does not implement matching rules or
+ * manufacture wildcards. A wildcard can cover a requirement only when it was
+ * already present in the supplied granted authority and the SDK says so.
+ */
+export function evaluateAuthority(
+  granted: readonly PermissionEntry[],
+  required: readonly PermissionEntry[],
+): AuthorityEvaluation {
+  const canonicalGranted = canonicalizeCapabilities(granted);
+  const canonicalRequired = canonicalizeCapabilities(required);
+  const result = isCapabilitySubset(canonicalRequired, canonicalGranted);
+
+  return {
+    satisfied: result.subset,
+    missing: canonicalizeCapabilities(result.missing),
+  };
+}
+
+/** Returns a stable exact identity for one capability without containment. */
+export function permissionIdentity(permission: PermissionEntry): string {
+  return JSON.stringify(canonicalizeCapability(permission));
+}
+
+/**
+ * Sorts actions and entries and removes only exactly-identical capabilities.
+ * It does not coalesce paths, services, spaces, or actions into a broader
+ * capability.
+ */
+export function canonicalizeCapabilities(
+  permissions: readonly PermissionEntry[],
+): CanonicalPermissionEntry[] {
+  const byIdentity = new Map<string, CanonicalPermissionEntry>();
+  for (const permission of permissions) {
+    const canonical = canonicalizeCapability(permission);
+    byIdentity.set(permissionIdentityFromCanonical(canonical), canonical);
+  }
+
+  return [...byIdentity.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, permission]) => permission);
+}
+
+function canonicalizeCapability(permission: PermissionEntry): CanonicalPermissionEntry {
+  const actions = [...new Set(permission.actions)].sort((left, right) => left.localeCompare(right));
+  return {
+    service: permission.service,
+    ...(permission.space !== undefined ? { space: permission.space } : {}),
+    path: permission.path,
+    actions,
+    ...(permission.skipPrefix !== undefined ? { skipPrefix: permission.skipPrefix } : {}),
+    ...(permission.expiry !== undefined ? { expiry: permission.expiry } : {}),
+    ...(permission.description !== undefined ? { description: permission.description } : {}),
+  };
+}
+
+function permissionIdentityFromCanonical(permission: CanonicalPermissionEntry): string {
+  return JSON.stringify({
+    service: permission.service,
+    ...(permission.space !== undefined ? { space: permission.space } : {}),
+    path: permission.path,
+    actions: permission.actions,
+    ...(permission.skipPrefix !== undefined ? { skipPrefix: permission.skipPrefix } : {}),
+    ...(permission.expiry !== undefined ? { expiry: permission.expiry } : {}),
+    ...(permission.description !== undefined ? { description: permission.description } : {}),
+  });
+}

--- a/packages/operations/src/import-boundary.test.ts
+++ b/packages/operations/src/import-boundary.test.ts
@@ -91,3 +91,13 @@ test("operations uses the SDK policy canonicalizer rather than a local JCS imple
   );
   expect(invokeSource).not.toMatch(/function\s+jcsCanonicalize\s*\(/);
 });
+
+test("authority uses only the public SDK subset boundary and artifacts stay surface-neutral", async () => {
+  const authoritySource = await readFile(resolve(packageDirectory, "src", "authority.ts"), "utf8");
+  const artifactsSource = await readFile(resolve(packageDirectory, "src", "artifacts.ts"), "utf8");
+
+  expect(authoritySource).toContain('from "@tinycloud/sdk-core"');
+  expect(authoritySource).not.toContain("sdk-core/src/");
+  expect(artifactsSource).not.toContain("packages/cli");
+  expect(artifactsSource).not.toContain("../cli/");
+});

--- a/packages/operations/src/operations/status.test.ts
+++ b/packages/operations/src/operations/status.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type {
+  OperationContext,
+  OperationDefinition,
+  OperationExecutionOutcome,
+} from "../contract.js";
+import {
+  additionalDelegationsPath,
+  profileConfigPath,
+  sessionPath,
+  tinycloudConfigPath,
+  writeJsonAtomic,
+} from "../state.js";
+import { statusOperationDefinitions } from "./status.js";
+
+type StatusOutput = {
+  readonly profile: string;
+  readonly host: string;
+  readonly posture: "owner-openkey" | "delegate-session" | "local-owner-key" | "unauthenticated";
+  readonly operatorType?: "human" | "agent";
+  readonly principalDid?: string;
+  readonly sessionDid?: string;
+  readonly ownerDid?: string;
+  readonly space?: string;
+  readonly session: {
+    readonly present: boolean;
+    readonly expired: boolean | null;
+    readonly expiresAt: string | null;
+  };
+  readonly liveAdditionalDelegationCount: number;
+};
+
+const originalTcHome = process.env.TC_HOME;
+const originalHome = process.env.HOME;
+const homes: string[] = [];
+
+afterEach(async () => {
+  if (originalTcHome === undefined) delete process.env.TC_HOME;
+  else process.env.TC_HOME = originalTcHome;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+test("defines exactly the two internal read-only v1 status operations with strict empty input", () => {
+  expect(statusOperationDefinitions.map((definition) => [definition.id, definition.version])).toEqual([
+    ["tinycloud.status.get", 1],
+    ["tinycloud.auth.status", 1],
+  ]);
+
+  for (const definition of statusOperationDefinitions) {
+    expect(definition.effects).toEqual(["read"]);
+    expect(definition.input.safeParse({}).success).toBe(true);
+    expect(definition.input.safeParse({ argument: "raw-argument-canary" }).success).toBe(false);
+    expect(definition.sensitivity).toEqual({ input: [], output: [] });
+  }
+});
+
+test("returns the same safe delegate summary for status and auth status", async () => {
+  await isolatedHome();
+  const now = Date.now();
+  const sessionExpiry = new Date(now + 60_000).toISOString();
+  await writeProfile("delegate", {
+    privateKey: "private-key-canary",
+    jwk: { d: "jwk-canary" },
+    token: "profile-token-canary",
+  });
+  await writeJsonAtomic(sessionPath("delegate"), {
+    expiresAt: sessionExpiry,
+    sessionKey: "session-key-canary",
+    signature: "signature-canary",
+    delegationHeader: { Authorization: "session-authorization-canary" },
+  });
+  await writeJsonAtomic(additionalDelegationsPath("delegate"), [
+    storedDelegation(new Date(now + 120_000).toISOString(), "live-one"),
+    storedDelegation(new Date(now + 180_000).toISOString(), "live-two"),
+    storedDelegation(new Date(now - 1).toISOString(), "expired"),
+  ]);
+
+  const expected: StatusOutput = {
+    profile: "delegate",
+    host: "https://node.tinycloud.test",
+    posture: "delegate-session",
+    operatorType: "agent",
+    principalDid: "did:key:delegate",
+    sessionDid: "did:key:session",
+    ownerDid: "did:pkh:eip155:1:0xowner",
+    space: "tinycloud:pkh:eip155:1:0xowner:secrets",
+    session: { present: true, expired: false, expiresAt: sessionExpiry },
+    liveAdditionalDelegationCount: 2,
+  };
+
+  for (const definition of statusOperationDefinitions) {
+    const result = await execute(definition, delegateContext());
+    expect(result).toEqual({ status: "ok", output: expected });
+    if (result.status === "ok") {
+      expect(definition.output.safeParse(result.output).success).toBe(true);
+      expect(definition.output.safeParse({ ...result.output, privateKey: "forbidden" }).success).toBe(false);
+    }
+  }
+});
+
+test("returns an owner-safe summary without a session while preserving operator type", async () => {
+  await isolatedHome();
+  await writeProfile("owner");
+  await writeJsonAtomic(additionalDelegationsPath("owner"), []);
+
+  const result = await execute(definition("tinycloud.auth.status"), {
+    summary: {
+      profile: "owner",
+      host: "https://node.tinycloud.test",
+      posture: "owner-openkey",
+      operatorType: "human",
+      principalDid: "did:pkh:eip155:1:0xowner",
+      ownerDid: "did:pkh:eip155:1:0xowner",
+    },
+  });
+
+  expect(result).toEqual({
+    status: "ok",
+    output: {
+      profile: "owner",
+      host: "https://node.tinycloud.test",
+      posture: "owner-openkey",
+      operatorType: "human",
+      principalDid: "did:pkh:eip155:1:0xowner",
+      ownerDid: "did:pkh:eip155:1:0xowner",
+      session: { present: false, expired: null, expiresAt: null },
+      liveAdditionalDelegationCount: 0,
+    },
+  });
+});
+
+test("reports a missing session and treats expiry at the boundary as expired", async () => {
+  await isolatedHome();
+  await writeProfile("delegate");
+  await writeJsonAtomic(additionalDelegationsPath("delegate"), []);
+
+  const missing = await execute(definition("tinycloud.status.get"), delegateContext());
+  expect(missing).toEqual({
+    status: "ok",
+    output: expect.objectContaining({
+      session: { present: false, expired: null, expiresAt: null },
+    }),
+  });
+
+  const boundary = new Date(Date.now()).toISOString();
+  await writeJsonAtomic(sessionPath("delegate"), { expiresAt: boundary });
+  const expired = await execute(definition("tinycloud.status.get"), delegateContext());
+  expect(expired).toEqual({
+    status: "ok",
+    output: expect.objectContaining({
+      session: { present: true, expired: true, expiresAt: boundary },
+    }),
+  });
+});
+
+test("counts only additional delegations whose expiry is strictly in the future", async () => {
+  await isolatedHome();
+  await writeProfile("delegate");
+  await writeJsonAtomic(additionalDelegationsPath("delegate"), [
+    storedDelegation(new Date(Date.now() - 1).toISOString(), "expired"),
+    storedDelegation(new Date(Date.now()).toISOString(), "boundary"),
+    storedDelegation(new Date(Date.now() + 60_000).toISOString(), "live"),
+  ]);
+
+  const result = await execute(definition("tinycloud.status.get"), delegateContext());
+  expect(result).toEqual({
+    status: "ok",
+    output: expect.objectContaining({ liveAdditionalDelegationCount: 1 }),
+  });
+});
+
+test("refuses a deleted pinned profile without reading the configured fallback", async () => {
+  await isolatedHome();
+  await writeJsonAtomic(tinycloudConfigPath(), { defaultProfile: "fallback", version: 1 });
+  await writeProfile("fallback");
+  await writeJsonAtomic(sessionPath("fallback"), { expiresAt: new Date(Date.now() + 60_000).toISOString() });
+
+  expect(await execute(definition("tinycloud.status.get"), {
+    summary: {
+      profile: "deleted",
+      host: "https://node.tinycloud.test",
+      posture: "delegate-session",
+      operatorType: "agent",
+    },
+  })).toEqual({
+    status: "error",
+    error: {
+      code: "PROFILE_NOT_FOUND",
+      message: 'Profile "deleted" is not available.',
+      retryable: false,
+    },
+  });
+});
+
+test("refuses malformed stores and never serializes stored secrets or raw artifacts", async () => {
+  await isolatedHome();
+  const canaries = {
+    privateKey: "private-key-canary",
+    jwk: "jwk-canary",
+    token: "token-canary",
+    authorization: "authorization-canary",
+    delegation: "raw-delegation-canary",
+    argument: "raw-argument-canary",
+    secret: "secret-value-canary",
+  };
+  await writeProfile("delegate", {
+    privateKey: canaries.privateKey,
+    jwk: { d: canaries.jwk },
+    token: canaries.token,
+    secret: canaries.secret,
+  });
+  await writeJsonAtomic(sessionPath("delegate"), {
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    token: canaries.token,
+    sessionKey: canaries.privateKey,
+  });
+  await writeJsonAtomic(additionalDelegationsPath("delegate"), [
+    {
+      delegation: {
+        expiry: new Date(Date.now() + 60_000).toISOString(),
+        bytes: canaries.delegation,
+        delegationHeader: { Authorization: canaries.authorization },
+      },
+    },
+  ]);
+
+  const statusDefinition = definition("tinycloud.status.get");
+  const successfulOutput = await execute(statusDefinition, delegateContext());
+  expect(successfulOutput).toMatchObject({
+    status: "ok",
+    output: { liveAdditionalDelegationCount: 1 },
+  });
+
+  await writeJsonAtomic(additionalDelegationsPath("delegate"), [
+    {
+      delegation: {
+        expiry: "not-a-date",
+        bytes: canaries.delegation,
+        delegationHeader: { Authorization: canaries.authorization },
+      },
+    },
+  ]);
+
+  const malformed = await execute(statusDefinition, delegateContext());
+  expect(malformed).toEqual({
+    status: "error",
+    error: {
+      code: "INTERNAL_ERROR",
+      message: "The profile state could not be inspected.",
+      retryable: false,
+    },
+  });
+
+  const serialized = JSON.stringify({
+    validInput: statusDefinition.input.safeParse({}),
+    rejectedInput: statusDefinition.input.safeParse({ argument: canaries.argument }),
+    successfulOutput,
+    outputOrError: malformed,
+  });
+  for (const canary of Object.values(canaries)) {
+    expect(serialized).not.toContain(canary);
+  }
+});
+
+async function isolatedHome(): Promise<void> {
+  const home = await mkdtemp(join(tmpdir(), "tinycloud-operations-status-"));
+  homes.push(home);
+  process.env.TC_HOME = home;
+  process.env.HOME = homedir();
+}
+
+async function writeProfile(profile: string, extra: Record<string, unknown> = {}): Promise<void> {
+  await writeJsonAtomic(profileConfigPath(profile), {
+    host: "https://node.tinycloud.test",
+    ...extra,
+  });
+}
+
+function storedDelegation(expiry: string, suffix: string): Record<string, unknown> {
+  return {
+    delegation: {
+      cid: `bafy-${suffix}`,
+      expiry,
+      delegationHeader: { Authorization: `authorization-${suffix}` },
+      bytes: `delegation-bytes-${suffix}`,
+    },
+  };
+}
+
+function definition(id: string): OperationDefinition<{}, StatusOutput> {
+  const candidate = statusOperationDefinitions.find((item) => item.id === id);
+  if (candidate === undefined) throw new Error(`Missing status definition ${id}.`);
+  return candidate;
+}
+
+async function execute(
+  operation: OperationDefinition<{}, StatusOutput>,
+  context: OperationContext,
+): Promise<OperationExecutionOutcome<StatusOutput>> {
+  return operation.execute(context, {});
+}
+
+function delegateContext(): OperationContext {
+  return {
+    summary: {
+      profile: "delegate",
+      host: "https://node.tinycloud.test",
+      posture: "delegate-session",
+      operatorType: "agent",
+      principalDid: "did:key:delegate",
+      sessionDid: "did:key:session",
+      ownerDid: "did:pkh:eip155:1:0xowner",
+      space: "tinycloud:pkh:eip155:1:0xowner:secrets",
+    },
+  };
+}

--- a/packages/operations/src/operations/status.ts
+++ b/packages/operations/src/operations/status.ts
@@ -1,0 +1,248 @@
+import { z } from "zod";
+
+import type {
+  OperationContext,
+  OperationDefinition,
+  OperationExecutionOutcome,
+  OperationExposure,
+  OperationSensitivity,
+  TinyCloudPosture,
+} from "../contract.js";
+import { operationError } from "../errors.js";
+import {
+  additionalDelegationsPath,
+  readJson,
+  readProfile,
+  readSession,
+  readStoreMetadata,
+} from "../state.js";
+
+type StatusInput = Record<never, never>;
+
+interface StatusOutput {
+  readonly profile: string;
+  readonly host: string;
+  readonly posture: TinyCloudPosture;
+  readonly operatorType?: "human" | "agent";
+  readonly principalDid?: string;
+  readonly sessionDid?: string;
+  readonly ownerDid?: string;
+  readonly space?: string;
+  readonly session: {
+    readonly present: boolean;
+    readonly expired: boolean | null;
+    readonly expiresAt: string | null;
+  };
+  readonly liveAdditionalDelegationCount: number;
+}
+
+const StatusInputSchema: z.ZodType<StatusInput> = z.object({}).strict();
+
+const StatusOutputSchema: z.ZodType<StatusOutput> = z.object({
+  profile: z.string().min(1),
+  host: z.string().min(1),
+  posture: z.enum([
+    "owner-openkey",
+    "delegate-session",
+    "local-owner-key",
+    "unauthenticated",
+  ]),
+  operatorType: z.enum(["human", "agent"]).optional(),
+  principalDid: z.string().min(1).optional(),
+  sessionDid: z.string().min(1).optional(),
+  ownerDid: z.string().min(1).optional(),
+  space: z.string().min(1).optional(),
+  session: z.object({
+    present: z.boolean(),
+    expired: z.boolean().nullable(),
+    expiresAt: z.string().datetime({ offset: true }).nullable(),
+  }).strict(),
+  liveAdditionalDelegationCount: z.number().int().nonnegative(),
+}).strict();
+
+const STATUS_POSTURES: readonly TinyCloudPosture[] = [
+  "owner-openkey",
+  "delegate-session",
+  "local-owner-key",
+  "unauthenticated",
+];
+
+const STATUS_EXPOSURE: OperationExposure = {
+  cli: { status: "required" },
+  mcp: { status: "required" },
+  skill: { status: "required" },
+  docs: { status: "required" },
+};
+
+const STATUS_SENSITIVITY: OperationSensitivity = { input: [], output: [] };
+
+/**
+ * Internal I2 definition material. The registry integration owner imports this
+ * collection; package entrypoints intentionally do not expose these handlers.
+ */
+export const statusOperationDefinitions: readonly OperationDefinition<StatusInput, StatusOutput>[] = [
+  createStatusDefinition({
+    id: "tinycloud.status.get",
+    title: "TinyCloud status",
+    description: "Inspect the selected TinyCloud profile's safe local status.",
+  }),
+  createStatusDefinition({
+    id: "tinycloud.auth.status",
+    title: "TinyCloud authentication status",
+    description: "Inspect the selected TinyCloud profile's safe authentication status.",
+  }),
+];
+
+function createStatusDefinition(params: Readonly<{
+  id: "tinycloud.status.get" | "tinycloud.auth.status";
+  title: string;
+  description: string;
+}>): OperationDefinition<StatusInput, StatusOutput> {
+  return {
+    id: params.id,
+    version: 1,
+    title: params.title,
+    description: params.description,
+    input: StatusInputSchema,
+    output: StatusOutputSchema,
+    effects: ["read"],
+    postures: STATUS_POSTURES,
+    exposure: STATUS_EXPOSURE,
+    sensitivity: STATUS_SENSITIVITY,
+    authority: async () => [],
+    execute: inspectPinnedProfileStatus,
+  };
+}
+
+async function inspectPinnedProfileStatus(
+  context: OperationContext,
+  _input: StatusInput,
+): Promise<OperationExecutionOutcome<StatusOutput>> {
+  const profile = context.summary.profile;
+  if (!(await pinnedProfileExists(profile))) return profileNotFound(profile);
+
+  try {
+    const [session, liveAdditionalDelegationCount] = await Promise.all([
+      readSession<Record<string, unknown>>(profile),
+      countLiveAdditionalDelegations(profile),
+    ]);
+    const sessionSummary = summarizeSession(session);
+
+    return {
+      status: "ok",
+      output: {
+        profile,
+        host: context.summary.host,
+        posture: context.summary.posture,
+        ...(context.summary.operatorType === undefined
+          ? {}
+          : { operatorType: context.summary.operatorType }),
+        ...(context.summary.principalDid === undefined
+          ? {}
+          : { principalDid: context.summary.principalDid }),
+        ...(context.summary.sessionDid === undefined
+          ? {}
+          : { sessionDid: context.summary.sessionDid }),
+        ...(context.summary.ownerDid === undefined
+          ? {}
+          : { ownerDid: context.summary.ownerDid }),
+        ...(context.summary.space === undefined ? {} : { space: context.summary.space }),
+        session: sessionSummary,
+        liveAdditionalDelegationCount,
+      },
+    };
+  } catch {
+    // Store contents may contain keys, session material, or delegation bytes.
+    // A state-inspection failure must not relay any part of that material.
+    return {
+      status: "error",
+      error: operationError(
+        "INTERNAL_ERROR",
+        "The profile state could not be inspected.",
+      ),
+    };
+  }
+}
+
+async function pinnedProfileExists(profile: string): Promise<boolean> {
+  try {
+    const storedProfile = await readProfile<Record<string, unknown>>(profile);
+    return isRecord(storedProfile);
+  } catch {
+    return false;
+  }
+}
+
+async function countLiveAdditionalDelegations(profile: string): Promise<number> {
+  await readStoreMetadata(profile, "additional-delegations");
+  const rawDelegations = await readJson<unknown>(additionalDelegationsPath(profile));
+  if (rawDelegations === null) return 0;
+  if (!Array.isArray(rawDelegations)) throw new TypeError("Invalid additional delegation store.");
+
+  const now = Date.now();
+  let count = 0;
+  for (const entry of rawDelegations) {
+    const expiry = storedDelegationExpiry(entry);
+    if (expiry.getTime() > now) count += 1;
+  }
+  return count;
+}
+
+function summarizeSession(session: Record<string, unknown> | null): StatusOutput["session"] {
+  if (session === null) return { present: false, expired: null, expiresAt: null };
+  if (!isRecord(session)) throw new TypeError("Invalid session store.");
+
+  const expiry = extractSessionExpiry(session);
+  if (expiry === null) return { present: true, expired: null, expiresAt: null };
+
+  return {
+    present: true,
+    expired: expiry.getTime() <= Date.now(),
+    expiresAt: expiry.toISOString(),
+  };
+}
+
+function storedDelegationExpiry(entry: unknown): Date {
+  if (!isRecord(entry) || !isRecord(entry.delegation) || !("expiry" in entry.delegation)) {
+    throw new TypeError("Invalid stored delegation.");
+  }
+  return parseExpiry(entry.delegation.expiry);
+}
+
+function extractSessionExpiry(session: Record<string, unknown>): Date | null {
+  for (const field of ["expiresAt", "expiry", "expirationTime"] as const) {
+    if (!(field in session) || session[field] === undefined || session[field] === null) continue;
+    return parseExpiry(session[field]);
+  }
+
+  if (!("siwe" in session) || session.siwe === undefined || session.siwe === null) return null;
+  if (typeof session.siwe !== "string") throw new TypeError("Invalid session expiry.");
+  const match = session.siwe.match(/^Expiration Time:\s*(.+)$/im);
+  return match === null ? null : parseExpiry(match[1].trim());
+}
+
+function parseExpiry(value: unknown): Date {
+  const date = value instanceof Date
+    ? value
+    : typeof value === "number" && Number.isFinite(value)
+    ? new Date(value > 0 && value < 1_000_000_000_000 ? value * 1_000 : value)
+    : typeof value === "string" && value.trim() !== ""
+    ? new Date(value)
+    : null;
+  if (date === null || Number.isNaN(date.getTime())) throw new TypeError("Invalid expiry.");
+  return date;
+}
+
+function profileNotFound(profile: string): OperationExecutionOutcome<never> {
+  return {
+    status: "error",
+    error: operationError(
+      "PROFILE_NOT_FOUND",
+      `Profile "${profile}" is not available.`,
+    ),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/operations/src/package-entrypoints.test.ts
+++ b/packages/operations/src/package-entrypoints.test.ts
@@ -53,6 +53,21 @@ test("packed operations package loads its real CJS and ESM entrypoints in Node",
       ],
       smokeDirectory,
     );
+    const assertArtifactsExport = "if (typeof artifacts.createOrReusePermissionRequest !== 'function' || typeof artifacts.evaluateAuthority !== 'function') throw new Error('missing artifacts exports');";
+    await run(
+      nodeBinary,
+      ["-e", `const artifacts = require('@tinycloud/operations/artifacts'); ${assertArtifactsExport}`],
+      smokeDirectory,
+    );
+    await run(
+      nodeBinary,
+      [
+        "--input-type=module",
+        "-e",
+        `const artifacts = await import('@tinycloud/operations/artifacts'); ${assertArtifactsExport}`,
+      ],
+      smokeDirectory,
+    );
   } finally {
     await rm(smokeDirectory, { recursive: true, force: true });
   }

--- a/packages/operations/src/state.test.ts
+++ b/packages/operations/src/state.test.ts
@@ -19,6 +19,7 @@ import {
   sessionPath,
   tinycloudConfigPath,
   tinycloudHomePath,
+  updateProfileStore,
   upsertProfileRecord,
   writeJsonAtomic,
   writeSession,
@@ -140,6 +141,32 @@ test("atomically appends records and replaces duplicate explicit keys", async ()
     { delegation: { cid: "bafy-two" }, revision: 1 },
     { delegation: { cid: "bafy-one" }, revision: 2 },
   ]);
+});
+
+test("updates a format-1 record store under the one profile lock without changing its legacy array layout", async () => {
+  await isolatedHome();
+  const profile = "delegate";
+  await upsertProfileRecord(
+    profile,
+    "auth-requests",
+    "req-old",
+    request("req-old"),
+    (candidate) => candidate.requestId,
+  );
+
+  const count = await updateProfileStore(
+    profile,
+    "auth-requests",
+    (records: readonly { requestId: string; revision: number }[]) => ({
+      records: [...records, request("req-new")],
+      result: records.length + 1,
+    }),
+  );
+
+  expect(count).toBe(2);
+  expect(await readFile(authRequestsPath(profile), "utf8")).toBe(
+    '[\n  {\n    "requestId": "req-old",\n    "revision": 1\n  },\n  {\n    "requestId": "req-new",\n    "revision": 1\n  }\n]\n',
+  );
 });
 
 test("writes and removes sessions under the profile lock with legacy JSON bytes", async () => {

--- a/packages/operations/src/state.ts
+++ b/packages/operations/src/state.ts
@@ -231,6 +231,31 @@ export async function upsertProfileRecord<T>(
   }, options);
 }
 
+/**
+ * Performs a typed read-modify-write of a legacy array store under the one
+ * per-profile lock. The payload stays an array and the sibling metadata stays
+ * format 1, so existing CLI readers keep their byte/layout contract.
+ */
+export async function updateProfileStore<T, Result>(
+  profile: string,
+  store: Exclude<ProfileStoreName, "session">,
+  update: (
+    records: readonly T[],
+  ) => Promise<{ readonly records: readonly T[]; readonly result: Result }> | {
+    readonly records: readonly T[];
+    readonly result: Result;
+  },
+  options: ProfileLockOptions = {},
+): Promise<Result> {
+  return withProfileLock(profile, async () => {
+    const current = await readProfileStore<T>(profile, store);
+    const next = await update(current.records);
+    await writeJsonAtomic(profileStorePath(profile, store), next.records);
+    await writeFormatOneMetadata(profile, store);
+    return next.result;
+  }, options);
+}
+
 export async function writeSession<T extends object>(
   profile: string,
   session: T,

--- a/packages/operations/test-support/create-artifact-request.ts
+++ b/packages/operations/test-support/create-artifact-request.ts
@@ -1,0 +1,23 @@
+import { createOrReusePermissionRequest } from "../src/artifacts.js";
+
+const [profile, requestId, isoNow] = process.argv.slice(2);
+if (!profile || !requestId || !isoNow) {
+  throw new Error("Expected profile, request ID, and clock timestamp.");
+}
+
+await createOrReusePermissionRequest({
+  profile,
+  posture: "delegate-session",
+  operatorType: "agent",
+  host: "https://node.tinycloud.test",
+  sessionDid: "did:key:session",
+  missing: [{
+    service: "tinycloud.kv",
+    space: "secrets",
+    path: "vault/secrets/WRITER_KEY",
+    actions: ["tinycloud.kv/get"],
+  }],
+  granted: [],
+  now: () => new Date(isoNow),
+  createRequestId: () => requestId,
+});

--- a/packages/operations/tsup.config.ts
+++ b/packages/operations/tsup.config.ts
@@ -16,16 +16,20 @@ export default defineConfig({
     'zod',
     'zod-to-json-schema',
   ],
-  noExternal: ['@tinycloud/sdk-core/policy'],
-  // Keep the source import on sdk-core's supported policy boundary, but bundle
-  // only its canonicalizer implementation. This avoids loading sdk-core's
-  // broader CJS entrypoint (and its ESM-only multiformats subpaths).
+  noExternal: ['@tinycloud/sdk-core/policy', '@tinycloud/sdk-core'],
+  // Keep source imports on supported sdk-core boundaries while bundling only
+  // the policy canonicalizer and capability-subset implementation. This avoids
+  // loading sdk-core's broader CJS entrypoint (and its ESM-only subpaths).
   esbuildOptions(options) {
     options.alias = {
       ...options.alias,
       '@tinycloud/sdk-core/policy': resolve(
         packageDirectory,
         '../sdk-core/src/policy/jcs.ts',
+      ),
+      '@tinycloud/sdk-core': resolve(
+        packageDirectory,
+        '../sdk-core/src/capabilities.ts',
       ),
     };
   },

--- a/packages/sdk-core/src/TinyCloud.ts
+++ b/packages/sdk-core/src/TinyCloud.ts
@@ -261,9 +261,12 @@ export class TinyCloud {
 
   /** @internal Retire this service graph after its owner replaces a session. */
   public retireServices(): void {
-    this._serviceContext?.retire();
-    this._services.clear();
-    this._servicesInitialized = false;
+    try {
+      this._serviceContext?.retire();
+    } finally {
+      this._services.clear();
+      this._servicesInitialized = false;
+    }
   }
 
   /**

--- a/packages/sdk-core/src/TinyCloud.ts
+++ b/packages/sdk-core/src/TinyCloud.ts
@@ -259,6 +259,13 @@ export class TinyCloud {
     return this._serviceContext;
   }
 
+  /** @internal Retire this service graph after its owner replaces a session. */
+  public retireServices(): void {
+    this._serviceContext?.retire();
+    this._services.clear();
+    this._servicesInitialized = false;
+  }
+
   /**
    * Get a registered service by name.
    *

--- a/packages/sdk-core/src/authorization/CapabilityKeyRegistry.ts
+++ b/packages/sdk-core/src/authorization/CapabilityKeyRegistry.ts
@@ -642,7 +642,29 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
       left.spaceId === right.spaceId &&
       left.path === right.path &&
       left.actions.length === right.actions.length &&
-      left.actions.every((action) => right.actions.includes(action));
+      left.actions.every((action) => right.actions.includes(action)) &&
+      this.sameCaveats(left.caveats, right.caveats);
+  }
+
+  /** Caveats are part of the signed delegation scope, not registry metadata. */
+  private sameCaveats(
+    left: readonly Record<string, unknown>[] | undefined,
+    right: readonly Record<string, unknown>[] | undefined,
+  ): boolean {
+    const canonicalize = (value: unknown): string => {
+      if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+        return JSON.stringify(value);
+      }
+      if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+      if (typeof value === "object") {
+        const object = value as Record<string, unknown>;
+        return `{${Object.keys(object).sort().map((key) =>
+          `${JSON.stringify(key)}:${canonicalize(object[key])}`,
+        ).join(",")}}`;
+      }
+      return JSON.stringify(value);
+    };
+    return canonicalize(left ?? []) === canonicalize(right ?? []);
   }
 
   /**

--- a/packages/sdk-core/src/authorization/CapabilityKeyRegistry.ts
+++ b/packages/sdk-core/src/authorization/CapabilityKeyRegistry.ts
@@ -76,8 +76,8 @@ export interface StoredDelegationChain {
 interface DelegationStore {
   /** Delegations indexed by key ID */
   byKey: Map<string, Delegation[]>;
-  /** Delegations indexed by CID */
-  byCid: Map<string, StoredDelegationChain>;
+  /** Delegations indexed by CID. A single signed ReCap can carry many scopes. */
+  byCid: Map<string, StoredDelegationChain[]>;
   /** Capability entries indexed by "resource|action" key */
   byCapability: Map<string, CapabilityEntry[]>;
 }
@@ -274,9 +274,17 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
     // Get delegations for this key
     const delegations = this.store.byKey.get(keyId) || [];
 
-    // Remove from byCid
+    // Remove this key's entries without dropping other scopes from the same
+    // signed ReCap.
     for (const delegation of delegations) {
-      this.store.byCid.delete(delegation.cid);
+      const chains = this.store.byCid.get(delegation.cid);
+      if (!chains) continue;
+      const remaining = chains.filter((chain) => chain.keyId !== keyId);
+      if (remaining.length === 0) {
+        this.store.byCid.delete(delegation.cid);
+      } else {
+        this.store.byCid.set(delegation.cid, remaining);
+      }
     }
 
     // Remove from byCapability
@@ -489,7 +497,7 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
   revokeDelegation(cid: string): Result<void, ServiceError> {
     const stored = this.store.byCid.get(cid);
 
-    if (!stored) {
+    if (!stored || stored.length === 0) {
       return err(
         serviceError(
           CapabilityKeyRegistryErrorCodes.KEY_NOT_FOUND,
@@ -499,15 +507,12 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
       );
     }
 
-    // Mark the delegation as revoked
-    stored.delegation.isRevoked = true;
-
-    // Update in byKey
-    const keyDelegations = this.store.byKey.get(stored.keyId);
-    if (keyDelegations) {
-      const delegation = keyDelegations.find((d) => d.cid === cid);
-      if (delegation) {
-        delegation.isRevoked = true;
+    // A CID identifies the signed delegation as a whole, including every
+    // scope reconstructed from its ReCap.
+    for (const chain of stored) chain.delegation.isRevoked = true;
+    for (const keyDelegations of this.store.byKey.values()) {
+      for (const delegation of keyDelegations) {
+        if (delegation.cid === cid) delegation.isRevoked = true;
       }
     }
 
@@ -570,19 +575,23 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
   private addDelegation(key: KeyInfo, delegation: Delegation): void {
     // Add to byKey
     const keyDelegations = this.store.byKey.get(key.id) || [];
-    if (!keyDelegations.some((d) => d.cid === delegation.cid)) {
+    if (!keyDelegations.some((d) => this.sameDelegationScope(d, delegation))) {
       keyDelegations.push(delegation);
       this.store.byKey.set(key.id, keyDelegations);
     }
 
     // Add to byCid
-    if (!this.store.byCid.has(delegation.cid)) {
-      this.store.byCid.set(delegation.cid, {
+    const chains = this.store.byCid.get(delegation.cid) ?? [];
+    if (!chains.some((chain) =>
+      chain.keyId === key.id && this.sameDelegationScope(chain.delegation, delegation)
+    )) {
+      chains.push({
         delegation,
         parentCid: delegation.parentCid,
         keyId: key.id,
         storedAt: new Date(),
       });
+      this.store.byCid.set(delegation.cid, chains);
     }
 
     // Add to byCapability for each action
@@ -591,7 +600,9 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
       const entries = this.store.byCapability.get(capKey) || [];
 
       // Check if we already have an entry for this exact delegation
-      const existingEntry = entries.find((e) => e.delegation.cid === delegation.cid);
+      const existingEntry = entries.find((e) =>
+        this.sameDelegationScope(e.delegation, delegation)
+      );
 
       if (existingEntry) {
         // Add this key if not already present
@@ -626,6 +637,14 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
     return `${resource}|${action}`;
   }
 
+  private sameDelegationScope(left: Delegation, right: Delegation): boolean {
+    return left.cid === right.cid &&
+      left.spaceId === right.spaceId &&
+      left.path === right.path &&
+      left.actions.length === right.actions.length &&
+      left.actions.every((action) => right.actions.includes(action));
+  }
+
   /**
    * Find capability entries that match a resource and action.
    *
@@ -658,7 +677,9 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
 
         // Check if the entry's resource pattern matches the requested resource
         if (this.resourceMatchesPattern(resource, entry.resource)) {
-          if (!results.some((r) => r.delegation.cid === entry.delegation.cid)) {
+          if (!results.some((r) =>
+            this.sameDelegationScope(r.delegation, entry.delegation)
+          )) {
             results.push(entry);
           }
         }

--- a/packages/sdk-core/src/authorization/CapabilityKeyRegistry.ts
+++ b/packages/sdk-core/src/authorization/CapabilityKeyRegistry.ts
@@ -19,7 +19,7 @@ import type {
   Delegation,
   IngestOptions,
 } from "../delegations/types";
-import { actionContains } from "../capabilities";
+import { actionContains, recapCaveatsEqual } from "../capabilities";
 
 // =============================================================================
 // Service Name
@@ -643,28 +643,7 @@ export class CapabilityKeyRegistry implements ICapabilityKeyRegistry {
       left.path === right.path &&
       left.actions.length === right.actions.length &&
       left.actions.every((action) => right.actions.includes(action)) &&
-      this.sameCaveats(left.caveats, right.caveats);
-  }
-
-  /** Caveats are part of the signed delegation scope, not registry metadata. */
-  private sameCaveats(
-    left: readonly Record<string, unknown>[] | undefined,
-    right: readonly Record<string, unknown>[] | undefined,
-  ): boolean {
-    const canonicalize = (value: unknown): string => {
-      if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
-        return JSON.stringify(value);
-      }
-      if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
-      if (typeof value === "object") {
-        const object = value as Record<string, unknown>;
-        return `{${Object.keys(object).sort().map((key) =>
-          `${JSON.stringify(key)}:${canonicalize(object[key])}`,
-        ).join(",")}}`;
-      }
-      return JSON.stringify(value);
-    };
-    return canonicalize(left ?? []) === canonicalize(right ?? []);
+      recapCaveatsEqual(left.caveats, right.caveats);
   }
 
   /**

--- a/packages/sdk-core/src/capabilities.test.ts
+++ b/packages/sdk-core/src/capabilities.test.ts
@@ -589,4 +589,44 @@ describe("ReCap caveats", () => {
     }], "fake-siwe");
     expect(output[0]?.caveats).toEqual([caveat]);
   });
+
+  it("equates only the empty and purely unconstrained caveat forms", () => {
+    const requested = {
+      service: "tinycloud.kv",
+      space: "default",
+      path: "narrow",
+      actions: ["tinycloud.kv/get"],
+    } satisfies PermissionEntry;
+
+    for (const caveats of [undefined, [], [{}]] as const) {
+      expect(isCapabilitySubset([
+        { ...requested, ...(caveats === undefined ? {} : { caveats }) },
+      ], [{ ...requested, caveats: [{}] }]).subset).toBe(true);
+    }
+  });
+
+  it("canonicalizes object keys and branch order without dropping mixed unconstrained branches", () => {
+    const requested = {
+      service: "tinycloud.kv",
+      space: "default",
+      path: "narrow",
+      actions: ["tinycloud.kv/get"],
+    } satisfies PermissionEntry;
+    const constrained = { tenant: "alpha", nested: { region: "us-east-1" } };
+
+    expect(isCapabilitySubset([{
+      ...requested,
+      caveats: [{ nested: { region: "us-east-1" }, tenant: "alpha" }, {}],
+    }], [{
+      ...requested,
+      caveats: [{}, constrained],
+    }]).subset).toBe(true);
+    expect(isCapabilitySubset([{
+      ...requested,
+      caveats: [{}, constrained],
+    }], [{
+      ...requested,
+      caveats: [constrained],
+    }]).subset).toBe(false);
+  });
 });

--- a/packages/sdk-core/src/capabilities.test.ts
+++ b/packages/sdk-core/src/capabilities.test.ts
@@ -555,3 +555,38 @@ describe("parseRecapCapabilities normalizes space", () => {
     expect(out[0].space).toBe("default");
   });
 });
+
+describe("ReCap caveats", () => {
+  const caveat = { tenant: "alpha", nested: { region: "us-east-1" } };
+  const granted: PermissionEntry[] = [{
+    service: "tinycloud.kv",
+    space: "default",
+    path: "narrow",
+    actions: ["tinycloud.kv/get"],
+    caveats: [caveat],
+  }];
+
+  it("does not treat caveated authority as an uncaveated delegation ceiling", () => {
+    expect(isCapabilitySubset([{
+      service: "tinycloud.kv",
+      space: "default",
+      path: "narrow",
+      actions: ["tinycloud.kv/get"],
+    }], granted).subset).toBe(false);
+    expect(isCapabilitySubset([{
+      ...granted[0]!,
+      caveats: [{ nested: { region: "us-east-1" }, tenant: "alpha" }],
+    }], granted).subset).toBe(true);
+  });
+
+  it("keeps exact caveat branches when normalizing raw WASM ReCap entries", () => {
+    const output = parseRecapCapabilities(() => [{
+      service: "kv",
+      space: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      path: "narrow",
+      actions: ["tinycloud.kv/get"],
+      caveats: [caveat],
+    }], "fake-siwe");
+    expect(output[0]?.caveats).toEqual([caveat]);
+  });
+});

--- a/packages/sdk-core/src/capabilities.ts
+++ b/packages/sdk-core/src/capabilities.ts
@@ -177,7 +177,38 @@ function canonicalizeEntryMatches(
       return false;
     }
   }
+  // There is no safe general partial ordering for arbitrary ReCap caveat
+  // objects. A caveated authority therefore only covers the same caveat set;
+  // treating it as uncaveated would authorize a broader child delegation.
+  if (!sameCaveats(requested.caveats, granted.caveats)) {
+    return false;
+  }
   return true;
+}
+
+function sameCaveats(
+  left: readonly Record<string, unknown>[] | undefined,
+  right: readonly Record<string, unknown>[] | undefined,
+): boolean {
+  const canonicalize = (value: unknown): string => {
+    if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+      return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+    if (typeof value === "object") {
+      const object = value as Record<string, unknown>;
+      return `{${Object.keys(object).sort().map((key) =>
+        `${JSON.stringify(key)}:${canonicalize(object[key])}`,
+      ).join(",")}}`;
+    }
+    return JSON.stringify(value);
+  };
+  // ReCap represents an unconstrained ability as `[{}]`; callers that do not
+  // mention caveats represent the same authority as `[]`. Preserve the raw
+  // value everywhere else, but compare those two semantic no-op forms alike.
+  const meaningful = (caveats: readonly Record<string, unknown>[] | undefined) =>
+    (caveats ?? []).filter((caveat) => Object.keys(caveat).length > 0);
+  return canonicalize(meaningful(left)) === canonicalize(meaningful(right));
 }
 
 /** Return whether a granted action pattern covers one requested action. */
@@ -213,6 +244,9 @@ function cloneEntry(entry: PermissionEntry): PermissionEntry {
     ...(entry.space !== undefined ? { space: entry.space } : {}),
     path: entry.path,
     actions: [...entry.actions],
+    ...(entry.caveats !== undefined
+      ? { caveats: JSON.parse(JSON.stringify(entry.caveats)) as Record<string, unknown>[] }
+      : {}),
     ...(entry.skipPrefix !== undefined ? { skipPrefix: entry.skipPrefix } : {}),
     ...(entry.expiry !== undefined ? { expiry: entry.expiry } : {}),
   };
@@ -235,6 +269,8 @@ export interface WasmRecapEntry {
   space: string;
   path: string;
   actions: string[];
+  /** Exact ReCap caveats shared by every action in this entry. */
+  caveats?: Record<string, unknown>[];
 }
 
 /**
@@ -289,6 +325,9 @@ export function parseRecapCapabilities(
       space: normalizeSpace(entry.space),
       path: entry.path,
       actions: [...entry.actions],
+      ...(entry.caveats === undefined
+        ? {}
+        : { caveats: JSON.parse(JSON.stringify(entry.caveats)) as Record<string, unknown>[] }),
     };
   });
 

--- a/packages/sdk-core/src/capabilities.ts
+++ b/packages/sdk-core/src/capabilities.ts
@@ -58,6 +58,25 @@ export class SessionExpiredError extends Error {
   }
 }
 
+/**
+ * Thrown when the installed WASM delegation boundary cannot encode every
+ * constrained ReCap branch in a requested child delegation.
+ */
+export class CaveatedDelegationUnsupportedError extends Error {
+  /** Stable machine-readable error code for fail-closed caveated delegation. */
+  code = "CAVEATED_DELEGATION_UNSUPPORTED" as const;
+  /** Requested entries whose constrained ReCap branches cannot be preserved. */
+  entries: PermissionEntry[];
+
+  constructor(entries: PermissionEntry[]) {
+    super(
+      "Cannot create a caveated delegation because this WASM delegation boundary cannot preserve every ReCap caveat branch exactly."
+    );
+    this.name = "CaveatedDelegationUnsupportedError";
+    this.entries = entries.map(cloneEntry);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Space normalization
 // ---------------------------------------------------------------------------
@@ -180,35 +199,63 @@ function canonicalizeEntryMatches(
   // There is no safe general partial ordering for arbitrary ReCap caveat
   // objects. A caveated authority therefore only covers the same caveat set;
   // treating it as uncaveated would authorize a broader child delegation.
-  if (!sameCaveats(requested.caveats, granted.caveats)) {
+  if (!recapCaveatsEqual(requested.caveats, granted.caveats)) {
     return false;
   }
   return true;
 }
 
-function sameCaveats(
+/**
+ * Compare ReCap caveat branch sets without losing signed branch structure.
+ *
+ * ReCap represents an unconstrained ability as `[{}]`, while SDK callers can
+ * represent that same authority as `undefined` or `[]`. Those three forms are
+ * equivalent. Every other branch, including an unconstrained branch mixed
+ * with a constrained one, remains part of the canonical comparison.
+ */
+export function recapCaveatsEqual(
   left: readonly Record<string, unknown>[] | undefined,
   right: readonly Record<string, unknown>[] | undefined,
 ): boolean {
+  return canonicalizeRecapCaveats(left) === canonicalizeRecapCaveats(right);
+}
+
+/**
+ * Canonicalize a ReCap caveat branch set for exact equality checks.
+ *
+ * Object keys and branch order do not affect equality. A lone unconstrained
+ * branch is normalized to the SDK's empty-caveat representation, but an
+ * unconstrained branch in a mixed set is deliberately retained.
+ */
+export function canonicalizeRecapCaveats(
+  caveats: readonly Record<string, unknown>[] | undefined,
+): string {
   const canonicalize = (value: unknown): string => {
-    if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    if (value === null || typeof value === "boolean" || typeof value === "string") {
       return JSON.stringify(value);
+    }
+    if (typeof value === "number") {
+      if (Number.isFinite(value)) return JSON.stringify(value);
+      throw new Error("ReCap caveats must contain only JSON values.");
     }
     if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
     if (typeof value === "object") {
       const object = value as Record<string, unknown>;
+      const prototype = Object.getPrototypeOf(object);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new Error("ReCap caveats must contain only JSON values.");
+      }
       return `{${Object.keys(object).sort().map((key) =>
         `${JSON.stringify(key)}:${canonicalize(object[key])}`,
       ).join(",")}}`;
     }
-    return JSON.stringify(value);
+    throw new Error("ReCap caveats must contain only JSON values.");
   };
-  // ReCap represents an unconstrained ability as `[{}]`; callers that do not
-  // mention caveats represent the same authority as `[]`. Preserve the raw
-  // value everywhere else, but compare those two semantic no-op forms alike.
-  const meaningful = (caveats: readonly Record<string, unknown>[] | undefined) =>
-    (caveats ?? []).filter((caveat) => Object.keys(caveat).length > 0);
-  return canonicalize(meaningful(left)) === canonicalize(meaningful(right));
+  const branches = (caveats ?? []).map(canonicalize).sort();
+  if (branches.length === 0 || (branches.length === 1 && branches[0] === "{}")) {
+    return "[]";
+  }
+  return `[${branches.join(",")}]`;
 }
 
 /** Return whether a granted action pattern covers one requested action. */

--- a/packages/sdk-core/src/delegations/SharingService.test.ts
+++ b/packages/sdk-core/src/delegations/SharingService.test.ts
@@ -3,6 +3,7 @@ import type { ServiceSession } from "@tinycloud/sdk-services";
 import { bases } from "multiformats/basics";
 import { ed25519 } from "@noble/curves/ed25519";
 import { CapabilityKeyRegistry } from "../authorization/CapabilityKeyRegistry";
+import { CaveatedDelegationUnsupportedError } from "../capabilities";
 import { SharingService, type EncodedShareData } from "./SharingService";
 import type { CreateDelegationWasmParams, KeyProvider } from "./types";
 
@@ -34,7 +35,10 @@ function childToken(params: CreateDelegationWasmParams, actions = Object.values(
   ].join(".");
 }
 
-function makeService() {
+function makeService(options: {
+  assertActive?: () => void;
+  fetch?: typeof globalThis.fetch;
+} = {}) {
   const createDelegationWasm = mock((params: CreateDelegationWasmParams) => ({
     delegation: childToken(params),
     cid: "bafy-child",
@@ -47,7 +51,7 @@ function makeService() {
       actions: Object.values(params.abilities.kv)[0],
     }],
   }));
-  const fetch = mock(async () => new Response(null, { status: 200 }));
+  const fetch = options.fetch ?? mock(async () => new Response(null, { status: 200 }));
   const service = new SharingService({
     hosts: [HOST],
     invoke: mock(async () => ({ ok: true, data: undefined })) as never,
@@ -57,6 +61,7 @@ function makeService() {
     createKVService: mock(() => ({})) as never,
     createDelegationWasm,
     computeCid: () => "bafy-child",
+    assertActive: options.assertActive,
   });
   return { service, createDelegationWasm, fetch };
 }
@@ -150,6 +155,144 @@ describe("SharingService.delegateReceivedShare", () => {
       expect(createDelegationWasm).not.toHaveBeenCalled();
       expect(fetch).not.toHaveBeenCalled();
     }
+  });
+
+  test("rejects every meaningful parent caveat branch before signing or network access", async () => {
+    const unconstrained: Array<Record<string, unknown>[] | undefined> = [undefined, [], [{}]];
+    for (const caveats of unconstrained) {
+      const { service, createDelegationWasm, fetch } = makeService();
+      const result = await service.delegateReceivedShare(
+        shareLink(service, { caveats }),
+        { delegateDID: "did:key:z6MkFeedHost" },
+      );
+      expect(result.ok).toBe(true);
+      expect(createDelegationWasm).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    }
+
+    const constrained: Record<string, unknown>[][] = [
+      [{ tenant: "alpha" }],
+      [{}, { tenant: "alpha" }],
+    ];
+    for (const caveats of constrained) {
+      const { service, createDelegationWasm, fetch } = makeService();
+      const result = service.delegateReceivedShare(
+        shareLink(service, { caveats }),
+        { delegateDID: "did:key:z6MkFeedHost" },
+      );
+      await expect(result).rejects.toBeInstanceOf(CaveatedDelegationUnsupportedError);
+      await expect(result).rejects.toMatchObject({
+        code: "CAVEATED_DELEGATION_UNSUPPORTED",
+        entries: [{ caveats }],
+      });
+      expect(createDelegationWasm).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+    }
+  });
+
+  test("does not report a registered child after its service graph retires", async () => {
+    let active = true;
+    let releaseRegistration!: (response: Response) => void;
+    let markRegistrationStarted!: () => void;
+    const registrationStarted = new Promise<void>((resolve) => {
+      markRegistrationStarted = resolve;
+    });
+    const fetch = mock(() => new Promise<Response>((resolve) => {
+      releaseRegistration = resolve;
+      markRegistrationStarted();
+    })) as unknown as typeof globalThis.fetch;
+    const { service } = makeService({
+      fetch,
+      assertActive: () => {
+        if (!active) throw new Error("retired");
+      },
+    });
+
+    const result = service.delegateReceivedShare(shareLink(service), {
+      delegateDID: "did:key:z6MkFeedHost",
+    });
+    await registrationStarted;
+    active = false;
+    releaseRegistration(new Response(null, { status: 200 }));
+
+    await expect(result).resolves.toMatchObject({
+      ok: false,
+      error: { code: "NOT_INITIALIZED" },
+    });
+  });
+
+  test("does not report a generated share after its service graph retires during registration", async () => {
+    let active = true;
+    let releaseRegistration!: (response: Response) => void;
+    let markRegistrationStarted!: () => void;
+    const registrationStarted = new Promise<void>((resolve) => {
+      markRegistrationStarted = resolve;
+    });
+    const fetch = mock(() => new Promise<Response>((resolve) => {
+      releaseRegistration = resolve;
+      markRegistrationStarted();
+    })) as unknown as typeof globalThis.fetch;
+    const registry = new CapabilityKeyRegistry();
+    registry.registerKey({
+      id: "parent-key",
+      did: "did:key:z6MkParent",
+      type: "session",
+      priority: 0,
+    }, [{
+      cid: "bafy-parent",
+      delegateDID: "did:key:z6MkParent",
+      spaceId: SPACE,
+      path: "shared",
+      actions: ["tinycloud.kv/get"],
+      expiry: PARENT_EXPIRY,
+      isRevoked: false,
+      allowSubDelegation: true,
+    }]);
+    const session: ServiceSession = {
+      delegationHeader: { Authorization: "parent.header.signature" },
+      delegationCid: "bafy-parent",
+      spaceId: SPACE,
+      verificationMethod: "did:key:z6MkParent#z6MkParent",
+      jwk: { kty: "OKP", crv: "Ed25519", x: "parent-x", d: "parent-d" },
+    };
+    const service = new SharingService({
+      hosts: [HOST],
+      session,
+      invoke: mock(async () => ({ ok: true, data: undefined })) as never,
+      fetch,
+      keyProvider: {
+        createSessionKey: mock(async () => "share-key"),
+        getDID: mock(async () => "did:key:z6MkShare#z6MkShare"),
+        getJWK: mock(() => ({ kty: "OKP", crv: "Ed25519", x: "share-x", d: "share-d" })),
+      },
+      registry,
+      createKVService: mock(() => ({})) as never,
+      createDelegationWasm: mock((params: CreateDelegationWasmParams) => ({
+        delegation: "child.header.signature",
+        cid: "bafy-child",
+        delegateDID: params.delegateDID,
+        expiry: new Date(params.expirationSecs * 1000),
+        resources: [{
+          service: "kv",
+          space: params.spaceId,
+          path: Object.keys(params.abilities.kv)[0]!,
+          actions: Object.values(params.abilities.kv)[0]!,
+        }],
+      })),
+      assertActive: () => {
+        if (!active) throw new Error("retired");
+      },
+    });
+
+    const result = service.generate({ path: "shared", actions: ["tinycloud.kv/get"] });
+    await registrationStarted;
+    active = false;
+    releaseRegistration(new Response(null, { status: 200 }));
+
+    await expect(result).resolves.toMatchObject({
+      ok: false,
+      error: { code: "NOT_INITIALIZED" },
+    });
   });
 
   test("narrows a service wildcard while rejecting cross-service actions", async () => {

--- a/packages/sdk-core/src/delegations/SharingService.ts
+++ b/packages/sdk-core/src/delegations/SharingService.ts
@@ -39,9 +39,13 @@ import { DelegationErrorCodes } from "./types";
 import type { DelegationManager } from "./DelegationManager";
 import type { ICapabilityKeyRegistry } from "../authorization/CapabilityKeyRegistry";
 import { validateEncodedShareData } from "./SharingService.schema.js";
-import { SERVICE_LONG_TO_SHORT } from "../manifest";
+import { SERVICE_LONG_TO_SHORT, type PermissionEntry } from "../manifest";
 import { principalDid } from "../identity";
-import { actionContains } from "../capabilities";
+import {
+  actionContains,
+  CaveatedDelegationUnsupportedError,
+  recapCaveatsEqual,
+} from "../capabilities";
 import { bases } from "multiformats/basics";
 import { ed25519 } from "@noble/curves/ed25519";
 
@@ -604,7 +608,11 @@ export class SharingService implements ISharingService {
     try {
       const shareKeyName = `share:${Date.now()}:${Math.random().toString(36).substring(2, 10)}`;
       keyId = await this.keyProvider.createSessionKey(shareKeyName);
+      const keyCreationActiveError = this.retiredGraphError();
+      if (keyCreationActiveError) return { ok: false, error: keyCreationActiveError };
       keyDid = await this.keyProvider.getDID(keyId);
+      const keyDidActiveError = this.retiredGraphError();
+      if (keyDidActiveError) return { ok: false, error: keyDidActiveError };
       keyJwk = this.keyProvider.getJWK(keyId) as JWK;
 
       // Ensure the private key is included
@@ -659,6 +667,8 @@ export class SharingService implements ISharingService {
     if (canSatisfyFromRegistry) {
       // An existing key can satisfy this request - use session delegation (no prompt)
       const delegationResult = await this.createSessionDelegation(plainDID, fullPath, actions, expiry);
+      const childDelegationActiveError = this.retiredGraphError();
+      if (childDelegationActiveError) return { ok: false, error: childDelegationActiveError };
       const parsed = handleDelegationResult(delegationResult);
       if ('ok' in parsed && parsed.ok === false) {
         return parsed;
@@ -674,6 +684,8 @@ export class SharingService implements ISharingService {
           actions,
           requestedExpiry,
         });
+        const rootDelegationActiveError = this.retiredGraphError();
+        if (rootDelegationActiveError) return { ok: false, error: rootDelegationActiveError };
 
         if (rootDelegation) {
           delegation = rootDelegation;
@@ -706,6 +718,9 @@ export class SharingService implements ISharingService {
         ),
       };
     }
+
+    const finalActiveError = this.retiredGraphError();
+    if (finalActiveError) return { ok: false, error: finalActiveError };
 
     // Step 3: Package the share data
     const shareData: EncodedShareData = {
@@ -862,6 +877,9 @@ export class SharingService implements ISharingService {
     actions: string[],
     expiry: Date
   ): Promise<Delegation | Result<never, DelegationError>> {
+    const activeError = this.retiredGraphError();
+    if (activeError) return { ok: false, error: activeError };
+
     if (!this.session) {
       return {
         ok: false,
@@ -918,6 +936,8 @@ export class SharingService implements ISharingService {
           },
           expirationSecs: Math.floor(expiry.getTime() / 1000),
         });
+        const childSigningActiveError = this.retiredGraphError();
+        if (childSigningActiveError) return { ok: false, error: childSigningActiveError };
 
         // Register the delegation with the server
         const registerRes = await this.fetchFn(`${this.host}/delegate`, {
@@ -926,9 +946,13 @@ export class SharingService implements ISharingService {
             Authorization: wasmResult.delegation,
           },
         });
+        const registrationActiveError = this.retiredGraphError();
+        if (registrationActiveError) return { ok: false, error: registrationActiveError };
 
         if (!registerRes.ok) {
           const errorText = await registerRes.text();
+          const registrationTextActiveError = this.retiredGraphError();
+          if (registrationTextActiveError) return { ok: false, error: registrationTextActiveError };
           return {
             ok: false,
             error: createError(
@@ -988,6 +1012,8 @@ export class SharingService implements ISharingService {
       const delegationResult = this.createDelegationFn
         ? await this.createDelegationFn(delegationParams)
         : await this.delegationManager!.create(delegationParams);
+      const delegationCreationActiveError = this.retiredGraphError();
+      if (delegationCreationActiveError) return { ok: false, error: delegationCreationActiveError };
 
       if (!delegationResult.ok) {
         return {
@@ -1149,6 +1175,7 @@ export class SharingService implements ISharingService {
     const decoded = this.decodeLinkWithValidation(link);
     if (!decoded.ok) return decoded;
     const shareData = decoded.data;
+    this.assertDelegationCaveatsPreservable(shareData.delegation);
 
     const parentExpiry = new Date(shareData.delegation.expiry);
     const now = new Date();
@@ -1299,6 +1326,8 @@ export class SharingService implements ISharingService {
         abilities: { [service]: { [path]: actions } },
         expirationSecs: Math.floor(expiry.getTime() / 1000),
       });
+      const childSigningActiveError = this.retiredGraphError();
+      if (childSigningActiveError) return { ok: false, error: childSigningActiveError };
       const verifiedChild = verifySignedChild(result, {
         delegateDID,
         issuerDID: principalDid(shareData.keyDid),
@@ -1326,6 +1355,8 @@ export class SharingService implements ISharingService {
         redirect: "error" as const,
       };
       const registration = await this.fetchFn(new URL("/delegate", trustedHost).toString(), registrationInit);
+      const registrationActiveError = this.retiredGraphError();
+      if (registrationActiveError) return { ok: false, error: registrationActiveError };
       if (!registration.ok) {
         throw new Error(`node rejected child delegation (${registration.status})`);
       }
@@ -1371,6 +1402,23 @@ export class SharingService implements ISharingService {
         ),
       };
     }
+  }
+
+  /**
+   * The child-delegation WASM boundary accepts action-only abilities. Reject
+   * every constrained parent branch before that boundary can broaden it.
+   */
+  private assertDelegationCaveatsPreservable(delegation: Delegation): void {
+    if (recapCaveatsEqual(delegation.caveats, undefined)) return;
+    const service = delegation.actions[0]?.split("/", 1)[0] ?? "tinycloud.unknown";
+    const entry: PermissionEntry = {
+      service,
+      space: delegation.spaceId,
+      path: delegation.path,
+      actions: [...delegation.actions],
+      caveats: delegation.caveats ?? [],
+    };
+    throw new CaveatedDelegationUnsupportedError([entry]);
   }
 
   /**

--- a/packages/sdk-core/src/delegations/SharingService.ts
+++ b/packages/sdk-core/src/delegations/SharingService.ts
@@ -355,6 +355,8 @@ export interface SharingServiceConfig {
     /** Requested expiry time */
     requestedExpiry: Date;
   }) => Promise<Delegation | undefined>;
+  /** Reject operations after the host session/service graph has been retired. */
+  assertActive?: () => void;
 }
 
 /**
@@ -455,6 +457,7 @@ export class SharingService implements ISharingService {
   private pathPrefix: string;
   private sessionExpiry?: Date;
   private onRootDelegationNeeded?: SharingServiceConfig["onRootDelegationNeeded"];
+  private assertActiveFn?: SharingServiceConfig["assertActive"];
 
   /**
    * Creates a new SharingService instance.
@@ -475,6 +478,7 @@ export class SharingService implements ISharingService {
     this.pathPrefix = config.pathPrefix ?? "";
     this.sessionExpiry = config.sessionExpiry;
     this.onRootDelegationNeeded = config.onRootDelegationNeeded;
+    this.assertActiveFn = config.assertActive;
   }
 
   /**
@@ -488,6 +492,7 @@ export class SharingService implements ISharingService {
    * Updates the session (e.g., after re-authentication).
    */
   public updateSession(session: ServiceSession): void {
+    this.assertActiveFn?.();
     this.session = session;
   }
 
@@ -495,7 +500,8 @@ export class SharingService implements ISharingService {
    * Updates the service configuration.
    * Used to add full capabilities (session, delegationManager, createDelegation, createDelegationWasm) after signIn.
    */
-  public updateConfig(config: Partial<Pick<SharingServiceConfig, "session" | "delegationManager" | "createDelegation" | "createDelegationWasm" | "sessionExpiry" | "onRootDelegationNeeded">>): void {
+  public updateConfig(config: Partial<Pick<SharingServiceConfig, "session" | "delegationManager" | "createDelegation" | "createDelegationWasm" | "sessionExpiry" | "onRootDelegationNeeded" | "assertActive">>): void {
+    this.assertActiveFn?.();
     if (config.session !== undefined) {
       this.session = config.session;
     }
@@ -514,6 +520,9 @@ export class SharingService implements ISharingService {
     if (config.onRootDelegationNeeded !== undefined) {
       this.onRootDelegationNeeded = config.onRootDelegationNeeded;
     }
+    if (config.assertActive !== undefined) {
+      this.assertActiveFn = config.assertActive;
+    }
   }
 
   /**
@@ -527,6 +536,9 @@ export class SharingService implements ISharingService {
    * 5. Return link string
    */
   async generate(params: GenerateShareParams): Promise<Result<ShareLink, DelegationError>> {
+    const activeError = this.retiredGraphError();
+    if (activeError) return { ok: false, error: activeError };
+
     // Require session for generating (not for receiving)
     if (!this.session) {
       return {
@@ -667,37 +679,32 @@ export class SharingService implements ISharingService {
           delegation = rootDelegation;
           expiry = requestedExpiry;
         } else {
-          // Root delegation declined, clamp to session expiry
-          const fallbackResult = await this.handleSessionExtensionFallback(requestedExpiry);
-          expiry = fallbackResult.expiry;
-          const delegationResult = await this.createSessionDelegation(plainDID, fullPath, actions, expiry);
-          const parsed = handleDelegationResult(delegationResult);
-          if ('ok' in parsed && parsed.ok === false) {
-            return parsed;
-          }
-          delegation = parsed as Delegation;
+          return {
+            ok: false,
+            error: createError(
+              DelegationErrorCodes.PERMISSION_DENIED,
+              "The active session ReCap does not authorize this sharing delegation.",
+            ),
+          };
         }
       } catch (err) {
-        // Root delegation failed, clamp to session expiry
-        const fallbackResult = await this.handleSessionExtensionFallback(requestedExpiry);
-        expiry = fallbackResult.expiry;
-        const delegationResult = await this.createSessionDelegation(plainDID, fullPath, actions, expiry);
-        const parsed = handleDelegationResult(delegationResult);
-        if ('ok' in parsed && parsed.ok === false) {
-          return parsed;
-        }
-        delegation = parsed as Delegation;
+        return {
+          ok: false,
+          error: createError(
+            DelegationErrorCodes.PERMISSION_DENIED,
+            "The active session ReCap does not authorize this sharing delegation.",
+            err instanceof Error ? err : undefined,
+          ),
+        };
       }
     } else {
-      // No root delegation callback, clamp to what session can provide
-      const fallbackResult = await this.handleSessionExtensionFallback(requestedExpiry);
-      expiry = fallbackResult.expiry;
-      const delegationResult = await this.createSessionDelegation(plainDID, fullPath, actions, expiry);
-      const parsed = handleDelegationResult(delegationResult);
-      if ('ok' in parsed && parsed.ok === false) {
-        return parsed;
-      }
-      delegation = parsed as Delegation;
+      return {
+        ok: false,
+        error: createError(
+          DelegationErrorCodes.PERMISSION_DENIED,
+          "The active session ReCap does not authorize this sharing delegation.",
+        ),
+      };
     }
 
     // Step 3: Package the share data
@@ -744,16 +751,18 @@ export class SharingService implements ISharingService {
     actions: string[],
     requestedExpiry: Date
   ): boolean {
-    // Check session expiry first (most common case)
-    if (this.sessionExpiry && requestedExpiry <= this.sessionExpiry) {
-      return true;
-    }
-
     // Check registry for keys with sufficient capabilities
     const allKeys = this.registry.getAllKeys();
     for (const key of allKeys) {
       const delegations = this.registry.getDelegationsForKey(key.id);
       for (const delegation of delegations) {
+        // A registry can contain capabilities for several spaces. A share
+        // created by this service may only spend authority for its own
+        // session space.
+        if (delegation.spaceId !== this.session?.spaceId) {
+          continue;
+        }
+
         // Check if delegation is valid and not expired
         if (!this.registry.isDelegationValid(delegation)) {
           continue;
@@ -792,6 +801,19 @@ export class SharingService implements ISharingService {
     return false;
   }
 
+  private retiredGraphError(): DelegationError | undefined {
+    try {
+      this.assertActiveFn?.();
+      return undefined;
+    } catch (err) {
+      return createError(
+        DelegationErrorCodes.NOT_INITIALIZED,
+        "The session service graph has been retired.",
+        err instanceof Error ? err : undefined,
+      );
+    }
+  }
+
   /**
    * Check if a delegation path matches/covers the requested path.
    * A delegation path covers the request if:
@@ -820,15 +842,6 @@ export class SharingService implements ISharingService {
     }
 
     return false;
-  }
-
-  /**
-   * Handle fallback to session extension when root delegation is not available.
-   * @internal
-   */
-  private async handleSessionExtensionFallback(requestedExpiry: Date): Promise<{ expiry: Date }> {
-    // Clamp to current session expiry
-    return { expiry: this.sessionExpiry ?? requestedExpiry };
   }
 
   /**
@@ -1000,6 +1013,9 @@ export class SharingService implements ISharingService {
     link: string,
     options: ReceiveOptions = {}
   ): Promise<Result<ShareAccess, DelegationError>> {
+    const activeError = this.retiredGraphError();
+    if (activeError) return { ok: false, error: activeError };
+
     const {
       autoSubdelegate = true,
       useSessionKey = true,
@@ -1120,6 +1136,9 @@ export class SharingService implements ISharingService {
     link: string,
     params: DelegateReceivedShareParams
   ): Promise<Result<DelegatedShareAccess, DelegationError>> {
+    const activeError = this.retiredGraphError();
+    if (activeError) return { ok: false, error: activeError };
+
     const decoded = this.decodeLinkWithValidation(link);
     if (!decoded.ok) return decoded;
     const shareData = decoded.data;

--- a/packages/sdk-core/src/delegations/SharingService.ts
+++ b/packages/sdk-core/src/delegations/SharingService.ts
@@ -763,6 +763,13 @@ export class SharingService implements ISharingService {
           continue;
         }
 
+        // SharingService cannot reproduce arbitrary signed ReCap caveats when
+        // issuing a child delegation.  Treat caveated authority as unusable
+        // here rather than minting a broader child capability.
+        if ((delegation.caveats?.length ?? 0) > 0) {
+          continue;
+        }
+
         // Check if delegation is valid and not expired
         if (!this.registry.isDelegationValid(delegation)) {
           continue;

--- a/packages/sdk-core/src/delegations/types.schema.ts
+++ b/packages/sdk-core/src/delegations/types.schema.ts
@@ -168,6 +168,8 @@ export const DelegationSchema = z.object({
   path: z.string(),
   /** Actions this delegation authorizes */
   actions: z.array(z.string()),
+  /** Exact ReCap caveats that constrain every action in this scope. */
+  caveats: z.array(z.record(z.string(), z.unknown())).optional(),
   /** When this delegation expires (accepts Date or ISO string from JSON) */
   expiry: z.coerce.date(),
   /** Whether this delegation has been revoked */
@@ -577,6 +579,8 @@ export const DelegatedResourceSchema = z.object({
   path: z.string(),
   /** Full-URN ability strings, e.g. ["tinycloud.kv/get", "tinycloud.kv/put"]. */
   actions: z.array(z.string()),
+  /** Exact ReCap caveats that constrain every action in this scope. */
+  caveats: z.array(z.record(z.string(), z.unknown())).optional(),
 });
 
 export type DelegatedResource = z.infer<typeof DelegatedResourceSchema>;

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -33,7 +33,12 @@ export {
 export { IENSResolver } from "./ens";
 
 // WASM bindings abstraction
-export { IWasmBindings, ISessionManager } from "./wasm";
+export {
+  IWasmBindings,
+  ISessionManager,
+  type PersistedSessionProof,
+  type ValidatedPersistedSessionProof,
+} from "./wasm";
 
 // Signer interface
 export { ISigner, Bytes } from "./signer";

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -614,12 +614,15 @@ export {
 // Capability subset checking and recap parsing
 export {
   // Errors
+  CaveatedDelegationUnsupportedError,
   PermissionNotInManifestError,
   SessionExpiredError,
   // Functions
   isCapabilitySubset,
   actionContains,
+  canonicalizeRecapCaveats,
   parseRecapCapabilities,
+  recapCaveatsEqual,
   // Types
   type ParseRecapFromSiwe,
   type SubsetCheckResult,

--- a/packages/sdk-core/src/manifest.ts
+++ b/packages/sdk-core/src/manifest.ts
@@ -50,6 +50,8 @@ export interface PermissionEntry {
    * Already-expanded URNs are passed through unchanged.
    */
   actions: string[];
+  /** Exact ReCap caveat branches when this authority came from a signed ReCap. */
+  caveats?: Record<string, unknown>[];
   /** When true, the manifest prefix is NOT prepended to `path`. Default false. */
   skipPrefix?: boolean;
   /** Per-entry expiry override, ms-format. */
@@ -794,6 +796,13 @@ function validatePermissionEntry(p: unknown, path: string): void {
       vaultActionExpansion(action);
     }
   }
+  if (entry.caveats !== undefined &&
+    (!Array.isArray(entry.caveats) || entry.caveats.some((caveat) =>
+      caveat === null || typeof caveat !== "object" || Array.isArray(caveat)
+    ))
+  ) {
+    throw new ManifestValidationError(`${path}.caveats must be an array of objects`);
+  }
   if (entry.expiry !== undefined) {
     parseExpiry(entry.expiry);
   }
@@ -1174,6 +1183,9 @@ function clonePermissionEntry(entry: PermissionEntry): PermissionEntry {
     ...(entry.space !== undefined ? { space: entry.space } : {}),
     path: entry.path,
     actions: [...entry.actions],
+    ...(entry.caveats !== undefined
+      ? { caveats: JSON.parse(JSON.stringify(entry.caveats)) as Record<string, unknown>[] }
+      : {}),
     ...(entry.skipPrefix !== undefined ? { skipPrefix: entry.skipPrefix } : {}),
     ...(entry.expiry !== undefined ? { expiry: entry.expiry } : {}),
     ...(entry.description !== undefined

--- a/packages/sdk-core/src/publicExports.test.ts
+++ b/packages/sdk-core/src/publicExports.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+
+import { CaveatedDelegationUnsupportedError as PublicError } from "@tinycloud/sdk-core";
+
+test("exports CaveatedDelegationUnsupportedError from sdk-core", () => {
+  const error = new PublicError([]);
+  expect(error.name).toBe("CaveatedDelegationUnsupportedError");
+  expect(error.code).toBe("CAVEATED_DELEGATION_UNSUPPORTED");
+});

--- a/packages/sdk-core/src/wasm.ts
+++ b/packages/sdk-core/src/wasm.ts
@@ -18,9 +18,11 @@ export interface PersistedSessionProof {
   delegationHeader: { Authorization: string };
   delegationCid: string;
   spaceId: string;
+  /** @deprecated Ignored by validation; capabilities come from the signed ReCap. */
   spaces?: Record<string, string>;
   jwk: object;
-  verificationMethod: string;
+  /** @deprecated Ignored by validation; the verification method is derived from `jwk`. */
+  verificationMethod?: string;
   address: string;
   chainId: number;
   siwe: string;
@@ -31,6 +33,8 @@ export interface PersistedSessionProof {
 export interface ValidatedPersistedSessionProof {
   /** The SIWE expiration exactly as signed, when the SIWE contains one. */
   expiresAt?: string;
+  /** Exact capabilities recovered while verifying the signed SIWE ReCap. */
+  recap: WasmRecapEntry[];
 }
 
 /**

--- a/packages/sdk-core/src/wasm.ts
+++ b/packages/sdk-core/src/wasm.ts
@@ -33,8 +33,15 @@ export interface PersistedSessionProof {
 export interface ValidatedPersistedSessionProof {
   /** The SIWE expiration exactly as signed, when the SIWE contains one. */
   expiresAt?: string;
-  /** Exact capabilities recovered while verifying the signed SIWE ReCap. */
-  recap: WasmRecapEntry[];
+  /** @deprecated Legacy caveat-free witness; restore does not trust it. */
+  recap?: WasmRecapEntry[];
+  /**
+   * Exact, caveat-preserving ReCap reconstruction from a verifier that
+   * implements persisted-session validation v2. This remains optional so a
+   * pre-existing custom binding stays source-compatible, but restore rejects
+   * authenticated authority unless this witness is available.
+   */
+  verifiedRecap?: Array<WasmRecapEntry & { caveats: Record<string, unknown>[] }>;
 }
 
 /**
@@ -70,6 +77,13 @@ export interface IWasmBindings {
    * Returns an empty array when the SIWE has no recap resource.
    */
   parseRecapFromSiwe: (siweString: string) => WasmRecapEntry[];
+  /**
+   * Optional verifier-v2 parser that preserves ReCap caveats. Kept optional
+   * so existing custom bindings remain source-compatible.
+   */
+  parseVerifiedRecapFromSiwe?: (siweString: string) => Array<WasmRecapEntry & {
+    caveats: Record<string, unknown>[];
+  }>;
   /** Generate a host SIWE message for space activation */
   generateHostSIWEMessage: (params: any) => string;
   /** Convert a signed SIWE message to delegation headers */

--- a/packages/sdk-core/src/wasm.ts
+++ b/packages/sdk-core/src/wasm.ts
@@ -11,6 +11,29 @@ import type { InvokeAnyFunction, InvokeFunction } from "@tinycloud/sdk-services"
 import type { WasmRecapEntry } from "./capabilities";
 
 /**
+ * The persisted authority material that must be verified as one unit before a
+ * restored session can use its ReCap or lifetime locally.
+ */
+export interface PersistedSessionProof {
+  delegationHeader: { Authorization: string };
+  delegationCid: string;
+  spaceId: string;
+  spaces?: Record<string, string>;
+  jwk: object;
+  verificationMethod: string;
+  address: string;
+  chainId: number;
+  siwe: string;
+  signature: string;
+}
+
+/** Canonical facts produced by the WASM-side persisted-session verifier. */
+export interface ValidatedPersistedSessionProof {
+  /** The SIWE expiration exactly as signed, when the SIWE contains one. */
+  expiresAt?: string;
+}
+
+/**
  * Platform-agnostic WASM bindings interface.
  *
  * Each platform provides its own implementation:
@@ -69,6 +92,16 @@ export interface IWasmBindings {
   /** Factory for session managers */
   createSessionManager: () => ISessionManager;
 
+  /**
+   * Verify a persisted EIP-191 SIWE proof and bind it to its reconstructed
+   * Cacao header/CID, session DID, address, chain and ReCap spaces. Optional
+   * so pre-existing custom bindings remain type-compatible; restore rejects
+   * authenticated persisted data when the primitive is unavailable.
+   */
+  validatePersistedSession?: (
+    proof: PersistedSessionProof,
+  ) => ValidatedPersistedSessionProof;
+
   /** Ensure WASM module is initialized (optional — some bindings auto-init) */
   ensureInitialized?: () => Promise<void>;
 }
@@ -86,6 +119,8 @@ export interface ISessionManager {
    * `restoreSession` detects support at runtime.
    */
   replaceSessionKey?(jwk: object, keyId: string): string;
+  /** List every live key so a primary-key replacement cannot discard shares. */
+  listSessionKeys?(): string[];
   /** Rename a session key ID */
   renameSessionKeyId(oldId: string, newId: string): void;
   /** Get the DID for a session key */

--- a/packages/sdk-core/src/wasm.ts
+++ b/packages/sdk-core/src/wasm.ts
@@ -81,6 +81,8 @@ export interface IWasmBindings {
 export interface ISessionManager {
   /** Create a new session key with the given ID, returns the DID */
   createSessionKey(id: string): string;
+  /** Replace an existing key with a validated private Ed25519 JWK. */
+  replaceSessionKey(jwk: object, keyId: string): string;
   /** Rename a session key ID */
   renameSessionKeyId(oldId: string, newId: string): void;
   /** Get the DID for a session key */

--- a/packages/sdk-core/src/wasm.ts
+++ b/packages/sdk-core/src/wasm.ts
@@ -81,8 +81,11 @@ export interface IWasmBindings {
 export interface ISessionManager {
   /** Create a new session key with the given ID, returns the DID */
   createSessionKey(id: string): string;
-  /** Replace an existing key with a validated private Ed25519 JWK. */
-  replaceSessionKey(jwk: object, keyId: string): string;
+  /**
+   * Optional for custom bindings built before persisted-key restore.
+   * `restoreSession` detects support at runtime.
+   */
+  replaceSessionKey?(jwk: object, keyId: string): string;
   /** Rename a session key ID */
   renameSessionKeyId(oldId: string, newId: string): void;
   /** Get the DID for a session key */

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -44,6 +44,7 @@ tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.gi
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.150"
 serde-wasm-bindgen = "0.6.5"
+time = { version = "0.3.47", features = ["parsing"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.70"
 

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -19,6 +19,7 @@ nodejs = ["k256", "sha3", "base64"]
 
 [dependencies]
 console_error_panic_hook = "0.1"
+ed25519-dalek = "2.2"
 hex = "0.4.3"
 iri-string = "0.7.12"
 js-sys = "0.3.59"

--- a/packages/sdk-rs/packages/node/src/index.ts
+++ b/packages/sdk-rs/packages/node/src/index.ts
@@ -37,6 +37,8 @@ export {
   // whether a requested delegation is derivable from the current session
   // without a fresh wallet prompt.
   parseRecapFromSiwe,
+  // Verifier-v2 ReCap parser that retains every signed caveat branch.
+  parseVerifiedRecapFromSiwe,
   // Protocol version
   protocolVersion,
   // Vault crypto

--- a/packages/sdk-rs/packages/node/src/index.ts
+++ b/packages/sdk-rs/packages/node/src/index.ts
@@ -15,6 +15,7 @@ export {
   TCWSessionManager,
   prepareSession,
   completeSessionSetup,
+  validatePersistedSession,
   invoke,
   invokeAny,
   computeCid,

--- a/packages/sdk-rs/packages/web/src/index.ts
+++ b/packages/sdk-rs/packages/web/src/index.ts
@@ -16,6 +16,7 @@ export namespace tcwSession {
 
 export namespace tinycloud {
   export import completeSessionSetup = lib.completeSessionSetup;
+  export import validatePersistedSession = lib.validatePersistedSession;
   export import generateHostSIWEMessage = lib.generateHostSIWEMessage;
   export import siweToDelegationHeaders = lib.siweToDelegationHeaders;
   export import invoke = lib.invoke;

--- a/packages/sdk-rs/packages/web/src/index.ts
+++ b/packages/sdk-rs/packages/web/src/index.ts
@@ -35,6 +35,7 @@ export namespace tinycloud {
   // whether a requested delegation is derivable from the current session
   // without a fresh wallet prompt.
   export import parseRecapFromSiwe = lib.parseRecapFromSiwe;
+  export import parseVerifiedRecapFromSiwe = lib.parseVerifiedRecapFromSiwe;
   // Protocol version
   export import protocolVersion = lib.protocolVersion;
   // Vault crypto

--- a/packages/sdk-rs/src/lib.rs
+++ b/packages/sdk-rs/src/lib.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, str::FromStr};
 use tinycloud_sdk_rs::authorization::InvocationHeaders;
 use tinycloud_sdk_rs::tinycloud_auth::{
-    resource::{Path, Service, SpaceId},
+    cacaos::siwe::Message,
+    resource::{Path, ResourceId, Service, SpaceId},
+    siwe_recap::Capability,
     ssi::{
         claims::{chrono, chrono::Timelike, jwt::NumericDate},
         dids::{DIDBuf, DIDURLBuf},
@@ -44,11 +46,72 @@ struct PersistedDelegationHeader {
 struct ValidatedPersistedSessionProof {
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<String>,
-    recap: Vec<tinycloud_sdk_wasm::session::ParsedRecapEntry>,
+    recap: Vec<VerifiedRecapEntry>,
+    /// A verifier-versioned witness. Restore requires this rather than the
+    /// legacy `recap` field, which lets existing custom bindings remain source
+    /// compatible without treating their caveat-free output as authority.
+    verified_recap: Vec<VerifiedRecapEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct VerifiedRecapEntry {
+    service: String,
+    space: String,
+    path: String,
+    actions: Vec<String>,
+    caveats: Vec<BTreeMap<String, serde_json::Value>>,
 }
 
 fn map_jserr<E: std::error::Error>(e: E) -> JsValue {
     e.to_string().into()
+}
+
+/// Extract the verified ReCap directly instead of the upstream convenience
+/// projection, which intentionally groups actions but drops their note-bene
+/// caveats. We emit one entry per action so a capability with a different
+/// caveat set can never be merged into a broader sibling scope.
+fn verified_recap_from_siwe(siwe_string: &str) -> Result<Vec<VerifiedRecapEntry>, JsValue> {
+    let message: Message = siwe_string
+        .parse::<Message>()
+        .map_err(|error| JsValue::from_str(&error.to_string()))?;
+    let capability = match Capability::<serde_json::Value>::extract_and_verify(&message) {
+        Ok(Some(capability)) => capability,
+        Ok(None) => return Ok(Vec::new()),
+        Err(error) => return Err(JsValue::from_str(&error.to_string())),
+    };
+    let (capabilities, _) = capability.into_inner();
+    let mut entries = Vec::new();
+    for (resource_uri, ability_map) in capabilities.abilities().iter() {
+        let (space, service, path) = match resource_uri.as_str().parse::<ResourceId>() {
+            Ok(resource) => (
+                resource.space().to_string(),
+                resource.service().to_string(),
+                resource.path().map(|path| path.as_str().to_string()).unwrap_or_default(),
+            ),
+            Err(error) if resource_uri.as_str().starts_with("urn:tinycloud:encryption:") => (
+                "encryption".to_string(),
+                "encryption".to_string(),
+                resource_uri.to_string(),
+            ),
+            Err(error) => {
+                return Err(JsValue::from_str(&format!(
+                    "invalid ReCap resource URI {}: {error}",
+                    resource_uri
+                )));
+            }
+        };
+        for (ability, caveats) in ability_map {
+            entries.push(VerifiedRecapEntry {
+                service: service.clone(),
+                space: space.clone(),
+                path: path.clone(),
+                actions: vec![ability.to_string()],
+                caveats: caveats.as_ref().to_vec(),
+            });
+        }
+    }
+    Ok(entries)
 }
 
 #[derive(Debug, Deserialize)]
@@ -153,9 +216,7 @@ pub fn validatePersistedSession(proof: JsValue) -> Result<JsValue, JsValue> {
     // The primary space is authority; additional `spaces` are persisted UI
     // metadata (for example the lazily hosted public space) and are not
     // implicitly elevated to signed authority merely by being present here.
-    let recap =
-        tinycloud_sdk_wasm::session::parse_recap_from_siwe(&signed.session.siwe.to_string())
-            .map_err(map_jserr)?;
+    let recap = verified_recap_from_siwe(&signed.session.siwe.to_string())?;
     let expected_spaces = [signed.session.space_id.to_string()];
     if !recap.is_empty()
         && expected_spaces
@@ -191,8 +252,22 @@ pub fn validatePersistedSession(proof: JsValue) -> Result<JsValue, JsValue> {
         ));
     }
 
-    serde_wasm_bindgen::to_value(&ValidatedPersistedSessionProof { expires_at, recap })
+    serde_wasm_bindgen::to_value(&ValidatedPersistedSessionProof {
+        recap: recap.clone(),
+        verified_recap: recap,
+        expires_at,
+    })
         .map_err(Into::into)
+}
+
+/// Parse a ReCap into exact action/caveat scopes. This is deliberately a new
+/// export: the upstream `parseRecapFromSiwe` remains available for old custom
+/// bindings, while first-party bindings can opt into the verifier v2 witness.
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn parseVerifiedRecapFromSiwe(siwe_string: &str) -> Result<JsValue, JsValue> {
+    let entries = verified_recap_from_siwe(siwe_string)?;
+    serde_wasm_bindgen::to_value(&entries).map_err(Into::into)
 }
 
 #[wasm_bindgen]
@@ -272,4 +347,46 @@ pub fn invokeAny(session: JsValue, entries: JsValue, facts: JsValue) -> Result<J
     Ok(serde_wasm_bindgen::to_value(&InvocationHeaders::new(
         authz,
     ))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tinycloud_sdk_rs::tinycloud_auth::cacaos::siwe::Version as SIWEVersion;
+
+    #[test]
+    fn verified_recap_keeps_each_signed_action_caveat() {
+        let mut capability = Capability::<serde_json::Value>::default();
+        let resource: UriString = "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default/kv/narrow"
+            .parse()
+            .unwrap();
+        let action: Ability = "tinycloud.kv/get".parse().unwrap();
+        let caveat = BTreeMap::from([(
+            "tenant".to_string(),
+            serde_json::Value::String("alpha".to_string()),
+        )]);
+        capability.with_actions(resource, [(action, vec![caveat.clone()])]);
+        let message = capability
+            .build_message(Message {
+                scheme: None,
+                domain: "restore.test".parse().unwrap(),
+                address: Default::default(),
+                statement: None,
+                uri: "did:key:z6Mkrestore".parse().unwrap(),
+                version: SIWEVersion::V1,
+                chain_id: 1,
+                nonce: "restore-caveat".into(),
+                issued_at: "2026-01-01T00:00:00.000Z".parse().unwrap(),
+                expiration_time: None,
+                not_before: None,
+                request_id: None,
+                resources: vec![],
+            })
+            .unwrap();
+
+        let recap = verified_recap_from_siwe(&message.to_string()).unwrap();
+        assert_eq!(recap.len(), 1);
+        assert_eq!(recap[0].actions, vec!["tinycloud.kv/get"]);
+        assert_eq!(recap[0].caveats, vec![caveat]);
+    }
 }

--- a/packages/sdk-rs/src/lib.rs
+++ b/packages/sdk-rs/src/lib.rs
@@ -6,7 +6,7 @@ pub mod session;
 pub mod keys;
 
 use iri_string::types::UriString;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, str::FromStr};
 use tinycloud_sdk_rs::authorization::InvocationHeaders;
 use tinycloud_sdk_rs::tinycloud_auth::{
@@ -19,6 +19,39 @@ use tinycloud_sdk_rs::tinycloud_auth::{
     ucan_capabilities_object::{Ability, Capabilities},
 };
 use wasm_bindgen::prelude::*;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedSessionProof {
+    delegation_header: PersistedDelegationHeader,
+    delegation_cid: String,
+    space_id: String,
+    #[serde(default)]
+    spaces: Option<BTreeMap<String, String>>,
+    jwk: serde_json::Value,
+    verification_method: String,
+    address: String,
+    chain_id: u64,
+    siwe: String,
+    signature: String,
+    /// The binding supplies its current clock value. This is deliberately not
+    /// part of persisted session data: SIWE validity must not be evaluated at
+    /// an attacker-selected time.
+    now: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedDelegationHeader {
+    #[serde(rename = "Authorization")]
+    authorization: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ValidatedPersistedSessionProof {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+}
 
 fn map_jserr<E: std::error::Error>(e: E) -> JsValue {
     e.to_string().into()
@@ -45,6 +78,102 @@ struct InvokeAnyEntry {
 /// Run once on initialisation.
 pub fn initPanicHook() {
     console_error_panic_hook::set_once();
+}
+
+/// Verify and reconstruct persisted session authority as a single operation.
+///
+/// This deliberately uses the TinyCloud SDK's SIWE parser, EIP-191 verifier,
+/// ReCap verifier, and Cacao constructor. TypeScript callers never parse a
+/// persisted SIWE to decide whether its permissions or expiry are trustworthy.
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn validatePersistedSession(proof: JsValue) -> Result<JsValue, JsValue> {
+    let proof: PersistedSessionProof = serde_wasm_bindgen::from_value(proof)?;
+
+    let signed: tinycloud_sdk_wasm::session::SignedSession =
+        serde_json::from_value(serde_json::json!({
+            "siwe": proof.siwe,
+            "signature": proof.signature,
+            "jwk": proof.jwk,
+            "spaceId": proof.space_id,
+            "additionalSpaces": proof.spaces,
+            "verificationMethod": proof.verification_method,
+        }))
+        .map_err(map_jserr)?;
+
+    let expected_address = tinycloud_sdk_rs::util::decode_eip55(
+        proof.address.strip_prefix("0x").unwrap_or(&proof.address),
+    )
+    .map_err(map_jserr)?;
+    if signed.session.siwe.address != expected_address
+        || signed.session.siwe.chain_id != proof.chain_id
+    {
+        return Err(JsValue::from_str(
+            "persisted SIWE address or chain does not match session metadata",
+        ));
+    }
+    if signed.session.siwe.uri.as_str() != signed.session.verification_method {
+        return Err(JsValue::from_str(
+            "persisted SIWE audience does not match the restored session key",
+        ));
+    }
+    let now =
+        time::OffsetDateTime::parse(&proof.now, &time::format_description::well_known::Rfc3339)
+            .map_err(map_jserr)?;
+    if !signed.session.siwe.valid_at(&now) {
+        return Err(JsValue::from_str(
+            "persisted SIWE is expired or not yet valid",
+        ));
+    }
+    signed
+        .session
+        .siwe
+        .verify_eip191(&signed.signature)
+        .map_err(map_jserr)?;
+
+    // ReCap extraction verifies the capability statement/resource binding.
+    // The primary space is authority; additional `spaces` are persisted UI
+    // metadata (for example the lazily hosted public space) and are not
+    // implicitly elevated to signed authority merely by being present here.
+    let recap =
+        tinycloud_sdk_wasm::session::parse_recap_from_siwe(&signed.session.siwe.to_string())
+            .map_err(map_jserr)?;
+    let expected_spaces = [signed.session.space_id.to_string()];
+    if !recap.is_empty()
+        && expected_spaces
+            .iter()
+            .any(|space| !recap.iter().any(|entry| entry.space == *space))
+    {
+        return Err(JsValue::from_str(
+            "persisted SIWE ReCap does not authorize every restored space",
+        ));
+    }
+
+    // Reconstruct the exact Cacao from the verified SIWE/signature and reject
+    // any persisted authorization bytes or CID that do not identify it.
+    let expires_at = signed
+        .session
+        .siwe
+        .expiration_time
+        .as_ref()
+        .map(ToString::to_string);
+    let reconstructed =
+        tinycloud_sdk_wasm::session::complete_session_setup(signed).map_err(map_jserr)?;
+    let reconstructed_header_value =
+        serde_json::to_value(&reconstructed.delegation_header).map_err(map_jserr)?;
+    let reconstructed_header = reconstructed_header_value
+        .get("Authorization")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| JsValue::from_str("failed to reconstruct persisted delegation header"))?;
+    if reconstructed_header != proof.delegation_header.authorization
+        || reconstructed.delegation_cid.to_string() != proof.delegation_cid
+    {
+        return Err(JsValue::from_str(
+            "persisted delegation header or CID does not match verified SIWE authority",
+        ));
+    }
+
+    serde_wasm_bindgen::to_value(&ValidatedPersistedSessionProof { expires_at }).map_err(Into::into)
 }
 
 #[wasm_bindgen]

--- a/packages/sdk-rs/src/lib.rs
+++ b/packages/sdk-rs/src/lib.rs
@@ -26,18 +26,11 @@ struct PersistedSessionProof {
     delegation_header: PersistedDelegationHeader,
     delegation_cid: String,
     space_id: String,
-    #[serde(default)]
-    spaces: Option<BTreeMap<String, String>>,
     jwk: serde_json::Value,
-    verification_method: String,
     address: String,
     chain_id: u64,
     siwe: String,
     signature: String,
-    /// The binding supplies its current clock value. This is deliberately not
-    /// part of persisted session data: SIWE validity must not be evaluated at
-    /// an attacker-selected time.
-    now: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -51,6 +44,7 @@ struct PersistedDelegationHeader {
 struct ValidatedPersistedSessionProof {
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<String>,
+    recap: Vec<tinycloud_sdk_wasm::session::ParsedRecapEntry>,
 }
 
 fn map_jserr<E: std::error::Error>(e: E) -> JsValue {
@@ -89,6 +83,26 @@ pub fn initPanicHook() {
 #[allow(non_snake_case)]
 pub fn validatePersistedSession(proof: JsValue) -> Result<JsValue, JsValue> {
     let proof: PersistedSessionProof = serde_wasm_bindgen::from_value(proof)?;
+    if proof.jwk.get("alg").is_some_and(serde_json::Value::is_null) {
+        return Err(JsValue::from_str(
+            "session key alg must be EdDSA when present",
+        ));
+    }
+
+    // The caller may supply persisted key material, but never the identity
+    // that validates it. Importing derives the canonical did:key verification
+    // method from the private Ed25519 JWK and applies the same private-key
+    // validation as the session manager used by restore.
+    let jwk = serde_json::from_value(proof.jwk.clone()).map_err(map_jserr)?;
+    let mut manager =
+        crate::session::SessionManager::new().map_err(|error| JsValue::from_str(&error))?;
+    let key_id = "persisted".to_owned();
+    manager
+        .replace_session_key(jwk, key_id.clone())
+        .map_err(|error| JsValue::from_str(&error))?;
+    let verification_method = manager
+        .get_did(Some(key_id))
+        .map_err(|error| JsValue::from_str(&error))?;
 
     let signed: tinycloud_sdk_wasm::session::SignedSession =
         serde_json::from_value(serde_json::json!({
@@ -96,8 +110,7 @@ pub fn validatePersistedSession(proof: JsValue) -> Result<JsValue, JsValue> {
             "signature": proof.signature,
             "jwk": proof.jwk,
             "spaceId": proof.space_id,
-            "additionalSpaces": proof.spaces,
-            "verificationMethod": proof.verification_method,
+            "verificationMethod": verification_method,
         }))
         .map_err(map_jserr)?;
 
@@ -117,9 +130,14 @@ pub fn validatePersistedSession(proof: JsValue) -> Result<JsValue, JsValue> {
             "persisted SIWE audience does not match the restored session key",
         ));
     }
-    let now =
-        time::OffsetDateTime::parse(&proof.now, &time::format_description::well_known::Rfc3339)
-            .map_err(map_jserr)?;
+    // `Date.now()` is obtained by the WASM module, rather than from caller
+    // input, so an expired proof cannot be revived with a historical clock.
+    let now_millis = js_sys::Date::now();
+    if !now_millis.is_finite() {
+        return Err(JsValue::from_str("current clock is unavailable"));
+    }
+    let now = time::OffsetDateTime::from_unix_timestamp_nanos((now_millis as i128) * 1_000_000)
+        .map_err(map_jserr)?;
     if !signed.session.siwe.valid_at(&now) {
         return Err(JsValue::from_str(
             "persisted SIWE is expired or not yet valid",
@@ -173,7 +191,8 @@ pub fn validatePersistedSession(proof: JsValue) -> Result<JsValue, JsValue> {
         ));
     }
 
-    serde_wasm_bindgen::to_value(&ValidatedPersistedSessionProof { expires_at }).map_err(Into::into)
+    serde_wasm_bindgen::to_value(&ValidatedPersistedSessionProof { expires_at, recap })
+        .map_err(Into::into)
 }
 
 #[wasm_bindgen]

--- a/packages/sdk-rs/src/session/manager.rs
+++ b/packages/sdk-rs/src/session/manager.rs
@@ -1,12 +1,16 @@
 use std::{collections::HashMap, str::FromStr};
 
+use ed25519_dalek::SigningKey;
 use iri_string::types::UriString;
 use js_sys::JsString;
 use serde_json::Value;
 use tinycloud_sdk_rs::tinycloud_auth::{
     cacaos::siwe::{generate_nonce, Message, Version as SiweVersion},
     siwe_recap::{Ability, Capability},
-    ssi::{dids::DIDKey, jwk::JWK},
+    ssi::{
+        dids::DIDKey,
+        jwk::{Params, JWK},
+    },
 };
 use wasm_bindgen::prelude::*;
 
@@ -28,6 +32,39 @@ pub struct SessionManager {
 }
 
 static DEFAULT_KEY_ID: &str = "default";
+
+/// Session keys are Ed25519 private JWKs. Validate both the JWK shape and
+/// that its public component is actually derived from its private component
+/// before storing it. The DID is derived from `x`, while invocation signing
+/// uses `d`; accepting a mismatched pair would make the restored identity and
+/// signer diverge.
+fn validate_private_ed25519_jwk(key: &JWK) -> Result<(), String> {
+    let params = match &key.params {
+        Params::OKP(params) if params.curve == "Ed25519" => params,
+        Params::OKP(_) => return Err("session key must use the Ed25519 curve".to_string()),
+        _ => return Err("session key must be an Ed25519 OKP JWK".to_string()),
+    };
+
+    let private_key = params
+        .private_key
+        .as_ref()
+        .ok_or_else(|| "session key must include an Ed25519 private component".to_string())?;
+    let private_key: [u8; 32] = private_key
+        .0
+        .as_slice()
+        .try_into()
+        .map_err(|_| "session key has an invalid Ed25519 private component".to_string())?;
+    if params.public_key.0.len() != 32 {
+        return Err("session key has an invalid Ed25519 public component".to_string());
+    }
+
+    let derived_public_key = SigningKey::from_bytes(&private_key).verifying_key();
+    if derived_public_key.as_bytes() != params.public_key.0.as_slice() {
+        return Err("session key Ed25519 public and private components do not match".to_string());
+    }
+
+    Ok(())
+}
 
 /// Builds an TCWSession.
 impl SessionManager {
@@ -183,6 +220,7 @@ impl SessionManager {
         key_id: Option<String>,
         override_key_id: bool,
     ) -> Result<String, String> {
+        validate_private_ed25519_jwk(&key)?;
         let key_id = key_id.unwrap_or(DEFAULT_KEY_ID.to_string());
         if self.sessions.contains_key(&key_id) && !override_key_id {
             return Err(format!("key already exists: {}", key_id));
@@ -199,6 +237,14 @@ impl SessionManager {
             },
         );
         Ok(key_id)
+    }
+
+    /// Replace one active session key after validating the supplied private
+    /// Ed25519 JWK. This is the restore path: validation happens before the
+    /// existing key entry is overwritten, so a malformed persisted key cannot
+    /// leave a manager with a half-installed session key.
+    pub fn replace_session_key(&mut self, key: JWK, key_id: String) -> Result<String, String> {
+        self.import_session_key(key, Some(key_id), true)
     }
 
     pub fn list_session_keys(&self) -> Vec<String> {
@@ -349,6 +395,39 @@ pub mod test {
         let result = manager.import_session_key(key, Some("imported_key".to_string()), false);
         assert!(result.is_ok());
         assert!(manager.sessions.contains_key("imported_key"));
+    }
+
+    #[tokio::test]
+    async fn test_import_session_key_rejects_public_or_mismatched_ed25519_jwk() {
+        let mut manager = SessionManager::new().unwrap();
+        let original_default = manager.jwk(Some("default".to_string())).unwrap();
+
+        let mut public_only = JWK::generate_ed25519().unwrap();
+        if let Params::OKP(params) = &mut public_only.params {
+            params.private_key = None;
+        }
+        assert!(manager
+            .replace_session_key(public_only, "default".to_string())
+            .is_err());
+        assert_eq!(
+            manager.jwk(Some("default".to_string())).unwrap(),
+            original_default
+        );
+
+        let mut mismatched = JWK::generate_ed25519().unwrap();
+        let unrelated = JWK::generate_ed25519().unwrap();
+        if let (Params::OKP(params), Params::OKP(unrelated_params)) =
+            (&mut mismatched.params, unrelated.params)
+        {
+            params.public_key = unrelated_params.public_key.clone();
+        }
+        assert!(manager
+            .replace_session_key(mismatched, "default".to_string())
+            .is_err());
+        assert_eq!(
+            manager.jwk(Some("default".to_string())).unwrap(),
+            original_default
+        );
     }
 
     #[tokio::test]

--- a/packages/sdk-rs/src/session/manager.rs
+++ b/packages/sdk-rs/src/session/manager.rs
@@ -9,7 +9,7 @@ use tinycloud_sdk_rs::tinycloud_auth::{
     siwe_recap::{Ability, Capability},
     ssi::{
         dids::DIDKey,
-        jwk::{Params, JWK},
+        jwk::{Algorithm, Params, JWK},
     },
 };
 use wasm_bindgen::prelude::*;
@@ -61,6 +61,14 @@ fn validate_private_ed25519_jwk(key: &JWK) -> Result<(), String> {
     let derived_public_key = SigningKey::from_bytes(&private_key).verifying_key();
     if derived_public_key.as_bytes() != params.public_key.0.as_slice() {
         return Err("session key Ed25519 public and private components do not match".to_string());
+    }
+
+    // `alg` is optional metadata, but when present it must agree with the only
+    // signing suite supported by an Ed25519 session key.
+    if let Some(algorithm) = key.algorithm {
+        if algorithm != Algorithm::EdDSA {
+            return Err("session key alg must be EdDSA when present".to_string());
+        }
     }
 
     Ok(())
@@ -428,6 +436,32 @@ pub mod test {
             manager.jwk(Some("default".to_string())).unwrap(),
             original_default
         );
+    }
+
+    #[tokio::test]
+    async fn test_import_session_key_rejects_contradictory_alg_and_accepts_missing_or_eddsa() {
+        let mut manager = SessionManager::new().unwrap();
+        let original_default = manager.jwk(Some("default".to_string())).unwrap();
+
+        let mut contradictory = JWK::generate_ed25519().unwrap();
+        contradictory.algorithm = Some(Algorithm::ES256);
+        assert!(manager
+            .replace_session_key(contradictory, "default".to_string())
+            .is_err());
+        assert_eq!(
+            manager.jwk(Some("default".to_string())).unwrap(),
+            original_default
+        );
+
+        assert!(manager
+            .replace_session_key(JWK::generate_ed25519().unwrap(), "default".to_string())
+            .is_ok());
+
+        let mut eddsa = JWK::generate_ed25519().unwrap();
+        eddsa.algorithm = Some(Algorithm::EdDSA);
+        assert!(manager
+            .replace_session_key(eddsa, "default".to_string())
+            .is_ok());
     }
 
     #[tokio::test]

--- a/packages/sdk-rs/src/session/wasm.rs
+++ b/packages/sdk-rs/src/session/wasm.rs
@@ -55,19 +55,16 @@ impl TCWSessionManager {
         self.manager.create_session_key(key_id)
     }
 
-    // #[allow(non_snake_case)]
-    // pub fn importSessionKey(
-    //     &mut self,
-    //     js_jwk: JsValue,
-    //     key_id: Option<String>,
-    //     override_key_id: bool,
-    // ) -> Result<String, String> {
-    //     let key    = match serde_wasm_bindgen::from_value(js_jwk) {
-    //         Ok(key) => key,
-    //         Err(e) => return Err(e.to_string()),
-    //     };
-    //     self.manager.test_import_session_key(key, key_id, override_key_id)
-    // }
+    /// Replace an existing session key with a persisted private Ed25519 JWK.
+    ///
+    /// The manager validates the private JWK before replacing the existing
+    /// entry. This is intentionally exposed on both the Node and browser WASM
+    /// builds so restore flows share one key lifecycle.
+    #[allow(non_snake_case)]
+    pub fn replaceSessionKey(&mut self, js_jwk: JsValue, key_id: String) -> Result<String, String> {
+        let key = serde_wasm_bindgen::from_value(js_jwk).map_err(|e| e.to_string())?;
+        self.manager.replace_session_key(key, key_id)
+    }
 
     #[allow(non_snake_case)]
     /// List the available session keys.

--- a/packages/sdk-rs/src/session/wasm.rs
+++ b/packages/sdk-rs/src/session/wasm.rs
@@ -62,6 +62,14 @@ impl TCWSessionManager {
     /// builds so restore flows share one key lifecycle.
     #[allow(non_snake_case)]
     pub fn replaceSessionKey(&mut self, js_jwk: JsValue, key_id: String) -> Result<String, String> {
+        // Serde represents an explicitly supplied JSON `null` as `None` for
+        // optional fields. `alg: null` is therefore observably different from
+        // an omitted `alg` and must not be accepted as the latter.
+        let raw: serde_json::Value =
+            serde_wasm_bindgen::from_value(js_jwk.clone()).map_err(|e| e.to_string())?;
+        if raw.get("alg").is_some_and(serde_json::Value::is_null) {
+            return Err("session key alg must be EdDSA when present".to_string());
+        }
         let key = serde_wasm_bindgen::from_value(js_jwk).map_err(|e| e.to_string())?;
         self.manager.replace_session_key(key, key_id)
     }

--- a/packages/sdk-services/src/base/BaseService.ts
+++ b/packages/sdk-services/src/base/BaseService.ts
@@ -109,7 +109,7 @@ export abstract class BaseService implements IService {
    * Combines the service-level abort with context-level abort.
    */
   protected get abortSignal(): AbortSignal {
-    return this.abortController.signal;
+    return this.combineSignals();
   }
 
   /**
@@ -240,7 +240,11 @@ export abstract class BaseService implements IService {
    */
   protected combineSignals(...signals: (AbortSignal | undefined)[]): AbortSignal {
     const controller = new AbortController();
-    const allSignals = [this.abortSignal, ...signals.filter(Boolean)] as AbortSignal[];
+    const allSignals = [
+      this.abortController.signal,
+      this.context?.abortSignal,
+      ...signals.filter(Boolean),
+    ].filter(Boolean) as AbortSignal[];
 
     for (const signal of allSignals) {
       if (signal.aborted) {

--- a/packages/sdk-services/src/context.test.ts
+++ b/packages/sdk-services/src/context.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { ServiceContext } from "./context";
 
 function createContext(telemetry?: ConstructorParameters<typeof ServiceContext>[0]["telemetry"]) {
@@ -29,5 +29,50 @@ describe("ServiceContext telemetry", () => {
     context.emit("service.response", { duration: 12 });
 
     expect(events).toEqual([["service.response", { duration: 12 }]]);
+  });
+});
+
+describe("ServiceContext retirement", () => {
+  test("keeps captured platform functions unusable, aborts their fetches, and isolates custom cleanup failures", async () => {
+    let requestSignal: AbortSignal | undefined;
+    let started!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => { started = resolve; });
+    const context = new ServiceContext({
+      invoke: () => ({}),
+      hosts: ["https://node.tinycloud.xyz"],
+      fetch: (_url, init) => new Promise((_resolve, reject) => {
+        requestSignal = init?.signal;
+        started();
+        requestSignal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      }),
+    });
+    context.registerService("throws-on-sign-out", {
+      config: {},
+      initialize: () => undefined,
+      onSessionChange: () => undefined,
+      onSignOut: () => { throw new Error("custom cleanup failed"); },
+    });
+    const capturedFetch = context.fetch;
+    const inFlight = capturedFetch("https://node.tinycloud.xyz/in-flight");
+    await fetchStarted;
+    const originalError = console.error;
+    console.error = mock(() => undefined);
+    try {
+      expect(() => context.retire()).not.toThrow();
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(requestSignal?.aborted).toBe(true);
+    await expect(inFlight).rejects.toThrow("aborted");
+    expect(context.abortSignal.aborted).toBe(true);
+    context.abort();
+    expect(context.abortSignal.aborted).toBe(true);
+    await expect(capturedFetch("https://node.tinycloud.xyz/after")).rejects.toThrow(
+      "Service graph has been retired",
+    );
+    expect(() => context.invoke({} as any, "kv", "after", "tinycloud.kv/get")).toThrow(
+      "Service graph has been retired",
+    );
   });
 });

--- a/packages/sdk-services/src/context.ts
+++ b/packages/sdk-services/src/context.ts
@@ -117,6 +117,7 @@ export class ServiceContext implements IServiceContext {
    * @param session - New session or null to clear
    */
   setSession(session: ServiceSession | null): void {
+    this.assertActive();
     this._session = session;
     this.emit('session.changed', { authenticated: session !== null });
 
@@ -158,6 +159,7 @@ export class ServiceContext implements IServiceContext {
    * Get the list of TinyCloud host URLs.
    */
   get hosts(): string[] {
+    this.assertActive();
     return this._hosts;
   }
 
@@ -289,7 +291,13 @@ export class ServiceContext implements IServiceContext {
     this._session = null;
     this._abortController.abort();
     for (const service of this._services.values()) {
-      service.onSignOut();
+      // User-provided services are part of the retired graph, but their
+      // cleanup must never make installing the replacement graph fail.
+      try {
+        service.onSignOut();
+      } catch (error) {
+        console.error("Error retiring service:", error);
+      }
     }
   }
 
@@ -298,12 +306,20 @@ export class ServiceContext implements IServiceContext {
    * Creates a new AbortController for future operations.
    */
   abort(): void {
+    // A retired graph must never receive a fresh abort signal. Captured
+    // services retain this context, so recreating its controller would make a
+    // stale graph look live to custom cleanup code.
+    if (this._retired) return;
     this._abortController.abort();
     this._abortController = new AbortController();
 
     // Notify all services
     for (const service of this._services.values()) {
-      service.onSignOut();
+      try {
+        service.onSignOut();
+      } catch (error) {
+        console.error("Error signing out service:", error);
+      }
     }
   }
 
@@ -311,6 +327,7 @@ export class ServiceContext implements IServiceContext {
    * Sign out - abort operations and clear session.
    */
   signOut(): void {
+    if (this._retired) return;
     this.abort();
     this.setSession(null);
     this.emit('session.expired', {});
@@ -329,6 +346,7 @@ export class ServiceContext implements IServiceContext {
 
   private wrapInvoke(invoke: InvokeFunction): InvokeFunction {
     return (session, service, path, action, facts) => {
+      this.assertActive();
       if (!tinyCloudDebugLogger.isEnabled()) {
         return invoke(session, service, path, action, facts);
       }
@@ -359,6 +377,7 @@ export class ServiceContext implements IServiceContext {
 
   private wrapInvokeAny(invokeAny: InvokeAnyFunction): InvokeAnyFunction {
     return (session, entries, facts) => {
+      this.assertActive();
       if (!tinyCloudDebugLogger.isEnabled()) {
         return invokeAny(session, entries, facts);
       }
@@ -381,22 +400,27 @@ export class ServiceContext implements IServiceContext {
 
   private wrapFetch(fetchFn: FetchFunction): FetchFunction {
     return async (url, init) => {
+      this.assertActive();
+      const request = {
+        ...init,
+        signal: this.combineSignals(init?.signal),
+      };
       if (!tinyCloudDebugLogger.isEnabled()) {
-        return fetchFn(url, init);
+        return fetchFn(url, request);
       }
 
       const timer = tinyCloudDebugLogger.startTimer("sdk.fetch", {
         url,
-        method: init?.method ?? "GET",
-        init,
+        method: request.method ?? "GET",
+        init: request,
       });
 
       try {
-        const response = await fetchFn(url, init);
+        const response = await fetchFn(url, request);
         timer.stop({
           ok: response.ok,
           url,
-          method: init?.method ?? "GET",
+          method: request.method ?? "GET",
           status: response.status,
           statusText: response.statusText,
         });
@@ -405,11 +429,30 @@ export class ServiceContext implements IServiceContext {
         timer.stop({
           ok: false,
           url,
-          method: init?.method ?? "GET",
+          method: request.method ?? "GET",
           error,
         });
         throw error;
       }
     };
+  }
+
+  private combineSignals(signal?: AbortSignal): AbortSignal {
+    if (!signal) return this._abortController.signal;
+    const combined = new AbortController();
+    const abort = (source: AbortSignal) => combined.abort(source.reason);
+    if (signal.aborted) {
+      abort(signal);
+    } else if (this._abortController.signal.aborted) {
+      abort(this._abortController.signal);
+    } else {
+      signal.addEventListener("abort", () => abort(signal), { once: true });
+      this._abortController.signal.addEventListener(
+        "abort",
+        () => abort(this._abortController.signal),
+        { once: true },
+      );
+    }
+    return combined.signal;
   }
 }

--- a/packages/sdk-services/src/context.ts
+++ b/packages/sdk-services/src/context.ts
@@ -64,6 +64,7 @@ export class ServiceContext implements IServiceContext {
   private _services: Map<string, IService> = new Map();
   private _eventHandlers: Map<string, Set<EventHandler>> = new Map();
   private _abortController: AbortController = new AbortController();
+  private _retired = false;
   private readonly _invoke: InvokeFunction;
   private readonly _invokeAny?: InvokeAnyFunction;
   private readonly _fetch: FetchFunction;
@@ -100,14 +101,14 @@ export class ServiceContext implements IServiceContext {
    * Get the current session.
    */
   get session(): ServiceSession | null {
-    return this._session;
+    return this._retired ? null : this._session;
   }
 
   /**
    * Check if the context has an authenticated session.
    */
   get isAuthenticated(): boolean {
-    return this._session !== null;
+    return !this._retired && this._session !== null;
   }
 
   /**
@@ -133,6 +134,7 @@ export class ServiceContext implements IServiceContext {
    * Get the invoke function for WASM operations.
    */
   get invoke(): InvokeFunction {
+    this.assertActive();
     return this._invoke;
   }
 
@@ -140,6 +142,7 @@ export class ServiceContext implements IServiceContext {
    * Get the multi-resource invoke function when available.
    */
   get invokeAny(): InvokeAnyFunction | undefined {
+    this.assertActive();
     return this._invokeAny;
   }
 
@@ -147,6 +150,7 @@ export class ServiceContext implements IServiceContext {
    * Get the fetch function for HTTP requests.
    */
   get fetch(): FetchFunction {
+    this.assertActive();
     return this._fetch;
   }
 
@@ -275,6 +279,21 @@ export class ServiceContext implements IServiceContext {
   }
 
   /**
+   * Permanently retire this graph after its owner installs a replacement.
+   * Unlike `abort()`, retirement never creates a fresh controller, so captured
+   * services cannot resume calls under a superseded session.
+   */
+  retire(): void {
+    if (this._retired) return;
+    this._retired = true;
+    this._session = null;
+    this._abortController.abort();
+    for (const service of this._services.values()) {
+      service.onSignOut();
+    }
+  }
+
+  /**
    * Abort all pending operations and notify services.
    * Creates a new AbortController for future operations.
    */
@@ -330,6 +349,12 @@ export class ServiceContext implements IServiceContext {
         throw error;
       }
     };
+  }
+
+  private assertActive(): void {
+    if (this._retired) {
+      throw new Error("Service graph has been retired by session replacement.");
+    }
   }
 
   private wrapInvokeAny(invokeAny: InvokeAnyFunction): InvokeAnyFunction {

--- a/packages/sdk-services/src/encryption/EncryptionService.ts
+++ b/packages/sdk-services/src/encryption/EncryptionService.ts
@@ -83,6 +83,7 @@ export interface DecryptTransport {
     networkId: string;
     authorization: string;
     canonicalBody: string;
+    signal?: AbortSignal;
   }): Promise<DecryptResponseBody>;
 }
 
@@ -92,6 +93,8 @@ export interface EncryptionServiceConfig {
   transport: DecryptTransport;
   node?: NodeDescriptorFetcher;
   wellKnown?: WellKnownDescriptorFetcher;
+  /** Bound by an owning service graph to prevent cross-session authority use. */
+  assertActive?: () => void;
   [key: string]: unknown;
 }
 
@@ -120,6 +123,7 @@ export class EncryptionService
     identifier: string,
     ownerDid?: string,
   ): Promise<Result<NetworkDescriptor, EncryptionError>> {
+    this.assertActive();
     const result = await discoverNetworkFn({
       identifier,
       ...(ownerDid !== undefined ? { ownerDid } : {}),
@@ -128,6 +132,7 @@ export class EncryptionService
         ? { wellKnown: this._config.wellKnown }
         : {}),
     });
+    this.assertActive();
     if (!result.ok) return result;
     return encOk(result.data.descriptor);
   }
@@ -138,6 +143,7 @@ export class EncryptionService
     options?: EncryptToNetworkOptions,
   ): Promise<Result<InlineEncryptedEnvelope, EncryptionError>> {
     try {
+      this.assertActive();
       const discovered = await this.discoverNetwork(networkId);
       if (!discovered.ok) return discovered;
       const usable = ensureNetworkUsableForDecrypt(discovered.data);
@@ -173,6 +179,7 @@ export class EncryptionService
     options?: DecryptEnvelopeOptions,
   ): Promise<Result<Uint8Array, EncryptionError>> {
     try {
+      this.assertActive();
       const validated = validateEnvelope(this.crypto, envelope);
       if (!validated.ok) return validated;
       if (
@@ -250,6 +257,7 @@ export class EncryptionService
         facts,
         proof: capabilityProof,
       });
+      this.assertActive();
       if (!built.ok) return built;
 
       let response: DecryptResponseBody;
@@ -259,7 +267,9 @@ export class EncryptionService
           networkId: envelope.networkId,
           authorization: built.data.authorization,
           canonicalBody: built.data.canonicalBody,
+          signal: this.abortSignal,
         });
+        this.assertActive();
       } catch (error) {
         return encErr(
           encryptionError({
@@ -298,5 +308,9 @@ export class EncryptionService
         }),
       );
     }
+  }
+
+  private assertActive(): void {
+    this._config.assertActive?.();
   }
 }

--- a/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
+++ b/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
@@ -1,4 +1,4 @@
-import { IWasmBindings, ISessionManager } from "@tinycloud/sdk-core";
+import { IWasmBindings, ISessionManager, type PersistedSessionProof } from "@tinycloud/sdk-core";
 import { tinycloud, tcwSession, initialized } from "@tinycloud/web-sdk-wasm";
 import { invoke, invokeAny, prepareSession, completeSessionSetup } from "../modules/Storage/tinycloud/module";
 
@@ -18,6 +18,12 @@ export class BrowserWasmBindings implements IWasmBindings {
   get invokeAny() { return invokeAny; }
   get prepareSession() { return prepareSession; }
   get completeSessionSetup() { return completeSessionSetup; }
+  validatePersistedSession(proof: PersistedSessionProof) {
+    return tinycloud.validatePersistedSession({
+      ...proof,
+      now: new Date().toISOString(),
+    });
+  }
   computeCid(data: Uint8Array, codec: bigint): string { return tinycloud.computeCid(data, codec); }
 
   ensureEip55(address: string): string { return tinycloud.ensureEip55(address); }
@@ -89,4 +95,5 @@ class BrowserSessionManager implements ISessionManager {
   renameSessionKeyId(oldId: string, newId: string): void { this.inner.renameSessionKeyId(oldId, newId); }
   getDID(keyId: string): string { return this.inner.getDID(keyId); }
   jwk(keyId: string): string | undefined { return this.inner.jwk(keyId); }
+  listSessionKeys(): string[] { return this.inner.listSessionKeys() as string[]; }
 }

--- a/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
+++ b/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
@@ -83,6 +83,9 @@ class BrowserSessionManager implements ISessionManager {
   private inner = new tcwSession.TCWSessionManager();
 
   createSessionKey(id: string): string { return this.inner.createSessionKey(id); }
+  replaceSessionKey(jwk: object, keyId: string): string {
+    return this.inner.replaceSessionKey(jwk, keyId);
+  }
   renameSessionKeyId(oldId: string, newId: string): void { this.inner.renameSessionKeyId(oldId, newId); }
   getDID(keyId: string): string { return this.inner.getDID(keyId); }
   jwk(keyId: string): string | undefined { return this.inner.jwk(keyId); }

--- a/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
+++ b/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
@@ -64,6 +64,15 @@ export class BrowserWasmBindings implements IWasmBindings {
       actions: string[];
     }[];
   }
+  parseVerifiedRecapFromSiwe(siweString: string) {
+    return tinycloud.parseVerifiedRecapFromSiwe(siweString) as {
+      service: string;
+      space: string;
+      path: string;
+      actions: string[];
+      caveats: Record<string, unknown>[];
+    }[];
+  }
   generateHostSIWEMessage(params: any): string { return tinycloud.generateHostSIWEMessage(params); }
   siweToDelegationHeaders(params: any) { return tinycloud.siweToDelegationHeaders(params); }
   protocolVersion(): number { return tinycloud.protocolVersion(); }

--- a/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
+++ b/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
@@ -19,10 +19,7 @@ export class BrowserWasmBindings implements IWasmBindings {
   get prepareSession() { return prepareSession; }
   get completeSessionSetup() { return completeSessionSetup; }
   validatePersistedSession(proof: PersistedSessionProof) {
-    return tinycloud.validatePersistedSession({
-      ...proof,
-      now: new Date().toISOString(),
-    });
+    return tinycloud.validatePersistedSession(proof);
   }
   computeCid(data: Uint8Array, codec: bigint): string { return tinycloud.computeCid(data, codec); }
 

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -352,6 +352,7 @@ export {
   DEFAULT_MANIFEST_VERSION,
   VAULT_PERMISSION_SERVICE,
   // Errors raised by delegateTo / requestPermissions.
+  CaveatedDelegationUnsupportedError,
   PermissionNotInManifestError,
   SessionExpiredError,
   ManifestValidationError,

--- a/packages/web-sdk/src/modules/browserSessionPersistence.ts
+++ b/packages/web-sdk/src/modules/browserSessionPersistence.ts
@@ -4,12 +4,14 @@ export interface RestorableSessionData {
   delegationHeader: { Authorization: string };
   delegationCid: string;
   spaceId: string;
+  spaces?: Record<string, string>;
   jwk: object;
   verificationMethod: string;
   address: string;
   chainId: number;
   siwe: string;
   signature: string;
+  expiresAt: string;
   /**
    * Hosts the session was created against. Absent for sessions persisted
    * before this field existed; in that case the node re-resolves lazily.
@@ -52,12 +54,14 @@ export function restoreDataFromPersisted(
     delegationHeader: data.tinycloudSession.delegationHeader,
     delegationCid: data.tinycloudSession.delegationCid,
     spaceId: data.tinycloudSession.spaceId,
+    spaces: data.tinycloudSession.spaces,
     jwk,
     verificationMethod: data.tinycloudSession.verificationMethod,
     address: data.address,
     chainId: data.chainId,
     siwe: data.siwe,
     signature: data.signature,
+    expiresAt: data.expiresAt,
     tinycloudHosts: data.tinycloudHosts,
   };
 }

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -577,11 +577,11 @@ export class TinyCloudWeb {
         session: clientSessionFromPersisted(loaded.data),
       };
     } catch (err) {
-      // A pre-TC-193 custom binding cannot replace a signer. That is an
-      // unsupported restore, not corrupt persisted state.
-      if ((err as { code?: unknown } | undefined)?.code !== "RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED") {
-        await this.sessionStorage.clear(restoreAddress);
-      }
+      // Restore rejection is intentionally transactional. Persisted storage
+      // is user state, and attempting best-effort cleanup here can both mask
+      // the authority error and strand this wrapper in "restoring" when a
+      // storage backend itself fails. Callers can explicitly clear a session
+      // after presenting the recoverable restore failure.
       this._sessionRestoreStatus = "restore-failed";
       return {
         status: "restore-failed",

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -577,7 +577,11 @@ export class TinyCloudWeb {
         session: clientSessionFromPersisted(loaded.data),
       };
     } catch (err) {
-      await this.sessionStorage.clear(restoreAddress);
+      // A pre-TC-193 custom binding cannot replace a signer. That is an
+      // unsupported restore, not corrupt persisted state.
+      if ((err as { code?: unknown } | undefined)?.code !== "RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED") {
+        await this.sessionStorage.clear(restoreAddress);
+      }
       this._sessionRestoreStatus = "restore-failed";
       return {
         status: "restore-failed",

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -561,13 +561,12 @@ export class TinyCloudWeb {
     }
 
     this._sessionRestoreStatus = "restoring";
-    const loaded = await this.loadPersistedSession(restoreAddress);
-    if (loaded.status !== "loaded") {
-      this._sessionRestoreStatus = loaded.status;
-      return { status: loaded.status };
-    }
-
     try {
+      const loaded = await this.loadPersistedSession(restoreAddress);
+      if (loaded.status !== "loaded") {
+        this._sessionRestoreStatus = loaded.status;
+        return { status: loaded.status };
+      }
       const node = await this.ensureNode();
       await node.restoreSession(restoreDataFromPersisted(loaded.data));
       this.resetSessionScopedCaches();

--- a/packages/web-sdk/tests/publicExports.test.ts
+++ b/packages/web-sdk/tests/publicExports.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+import type { CaveatedDelegationUnsupportedError as SdkCoreError } from "@tinycloud/sdk-core";
+import type { CaveatedDelegationUnsupportedError as WebError } from "../src/index";
+
+type Assert<T extends true> = T;
+type SamePublicError = WebError extends SdkCoreError
+  ? SdkCoreError extends WebError
+    ? true
+    : false
+  : false;
+const hasPublicError: Assert<SamePublicError> = true;
+
+test("exports CaveatedDelegationUnsupportedError from the web facade", () => {
+  expect(hasPublicError).toBe(true);
+});

--- a/packages/web-sdk/tests/signInManifestRestore.test.ts
+++ b/packages/web-sdk/tests/signInManifestRestore.test.ts
@@ -74,6 +74,7 @@ mock.module("@tinycloud/web-sdk-wasm", () => ({
 
 const { TinyCloudWeb } = require("../src/modules/tcw");
 const { BrowserWasmBindings } = require("../src/adapters/BrowserWasmBindings");
+const { BrowserSessionStorage } = require("../src/adapters/BrowserSessionStorage");
 const { restoreDataFromPersisted } = require("../src/modules/browserSessionPersistence");
 
 test("passes persisted additional spaces and expiry through browser restore data", () => {
@@ -198,6 +199,50 @@ test("keeps persisted storage and reports the original rejection when cleanup wo
   expect(result.status).toBe("restore-failed");
   expect(result.error?.message).toBe("persisted authority rejected");
   expect(storage.clear).not.toHaveBeenCalled();
+  expect(tcw.sessionRestoreStatus).toBe("restore-failed");
+});
+
+test("reports storage load exceptions as restore failures without clearing persisted state", async () => {
+  const address = "0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1";
+  const persisted = { marker: "leave-me-intact" };
+  const storage = {
+    save: mock(async () => undefined),
+    load: mock(async () => { throw new Error("storage read failed"); }),
+    clear: mock(async () => undefined),
+  };
+  const tcw = new TinyCloudWeb({ sessionStorage: storage as any });
+  await (tcw as any)._initPromise;
+
+  const result = await tcw.restoreSession(address);
+
+  expect(result.status).toBe("restore-failed");
+  expect(result.error?.message).toBe("storage read failed");
+  expect(storage.clear).not.toHaveBeenCalled();
+  expect(persisted).toEqual({ marker: "leave-me-intact" });
+  expect(tcw.sessionRestoreStatus).toBe("restore-failed");
+});
+
+test("reports browser getItem exceptions as restore failures without attempting storage cleanup", async () => {
+  const address = "0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1";
+  const removeItem = mock(() => undefined);
+  const backend = {
+    get length() { return 1; },
+    clear: () => undefined,
+    getItem: mock(() => { throw new Error("getItem failed"); }),
+    key: () => null,
+    removeItem,
+    setItem: () => undefined,
+  } as Storage;
+  const tcw = new TinyCloudWeb({
+    sessionStorage: new BrowserSessionStorage({ storage: backend }),
+  });
+  await (tcw as any)._initPromise;
+
+  const result = await tcw.restoreSession(address);
+
+  expect(result.status).toBe("restore-failed");
+  expect(result.error?.message).toBe("getItem failed");
+  expect(removeItem).not.toHaveBeenCalled();
   expect(tcw.sessionRestoreStatus).toBe("restore-failed");
 });
 

--- a/packages/web-sdk/tests/signInManifestRestore.test.ts
+++ b/packages/web-sdk/tests/signInManifestRestore.test.ts
@@ -57,6 +57,7 @@ mock.module("@tinycloud/web-sdk-wasm", () => ({
   tcwSession: {
     TCWSessionManager: class {
       createSessionKey(id: string) { return id; }
+      replaceSessionKey(_jwk: object, keyId: string) { return keyId; }
       renameSessionKeyId() {}
       getDID(keyId: string) { return `did:key:${keyId}`; }
       jwk() {

--- a/packages/web-sdk/tests/signInManifestRestore.test.ts
+++ b/packages/web-sdk/tests/signInManifestRestore.test.ts
@@ -58,6 +58,7 @@ mock.module("@tinycloud/web-sdk-wasm", () => ({
     TCWSessionManager: class {
       createSessionKey(id: string) { return id; }
       replaceSessionKey(_jwk: object, keyId: string) { return keyId; }
+      listSessionKeys() { return ["default", "share-recipient"]; }
       renameSessionKeyId() {}
       getDID(keyId: string) { return `did:key:${keyId}`; }
       jwk() {
@@ -72,6 +73,41 @@ mock.module("@tinycloud/web-sdk-wasm", () => ({
 }));
 
 const { TinyCloudWeb } = require("../src/modules/tcw");
+const { BrowserWasmBindings } = require("../src/adapters/BrowserWasmBindings");
+const { restoreDataFromPersisted } = require("../src/modules/browserSessionPersistence");
+
+test("passes persisted additional spaces and expiry through browser restore data", () => {
+  const address = "0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1";
+  const expiresAt = "2099-01-01T00:00:00.000Z";
+  const spaces = { public: `tinycloud:pkh:eip155:1:${address}:public` };
+
+  const restored = restoreDataFromPersisted({
+    address,
+    chainId: 1,
+    sessionKey: JSON.stringify({ kty: "OKP", crv: "Ed25519", d: "private" }),
+    siwe: "siwe",
+    signature: "signature",
+    tinycloudSession: {
+      delegationHeader: { Authorization: "Bearer persisted" },
+      delegationCid: "bafy-persisted",
+      spaceId: `tinycloud:pkh:eip155:1:${address}:default`,
+      spaces,
+      verificationMethod: "did:key:zPersisted#zPersisted",
+    },
+    expiresAt,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    version: "1.0",
+  });
+
+  expect(restored.spaces).toEqual(spaces);
+  expect(restored.expiresAt).toBe(expiresAt);
+});
+
+test("browser session managers expose every live key before restore can replace one", () => {
+  const manager = new BrowserWasmBindings().createSessionManager();
+
+  expect(manager.listSessionKeys?.()).toEqual(["default", "share-recipient"]);
+});
 
 test("forwards signStrategy to the underlying TinyCloudNode", async () => {
   const signStrategy = {
@@ -123,6 +159,44 @@ test("keeps a valid persisted session when the loaded binding cannot restore its
 
   expect(result.status).toBe("restore-failed");
   expect(result.error?.message).not.toContain("private");
+  expect(storage.clear).not.toHaveBeenCalled();
+  expect(tcw.sessionRestoreStatus).toBe("restore-failed");
+});
+
+test("keeps persisted storage and reports the original rejection when cleanup would fail", async () => {
+  const address = "0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1";
+  const storage = {
+    save: mock(async () => undefined),
+    load: mock(async () => ({
+      address,
+      chainId: 1,
+      sessionKey: JSON.stringify({ kty: "OKP", crv: "Ed25519", d: "private" }),
+      siwe: "siwe",
+      signature: "signature",
+      tinycloudSession: {
+        delegationHeader: { Authorization: "Bearer persisted" },
+        delegationCid: "bafy-persisted",
+        spaceId: `tinycloud:pkh:eip155:1:${address}:default`,
+        spaces: { public: `tinycloud:pkh:eip155:1:${address}:public` },
+        verificationMethod: "did:key:zPersisted#zPersisted",
+      },
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      version: "1.0",
+    })),
+    clear: mock(async () => { throw new Error("storage clear failed"); }),
+  };
+  const tcw = new TinyCloudWeb({ sessionStorage: storage as any });
+  await (tcw as any)._initPromise;
+  (tcw as any)._node = {
+    restoreSession: mock(async () => { throw new Error("persisted authority rejected"); }),
+  };
+  (tcw as any)._initPromise = Promise.resolve();
+
+  const result = await tcw.restoreSession(address);
+
+  expect(result.status).toBe("restore-failed");
+  expect(result.error?.message).toBe("persisted authority rejected");
   expect(storage.clear).not.toHaveBeenCalled();
   expect(tcw.sessionRestoreStatus).toBe("restore-failed");
 });

--- a/packages/web-sdk/tests/signInManifestRestore.test.ts
+++ b/packages/web-sdk/tests/signInManifestRestore.test.ts
@@ -86,6 +86,47 @@ test("forwards signStrategy to the underlying TinyCloudNode", async () => {
   expect((tcw as any)._node.config.signStrategy).toBe(signStrategy);
 });
 
+test("keeps a valid persisted session when the loaded binding cannot restore its signer", async () => {
+  const address = "0x96F7fB7ed32640d9D3a982f67CD6c09fc53EBEF1";
+  const storage = {
+    save: mock(async () => undefined),
+    load: mock(async () => ({
+      address,
+      chainId: 1,
+      sessionKey: JSON.stringify({ kty: "OKP", crv: "Ed25519", d: "private" }),
+      siwe: "siwe",
+      signature: "signature",
+      tinycloudSession: {
+        delegationHeader: { Authorization: "Bearer persisted" },
+        delegationCid: "bafy-persisted",
+        spaceId: `tinycloud:pkh:eip155:1:${address}:default`,
+        verificationMethod: "did:key:zPersisted#zPersisted",
+      },
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      version: "1.0",
+    })),
+    clear: mock(async () => undefined),
+  };
+  const tcw = new TinyCloudWeb({ sessionStorage: storage as any });
+  await (tcw as any)._initPromise;
+  (tcw as any)._node = {
+    restoreSession: mock(async () => {
+      const error = new Error("binding does not support signer replacement") as Error & { code: string };
+      error.code = "RESTORE_SESSION_KEY_REPLACEMENT_UNSUPPORTED";
+      throw error;
+    }),
+  };
+  (tcw as any)._initPromise = Promise.resolve();
+
+  const result = await tcw.restoreSession(address);
+
+  expect(result.status).toBe("restore-failed");
+  expect(result.error?.message).not.toContain("private");
+  expect(storage.clear).not.toHaveBeenCalled();
+  expect(tcw.sessionRestoreStatus).toBe("restore-failed");
+});
+
 test("signIn refreshes a restored session that does not cover the configured manifest", async () => {
   const tcw = new TinyCloudWeb({
     manifest: {


### PR DESCRIPTION
## Summary

- restore persisted Node SDK sessions only after cryptographic and ReCap validation
- preserve exact delegation caveats and fail closed where action-only child delegation would broaden authority
- bind service, sharing, encryption, signer, and owner-delegation work to the service graph that started it
- export stable public errors and cover restore, replacement, retirement, and package compatibility paths

## Verification

- pinned Bun 1.2.0 Node SDK suite: 191/191
- focused owner-delegation sharing suite: 11/11
- sdk-core suite: 726 passing
- sdk-services suite: 169 passing
- Rust tests: 15 passing
- Node, core, services, and web builds pass
- `git diff --check` passes
- Sol final review: `VERDICT GO`, no release-blocking findings

## Review status

This PR intentionally remains draft and unmerged. Fable review was attempted at each repair stage, but the Claude CLI account is blocked by its monthly spend limit. Sol independently reviewed the final range and returned GO.

Linear: TC-193
