### PR TITLE
TC-224: recipient-DID share signing SDK

### DIFF
--- a/.changeset/recipient-did-envelope-signing.md
+++ b/.changeset/recipient-did-envelope-signing.md
@@ -1,0 +1,19 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/web-sdk": minor
+"@tinycloud/sdk-rs": minor
+"@tinycloud/node-sdk-wasm": minor
+"@tinycloud/web-sdk-wasm": minor
+---
+
+Add the fixed-purpose recipient-DID share-envelope v2 signing and owner-proof
+export operation. Node and browser runtimes now expose the atomic, network-free
+native delegation-bundle verifier and continue to fail closed for custom or
+older WASM bindings that do not implement it. Recipient signatures use strict
+RFC8032 Ed25519 verification, and share expiry is normalized to whole seconds.
+
+Publishing is gated on the first tinycloud-node release tag after v1.4.5 that
+contains the recipient-DID verifier and exact typed WASM declaration. That tag
+must replace both Rust dependency pins before regenerating and publishing the
+Node/browser WASM packages currently consumed at version 1.7.4.

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -30,6 +30,7 @@
     "build": "tsup",
     "clean": "rm -rf dist",
     "test": "bun test src/",
+    "test:recipient-did-native": "TINYCLOUD_REQUIRE_RECIPIENT_DID_NATIVE_VERIFIER=1 bun test src/recipientDidSharing.test.ts",
     "test:integration": "echo 'Integration tests live in tests/node-sdk workspace'"
   },
   "dependencies": {

--- a/packages/node-sdk/src/NodeWasmBindings.ts
+++ b/packages/node-sdk/src/NodeWasmBindings.ts
@@ -17,6 +17,7 @@ import {
   makeSpaceId,
   createDelegation,
   parseRecapFromSiwe,
+  verifyRecipientDidDelegationBundleV2,
   generateHostSIWEMessage,
   siweToDelegationHeaders,
   protocolVersion,
@@ -30,7 +31,12 @@ import {
   vault_random_bytes,
   vault_sha256,
 } from "@tinycloud/node-sdk-wasm";
-import type { IWasmBindings, ISessionManager } from "@tinycloud/sdk-core";
+import type {
+  IWasmBindings,
+  ISessionManager,
+  NativeVerifiedRecipientDidDelegationBundleV2,
+  RecipientDidDelegationBundleV2,
+} from "@tinycloud/sdk-core";
 
 /**
  * Node.js WASM bindings using @tinycloud/node-sdk-wasm.
@@ -58,6 +64,18 @@ export class NodeWasmBindings implements IWasmBindings {
   makeSpaceId = makeSpaceId;
   createDelegation = createDelegation;
   parseRecapFromSiwe = parseRecapFromSiwe;
+  verifyRecipientDidDelegationBundleV2(
+    bundle: RecipientDidDelegationBundleV2,
+    nowUnixSeconds: bigint,
+  ): NativeVerifiedRecipientDidDelegationBundleV2 {
+    return verifyRecipientDidDelegationBundleV2(
+      {
+        ...bundle,
+        issuerProofs: bundle.issuerProofs.map((proof) => ({ ...proof })),
+      },
+      nowUnixSeconds,
+    );
+  }
   generateHostSIWEMessage = generateHostSIWEMessage;
   siweToDelegationHeaders = siweToDelegationHeaders;
   protocolVersion = protocolVersion;

--- a/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.delegateTo.test.ts
@@ -283,8 +283,9 @@ describe("TinyCloudNode.delegateTo", () => {
     // WASM path was used.
     expect(createDelegationSpy).toHaveBeenCalledTimes(1);
     expect((createDelegationSpy as any).mock.calls[0][0].verificationMethod).toBe(
-      "did:key:z6MkTestSession",
+      "did:key:z6MkTestSession#z6MkTestSession",
     );
+    expect((createDelegationSpy as any).mock.calls[0][0].jwk.alg).toBe("EdDSA");
     // Wallet path was NOT used.
     expect(prepareSessionSpy).not.toHaveBeenCalled();
   });

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -129,6 +129,8 @@ import {
   type DecryptTransport,
   type EncryptionCrypto,
   type NetworkDescriptor,
+  type NativeVerifiedRecipientDidDelegationBundleV2,
+  type RecipientDidDelegationBundleV2,
 } from "@tinycloud/sdk-core";
 import { NodeUserAuthorization } from "./authorization/NodeUserAuthorization";
 import type { SignStrategy } from "./authorization/strategies";
@@ -144,6 +146,12 @@ import {
   extractSiweExpiration,
 } from "./delegateToHelpers";
 import { NodeSecretsService } from "./NodeSecretsService";
+import {
+  signShareEnvelopeV2WithSession,
+  verifyRecipientDidDelegationBundleV2Native,
+  type SignShareEnvelopeV2Input,
+  type SignShareEnvelopeV2Result,
+} from "./recipientDidSharing";
 
 /** Default TinyCloud host */
 const DEFAULT_HOST = "https://node.tinycloud.xyz";
@@ -457,11 +465,10 @@ function base64UrlDecode(value: string): Uint8Array {
   return new Uint8Array(bytes);
 }
 
-async function signJwtInputWithJwk(
-  signingInput: string,
+async function signBytesWithJwk(
+  bytes: Uint8Array,
   jwk: object,
 ): Promise<Uint8Array> {
-  const bytes = new TextEncoder().encode(signingInput);
   try {
     const subtle = globalThis.crypto?.subtle;
     if (!subtle) {
@@ -480,6 +487,13 @@ async function signJwtInputWithJwk(
     const key = nodeCrypto.createPrivateKey({ key: jwk as any, format: "jwk" });
     return new Uint8Array(nodeCrypto.sign(null, Buffer.from(bytes), key));
   }
+}
+
+async function signJwtInputWithJwk(
+  signingInput: string,
+  jwk: object,
+): Promise<Uint8Array> {
+  return signBytesWithJwk(new TextEncoder().encode(signingInput), jwk);
 }
 
 async function rewriteInvocationAudience(
@@ -2709,12 +2723,11 @@ export class TinyCloudNode {
     const wasmSession = {
       delegationHeader: params.session.delegationHeader,
       delegationCid: params.session.delegationCid,
-      jwk: params.session.jwk,
+      jwk: { ...params.session.jwk, alg: "EdDSA" },
       spaceId: params.session.spaceId,
-      // Session storage carries the verification method as a DID URL
-      // (`did:key:...#key-id`). The Rust UCAN builder expects the principal
-      // DID here and rejects the fragment as an invalid audience DID.
-      verificationMethod: params.session.verificationMethod.split("#", 1)[0],
+      // UCAN issuers are verification-method DID URLs. Preserve the canonical
+      // `did:key:<multibase>#<same multibase>` stored with the session.
+      verificationMethod: params.session.verificationMethod,
     };
 
     const result = this.wasmBindings.createDelegation(
@@ -3710,6 +3723,48 @@ export class TinyCloudNode {
     return this.wasmBindings.computeCid(
       new TextEncoder().encode(authorization),
       0x55n,
+    );
+  }
+
+  /**
+   * Build and sign one recipient-DID share envelope v2 with the active
+   * TinyCloud session key.
+   *
+   * This deliberately accepts structured contract fields and a portable
+   * delegation, never raw bytes, a caller-selected signer, or a private JWK.
+   * It exports only the owner Cacao artifact needed by the recipient's native
+   * authority verifier and rejects grants that are not directly parented by
+   * that active owner session.
+   */
+  async signShareEnvelopeV2(
+    input: SignShareEnvelopeV2Input,
+  ): Promise<SignShareEnvelopeV2Result> {
+    const session = this.currentTinyCloudSession();
+    if (!session) {
+      throw new Error(
+        "signShareEnvelopeV2 requires an active TinyCloud session",
+      );
+    }
+    return signShareEnvelopeV2WithSession(input, {
+      session,
+      wasm: this.wasmBindings,
+      signBytes: (bytes) => signBytesWithJwk(bytes, session.jwk),
+    });
+  }
+
+  /**
+   * Atomically verify a recipient-DID delegation bundle without network I/O.
+   * Fails closed until the configured tinycloud-node/WASM runtime implements
+   * `verifyRecipientDidDelegationBundleV2`.
+   */
+  verifyRecipientDidDelegationBundleV2(
+    bundle: RecipientDidDelegationBundleV2,
+    now = new Date(),
+  ): NativeVerifiedRecipientDidDelegationBundleV2 {
+    return verifyRecipientDidDelegationBundleV2Native(
+      this.wasmBindings,
+      bundle,
+      now,
     );
   }
 

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -42,6 +42,16 @@ export type {
   TinyCloudDebugLevel,
   TinyCloudDebugEnableOptions,
   TinyCloudDebugTimer,
+  NativeVerifiedRecipientDidDelegationBundleV2,
+  RecipientDidCacaoArtifactV2,
+  RecipientDidDelegationArtifactV2,
+  RecipientDidDelegationBundleV2,
+  RecipientDidDelegationRoutingV2,
+  RecipientDidShareDisplayV2,
+  RecipientDidShareEnvelopeV2,
+  RecipientDidShareEnvelopeV2SigningPayload,
+  RecipientDidShareTargetV2,
+  RecipientDidUcanArtifactV2,
 } from "@tinycloud/sdk-core";
 
 // Re-export core values for extensibility
@@ -171,6 +181,11 @@ export {
 export { DelegatedAccess } from "./DelegatedAccess";
 export { serializeDelegation, deserializeDelegation } from "./delegation";
 export type { PortableDelegation } from "./delegation";
+export { RecipientDidSharingError } from "./recipientDidSharing";
+export type {
+  SignShareEnvelopeV2Input,
+  SignShareEnvelopeV2Result,
+} from "./recipientDidSharing";
 
 // Re-export KV service values
 export {

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -66,6 +66,16 @@ export type {
   TinyCloudDebugLevel,
   TinyCloudDebugEnableOptions,
   TinyCloudDebugTimer,
+  NativeVerifiedRecipientDidDelegationBundleV2,
+  RecipientDidCacaoArtifactV2,
+  RecipientDidDelegationArtifactV2,
+  RecipientDidDelegationBundleV2,
+  RecipientDidDelegationRoutingV2,
+  RecipientDidShareDisplayV2,
+  RecipientDidShareEnvelopeV2,
+  RecipientDidShareEnvelopeV2SigningPayload,
+  RecipientDidShareTargetV2,
+  RecipientDidUcanArtifactV2,
 } from "@tinycloud/sdk-core";
 
 // Re-export core values for extensibility
@@ -206,6 +216,11 @@ export type {
   AuthDelegationArtifact,
   DelegationAuthority,
 } from "./delegation";
+export { RecipientDidSharingError } from "./recipientDidSharing";
+export type {
+  SignShareEnvelopeV2Input,
+  SignShareEnvelopeV2Result,
+} from "./recipientDidSharing";
 
 // Re-export KV service values
 export {

--- a/packages/node-sdk/src/recipientDidSharing.test.ts
+++ b/packages/node-sdk/src/recipientDidSharing.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  IWasmBindings,
+  ISessionManager,
+  RecipientDidDelegationBundleV2,
+  TinyCloudSession,
+} from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+import {
+  RecipientDidSharingError,
+  type SignShareEnvelopeV2Input,
+} from "./recipientDidSharing";
+import vector from "./test-fixtures/recipient-did-v2.json";
+
+const accepted = vector.envelope;
+const grantJwt = accepted.delegation.grant.value;
+const grantHeader = JSON.parse(
+  Buffer.from(grantJwt.split(".")[0], "base64url").toString("utf8"),
+) as { jwk: Record<string, string> };
+const sessionJwk = {
+  ...grantHeader.jwk,
+  d: vector.currentSdkFixture.sessionJwkD,
+};
+const rootProof = accepted.delegation.issuerProofs[0];
+
+function sessionManager(): ISessionManager {
+  let exists = false;
+  return {
+    createSessionKey(id) {
+      exists = true;
+      return id;
+    },
+    renameSessionKeyId() {},
+    getDID() {
+      return accepted.signature.signerDid;
+    },
+    jwk() {
+      return exists ? JSON.stringify(sessionJwk) : undefined;
+    },
+  };
+}
+
+function wasm(overrides: Partial<IWasmBindings> = {}): IWasmBindings {
+  const rootBytes = Buffer.from(rootProof.value, "base64url");
+  return {
+    invoke: mock(() => Promise.resolve({} as never)) as never,
+    prepareSession: mock(() => ({})),
+    completeSessionSetup: mock(() => ({})),
+    computeCid(data) {
+      if (Buffer.from(data).equals(rootBytes)) return rootProof.cid;
+      if (new TextDecoder().decode(data).split(".").length === 3) {
+        return accepted.delegation.grant.cid;
+      }
+      throw new Error("unexpected CID preimage");
+    },
+    ensureEip55: (address) => address,
+    makeSpaceId: (address, chainId, prefix) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${prefix}`,
+    createDelegation: mock(() => ({})),
+    parseRecapFromSiwe: mock(() => []),
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(),
+      privateKey: new Uint8Array(),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array()),
+    vault_sha256: mock(() => new Uint8Array()),
+    createSessionManager: sessionManager,
+    ...overrides,
+  };
+}
+
+function activeSession(): TinyCloudSession {
+  const grantPayload = JSON.parse(
+    Buffer.from(grantJwt.split(".")[1], "base64url").toString("utf8"),
+  ) as { iss: string };
+  const address = accepted.target.spaceId.split(":")[4];
+  return {
+    address,
+    chainId: 1,
+    sessionKey: "default",
+    spaceId: accepted.target.spaceId,
+    delegationCid: rootProof.cid,
+    delegationHeader: { Authorization: rootProof.value },
+    verificationMethod: grantPayload.iss,
+    jwk: sessionJwk,
+    siwe: "fixture SIWE",
+    signature: "fixture wallet signature",
+  };
+}
+
+function input(): SignShareEnvelopeV2Input {
+  const address = accepted.target.spaceId.split(":")[4];
+  return {
+    version: 2,
+    shareId: accepted.shareId,
+    delegation: {
+      routing: accepted.delegation.routing,
+      grant: {
+        cid: accepted.delegation.grant.cid,
+        delegationHeader: { Authorization: grantJwt },
+        spaceId: accepted.target.spaceId,
+        path: accepted.target.resource.path,
+        actions: [...accepted.target.actions],
+        expiry: new Date(accepted.expiry),
+        delegateDID: accepted.authorizationTarget.did,
+        ownerAddress: address,
+        chainId: 1,
+        host: accepted.target.origin,
+      },
+    },
+    authorizationTarget: accepted.authorizationTarget,
+    target: accepted.target,
+    display: accepted.display,
+    expiry: accepted.expiry,
+  };
+}
+
+function nodeWithSession(
+  bindings = wasm(),
+  session = activeSession(),
+): TinyCloudNode {
+  const node = new TinyCloudNode({ wasmBindings: bindings });
+  (node as unknown as { auth: { tinyCloudSession: TinyCloudSession } }).auth = {
+    tinyCloudSession: session,
+  };
+  return node;
+}
+
+const nativeRuntime = await import("@tinycloud/node-sdk-wasm").catch(
+  () => undefined,
+);
+const nativeVerifierAvailable =
+  typeof nativeRuntime?.verifyRecipientDidDelegationBundleV2 === "function";
+const nativeVerifierRequired =
+  process.env.TINYCLOUD_REQUIRE_RECIPIENT_DID_NATIVE_VERIFIER === "1";
+const nativeVerifierTest = test.skipIf(!nativeVerifierAvailable);
+
+async function realNativeBindings(): Promise<IWasmBindings> {
+  if (!nativeVerifierAvailable) {
+    throw new Error("Native recipient-DID verifier test was not skipped");
+  }
+  const { NodeWasmBindings } = await import("./NodeWasmBindings");
+  return new NodeWasmBindings();
+}
+
+describe("recipient-DID share envelope v2 SDK seam", () => {
+  test("matches the Stage 0A genuine SDK golden signature", async () => {
+    const node = nodeWithSession();
+    const result = await node.signShareEnvelopeV2(input());
+
+    expect(result.envelope).toEqual(accepted);
+    expect(result.signature).toBe(accepted.signature.value);
+    expect(result.signerDid).toBe(accepted.signature.signerDid);
+    expect(result.issuerProofs).toEqual(accepted.delegation.issuerProofs);
+    expect(JSON.stringify(result)).not.toContain(
+      vector.currentSdkFixture.sessionJwkD,
+    );
+    expect("jwk" in result).toBe(false);
+    expect(
+      (node as unknown as Record<string, unknown>).signBytes,
+    ).toBeUndefined();
+  });
+
+  test("reconstructs the signed projection instead of signing caller extras", async () => {
+    const draft = input() as SignShareEnvelopeV2Input & {
+      unsignedExtension: string;
+      signature: { signerDid: string; algorithm: string };
+    };
+    draft.unsignedExtension = "must-not-be-signed";
+    draft.signature = { signerDid: "did:key:attacker", algorithm: "arbitrary" };
+
+    const result = await nodeWithSession().signShareEnvelopeV2(draft);
+
+    expect(result.envelope).toEqual(accepted);
+    expect("unsignedExtension" in result.envelope).toBe(false);
+    expect(result.envelope.signature.signerDid).toBe(
+      accepted.signature.signerDid,
+    );
+  });
+
+  test("rejects non-string and empty share IDs before signing", async () => {
+    for (const shareId of [42, {}, [], ""]) {
+      const draft = input();
+      Object.defineProperty(draft, "shareId", { value: shareId });
+
+      await expect(
+        nodeWithSession().signShareEnvelopeV2(draft),
+      ).rejects.toMatchObject({
+        name: "RecipientDidSharingError",
+        code: "INVALID_INPUT",
+      });
+    }
+  });
+
+  test("rejects a grant not directly parented by the active owner Cacao", async () => {
+    const session = activeSession();
+    session.delegationCid = "bafkr4i-different-active-owner-cacao";
+    const bindings = wasm({
+      computeCid(data) {
+        return new TextDecoder().decode(data).split(".").length === 3
+          ? accepted.delegation.grant.cid
+          : session.delegationCid;
+      },
+    });
+
+    await expect(
+      nodeWithSession(bindings, session).signShareEnvelopeV2(input()),
+    ).rejects.toMatchObject({
+      name: "RecipientDidSharingError",
+      code: "SESSION_NOT_OWNER_ROOT",
+    });
+  });
+
+  test("rejects a tampered recipient UCAN signature", async () => {
+    const draft = input();
+    const segments =
+      draft.delegation.grant.delegationHeader.Authorization.split(".");
+    segments[2] = `${segments[2].slice(0, -1)}${segments[2].endsWith("A") ? "B" : "A"}`;
+    (
+      draft.delegation.grant.delegationHeader as { Authorization: string }
+    ).Authorization = segments.join(".");
+
+    await expect(
+      nodeWithSession().signShareEnvelopeV2(draft),
+    ).rejects.toBeInstanceOf(RecipientDidSharingError);
+  });
+
+  test("keeps the optional native boundary compatible and fails closed when absent", () => {
+    const node = nodeWithSession();
+    expect(() =>
+      node.verifyRecipientDidDelegationBundleV2(
+        accepted.delegation as RecipientDidDelegationBundleV2,
+      ),
+    ).toThrow("does not provide atomic recipient-DID delegation verification");
+  });
+
+  test("passes the complete bundle and deterministic epoch to the native verifier", () => {
+    const verify = mock(() => vector.nativeVerified);
+    const node = nodeWithSession(
+      wasm({
+        verifyRecipientDidDelegationBundleV2: verify,
+      }),
+    );
+    const now = new Date("2030-01-01T00:00:00.999Z");
+
+    const result = node.verifyRecipientDidDelegationBundleV2(
+      accepted.delegation as RecipientDidDelegationBundleV2,
+      now,
+    );
+
+    expect(result).toEqual(vector.nativeVerified);
+    expect(verify).toHaveBeenCalledWith(accepted.delegation, 1_893_456_000n);
+  });
+
+  test.skipIf(!nativeVerifierRequired)(
+    "release gate requires the native recipient-DID verifier symbol",
+    () => {
+      expect(nativeVerifierAvailable).toBe(true);
+    },
+  );
+
+  nativeVerifierTest(
+    "verifies the genuine direct vector through built Node WASM (skipped when the pinned runtime lacks the native verifier)",
+    async () => {
+      const bindings = await realNativeBindings();
+
+      const verified = nodeWithSession(
+        bindings,
+      ).verifyRecipientDidDelegationBundleV2(
+        accepted.delegation as RecipientDidDelegationBundleV2,
+        new Date("2029-01-01T00:00:00.000Z"),
+      );
+
+      expect(verified).toEqual(vector.nativeVerified);
+    },
+  );
+
+  nativeVerifierTest(
+    "verifies a genuine intermediate UCAN chain through built Node WASM (skipped when the pinned runtime lacks the native verifier)",
+    async () => {
+      const bindings = await realNativeBindings();
+
+      const sessionTwoManager = bindings.createSessionManager();
+      sessionTwoManager.createSessionKey("intermediate");
+      const sessionTwoVerificationMethod =
+        sessionTwoManager.getDID("intermediate");
+      const sessionTwoDid = sessionTwoVerificationMethod.split("#", 1)[0];
+      const sessionTwoJwk = {
+        ...(JSON.parse(
+          sessionTwoManager.jwk("intermediate") as string,
+        ) as object),
+        alg: "EdDSA",
+      };
+      const abilities = {
+        kv: { [accepted.target.resource.path]: ["tinycloud.kv/get"] },
+      };
+      const intermediate = bindings.createDelegation(
+        {
+          delegationHeader: { Authorization: rootProof.value },
+          delegationCid: rootProof.cid,
+          jwk: sessionJwk,
+          spaceId: accepted.target.spaceId,
+          verificationMethod: activeSession().verificationMethod,
+        },
+        sessionTwoDid,
+        accepted.target.spaceId,
+        abilities,
+        4_100_000_000,
+        undefined,
+      ) as { cid: string; delegation: string };
+      const grant = bindings.createDelegation(
+        {
+          delegationHeader: { Authorization: intermediate.delegation },
+          delegationCid: intermediate.cid,
+          jwk: sessionTwoJwk,
+          spaceId: accepted.target.spaceId,
+          verificationMethod: sessionTwoVerificationMethod,
+        },
+        accepted.authorizationTarget.did,
+        accepted.target.spaceId,
+        abilities,
+        4_000_000_000,
+        undefined,
+      ) as { cid: string; delegation: string };
+      const bundle: RecipientDidDelegationBundleV2 = {
+        ...accepted.delegation,
+        grant: {
+          kind: "ucan",
+          cid: grant.cid,
+          encoding: "jwt",
+          value: grant.delegation,
+        },
+        issuerProofs: [
+          rootProof,
+          {
+            kind: "ucan",
+            cid: intermediate.cid,
+            encoding: "jwt",
+            value: intermediate.delegation,
+          },
+        ],
+      };
+
+      const verified = nodeWithSession(
+        bindings,
+      ).verifyRecipientDidDelegationBundleV2(
+        bundle,
+        new Date("2029-01-01T00:00:00.000Z"),
+      );
+
+      expect(verified.sessionPrincipalDid).toBe(sessionTwoDid);
+      expect(verified.grantCid).toBe(grant.cid);
+      expect(verified.proofCids).toEqual([rootProof.cid, intermediate.cid]);
+      expect(verified.scope).toEqual(vector.nativeVerified.scope);
+    },
+  );
+
+  test("normalizes envelope expiry to the grant's whole epoch second", async () => {
+    const draft = input() as { expiry: string } & SignShareEnvelopeV2Input;
+    draft.expiry = draft.expiry.replace(".000Z", ".999Z");
+
+    const result = await nodeWithSession().signShareEnvelopeV2(draft);
+
+    expect(result.envelope.expiry).toBe(accepted.expiry);
+    expect(result.envelope).toEqual(accepted);
+  });
+});

--- a/packages/node-sdk/src/recipientDidSharing.ts
+++ b/packages/node-sdk/src/recipientDidSharing.ts
@@ -1,0 +1,641 @@
+import {
+  RECIPIENT_DID_SHARE_ENVELOPE_V2_DOMAIN,
+  canonicalizeAddress,
+  canonicalizeDid,
+  jcsCanonicalize,
+  pkhDid,
+  verifyDidKeyEd25519Signature,
+  type IWasmBindings,
+  type NativeVerifiedRecipientDidDelegationBundleV2,
+  type RecipientDidCacaoArtifactV2,
+  type RecipientDidDelegationBundleV2,
+  type RecipientDidDelegationRoutingV2,
+  type RecipientDidShareDisplayV2,
+  type RecipientDidShareEnvelopeV2,
+  type RecipientDidShareEnvelopeV2SigningPayload,
+  type RecipientDidShareTargetV2,
+  type RecipientDidUcanArtifactV2,
+  type TinyCloudSession,
+} from "@tinycloud/sdk-core";
+
+import type { PortableDelegation } from "./delegation";
+
+const RAW_CODEC = 0x55n;
+const RECIPIENT_READ_ACTION = "tinycloud.kv/get";
+const DNS_HOSTNAME_RE =
+  /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export interface SignShareEnvelopeV2Input {
+  readonly version: 2;
+  readonly shareId: string;
+  readonly delegation: {
+    readonly routing: RecipientDidDelegationRoutingV2;
+    readonly grant: PortableDelegation;
+  };
+  readonly authorizationTarget: {
+    readonly kind: "recipientDid";
+    readonly did: string;
+  };
+  readonly target: RecipientDidShareTargetV2;
+  readonly display: RecipientDidShareDisplayV2;
+  readonly expiry: string;
+}
+
+export interface SignShareEnvelopeV2Result {
+  readonly envelope: RecipientDidShareEnvelopeV2;
+  readonly signerDid: string;
+  readonly signature: string;
+  readonly issuerProofs: readonly [RecipientDidCacaoArtifactV2];
+}
+
+interface SignShareEnvelopeV2Context {
+  readonly session: TinyCloudSession;
+  readonly wasm: IWasmBindings;
+  signBytes(bytes: Uint8Array): Promise<Uint8Array>;
+}
+
+export class RecipientDidSharingError extends Error {
+  readonly code:
+    | "INVALID_INPUT"
+    | "SESSION_NOT_OWNER_ROOT"
+    | "DELEGATION_MISMATCH"
+    | "NATIVE_VERIFIER_UNAVAILABLE";
+
+  constructor(code: RecipientDidSharingError["code"], message: string) {
+    super(message);
+    this.name = "RecipientDidSharingError";
+    this.code = code;
+  }
+}
+
+/** @internal Fixed-purpose implementation used only by TinyCloudNode. */
+export async function signShareEnvelopeV2WithSession(
+  input: SignShareEnvelopeV2Input,
+  context: SignShareEnvelopeV2Context,
+): Promise<SignShareEnvelopeV2Result> {
+  const { session, wasm } = context;
+  const normalizedInput: SignShareEnvelopeV2Input = {
+    ...input,
+    expiry: canonicalWholeSecondExpiry(input.expiry),
+  };
+  const signerDid = sessionPrincipalFromVerificationMethod(
+    session.verificationMethod,
+  );
+  assertEnvelopeFields(normalizedInput, session);
+
+  const computeCid = wasm.computeCid;
+  if (!computeCid) {
+    throw new RecipientDidSharingError(
+      "SESSION_NOT_OWNER_ROOT",
+      "Recipient-DID sharing requires native delegation CID computation",
+    );
+  }
+
+  const cacaoBytes = decodeCanonicalCacaoAuthorization(
+    session.delegationHeader.Authorization,
+  );
+  const cacaoCid = computeCid(cacaoBytes, RAW_CODEC);
+  if (cacaoCid !== session.delegationCid) {
+    throw new RecipientDidSharingError(
+      "SESSION_NOT_OWNER_ROOT",
+      "Active session Cacao CID does not match its signed authorization bytes",
+    );
+  }
+  const cacao: RecipientDidCacaoArtifactV2 = {
+    kind: "cacao",
+    cid: cacaoCid,
+    encoding: "dag-cbor-base64url-pad",
+    value: paddedBase64Url(cacaoBytes),
+  };
+
+  const grant = recipientGrantArtifact(
+    normalizedInput.delegation.grant,
+    computeCid,
+  );
+  assertRecipientGrantClaims(
+    grant.value,
+    normalizedInput,
+    session,
+    signerDid,
+    cacaoCid,
+  );
+
+  const issuerProofs = [cacao] as const;
+  const bundle: RecipientDidDelegationBundleV2 = {
+    format: "tinycloud-recipient-delegation-v2",
+    routing: {
+      origin: normalizedInput.delegation.routing.origin,
+      nodeAudience: normalizedInput.delegation.routing.nodeAudience,
+    },
+    grant,
+    issuerProofs,
+  };
+  const payload: RecipientDidShareEnvelopeV2SigningPayload = {
+    version: 2,
+    shareId: normalizedInput.shareId,
+    delegation: bundle,
+    authorizationTarget: {
+      kind: "recipientDid",
+      did: normalizedInput.authorizationTarget.did,
+    },
+    target: {
+      origin: normalizedInput.target.origin,
+      nodeAudience: normalizedInput.target.nodeAudience,
+      spaceId: normalizedInput.target.spaceId,
+      resource: { kind: "exact", path: normalizedInput.target.resource.path },
+      actions: [...normalizedInput.target.actions],
+    },
+    display: copyDisplay(normalizedInput.display),
+    expiry: normalizedInput.expiry,
+    signature: { signerDid, algorithm: "Ed25519" },
+  };
+  const signatureBytes = await context.signBytes(signingBytes(payload));
+  if (signatureBytes.length !== 64) {
+    throw new RecipientDidSharingError(
+      "SESSION_NOT_OWNER_ROOT",
+      "Active session signer did not return a 64-byte Ed25519 signature",
+    );
+  }
+  const signature = base64UrlEncode(signatureBytes);
+  return {
+    envelope: {
+      ...payload,
+      signature: { ...payload.signature, value: signature },
+    },
+    signerDid,
+    signature,
+    issuerProofs,
+  };
+}
+
+/**
+ * Invoke the atomic native authority verifier, failing closed while the
+ * corresponding tinycloud-node/WASM primitive is unavailable.
+ */
+export function verifyRecipientDidDelegationBundleV2Native(
+  wasm: IWasmBindings,
+  bundle: RecipientDidDelegationBundleV2,
+  now: Date,
+): NativeVerifiedRecipientDidDelegationBundleV2 {
+  const verify = wasm.verifyRecipientDidDelegationBundleV2;
+  if (!verify) {
+    throw new RecipientDidSharingError(
+      "NATIVE_VERIFIER_UNAVAILABLE",
+      "This SDK runtime does not provide atomic recipient-DID delegation verification",
+    );
+  }
+  const milliseconds = now.getTime();
+  if (!Number.isFinite(milliseconds)) {
+    throw new RecipientDidSharingError(
+      "INVALID_INPUT",
+      "now must be a valid Date",
+    );
+  }
+  return verify(bundle, BigInt(Math.floor(milliseconds / 1000)));
+}
+
+function canonicalWholeSecondExpiry(value: string): string {
+  const expiry = new Date(value);
+  if (Number.isNaN(expiry.getTime()) || expiry.toISOString() !== value) {
+    throw new RecipientDidSharingError(
+      "INVALID_INPUT",
+      "expiry must be a canonical ISO-8601 UTC instant",
+    );
+  }
+  return new Date(Math.floor(expiry.getTime() / 1000) * 1000).toISOString();
+}
+
+function assertEnvelopeFields(
+  input: SignShareEnvelopeV2Input,
+  session: TinyCloudSession,
+): void {
+  if (
+    input.version !== 2 ||
+    typeof input.shareId !== "string" ||
+    input.shareId.length === 0
+  ) {
+    invalid(
+      "Expected recipient-DID share envelope version 2 and a non-empty shareId",
+    );
+  }
+  assertCanonicalRecipientDid(input.authorizationTarget.did);
+  if (input.authorizationTarget.kind !== "recipientDid") {
+    invalid("authorizationTarget must be recipientDid");
+  }
+  assertRouting(input.delegation.routing);
+  assertRouting({
+    origin: input.target.origin,
+    nodeAudience: input.target.nodeAudience,
+  });
+  if (
+    input.delegation.routing.origin !== input.target.origin ||
+    input.delegation.routing.nodeAudience !== input.target.nodeAudience
+  ) {
+    invalid("Delegation routing and target routing must match exactly");
+  }
+
+  const grant = input.delegation.grant;
+  if (grant.host !== input.target.origin) {
+    mismatch("Portable delegation host must equal the signed target origin");
+  }
+  if (grant.delegateDID !== input.authorizationTarget.did) {
+    mismatch(
+      "Portable delegation audience must equal the signed recipient DID",
+    );
+  }
+  if (grant.spaceId !== input.target.spaceId) {
+    mismatch("Portable delegation space must equal the signed target space");
+  }
+  if (
+    input.target.resource.kind !== "exact" ||
+    !isCanonicalResourcePath(input.target.resource.path) ||
+    grant.path !== input.target.resource.path
+  ) {
+    mismatch(
+      "Portable delegation path must equal the canonical exact target path",
+    );
+  }
+  if (
+    input.target.actions.length !== 1 ||
+    input.target.actions[0] !== RECIPIENT_READ_ACTION ||
+    grant.actions.length !== 1 ||
+    grant.actions[0] !== RECIPIENT_READ_ACTION
+  ) {
+    mismatch("Recipient-DID v2 requires exactly tinycloud.kv/get");
+  }
+  if (grant.disableSubDelegation === true) {
+    mismatch(
+      "Recipient grant must remain usable as the holder's invocation parent",
+    );
+  }
+
+  const expiry = new Date(input.expiry);
+  if (
+    Number.isNaN(expiry.getTime()) ||
+    expiry.toISOString() !== input.expiry ||
+    grant.expiry.toISOString() !== input.expiry ||
+    expiry.getTime() <= Date.now()
+  ) {
+    mismatch(
+      "Envelope and portable delegation expiry must be equal, canonical, and future",
+    );
+  }
+
+  if (session.chainId !== 1 || grant.chainId !== 1) {
+    invalid("Recipient-DID v2 supports EIP-155 chain 1 only");
+  }
+  const ownerDid = pkhDid(canonicalizeAddress(session.address), 1);
+  if (canonicalizeDid(ownerDid) !== ownerDid) {
+    invalid("Active session owner DID is not canonical");
+  }
+  if (
+    canonicalizeAddress(grant.ownerAddress) !==
+    canonicalizeAddress(session.address)
+  ) {
+    mismatch(
+      "Portable delegation owner does not match the active session owner",
+    );
+  }
+  const expectedSpacePrefix = `tinycloud:pkh:eip155:1:${ownerDid.slice(ownerDid.lastIndexOf(":") + 1)}:`;
+  const spaceName = input.target.spaceId.slice(expectedSpacePrefix.length);
+  if (
+    !input.target.spaceId.startsWith(expectedSpacePrefix) ||
+    !/^[A-Za-z0-9_-]+$/.test(spaceName)
+  ) {
+    mismatch("Signed target space is not owned by the active session owner");
+  }
+  assertDisplay(input.display);
+}
+
+function recipientGrantArtifact(
+  delegation: PortableDelegation,
+  computeCid: NonNullable<IWasmBindings["computeCid"]>,
+): RecipientDidUcanArtifactV2 {
+  const value = delegation.delegationHeader.Authorization.replace(
+    /^Bearer /i,
+    "",
+  );
+  decodeCanonicalJwt(value);
+  const computed = computeCid(new TextEncoder().encode(value), RAW_CODEC);
+  if (computed !== delegation.cid) {
+    mismatch("Recipient grant CID does not match its signed UCAN bytes");
+  }
+  return { kind: "ucan", cid: computed, encoding: "jwt", value };
+}
+
+function assertRecipientGrantClaims(
+  jwt: string,
+  input: SignShareEnvelopeV2Input,
+  session: TinyCloudSession,
+  signerDid: string,
+  cacaoCid: string,
+): void {
+  const payload = decodeCanonicalJwt(jwt);
+  const segments = jwt.split(".");
+  const header = decodeCanonicalJsonObject(segments[0], "header");
+  if (header.alg !== "EdDSA") {
+    mismatch("Recipient grant JWT must use EdDSA");
+  }
+  const signature = base64UrlDecode(segments[2]);
+  if (
+    signature.length !== 64 ||
+    !verifyDidKeyEd25519Signature(
+      signerDid,
+      new TextEncoder().encode(`${segments[0]}.${segments[1]}`),
+      signature,
+    )
+  ) {
+    mismatch(
+      "Recipient grant JWT signature is not valid for the active session signer",
+    );
+  }
+  const issuer = requiredString(payload, "iss");
+  if (sessionPrincipalFromVerificationMethod(issuer) !== signerDid) {
+    mismatch("Recipient grant issuer must be the active session signer");
+  }
+  if (requiredString(payload, "aud") !== input.authorizationTarget.did) {
+    mismatch("Recipient grant JWT audience does not match authorizationTarget");
+  }
+  const proofs = payload.prf;
+  if (!Array.isArray(proofs) || proofs.length !== 1 || proofs[0] !== cacaoCid) {
+    throw new RecipientDidSharingError(
+      "SESSION_NOT_OWNER_ROOT",
+      "Recipient grant must be directly parented by the active owner Cacao",
+    );
+  }
+  const exp = payload.exp;
+  if (
+    !Number.isSafeInteger(exp) ||
+    new Date((exp as number) * 1000).toISOString() !== input.expiry
+  ) {
+    mismatch(
+      "Recipient grant JWT expiry does not match the signed envelope expiry",
+    );
+  }
+  if (
+    typeof payload.nbf === "number" &&
+    payload.nbf > Math.floor(Date.now() / 1000)
+  ) {
+    mismatch("Recipient grant is not active yet");
+  }
+
+  const expectedResource = `${input.target.spaceId}/kv/${input.target.resource.path}`;
+  const attenuation = payload.att;
+  if (!isPlainObject(attenuation) || Object.keys(attenuation).length !== 1) {
+    mismatch("Recipient grant must contain exactly one attenuated resource");
+  }
+  const abilities = attenuation[expectedResource];
+  if (!isPlainObject(abilities) || Object.keys(abilities).length !== 1) {
+    mismatch(
+      "Recipient grant resource does not exactly match the signed target",
+    );
+  }
+  const caveats = abilities[RECIPIENT_READ_ACTION];
+  if (
+    !Array.isArray(caveats) ||
+    caveats.length !== 1 ||
+    !isPlainObject(caveats[0]) ||
+    Object.keys(caveats[0]).length !== 0
+  ) {
+    mismatch(
+      "Recipient grant must contain only an uncaveated tinycloud.kv/get ability",
+    );
+  }
+}
+
+function signingBytes(
+  payload: RecipientDidShareEnvelopeV2SigningPayload,
+): Uint8Array {
+  return concatBytes(
+    new TextEncoder().encode(RECIPIENT_DID_SHARE_ENVELOPE_V2_DOMAIN),
+    new TextEncoder().encode(jcsCanonicalize(payload)),
+  );
+}
+
+function assertCanonicalRecipientDid(did: string): void {
+  let canonical: string;
+  try {
+    canonical = canonicalizeDid(did);
+  } catch {
+    invalid("Recipient DID is invalid");
+  }
+  if (!did.startsWith("did:pkh:eip155:1:") || canonical! !== did) {
+    invalid("Recipient DID must be the exact canonical chain-1 did:pkh");
+  }
+}
+
+function assertRouting(routing: RecipientDidDelegationRoutingV2): void {
+  let url: URL;
+  try {
+    url = new URL(routing.origin);
+  } catch {
+    invalid("Recipient-DID route origin is invalid");
+  }
+  if (
+    url!.protocol !== "https:" ||
+    url!.origin !== routing.origin ||
+    url!.port !== "" ||
+    !DNS_HOSTNAME_RE.test(url!.hostname) ||
+    isIpv4Literal(url!.hostname) ||
+    routing.nodeAudience !== `did:web:${url!.hostname}`
+  ) {
+    invalid(
+      "Recipient-DID route must be canonical HTTPS with its exact did:web audience",
+    );
+  }
+}
+
+function assertDisplay(display: RecipientDidShareDisplayV2): void {
+  for (const value of [
+    display.senderName,
+    display.filename,
+    display.recipientHint,
+  ]) {
+    if (value !== undefined && typeof value !== "string") {
+      invalid("Share display text fields must be strings");
+    }
+  }
+  if (
+    display.mode !== undefined &&
+    display.mode !== "document" &&
+    display.mode !== "source" &&
+    display.mode !== "folder"
+  ) {
+    invalid("Share display mode is invalid");
+  }
+}
+
+function copyDisplay(
+  display: RecipientDidShareDisplayV2,
+): RecipientDidShareDisplayV2 {
+  return {
+    ...(display.senderName !== undefined
+      ? { senderName: display.senderName }
+      : {}),
+    ...(display.filename !== undefined ? { filename: display.filename } : {}),
+    ...(display.recipientHint !== undefined
+      ? { recipientHint: display.recipientHint }
+      : {}),
+    ...(display.mode !== undefined ? { mode: display.mode } : {}),
+  };
+}
+
+function sessionPrincipalFromVerificationMethod(value: string): string {
+  const match = value.match(
+    /^(did:key:(z[1-9A-HJ-NP-Za-km-z]+))#(z[1-9A-HJ-NP-Za-km-z]+)$/,
+  );
+  if (!match || match[2] !== match[3]) {
+    throw new RecipientDidSharingError(
+      "SESSION_NOT_OWNER_ROOT",
+      "Active session must use the canonical did:key verification method",
+    );
+  }
+  return match[1];
+}
+
+function decodeCanonicalCacaoAuthorization(value: string): Uint8Array {
+  const encoded = value.replace(/^Bearer /i, "");
+  if (!/^[A-Za-z0-9_-]+={0,2}$/.test(encoded) || encoded.length % 4 !== 0) {
+    throw new RecipientDidSharingError(
+      "SESSION_NOT_OWNER_ROOT",
+      "Active session authorization is not canonical padded base64url Cacao",
+    );
+  }
+  const unpadded = encoded.replace(/=+$/, "");
+  const bytes = base64UrlDecode(unpadded);
+  if (paddedBase64Url(bytes) !== encoded) {
+    throw new RecipientDidSharingError(
+      "SESSION_NOT_OWNER_ROOT",
+      "Active session authorization is not canonical padded base64url Cacao",
+    );
+  }
+  return bytes;
+}
+
+function decodeCanonicalJwt(jwt: string): Record<string, unknown> {
+  const segments = jwt.split(".");
+  if (
+    segments.length !== 3 ||
+    segments.some((segment) => segment.length === 0)
+  ) {
+    mismatch("Recipient grant is not a compact UCAN JWT");
+  }
+  for (const segment of segments) {
+    const decoded = base64UrlDecode(segment);
+    if (base64UrlEncode(decoded) !== segment) {
+      mismatch(
+        "Recipient grant JWT segments must be canonical unpadded base64url",
+      );
+    }
+  }
+  return decodeCanonicalJsonObject(segments[1], "payload");
+}
+
+function decodeCanonicalJsonObject(
+  segment: string,
+  label: "header" | "payload",
+): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(
+      new TextDecoder().decode(base64UrlDecode(segment)),
+    );
+    if (!isPlainObject(parsed))
+      mismatch(`Recipient grant JWT ${label} must be an object`);
+    return parsed;
+  } catch (error) {
+    if (error instanceof RecipientDidSharingError) throw error;
+    mismatch(`Recipient grant JWT ${label} is invalid JSON`);
+  }
+}
+
+function requiredString(object: Record<string, unknown>, key: string): string {
+  const value = object[key];
+  if (typeof value !== "string" || value.length === 0) {
+    mismatch(`Recipient grant JWT ${key} claim is missing`);
+  }
+  return value;
+}
+
+function isCanonicalResourcePath(value: string): boolean {
+  if (value.length === 0 || /[\u0000-\u001f\u007f\\]/.test(value)) return false;
+  if (/%2f|%5c|%2e/i.test(value)) return false;
+  return value
+    .split("/")
+    .every((part) => part.length > 0 && part !== "." && part !== "..");
+}
+
+function isIpv4Literal(hostname: string): boolean {
+  const octets = hostname.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function concatBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const output = new Uint8Array(left.length + right.length);
+  output.set(left);
+  output.set(right, left.length);
+  return output;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  const alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  let output = "";
+  for (let index = 0; index < bytes.length; index += 3) {
+    const a = bytes[index];
+    const b = bytes[index + 1];
+    const c = bytes[index + 2];
+    const triplet = (a << 16) | ((b ?? 0) << 8) | (c ?? 0);
+    output += alphabet[(triplet >> 18) & 63];
+    output += alphabet[(triplet >> 12) & 63];
+    if (index + 1 < bytes.length) output += alphabet[(triplet >> 6) & 63];
+    if (index + 2 < bytes.length) output += alphabet[triplet & 63];
+  }
+  return output;
+}
+
+function base64UrlDecode(value: string): Uint8Array {
+  if (
+    value.length === 0 ||
+    !/^[A-Za-z0-9_-]+$/.test(value) ||
+    value.length % 4 === 1
+  ) {
+    mismatch("Expected canonical base64url data");
+  }
+  const alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bits = 0;
+  for (const char of value) {
+    buffer = (buffer << 6) | alphabet.indexOf(char);
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((buffer >> bits) & 0xff);
+    }
+  }
+  return new Uint8Array(bytes);
+}
+
+function paddedBase64Url(bytes: Uint8Array): string {
+  const unpadded = base64UrlEncode(bytes);
+  return `${unpadded}${"=".repeat((4 - (unpadded.length % 4)) % 4)}`;
+}
+
+function invalid(message: string): never {
+  throw new RecipientDidSharingError("INVALID_INPUT", message);
+}
+
+function mismatch(message: string): never {
+  throw new RecipientDidSharingError("DELEGATION_MISMATCH", message);
+}

--- a/packages/node-sdk/src/test-fixtures/recipient-did-v2.json
+++ b/packages/node-sdk/src/test-fixtures/recipient-did-v2.json
@@ -1,0 +1,311 @@
+{
+  "contract": "xyz.tinycloud.share/recipient-did-v2",
+  "currentSdkFixture": {
+    "generator": {
+      "nodeCommit": "390253aca30628f2ac2be28e64d8e3830da07aaa",
+      "sdk": "tinycloud-sdk-wasm",
+      "sdkVersion": "1.3.0",
+      "apis": [
+        "prepare_session",
+        "complete_session_setup",
+        "Session.create_delegation"
+      ]
+    },
+    "sessionJwkD": "WfeGHxh9kdePavqU9KOk2vBhGo8LminMpbvERmrKqTw"
+  },
+  "signingBytesHex": "78797a2e74696e79636c6f75642e73686172652f656e76656c6f70652f7632007b22617574686f72697a6174696f6e546172676574223a7b22646964223a226469643a706b683a6569703135353a313a307864653730396632313032333036323230393231303630333134373135363239303830653266623737222c226b696e64223a22726563697069656e74446964227d2c2264656c65676174696f6e223a7b22666f726d6174223a2274696e79636c6f75642d726563697069656e742d64656c65676174696f6e2d7632222c226772616e74223a7b22636964223a226261666b72346964343534716e68346573726b6d74666e686d3574646f6d78706277716d7236766a37343633356d6c63626b6a786e637236343579222c22656e636f64696e67223a226a7774222c226b696e64223a227563616e222c2276616c7565223a2265794a68624763694f694a465a45525451534973496d70336179493665794a68624763694f694a465a45525451534973496d743065534936496b394c55434973496d4e7964694936496b566b4d6a55314d546b694c434a34496a6f69595664704d574a535457786151307472616b3948623356495a6e6c705a324a7a4e305a524d575a514e6b55745a586c365532684e656b526164794a394c434a30655841694f694a4b563151694c434a31593359694f6949774c6a45774c6a416966512e65794a7063334d694f694a6b61575136613256354f6e6f325457747457577055576a683252304e714d574643596d553064336834627a4e615a3145345533424456466332616e4653537a4e6b626d46305246647154534e364e6b317262566c7156466f34646b6444616a4668516d4a6c4e4864346547387a576d64524f464e77513152584e6d7078556b737a5a47356864455258616b30694c434a68645751694f694a6b615751366347746f4f6d5670634445314e546f784f6a42345a4755334d446c6d4d6a45774d6a4d774e6a49794d446b794d5441324d444d784e4463784e5459794f5441344d4755795a6d49334e794973496d5634634349364e4441774d4441774d4441774d437769626d356a496a6f6964584a754f6e5631615751364e57466b4e7a49794e6a49745954686b4d5330304e4464684c546b304d3249744e44426d4d6a4a6859575a6c4d6a55794969776963484a6d496a7062496d4a685a6d74794e476c6c63576869636e42776332307a4e544d31636d706f636d4632613239754d335a3063444a755a6e4d33636d5272646d4e72645774305a586c73615773325a4842364e585a31496c3073496d46306443493665794a306157353559327876645751366347746f4f6d5670634445314e546f784f6a42344d546c464e30557a4e7a5a464e304d794d544e434e3055335a54646c4e445a6a597a63775154566b524441344e6b52425a6d59795154706b5a575a68645778304c3274324c334268644767694f6e736964476c7565574e736233566b4c6d74324c32646c64434936573374395858313966512e527861562d4a5a716f4f79756d4934774975763836713839367179613973596d697857676a597672676a796433754575616a5146707a57343156306a6f4656636e7a4c776f6a496e634466614f4335575f2d57724351227d2c2269737375657250726f6f6673223a5b7b22636964223a226261666b72346965716862727070736d33353335726a687261766b6f6e33767470326e66733772646b76636b756b7465796c696b3664707a357675222c22656e636f64696e67223a226461672d63626f722d62617365363475726c2d706164222c226b696e64223a22636163616f222c2276616c7565223a226f32466f6f5746305a3256706344517a4e6a4668634b6c6a5958566b65476c6b61575136613256354f6e6f325457747457577055576a683252304e714d574643596d553064336834627a4e615a3145345533424456466332616e4653537a4e6b626d46305246647154534e364e6b317262566c7156466f34646b6444616a4668516d4a6c4e4864346547387a576d64524f464e77513152584e6d7078556b737a5a47356864455258616b316a5a5868776542677a4d4441774c5441784c544178564441774f6a41774f6a41774c6a41774d46706a61574630654267794d4449794c5441784c544178564441774f6a41774f6a41774c6a41774d46706a61584e7a6544746b615751366347746f4f6d5670634445314e546f784f6a42344d546c464e30557a4e7a5a464e304d794d544e434e3055335a54646c4e445a6a597a63775154566b524441344e6b52425a6d5979515756756232356a5a58426d6158683064584a6c546d3975593255784d6a4d305a6d527662574670626d746c654746746347786c4c6d4e76625764325a584a7a6157397541576c795a584e7664584a6a5a584f42654e5631636d3436636d566a595841365a586c4b6147524955576c50626e4e705a45647364575658546e4e694d315a7254323543636d46456347786857454634546c52564e6b31556233646c52455531556c526b526b3136597a4a535647524554577046656c46715a455a4f4d6c557a576c52524d6c6b7954544e4e52555578576b565264303945576b565256317074545774464e6c7048566d315a57465a7a5a454d35636d52704f58645a57464a76535770774e306c75556e4269626d7871596b63354d5670444e584a6b61546c75576c6852615539736444646d566a427a5357355363474a7562477069527a6b78576b4d31636d52704f58646b57464670543278304e325a574d546c6d553364705930684b62556c7163474a595744427063335268644756745a573530654d744a49475a31636e526f5a58496759585630614739796158706c4948526f5a53427a644746305a57516756564a4a494852764948426c636d5a76636d30676447686c49475a766247787664326c755a794268593352706232357a494739754947313549474a6c614746735a6a6f674b444570494364306157353559327876645751756133596e4f69416e5a3256304a7977674a334231644363675a6d3979494364306157353559327876645751366347746f4f6d5670634445314e546f784f6a42344d546c464e30557a4e7a5a464e304d794d544e434e3055335a54646c4e445a6a597a63775154566b524441344e6b52425a6d59795154706b5a575a68645778304c3274324c3342686447676e4c6d467a6f6d467a5745457171316f3653316f664c552d563776797a6d497332474f305a4e556e6876394b774e6d6879675a693972326c47615844517742314f4b6d4e73757a4d734e31704451555646766a425876786652546944396d41384c484746305a6d5670634445354d513d3d227d5d2c22726f7574696e67223a7b226e6f646541756469656e6365223a226469643a7765623a6e6f64652e74696e79636c6f75642e78797a222c226f726967696e223a2268747470733a2f2f6e6f64652e74696e79636c6f75642e78797a227d7d2c22646973706c6179223a7b2266696c656e616d65223a227265706f72742e6d64222c22726563697069656e7448696e74223a22307864653730e280a666623737222c2273656e6465724e616d65223a224164616d227d2c22657870697279223a22323039362d31302d30325430373a30363a34302e3030305a222c2273686172654964223a2273686172652d726563697069656e742d73646b2d66697874757265222c227369676e6174757265223a7b22616c676f726974686d223a2245643235353139222c227369676e6572446964223a226469643a6b65793a7a364d6b6d596a545a387647436a3161426265347778786f335a6751385370435457366a71524b33646e617444576a4d227d2c22746172676574223a7b22616374696f6e73223a5b2274696e79636c6f75642e6b762f676574225d2c226e6f646541756469656e6365223a226469643a7765623a6e6f64652e74696e79636c6f75642e78797a222c226f726967696e223a2268747470733a2f2f6e6f64652e74696e79636c6f75642e78797a222c227265736f75726365223a7b226b696e64223a226578616374222c2270617468223a2270617468227d2c2273706163654964223a2274696e79636c6f75643a706b683a6569703135353a313a3078313945374533373645374332313342374537653765343663633730413564443038364441666632413a64656661756c74227d2c2276657273696f6e223a327d",
+  "signatureHex": "a318140988446fa03b4a6945e18b9af6954e6f5413b423a6be506365cca5b46a67fcadb5da21152c82da0bf79ab7becc8fb35f3ea09ebf800e3bc01b1b721e05",
+  "envelope": {
+    "version": 2,
+    "shareId": "share-recipient-sdk-fixture",
+    "delegation": {
+      "format": "tinycloud-recipient-delegation-v2",
+      "routing": {
+        "origin": "https://node.tinycloud.xyz",
+        "nodeAudience": "did:web:node.tinycloud.xyz"
+      },
+      "grant": {
+        "kind": "ucan",
+        "cid": "bafkr4id454qnh4esrkmtfnhm5tdomxpbwqmr6vj74635mlcbkjxncr645y",
+        "encoding": "jwt",
+        "value": "eyJhbGciOiJFZERTQSIsImp3ayI6eyJhbGciOiJFZERTQSIsImt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiYVdpMWJSTWxaQ0trak9Hb3VIZnlpZ2JzN0ZRMWZQNkUtZXl6U2hNekRadyJ9LCJ0eXAiOiJKV1QiLCJ1Y3YiOiIwLjEwLjAifQ.eyJpc3MiOiJkaWQ6a2V5Ono2TWttWWpUWjh2R0NqMWFCYmU0d3h4bzNaZ1E4U3BDVFc2anFSSzNkbmF0RFdqTSN6Nk1rbVlqVFo4dkdDajFhQmJlNHd4eG8zWmdROFNwQ1RXNmpxUkszZG5hdERXak0iLCJhdWQiOiJkaWQ6cGtoOmVpcDE1NToxOjB4ZGU3MDlmMjEwMjMwNjIyMDkyMTA2MDMxNDcxNTYyOTA4MGUyZmI3NyIsImV4cCI6NDAwMDAwMDAwMCwibm5jIjoidXJuOnV1aWQ6NWFkNzIyNjItYThkMS00NDdhLTk0M2ItNDBmMjJhYWZlMjUyIiwicHJmIjpbImJhZmtyNGllcWhicnBwc20zNTM1cmpocmF2a29uM3Z0cDJuZnM3cmRrdmNrdWt0ZXlsaWs2ZHB6NXZ1Il0sImF0dCI6eyJ0aW55Y2xvdWQ6cGtoOmVpcDE1NToxOjB4MTlFN0UzNzZFN0MyMTNCN0U3ZTdlNDZjYzcwQTVkRDA4NkRBZmYyQTpkZWZhdWx0L2t2L3BhdGgiOnsidGlueWNsb3VkLmt2L2dldCI6W3t9XX19fQ.RxaV-JZqoOyumI4wIuv86q896qya9sYmixWgjYvrgjyd3uEuajQFpzW41V0joFVcnzLwojIncDfaOC5W_-WrCQ"
+      },
+      "issuerProofs": [
+        {
+          "kind": "cacao",
+          "cid": "bafkr4ieqhbrppsm3535rjhravkon3vtp2nfs7rdkvckukteylik6dpz5vu",
+          "encoding": "dag-cbor-base64url-pad",
+          "value": "o2FooWF0Z2VpcDQzNjFhcKljYXVkeGlkaWQ6a2V5Ono2TWttWWpUWjh2R0NqMWFCYmU0d3h4bzNaZ1E4U3BDVFc2anFSSzNkbmF0RFdqTSN6Nk1rbVlqVFo4dkdDajFhQmJlNHd4eG8zWmdROFNwQ1RXNmpxUkszZG5hdERXak1jZXhweBgzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMFpjaWF0eBgyMDIyLTAxLTAxVDAwOjAwOjAwLjAwMFpjaXNzeDtkaWQ6cGtoOmVpcDE1NToxOjB4MTlFN0UzNzZFN0MyMTNCN0U3ZTdlNDZjYzcwQTVkRDA4NkRBZmYyQWVub25jZXBmaXh0dXJlTm9uY2UxMjM0ZmRvbWFpbmtleGFtcGxlLmNvbWd2ZXJzaW9uAWlyZXNvdXJjZXOBeNV1cm46cmVjYXA6ZXlKaGRIUWlPbnNpZEdsdWVXTnNiM1ZrT25CcmFEcGxhWEF4TlRVNk1Ub3dlREU1UlRkRk16YzJSVGRETWpFelFqZEZOMlUzWlRRMlkyTTNNRUUxWkVRd09EWkVRV1ptTWtFNlpHVm1ZWFZzZEM5cmRpOXdZWFJvSWpwN0luUnBibmxqYkc5MVpDNXJkaTluWlhRaU9sdDdmVjBzSW5ScGJubGpiRzkxWkM1cmRpOXdkWFFpT2x0N2ZWMTlmU3dpY0hKbUlqcGJYWDBpc3RhdGVtZW50eMtJIGZ1cnRoZXIgYXV0aG9yaXplIHRoZSBzdGF0ZWQgVVJJIHRvIHBlcmZvcm0gdGhlIGZvbGxvd2luZyBhY3Rpb25zIG9uIG15IGJlaGFsZjogKDEpICd0aW55Y2xvdWQua3YnOiAnZ2V0JywgJ3B1dCcgZm9yICd0aW55Y2xvdWQ6cGtoOmVpcDE1NToxOjB4MTlFN0UzNzZFN0MyMTNCN0U3ZTdlNDZjYzcwQTVkRDA4NkRBZmYyQTpkZWZhdWx0L2t2L3BhdGgnLmFzomFzWEEqq1o6S1ofLU-V7vyzmIs2GO0ZNUnhv9KwNmhygZi9r2lGaXDQwB1OKmNsuzMsN1pDQUVFvjBXvxfRTiD9mA8LHGF0ZmVpcDE5MQ=="
+        }
+      ]
+    },
+    "authorizationTarget": {
+      "kind": "recipientDid",
+      "did": "did:pkh:eip155:1:0xde709f2102306220921060314715629080e2fb77"
+    },
+    "target": {
+      "origin": "https://node.tinycloud.xyz",
+      "nodeAudience": "did:web:node.tinycloud.xyz",
+      "spaceId": "tinycloud:pkh:eip155:1:0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A:default",
+      "resource": {
+        "kind": "exact",
+        "path": "path"
+      },
+      "actions": ["tinycloud.kv/get"]
+    },
+    "display": {
+      "senderName": "Adam",
+      "filename": "report.md",
+      "recipientHint": "0xde70…fb77"
+    },
+    "expiry": "2096-10-02T07:06:40.000Z",
+    "signature": {
+      "signerDid": "did:key:z6MkmYjTZ8vGCj1aBbe4wxxo3ZgQ8SpCTW6jqRK3dnatDWjM",
+      "algorithm": "Ed25519",
+      "value": "oxgUCYhEb6A7SmlF4Yua9pVOb1QTtCOmvlBjZcyltGpn_K212iEVLILaC_eat77Mj7NfPqCev4AOO8AbG3IeBQ"
+    }
+  },
+  "nativeVerified": {
+    "verification": "tinycloud-native-authority-v1",
+    "ownerDid": "did:pkh:eip155:1:0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A",
+    "sessionPrincipalDid": "did:key:z6MkmYjTZ8vGCj1aBbe4wxxo3ZgQ8SpCTW6jqRK3dnatDWjM",
+    "sessionVerificationMethod": "did:key:z6MkmYjTZ8vGCj1aBbe4wxxo3ZgQ8SpCTW6jqRK3dnatDWjM#z6MkmYjTZ8vGCj1aBbe4wxxo3ZgQ8SpCTW6jqRK3dnatDWjM",
+    "recipientDid": "did:pkh:eip155:1:0xde709f2102306220921060314715629080e2fb77",
+    "grantCid": "bafkr4id454qnh4esrkmtfnhm5tdomxpbwqmr6vj74635mlcbkjxncr645y",
+    "proofCids": [
+      "bafkr4ieqhbrppsm3535rjhravkon3vtp2nfs7rdkvckukteylik6dpz5vu"
+    ],
+    "scope": {
+      "spaceId": "tinycloud:pkh:eip155:1:0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A:default",
+      "resource": {
+        "kind": "exact",
+        "path": "path"
+      },
+      "actions": ["tinycloud.kv/get"]
+    },
+    "expiry": "2096-10-02T07:06:40.000Z"
+  },
+  "reject": [
+    {
+      "name": "multi-parent-order",
+      "mutation": {
+        "target": "envelope",
+        "op": "misorder-corrupt-grant-proof"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "missing-parent",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/delegation/issuerProofs",
+        "value": []
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "extra-parent",
+      "mutation": {
+        "target": "envelope",
+        "op": "append-corrupt-grant-proof",
+        "resign": true,
+        "nativeReject": true
+      },
+      "expected": "delegation-invalid"
+    },
+    {
+      "name": "duplicate-parent",
+      "mutation": {
+        "target": "envelope",
+        "op": "duplicate-root"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "artifact-cid-preimage-mismatch",
+      "mutation": {
+        "target": "envelope",
+        "op": "corrupt-grant-value"
+      },
+      "expected": "artifact-cid-mismatch"
+    },
+    {
+      "name": "invalid-native-signature",
+      "mutation": {
+        "target": "native",
+        "op": "reject"
+      },
+      "expected": "delegation-invalid"
+    },
+    {
+      "name": "invalid-envelope-signature",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/display/filename",
+        "value": "tampered.md"
+      },
+      "expected": "signature"
+    },
+    {
+      "name": "owner-space-mismatch",
+      "mutation": {
+        "target": "native",
+        "op": "set",
+        "path": "/ownerDid",
+        "value": "did:pkh:eip155:1:0xde709f2102306220921060314715629080e2fb77"
+      },
+      "expected": "authority-mismatch"
+    },
+    {
+      "name": "route-mismatch",
+      "mutation": {
+        "target": "envelope",
+        "op": "set-route",
+        "origin": "https://other.tinycloud.xyz",
+        "nodeAudience": "did:web:other.tinycloud.xyz",
+        "resign": true
+      },
+      "expected": "target-mismatch"
+    },
+    {
+      "name": "scope-broadening",
+      "mutation": {
+        "target": "native",
+        "op": "set",
+        "path": "/scope/actions",
+        "value": ["tinycloud.kv/get", "tinycloud.kv/put"]
+      },
+      "expected": "target-mismatch"
+    },
+    {
+      "name": "expiry-attenuation",
+      "mutation": {
+        "target": "native",
+        "op": "set",
+        "path": "/expiry",
+        "value": "2096-10-02T07:06:39.000Z"
+      },
+      "expected": "expiry-mismatch"
+    },
+    {
+      "name": "future-not-before",
+      "mutation": {
+        "target": "native",
+        "op": "set",
+        "path": "/notBefore",
+        "value": "2030-01-01T00:00:00.000Z"
+      },
+      "expected": "delegation-invalid"
+    },
+    {
+      "name": "noncanonical-recipient-did",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/authorizationTarget/did",
+        "value": "did:pkh:eip155:1:0x7bd63aa37326a64d458559f44432103e3d6eede9"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "noncanonical-cid",
+      "mutation": {
+        "target": "envelope",
+        "op": "uppercase",
+        "path": "/delegation/grant/cid"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "wrong-cid-digest-length",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/delegation/grant/cid",
+        "value": "bafkr4hyaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "noncanonical-cacao-base64",
+      "mutation": {
+        "target": "envelope",
+        "op": "remove-padding",
+        "path": "/delegation/issuerProofs/0/value"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "noncanonical-signature-base64",
+      "mutation": {
+        "target": "envelope",
+        "op": "append",
+        "path": "/signature/value",
+        "value": "="
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "node-audience-fragment",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/target/nodeAudience",
+        "value": "did:web:node.tinycloud.xyz#key"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "node-audience-whitespace",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/target/nodeAudience",
+        "value": "did:web:node.tinycloud.xyz "
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "node-audience-control",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/target/nodeAudience",
+        "value": "did:web:node.tinycloud.xyz\n"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "node-audience-malformed",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/target/nodeAudience",
+        "value": "did:web:Node..tinycloud.xyz"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "node-audience-ipv4-literal",
+      "mutation": {
+        "target": "envelope",
+        "op": "set-target-route",
+        "origin": "https://127.0.0.1",
+        "nodeAudience": "did:web:127.0.0.1"
+      },
+      "expected": "schema"
+    },
+    {
+      "name": "origin-audience-pairing",
+      "mutation": {
+        "target": "envelope",
+        "op": "set",
+        "path": "/target/nodeAudience",
+        "value": "did:web:other.tinycloud.xyz"
+      },
+      "expected": "schema"
+    }
+  ]
+}

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -629,6 +629,21 @@ export {
   type ExpiryTier,
 } from "./expiry";
 
+// Recipient-DID sharing v2 transport and native authority boundary.
+export {
+  RECIPIENT_DID_SHARE_ENVELOPE_V2_DOMAIN,
+  type NativeVerifiedRecipientDidDelegationBundleV2,
+  type RecipientDidCacaoArtifactV2,
+  type RecipientDidDelegationArtifactV2,
+  type RecipientDidDelegationBundleV2,
+  type RecipientDidDelegationRoutingV2,
+  type RecipientDidShareDisplayV2,
+  type RecipientDidShareEnvelopeV2,
+  type RecipientDidShareEnvelopeV2SigningPayload,
+  type RecipientDidShareTargetV2,
+  type RecipientDidUcanArtifactV2,
+} from "./recipientDidSharing";
+
 // Policy signed-object profile core
 export {
   ED25519_JCS_SIGNATURE_SUITE,

--- a/packages/sdk-core/src/location.test.ts
+++ b/packages/sdk-core/src/location.test.ts
@@ -13,6 +13,7 @@ import {
   resolveTinyCloudHosts,
   signLocationRecord,
   validateLocationRecord,
+  verifyDidKeyEd25519Signature,
   verifyLocationRecord,
   type LocationRecordPayload,
 } from "./location";
@@ -62,6 +63,47 @@ describe("location records", () => {
     });
 
     expect(await verifyLocationRecord(record)).toBe(true);
+  });
+
+  it("rejects the legacy one-byte Ed25519 did:key multicodec", () => {
+    const privateKey = new Uint8Array(32).fill(9);
+    const publicKey = ed25519.getPublicKey(privateKey);
+    const legacyDid = `did:key:${bases.base58btc.encode(
+      Uint8Array.of(0xed, ...publicKey),
+    )}`;
+
+    expect(() =>
+      verifyDidKeyEd25519Signature(
+        legacyDid,
+        new Uint8Array([1]),
+        ed25519.sign(new Uint8Array([1]), privateKey),
+      ),
+    ).toThrow("did:key must be an Ed25519 public key");
+  });
+
+  it("rejects a ZIP-215 small-order identity before signature use", () => {
+    const weakPublicKey = Uint8Array.of(1, ...new Uint8Array(31));
+    const weakSignature = Uint8Array.of(1, ...new Uint8Array(63));
+    const did = `did:key:${bases.base58btc.encode(
+      Uint8Array.of(0xed, 0x01, ...weakPublicKey),
+    )}`;
+
+    expect(() =>
+      verifyDidKeyEd25519Signature(did, new Uint8Array(), weakSignature),
+    ).toThrow("canonical torsion-free point");
+  });
+
+  it("rejects a mixed-torsion Ed25519 did:key before signature use", () => {
+    const mixedTorsionDid =
+      "did:key:z6MkpXEduLbfEpxGpadTPFodnKeo8qCZdotBqyemjeahLyVA";
+
+    expect(() =>
+      verifyDidKeyEd25519Signature(
+        mixedTorsionDid,
+        new Uint8Array(),
+        new Uint8Array(64),
+      ),
+    ).toThrow("canonical torsion-free point");
   });
 
   it("converts http URLs and multiaddrs", () => {

--- a/packages/sdk-core/src/location.ts
+++ b/packages/sdk-core/src/location.ts
@@ -532,6 +532,7 @@ function verifyDidKeySignature(
     signatureBytes,
     new TextEncoder().encode(payload),
     publicKey,
+    { zip215: false },
   );
 }
 
@@ -541,10 +542,15 @@ export function verifyDidKeyEd25519Signature(
   signature: Uint8Array,
 ): boolean {
   const publicKey = ed25519PublicKeyFromDidKey(did);
-  return ed25519.verify(signature, payload, publicKey);
+  return ed25519.verify(signature, payload, publicKey, { zip215: false });
 }
 
 function ed25519PublicKeyFromDidKey(did: string): Uint8Array {
+  if (!did.startsWith("did:key:")) {
+    throw new LocationRecordValidationError(
+      "did:key must be an Ed25519 public key",
+    );
+  }
   const identifier = did.slice("did:key:".length);
   if (!identifier.startsWith("z")) {
     throw new LocationRecordValidationError(
@@ -552,15 +558,48 @@ function ed25519PublicKeyFromDidKey(did: string): Uint8Array {
     );
   }
 
-  const bytes = bases.base58btc.decode(identifier);
-  if (bytes.length === 34 && bytes[0] === 0xed && bytes[1] === 0x01) {
-    return bytes.slice(2);
+  let bytes: Uint8Array;
+  try {
+    bytes = bases.base58btc.decode(identifier);
+  } catch {
+    throw new LocationRecordValidationError(
+      "did:key must use canonical base58btc multibase",
+    );
   }
-  if (bytes.length === 33 && bytes[0] === 0xed) {
-    return bytes.slice(1);
+  if (bases.base58btc.encode(bytes) !== identifier) {
+    throw new LocationRecordValidationError(
+      "did:key must use canonical base58btc multibase",
+    );
   }
-  throw new LocationRecordValidationError(
-    "did:key must be an Ed25519 public key",
+  if (bytes.length !== 34 || bytes[0] !== 0xed || bytes[1] !== 0x01) {
+    throw new LocationRecordValidationError(
+      "did:key must be an Ed25519 public key",
+    );
+  }
+
+  const publicKey = bytes.slice(2);
+  try {
+    const point = ed25519.Point.fromBytes(publicKey, false);
+    point.assertValidity();
+    if (
+      point.isSmallOrder() ||
+      !point.isTorsionFree() ||
+      !bytesEqual(point.toBytes(), publicKey)
+    ) {
+      throw new Error("invalid Ed25519 subgroup or encoding");
+    }
+  } catch {
+    throw new LocationRecordValidationError(
+      "did:key Ed25519 key must be a canonical torsion-free point",
+    );
+  }
+  return publicKey;
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
   );
 }
 

--- a/packages/sdk-core/src/recipientDidSharing.ts
+++ b/packages/sdk-core/src/recipientDidSharing.ts
@@ -1,0 +1,112 @@
+/**
+ * Recipient-DID share envelope v2 wire types.
+ *
+ * These types mirror the normative `@tinycloud/share-envelope` contract. The
+ * share-envelope package remains the schema/semantic verifier; this module
+ * only gives the SDK's fixed-purpose signer and native WASM boundary one
+ * dependency-free transport vocabulary.
+ */
+
+export const RECIPIENT_DID_SHARE_ENVELOPE_V2_DOMAIN =
+  "xyz.tinycloud.share/envelope/v2\0";
+
+export interface RecipientDidCacaoArtifactV2 {
+  readonly kind: "cacao";
+  readonly cid: string;
+  readonly encoding: "dag-cbor-base64url-pad";
+  readonly value: string;
+}
+
+export interface RecipientDidUcanArtifactV2 {
+  readonly kind: "ucan";
+  readonly cid: string;
+  readonly encoding: "jwt";
+  readonly value: string;
+}
+
+export type RecipientDidDelegationArtifactV2 =
+  | RecipientDidCacaoArtifactV2
+  | RecipientDidUcanArtifactV2;
+
+export interface RecipientDidDelegationRoutingV2 {
+  readonly origin: string;
+  readonly nodeAudience: string;
+}
+
+export interface RecipientDidDelegationBundleV2 {
+  readonly format: "tinycloud-recipient-delegation-v2";
+  readonly routing: RecipientDidDelegationRoutingV2;
+  readonly grant: RecipientDidUcanArtifactV2;
+  /** Authority order: owner Cacao followed by any intermediate UCANs. */
+  readonly issuerProofs: readonly RecipientDidDelegationArtifactV2[];
+}
+
+export interface RecipientDidShareDisplayV2 {
+  readonly senderName?: string;
+  readonly filename?: string;
+  readonly recipientHint?: string;
+  readonly mode?: "document" | "source" | "folder";
+}
+
+export interface RecipientDidShareTargetV2 {
+  readonly origin: string;
+  readonly nodeAudience: string;
+  readonly spaceId: string;
+  readonly resource: {
+    readonly kind: "exact";
+    readonly path: string;
+  };
+  readonly actions: readonly string[];
+}
+
+export interface RecipientDidShareEnvelopeV2SigningPayload {
+  readonly version: 2;
+  readonly shareId: string;
+  readonly delegation: RecipientDidDelegationBundleV2;
+  readonly authorizationTarget: {
+    readonly kind: "recipientDid";
+    readonly did: string;
+  };
+  readonly target: RecipientDidShareTargetV2;
+  readonly display: RecipientDidShareDisplayV2;
+  readonly expiry: string;
+  readonly signature: {
+    readonly signerDid: string;
+    readonly algorithm: "Ed25519";
+  };
+}
+
+export interface RecipientDidShareEnvelopeV2 extends Omit<
+  RecipientDidShareEnvelopeV2SigningPayload,
+  "signature"
+> {
+  readonly signature: RecipientDidShareEnvelopeV2SigningPayload["signature"] & {
+    readonly value: string;
+  };
+}
+
+/**
+ * Successful output of the native, atomic authority verifier.
+ *
+ * A conforming implementation verifies the complete bundle together. It must
+ * not synthesize this result from per-artifact parsing or adjacency checks.
+ */
+export interface NativeVerifiedRecipientDidDelegationBundleV2 {
+  readonly verification: "tinycloud-native-authority-v1";
+  readonly ownerDid: string;
+  readonly sessionPrincipalDid: string;
+  readonly sessionVerificationMethod: string;
+  readonly recipientDid: string;
+  readonly grantCid: string;
+  readonly proofCids: readonly string[];
+  readonly scope: {
+    readonly spaceId: string;
+    readonly resource: {
+      readonly kind: "exact";
+      readonly path: string;
+    };
+    readonly actions: readonly string[];
+  };
+  readonly notBefore?: string;
+  readonly expiry: string;
+}

--- a/packages/sdk-core/src/wasm.ts
+++ b/packages/sdk-core/src/wasm.ts
@@ -7,8 +7,15 @@
  * @packageDocumentation
  */
 
-import type { InvokeAnyFunction, InvokeFunction } from "@tinycloud/sdk-services";
+import type {
+  InvokeAnyFunction,
+  InvokeFunction,
+} from "@tinycloud/sdk-services";
 import type { WasmRecapEntry } from "./capabilities";
+import type {
+  NativeVerifiedRecipientDidDelegationBundleV2,
+  RecipientDidDelegationBundleV2,
+} from "./recipientDidSharing";
 
 /**
  * Platform-agnostic WASM bindings interface.
@@ -43,6 +50,29 @@ export interface IWasmBindings {
    * Returns an empty array when the SIWE has no recap resource.
    */
   parseRecapFromSiwe: (siweString: string) => WasmRecapEntry[];
+  /**
+   * Atomically verify a recipient-DID delegation bundle without network I/O.
+   *
+   * Optional so custom and older runtimes remain source compatible. Consumers
+   * must fail closed when this is absent; parsing individual artifacts is not
+   * an authority proof. One successful call MUST jointly verify genuine
+   * Cacao/UCAN signatures and recomputed CIDs; SIWE ReCap root authority;
+   * issuer-to-audience and cited-parent continuity; resource/action/caveat and
+   * delegation-mode attenuation at every edge; not-before/expiry bounds; and
+   * exact, complete, authority-contributing proof membership in the supplied
+   * root-to-leaf order. The returned owner, session principal + DID URL,
+   * recipient, proof/grant CIDs, scope, and effective times MUST all come from
+   * that same verified graph. No node fetch, registry lookup, status request,
+   * or unsigned discovery is permitted inside this operation.
+   *
+   * `nowUnixSeconds` is an integer UTC epoch supplied by the caller so
+   * verification is deterministic and testable. Native errors cross the WASM
+   * boundary as rejection; they MUST NOT be converted into partial output.
+   */
+  verifyRecipientDidDelegationBundleV2?: (
+    bundle: RecipientDidDelegationBundleV2,
+    nowUnixSeconds: bigint,
+  ) => NativeVerifiedRecipientDidDelegationBundleV2;
   /** Generate a host SIWE message for space activation */
   generateHostSIWEMessage: (params: any) => string;
   /** Convert a signed SIWE message to delegation headers */
@@ -58,7 +88,10 @@ export interface IWasmBindings {
     signature: Uint8Array,
     info: Uint8Array,
   ) => Uint8Array;
-  vault_x25519_from_seed: (seed: Uint8Array) => { publicKey: Uint8Array; privateKey: Uint8Array };
+  vault_x25519_from_seed: (seed: Uint8Array) => {
+    publicKey: Uint8Array;
+    privateKey: Uint8Array;
+  };
   vault_x25519_dh: (
     privateKey: Uint8Array,
     publicKey: Uint8Array,

--- a/packages/sdk-rs/Cargo.toml
+++ b/packages/sdk-rs/Cargo.toml
@@ -38,6 +38,12 @@ js-sys = "0.3.59"
 # remains the authoritative registry source. Bump this pin only to newer node
 # release tags, in lockstep with the re-vendor + anchor update (TC-121 covers the
 # codegen source-sha headers those steps rely on).
+#
+# TC-224 release blocker: v1.4.5 predates the recipient-DID authority verifier.
+# Keep this production pin on a release tag. Before publishing the TC-224 SDK
+# packages, bump both tinycloud-node dependencies to the first release tag that
+# includes the verifier and its exact typed WASM declaration, then regenerate
+# and publish the Node/browser WASM packages (consumers currently pin 1.7.4).
 tinycloud-sdk-rs = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", tag = "v1.4.5" }
 tinycloud-sdk-wasm = { git = "https://github.com/tinycloudlabs/tinycloud-node.git", tag = "v1.4.5" }
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/sdk-rs/packages/node/src/index.ts
+++ b/packages/sdk-rs/packages/node/src/index.ts
@@ -36,6 +36,7 @@ export {
   // whether a requested delegation is derivable from the current session
   // without a fresh wallet prompt.
   parseRecapFromSiwe,
+  verifyRecipientDidDelegationBundleV2,
   // Protocol version
   protocolVersion,
   // Vault crypto

--- a/packages/sdk-rs/packages/web/src/index.ts
+++ b/packages/sdk-rs/packages/web/src/index.ts
@@ -34,6 +34,7 @@ export namespace tinycloud {
   // whether a requested delegation is derivable from the current session
   // without a fresh wallet prompt.
   export import parseRecapFromSiwe = lib.parseRecapFromSiwe;
+  export import verifyRecipientDidDelegationBundleV2 = lib.verifyRecipientDidDelegationBundleV2;
   // Protocol version
   export import protocolVersion = lib.protocolVersion;
   // Vault crypto

--- a/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
+++ b/packages/web-sdk/src/adapters/BrowserWasmBindings.ts
@@ -1,4 +1,9 @@
-import { IWasmBindings, ISessionManager } from "@tinycloud/sdk-core";
+import {
+  IWasmBindings,
+  ISessionManager,
+  type NativeVerifiedRecipientDidDelegationBundleV2,
+  type RecipientDidDelegationBundleV2,
+} from "@tinycloud/sdk-core";
 import { tinycloud, tcwSession, initialized } from "@tinycloud/web-sdk-wasm";
 import { invoke, invokeAny, prepareSession, completeSessionSetup } from "../modules/Storage/tinycloud/module";
 
@@ -60,6 +65,18 @@ export class BrowserWasmBindings implements IWasmBindings {
       path: string;
       actions: string[];
     }[];
+  }
+  verifyRecipientDidDelegationBundleV2(
+    bundle: RecipientDidDelegationBundleV2,
+    nowUnixSeconds: bigint,
+  ): NativeVerifiedRecipientDidDelegationBundleV2 {
+    return tinycloud.verifyRecipientDidDelegationBundleV2(
+      {
+        ...bundle,
+        issuerProofs: bundle.issuerProofs.map((proof) => ({ ...proof })),
+      },
+      nowUnixSeconds,
+    );
   }
   generateHostSIWEMessage(params: any): string { return tinycloud.generateHostSIWEMessage(params); }
   siweToDelegationHeaders(params: any) { return tinycloud.siweToDelegationHeaders(params); }

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -322,6 +322,23 @@ export {
   deserializeDelegation,
 } from "@tinycloud/node-sdk/core";
 export type { PortableDelegation } from "@tinycloud/node-sdk/core";
+export {
+  RecipientDidSharingError,
+  type SignShareEnvelopeV2Input,
+  type SignShareEnvelopeV2Result,
+} from "@tinycloud/node-sdk/core";
+export type {
+  NativeVerifiedRecipientDidDelegationBundleV2,
+  RecipientDidCacaoArtifactV2,
+  RecipientDidDelegationArtifactV2,
+  RecipientDidDelegationBundleV2,
+  RecipientDidDelegationRoutingV2,
+  RecipientDidShareDisplayV2,
+  RecipientDidShareEnvelopeV2,
+  RecipientDidShareEnvelopeV2SigningPayload,
+  RecipientDidShareTargetV2,
+  RecipientDidUcanArtifactV2,
+} from "@tinycloud/sdk-core";
 
 // TinyCloudNode re-export (for advanced usage)
 export {

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -18,6 +18,8 @@ import {
   type ISessionStorage,
   type PersistedSessionData,
   type SignStrategy,
+  type SignShareEnvelopeV2Input,
+  type SignShareEnvelopeV2Result,
 } from "@tinycloud/node-sdk/core";
 import {
   IKVService,
@@ -53,6 +55,8 @@ import {
   type NetworkDescriptor,
   SignInOptions,
   composeManifestRequest,
+  type NativeVerifiedRecipientDidDelegationBundleV2,
+  type RecipientDidDelegationBundleV2,
 } from "@tinycloud/sdk-core";
 import { showPermissionRequestModal } from "../notifications/ModalManager";
 import {
@@ -727,6 +731,23 @@ export class TinyCloudWeb {
   ): Promise<DelegateToResult> => {
     const node = await this.ensureNode();
     return node.delegateTo(did, permissions, options);
+  };
+
+  /** Build and sign the fixed recipient-DID share envelope v2 payload. */
+  signShareEnvelopeV2 = async (
+    input: SignShareEnvelopeV2Input,
+  ): Promise<SignShareEnvelopeV2Result> => {
+    const node = await this.ensureNode();
+    return node.signShareEnvelopeV2(input);
+  };
+
+  /** Invoke the runtime's atomic, network-free recipient authority verifier. */
+  verifyRecipientDidDelegationBundleV2 = async (
+    bundle: RecipientDidDelegationBundleV2,
+    now = new Date(),
+  ): Promise<NativeVerifiedRecipientDidDelegationBundleV2> => {
+    const node = await this.ensureNode();
+    return node.verifyRecipientDidDelegationBundleV2(bundle, now);
   };
 
   materializeDelegation = async (


### PR DESCRIPTION
## Status

Draft and release-blocked. Do not merge or publish until TinyCloud Node PR #116 is released and the generated WASM packages/pins are updated.

## Summary
- add fixed-purpose recipient-DID envelope signing without exposing session private keys or arbitrary signing
- add strict canonical/torsion-free Ed25519 did:key and projection/CID/recipient/routing/scope/time validation
- add typed Node and browser native-verifier adapters with bigint epoch handling and fail-closed absence
- preserve full session verification-method DID URLs and EdDSA JWK metadata
- add direct/intermediate authority vectors and honest release-required test gating

## Verified checkpoint
- sdk-core 725/725
- Node 169 pass / 1 intentional release-gate skip
- released seam 8 pass / 3 explicit native-dependent skips
- independently rebuilt native c9164b0 required seam 11/11, including genuine direct and intermediate chains
- browser/local-native production builds pass
- fresh Sol review: APPROVE for Draft checkpoint

## Release blocker
Current Rust pins are v1.4.5 and published WASM packages are 1.7.4; they do not export verifyRecipientDidDelegationBundleV2. After #116 is released: bump both Rust pins, regenerate/publish Node and Web WASM, bump consumers, and require all native Node/browser gates before making this PR ready.

Linear: TC-224
Native dependency: https://github.com/TinyCloudLabs/tinycloud-node/pull/116