### PR TITLE
feat: add delegated stdio MCP projection

### DIFF
--- a/.changeset/tidy-mcp-projection.md
+++ b/.changeset/tidy-mcp-projection.md
@@ -1,0 +1,9 @@
+---
+"@tinycloud/mcp": minor
+"@tinycloud/operations": patch
+---
+
+Add the experimental delegated stdio MCP projection with generated operation
+schemas, pinned startup profile selection, canonical structured envelopes, and
+the packaged delegated-secrets workflow. Expose the existing operations-owned
+profile-name resolver needed to pin a projection process before stdio starts.

--- a/.changeset/tidy-mcp-projection.md
+++ b/.changeset/tidy-mcp-projection.md
@@ -1,5 +1,4 @@
 ---
-"@tinycloud/mcp": minor
 "@tinycloud/operations": patch
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tests/sdk-services/dist
 tests/node-sdk/benchmarks/results/
 packages/cli/dist
 packages/operations/dist/
+packages/mcp/dist/

--- a/bun.lock
+++ b/bun.lock
@@ -198,6 +198,23 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/mcp": {
+      "name": "@tinycloud/mcp",
+      "version": "0.1.0-beta.0",
+      "bin": {
+        "tinycloud-mcp": "./bin/tinycloud-mcp"
+      },
+      "dependencies": {
+        "@modelcontextprotocol/server": "2.0.0-beta.4",
+        "@tinycloud/operations": "0.1.0-beta.0",
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/client": "2.0.0-beta.4",
+        "@types/node": "^20",
+        "tsup": "^8.0.0",
+        "typescript": "^5.9.3",
+      },
+    },
     "packages/node-sdk": {
       "name": "@tinycloud/node-sdk",
       "version": "2.7.0-beta.2",
@@ -445,7 +462,7 @@
   "overrides": {
     "typescript": "5.7.3",
     "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5"
+    "@types/react-dom": "^18.3.5",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -1795,6 +1812,8 @@
     "@tinycloud/cli": ["@tinycloud/cli@workspace:packages/cli"],
 
     "@tinycloud/cli-tests": ["@tinycloud/cli-tests@workspace:tests/cli"],
+
+    "@tinycloud/mcp": ["@tinycloud/mcp@workspace:packages/mcp"],
 
     "@tinycloud/mcp-sdk-contract": ["@tinycloud/mcp-sdk-contract@workspace:tests/mcp-sdk-contract"],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "packages/server",
     "packages/vfs",
     "packages/operations",
+    "packages/mcp",
     "packages/cli",
     "apps/*",
     "tests/*"

--- a/packages/mcp/bin/tinycloud-mcp
+++ b/packages/mcp/bin/tinycloud-mcp
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import("../dist/cli.js");

--- a/packages/mcp/generated/mcp-facts.json
+++ b/packages/mcp/generated/mcp-facts.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": 1,
+  "tools": [
+    {
+      "name": "tinycloud_auth_capabilities",
+      "operationId": "tinycloud.auth.capabilities",
+      "operationVersion": 1,
+      "effects": [
+        "read"
+      ],
+      "postures": [
+        "owner-openkey",
+        "delegate-session",
+        "local-owner-key"
+      ],
+      "sensitiveOutput": false
+    },
+    {
+      "name": "tinycloud_auth_import",
+      "operationId": "tinycloud.auth.import",
+      "operationVersion": 1,
+      "effects": [
+        "local_write"
+      ],
+      "postures": [
+        "owner-openkey",
+        "delegate-session",
+        "local-owner-key"
+      ],
+      "sensitiveOutput": false
+    },
+    {
+      "name": "tinycloud_auth_request",
+      "operationId": "tinycloud.auth.request",
+      "operationVersion": 1,
+      "effects": [
+        "local_write"
+      ],
+      "postures": [
+        "owner-openkey",
+        "delegate-session",
+        "local-owner-key"
+      ],
+      "sensitiveOutput": false
+    },
+    {
+      "name": "tinycloud_auth_status",
+      "operationId": "tinycloud.auth.status",
+      "operationVersion": 1,
+      "effects": [
+        "read"
+      ],
+      "postures": [
+        "owner-openkey",
+        "delegate-session",
+        "local-owner-key",
+        "unauthenticated"
+      ],
+      "sensitiveOutput": false
+    },
+    {
+      "name": "tinycloud_secrets_get",
+      "operationId": "tinycloud.secrets.get",
+      "operationVersion": 1,
+      "effects": [
+        "read",
+        "local_write"
+      ],
+      "postures": [
+        "owner-openkey",
+        "delegate-session",
+        "local-owner-key"
+      ],
+      "sensitiveOutput": true
+    },
+    {
+      "name": "tinycloud_status",
+      "operationId": "tinycloud.status.get",
+      "operationVersion": 1,
+      "effects": [
+        "read"
+      ],
+      "postures": [
+        "owner-openkey",
+        "delegate-session",
+        "local-owner-key",
+        "unauthenticated"
+      ],
+      "sensitiveOutput": false
+    }
+  ]
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@tinycloud/mcp",
+  "version": "0.1.0-beta.0",
+  "description": "TinyCloud delegated operations MCP server",
+  "author": "TinyCloud, Inc.",
+  "license": "EGPL",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "tinycloud-mcp": "./bin/tinycloud-mcp"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js",
+      "require": "./dist/server.cjs"
+    },
+    "./tools": {
+      "types": "./dist/tools.d.ts",
+      "import": "./dist/tools.js",
+      "require": "./dist/tools.cjs"
+    },
+    "./results": {
+      "types": "./dist/results.d.ts",
+      "import": "./dist/results.js",
+      "require": "./dist/results.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "bin",
+    "generated",
+    "skills"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "test": "bun run build && bun scripts/test.ts && bun run check:generated",
+    "test:stdio": "bun run build && bun test src/stdio.test.ts",
+    "typecheck": "tsc -p tsconfig.json",
+    "generate": "bun scripts/generate.ts",
+    "check:generated": "bun scripts/generate.ts --check"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/server": "2.0.0-beta.4",
+    "@tinycloud/operations": "0.1.0-beta.0"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/client": "2.0.0-beta.4",
+    "@types/node": "^20",
+    "tsup": "^8.0.0",
+    "typescript": "^5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tinycloudlabs/web-sdk"
+  }
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tinycloud/mcp",
   "version": "0.1.0-beta.0",
+  "private": true,
   "description": "TinyCloud delegated operations MCP server",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",

--- a/packages/mcp/scripts/generate.ts
+++ b/packages/mcp/scripts/generate.ts
@@ -1,0 +1,77 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const packageDirectory = resolve(scriptDirectory, "..");
+const operationsCatalogPath = resolve(packageDirectory, "../operations/generated/operations.json");
+const factsPath = resolve(packageDirectory, "generated/mcp-facts.json");
+const skillPath = resolve(packageDirectory, "skills/tinycloud-delegated-secrets/SKILL.md");
+
+interface CatalogOperation {
+  readonly id: string;
+  readonly version: number;
+  readonly title: string;
+  readonly description: string;
+  readonly effects: readonly string[];
+  readonly postures: readonly string[];
+  readonly sensitivity: { readonly input: boolean; readonly output: boolean };
+}
+
+interface OperationsCatalog {
+  readonly operations: readonly CatalogOperation[];
+}
+
+const TOOL_NAMES: Record<string, string> = {
+  "tinycloud.status.get": "tinycloud_status",
+  "tinycloud.auth.status": "tinycloud_auth_status",
+  "tinycloud.auth.capabilities": "tinycloud_auth_capabilities",
+  "tinycloud.auth.request": "tinycloud_auth_request",
+  "tinycloud.auth.import": "tinycloud_auth_import",
+  "tinycloud.secrets.get": "tinycloud_secrets_get",
+};
+
+const catalog = JSON.parse(await readFile(operationsCatalogPath, "utf8")) as OperationsCatalog;
+const operations = [...catalog.operations].sort((left, right) =>
+  left.id.localeCompare(right.id) || left.version - right.version,
+);
+const facts = {
+  schemaVersion: 1,
+  tools: operations.map((operation) => ({
+    name: TOOL_NAMES[operation.id] ?? operation.id,
+    operationId: operation.id,
+    operationVersion: operation.version,
+    effects: operation.effects,
+    postures: operation.postures,
+    sensitiveOutput: operation.sensitivity.output,
+  })),
+};
+const serializedFacts = `${JSON.stringify(facts, null, 2)}\n`;
+const generatedBlock = [
+  "<!-- BEGIN GENERATED TINYCloud operation facts -->",
+  "The following facts are generated from `@tinycloud/operations/operations.json`:",
+  "",
+  ...operations.map((operation) =>
+    `- \`${TOOL_NAMES[operation.id] ?? operation.id}\` -> \`${operation.id}@${operation.version}\`; effects: ${operation.effects.join(", ")}; postures: ${operation.postures.join(", ")}; sensitive output: ${operation.sensitivity.output ? "yes" : "no"}.`,
+  ),
+  "<!-- END GENERATED TINYCloud operation facts -->",
+].join("\n");
+
+const existingSkill = await readFile(skillPath, "utf8");
+const blockPattern = /<!-- BEGIN GENERATED TINYCloud operation facts -->[\s\S]*?<!-- END GENERATED TINYCloud operation facts -->/;
+if (!blockPattern.test(existingSkill)) throw new Error("Skill is missing its generated facts markers.");
+const generatedSkill = `${existingSkill.replace(blockPattern, generatedBlock).trimEnd()}\n`;
+
+if (process.argv.includes("--check")) {
+  const [existingFacts, currentSkill] = await Promise.all([
+    readFile(factsPath, "utf8").catch(() => ""),
+    readFile(skillPath, "utf8"),
+  ]);
+  if (existingFacts !== serializedFacts || currentSkill !== generatedSkill) {
+    console.error("Generated MCP facts or skill block is out of date. Run bun run generate.");
+    process.exitCode = 1;
+  }
+} else {
+  await writeFile(factsPath, serializedFacts, "utf8");
+  await writeFile(skillPath, generatedSkill, "utf8");
+}

--- a/packages/mcp/scripts/test.ts
+++ b/packages/mcp/scripts/test.ts
@@ -1,0 +1,25 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const testFiles = (await collectTestFiles(join(process.cwd(), "src"))).sort();
+if (testFiles.length === 0) throw new Error("MCP test runner found no test files.");
+
+for (const testFile of testFiles) {
+  const child = Bun.spawn([process.execPath, "test", testFile], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) process.exit(exitCode);
+}
+
+async function collectTestFiles(directory: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await collectTestFiles(path));
+    else if (entry.isFile() && entry.name.endsWith(".test.ts")) files.push(path);
+  }
+  return files;
+}

--- a/packages/mcp/skills/tinycloud-delegated-secrets/SKILL.md
+++ b/packages/mcp/skills/tinycloud-delegated-secrets/SKILL.md
@@ -1,0 +1,47 @@
+# TinyCloud delegated secrets
+
+Use the TinyCloud MCP tools as a resumable authority workflow. Never ask the
+user to paste a secret value, private key, token, or delegation credential into
+chat.
+
+<!-- BEGIN GENERATED TINYCloud operation facts -->
+The following facts are generated from `@tinycloud/operations/operations.json`:
+
+- `tinycloud_auth_capabilities` -> `tinycloud.auth.capabilities@1`; effects: read; postures: owner-openkey, delegate-session, local-owner-key; sensitive output: no.
+- `tinycloud_auth_import` -> `tinycloud.auth.import@1`; effects: local_write; postures: owner-openkey, delegate-session, local-owner-key; sensitive output: no.
+- `tinycloud_auth_request` -> `tinycloud.auth.request@1`; effects: local_write; postures: owner-openkey, delegate-session, local-owner-key; sensitive output: no.
+- `tinycloud_auth_status` -> `tinycloud.auth.status@1`; effects: read; postures: owner-openkey, delegate-session, local-owner-key, unauthenticated; sensitive output: no.
+- `tinycloud_secrets_get` -> `tinycloud.secrets.get@1`; effects: read, local_write; postures: owner-openkey, delegate-session, local-owner-key; sensitive output: yes.
+- `tinycloud_status` -> `tinycloud.status.get@1`; effects: read; postures: owner-openkey, delegate-session, local-owner-key, unauthenticated; sensitive output: no.
+<!-- END GENERATED TINYCloud operation facts -->
+
+## Workflow
+
+1. Inspect posture first with `tinycloud_status` or `tinycloud_auth_status`.
+   Treat `delegate-session` as delegated authority even when its owner DID is
+   the target space owner. Do not infer owner authority from metadata.
+2. Call `tinycloud_secrets_get` with the validated secret reference (`name`,
+   and optional `scope` or `space`). If the result is `authority_required`,
+   do not retry blindly and do not infer whether the secret exists.
+3. Present the exact structured `request` and its exact `approval` OpenKey
+   action to the user for out-of-band approval. Preserve the request ID and
+   do not edit, broaden, or replace its requested entries.
+4. In a later call, use `tinycloud_auth_import` with the returned request ID
+   and the approved delegation artifact. A process restart is expected to be
+   safe. If the session rotated, the old artifact must be rejected with an
+   audience mismatch; rerun the original secret call for a new request.
+5. Retry the original `tinycloud_secrets_get` call after a successful import.
+   The successful structured result is authoritative. Do not copy its value
+   into text, a follow-up message, diagnostics, or a transcript summary.
+6. If the result is `setup_required`, show the structured Secret Manager setup
+   link. The link contains only the secret reference and target space; it never
+   contains a secret value.
+
+MCP hosts may retain tool arguments and successful results in their own
+transcripts, caches, or evaluation records. TinyCloud controls only its own
+logs and local profile state, not host-side transcript retention. Hosts should
+apply their own sensitive-result retention and access controls.
+
+This proving surface uses local stdio only. It has no continuation tool,
+resources, prompts, elicitation, remote transport, generic permission grant,
+or secret mutation tool.

--- a/packages/mcp/src/cli.test.ts
+++ b/packages/mcp/src/cli.test.ts
@@ -23,5 +23,9 @@ test("parses startup options and records whether profile selection was explicit"
 
 test("rejects unknown options and missing profile values before transport startup", () => {
   expect(() => parseCliOptions(["--profile"])).toThrow("--profile requires");
+  expect(() => parseCliOptions(["--profile", ""])).toThrow("--profile requires");
+  expect(() => parseCliOptions(["--profile", " \t "])).toThrow("--profile requires");
+  expect(() => parseCliOptions(["--profile="])).toThrow("--profile requires");
+  expect(() => parseCliOptions(["--profile= \t "])).toThrow("--profile requires");
   expect(() => parseCliOptions(["--unexpected"])).toThrow("Unknown option");
 });

--- a/packages/mcp/src/cli.test.ts
+++ b/packages/mcp/src/cli.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+
+import { parseCliOptions } from "./cli.js";
+
+test("parses startup options and records whether profile selection was explicit", () => {
+  expect(parseCliOptions([
+    "--profile",
+    "owner",
+    "--allow-owner-profile",
+  ])).toEqual({
+    profile: "owner",
+    explicitProfile: true,
+    allowOwnerProfile: true,
+    help: false,
+    version: false,
+  });
+
+  expect(parseCliOptions(["--allow-owner-profile"])).toMatchObject({
+    explicitProfile: false,
+    allowOwnerProfile: true,
+  });
+});
+
+test("rejects unknown options and missing profile values before transport startup", () => {
+  expect(() => parseCliOptions(["--profile"])).toThrow("--profile requires");
+  expect(() => parseCliOptions(["--unexpected"])).toThrow("Unknown option");
+});

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,0 +1,119 @@
+import { basename } from "node:path";
+
+import { resolveInvocationProfileName } from "@tinycloud/operations/profile";
+
+import { serveTinyCloudMcp, MCP_VERSION } from "./server.js";
+
+export interface ParsedCliOptions {
+  readonly profile?: string;
+  readonly explicitProfile: boolean;
+  readonly allowOwnerProfile: boolean;
+  readonly help: boolean;
+  readonly version: boolean;
+}
+
+const HELP = `TinyCloud delegated operations MCP server
+
+Usage: tinycloud-mcp [options]
+
+Options:
+  --profile <name>       Pin the TinyCloud profile for this process
+  --allow-owner-profile  Allow data execution for an explicitly selected owner profile
+  --help                 Show this help
+  --version              Show the package version
+`;
+
+export function parseCliOptions(arguments_: readonly string[]): ParsedCliOptions {
+  let profile: string | undefined;
+  let explicitProfile = false;
+  let allowOwnerProfile = false;
+  let help = false;
+  let version = false;
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === "--help" || argument === "-h") {
+      help = true;
+      continue;
+    }
+    if (argument === "--version" || argument === "-v") {
+      version = true;
+      continue;
+    }
+    if (argument === "--allow-owner-profile") {
+      allowOwnerProfile = true;
+      continue;
+    }
+    if (argument === "--profile") {
+      const value = arguments_[index + 1];
+      if (value === undefined || value.startsWith("-")) {
+        throw new Error("--profile requires a non-empty profile name.");
+      }
+      profile = value;
+      explicitProfile = true;
+      index += 1;
+      continue;
+    }
+    if (argument?.startsWith("--profile=")) {
+      const value = argument.slice("--profile=".length);
+      if (value.length === 0) throw new Error("--profile requires a non-empty profile name.");
+      profile = value;
+      explicitProfile = true;
+      continue;
+    }
+    throw new Error(`Unknown option: ${argument}`);
+  }
+
+  return { profile, explicitProfile, allowOwnerProfile, help, version };
+}
+
+export async function main(arguments_: readonly string[] = process.argv.slice(2)): Promise<number> {
+  let options: ParsedCliOptions;
+  try {
+    options = parseCliOptions(arguments_);
+  } catch (error) {
+    process.stderr.write("[tinycloud-mcp] Invalid command line.\n");
+    return 2;
+  }
+
+  if (options.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (options.version) {
+    process.stdout.write(`${MCP_VERSION}\n`);
+    return 0;
+  }
+
+  let profile: string;
+  try {
+    profile = await resolveInvocationProfileName(options.profile);
+  } catch {
+    process.stderr.write("[tinycloud-mcp] Could not select a profile.\n");
+    return 2;
+  }
+
+  // The selected profile is now a value captured by the server closure. Every
+  // operation receives it explicitly and cannot re-read TC_PROFILE/config.
+  serveTinyCloudMcp({
+    profile,
+    explicitProfile: options.explicitProfile,
+    allowOwnerProfile: options.allowOwnerProfile,
+  });
+  return 0;
+}
+
+function isDirectInvocation(): boolean {
+  const argv = process.argv[1];
+  if (argv === undefined) return false;
+  return basename(argv) === "cli.js" || basename(argv) === "tinycloud-mcp";
+}
+
+if (isDirectInvocation()) {
+  void main().then((code) => {
+    if (code !== 0) process.exitCode = code;
+  }).catch(() => {
+    process.stderr.write("[tinycloud-mcp] Startup failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -46,7 +46,7 @@ export function parseCliOptions(arguments_: readonly string[]): ParsedCliOptions
     }
     if (argument === "--profile") {
       const value = arguments_[index + 1];
-      if (value === undefined || value.startsWith("-")) {
+      if (value === undefined || value.startsWith("-") || value.trim().length === 0) {
         throw new Error("--profile requires a non-empty profile name.");
       }
       profile = value;
@@ -56,7 +56,7 @@ export function parseCliOptions(arguments_: readonly string[]): ParsedCliOptions
     }
     if (argument?.startsWith("--profile=")) {
       const value = argument.slice("--profile=".length);
-      if (value.length === 0) throw new Error("--profile requires a non-empty profile name.");
+      if (value.trim().length === 0) throw new Error("--profile requires a non-empty profile name.");
       profile = value;
       explicitProfile = true;
       continue;
@@ -106,7 +106,7 @@ export async function main(arguments_: readonly string[] = process.argv.slice(2)
 function isDirectInvocation(): boolean {
   const argv = process.argv[1];
   if (argv === undefined) return false;
-  return basename(argv) === "cli.js" || basename(argv) === "tinycloud-mcp";
+  return basename(argv) === "cli.js" || basename(argv) === "cli.cjs" || basename(argv) === "tinycloud-mcp";
 }
 
 if (isDirectInvocation()) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,4 @@
+export { main, parseCliOptions } from "./cli.js";
+export { createTinyCloudMcpServer, serveTinyCloudMcp, MCP_SERVER_NAME, MCP_VERSION } from "./server.js";
+export { registerTinyCloudTools, TOOL_NAMES } from "./tools.js";
+export { toMcpToolResult } from "./results.js";

--- a/packages/mcp/src/packed-cli.test.ts
+++ b/packages/mcp/src/packed-cli.test.ts
@@ -1,6 +1,17 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
+import { copyFile, cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const packageDirectory = new URL("..", import.meta.url).pathname;
+const nodeBinary = process.env.NODE_BINARY ?? "node";
+const fixtures: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(fixtures.splice(0).map((fixture) =>
+    rm(fixture, { recursive: true, force: true })
+  ));
+});
 
 test("packed ESM and CJS CLI entrypoints print the metadata version directly", async () => {
   const metadata = await Bun.file(new URL("../package.json", import.meta.url)).json() as { version: string };
@@ -9,5 +20,86 @@ test("packed ESM and CJS CLI entrypoints print the metadata version directly", a
     expect(result.exitCode).toBe(0);
     expect(new TextDecoder().decode(result.stdout)).toBe(`${metadata.version}\n`);
     expect(new TextDecoder().decode(result.stderr)).toBe("");
+  }
+});
+
+test("packed ESM and CJS resolve the exact nested operations catalog", async () => {
+  const fixture = await mkdtemp(join(packageDirectory, ".packed-layout-"));
+  fixtures.push(fixture);
+  const mcpDist = join(fixture, "node_modules/@tinycloud/mcp/dist");
+  const operationsDirectory = new URL("../../operations", import.meta.url).pathname;
+  const nestedOperations = join(fixture, "node_modules/@tinycloud/mcp/node_modules/@tinycloud/operations");
+  const hoistedOperations = join(fixture, "node_modules/@tinycloud/operations");
+  await Promise.all([
+    mkdir(mcpDist, { recursive: true }),
+    mkdir(join(nestedOperations, "generated"), { recursive: true }),
+    mkdir(join(hoistedOperations, "generated"), { recursive: true }),
+  ]);
+  await Promise.all([
+    copyFile(join(packageDirectory, "dist/tools.js"), join(mcpDist, "tools.js")),
+    copyFile(join(packageDirectory, "dist/tools.cjs"), join(mcpDist, "tools.cjs")),
+    copyFile(join(operationsDirectory, "package.json"), join(nestedOperations, "package.json")),
+    copyFile(
+      join(operationsDirectory, "generated/operations.json"),
+      join(nestedOperations, "generated/operations.json"),
+    ),
+    cp(join(operationsDirectory, "dist"), join(nestedOperations, "dist"), { recursive: true }),
+    writeFile(join(hoistedOperations, "package.json"), JSON.stringify({
+      name: "@tinycloud/operations",
+      type: "module",
+      exports: { "./operations.json": "./generated/operations.json" },
+    })),
+    writeFile(
+      join(hoistedOperations, "generated/operations.json"),
+      JSON.stringify({ operations: [] }),
+    ),
+  ]);
+
+  const probe = join(fixture, "probe.mjs");
+  await writeFile(probe, `
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+const [format, modulePath] = process.argv.slice(2);
+const loaded = format === "esm"
+  ? await import(pathToFileURL(modulePath).href)
+  : createRequire(import.meta.url)(modulePath);
+const tools = [];
+loaded.registerTinyCloudTools(
+  { registerTool(name, definition) { tools.push({ name, title: definition.title }); } },
+  { profile: "packed", explicitProfile: true, allowOwnerProfile: false },
+  loaded.createJsonSchemaValidator(),
+);
+process.stdout.write(JSON.stringify(tools));
+`);
+
+  const catalog = (await Bun.file(
+    new URL("../../operations/generated/operations.json", import.meta.url),
+  ).json() as { operations: Array<{ id: string; title: string }> }).operations;
+  const titlesByOperation = new Map(catalog.map((operation) => [operation.id, operation.title]));
+  const operationByTool: Record<string, string> = {
+    tinycloud_status: "tinycloud.status.get",
+    tinycloud_auth_status: "tinycloud.auth.status",
+    tinycloud_auth_capabilities: "tinycloud.auth.capabilities",
+    tinycloud_auth_request: "tinycloud.auth.request",
+    tinycloud_auth_import: "tinycloud.auth.import",
+    tinycloud_secrets_get: "tinycloud.secrets.get",
+  };
+  for (const format of ["esm", "cjs"] as const) {
+    const result = Bun.spawnSync([
+      nodeBinary,
+      probe,
+      format,
+      join(mcpDist, `tools.${format === "esm" ? "js" : "cjs"}`),
+    ]);
+    expect(new TextDecoder().decode(result.stderr)).toBe("");
+    expect(result.exitCode).toBe(0);
+    const tools = JSON.parse(new TextDecoder().decode(result.stdout)) as Array<{
+      name: string;
+      title: string;
+    }>;
+    expect(tools).toHaveLength(6);
+    expect(tools.map((tool) => tool.title)).toEqual(
+      tools.map((tool) => titlesByOperation.get(operationByTool[tool.name]!)!),
+    );
   }
 });

--- a/packages/mcp/src/packed-cli.test.ts
+++ b/packages/mcp/src/packed-cli.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+
+const packageDirectory = new URL("..", import.meta.url).pathname;
+
+test("packed ESM and CJS CLI entrypoints print the metadata version directly", async () => {
+  const metadata = await Bun.file(new URL("../package.json", import.meta.url)).json() as { version: string };
+  for (const entrypoint of ["dist/cli.js", "dist/cli.cjs"]) {
+    const result = Bun.spawnSync(["node", `${packageDirectory}/${entrypoint}`, "--version"]);
+    expect(result.exitCode).toBe(0);
+    expect(new TextDecoder().decode(result.stdout)).toBe(`${metadata.version}\n`);
+    expect(new TextDecoder().decode(result.stderr)).toBe("");
+  }
+});

--- a/packages/mcp/src/results.test.ts
+++ b/packages/mcp/src/results.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+
+import { toMcpToolResult } from "./results.js";
+
+test("uses one structured envelope and never copies a successful value into text", () => {
+  const canary = "mcp-secret-canary-results";
+  const result = toMcpToolResult({
+    status: "ok",
+    operation: { operationId: "tinycloud.secrets.get", operationVersion: 1 },
+    context: { profile: "default", host: "https://node.example", posture: "local-owner-key" },
+    output: { value: canary },
+  });
+
+  expect(result.structuredContent.output).toEqual({ value: canary });
+  expect(JSON.stringify(result.content)).not.toContain(canary);
+  expect(result.content).toEqual([{
+    type: "text",
+    text: "TinyCloud operation completed; use the structured result.",
+  }]);
+});
+
+test("does not serialize authority or setup artifacts into text", () => {
+  const result = toMcpToolResult({
+    status: "setup_required",
+    operation: { operationId: "tinycloud.secrets.get", operationVersion: 1 },
+    context: {},
+    setup: { kind: "secret_manager", url: "https://secrets.example/setup?name=canary" },
+  });
+
+  expect(result.content[0]?.text).not.toContain("secrets.example");
+  expect(result.structuredContent.setup).toBeDefined();
+});

--- a/packages/mcp/src/results.test.ts
+++ b/packages/mcp/src/results.test.ts
@@ -30,3 +30,34 @@ test("does not serialize authority or setup artifacts into text", () => {
   expect(result.content[0]?.text).not.toContain("secrets.example");
   expect(result.structuredContent.setup).toBeDefined();
 });
+
+test("projects every canonical envelope category through the same fixed text channel", () => {
+  const samples = [
+    {
+      status: "authority_required",
+      operation: { operationId: "tinycloud.secrets.get", operationVersion: 1 },
+      context: { profile: "delegate", host: "https://node.example", posture: "delegate-session" },
+      missing: [{ service: "tinycloud.kv", path: "vault/secrets/KEY", actions: ["tinycloud.kv/get"] }],
+      request: {
+        kind: "tinycloud.auth.request", version: 1, requestId: "req-1",
+        createdAt: "2026-07-16T00:00:00.000Z", profile: "delegate", posture: "delegate-session",
+        operatorType: "agent", host: "https://node.example", sessionDid: "did:key:session",
+        requested: [{ service: "tinycloud.kv", path: "vault/secrets/KEY", actions: ["tinycloud.kv/get"] }],
+      },
+      approval: { kind: "openkey", requestId: "req-1", fallback: "tc auth grant <request-artifact>" },
+      retry: { operationId: "tinycloud.secrets.get", operationVersion: 1, inputDigest: "a".repeat(64), requiresCallerInput: false },
+    },
+    {
+      status: "error",
+      operation: { operationId: "tinycloud.status.get", operationVersion: 1 },
+      context: { profile: "missing", host: "https://node.example", posture: "unauthenticated" },
+      error: { code: "PROFILE_NOT_FOUND", message: "Profile is not available.", retryable: false },
+    },
+  ] as const;
+
+  for (const sample of samples) {
+    const projected = toMcpToolResult(sample);
+    expect(projected.content[0]?.text).not.toContain(JSON.stringify(sample));
+    expect(projected.structuredContent.status).toBe(sample.status);
+  }
+});

--- a/packages/mcp/src/results.ts
+++ b/packages/mcp/src/results.ts
@@ -1,0 +1,52 @@
+/**
+ * MCP has one structured result channel for a TinyCloud operation. Text is a
+ * fixed, non-sensitive status line; it never serializes the operation result.
+ */
+export interface CanonicalOperationResult {
+  readonly status: "ok" | "authority_required" | "setup_required" | "error";
+  readonly [key: string]: unknown;
+}
+
+export interface McpToolResult extends CallToolResult {
+  readonly content: [{ readonly type: "text"; readonly text: string }];
+  readonly structuredContent: CanonicalOperationResult;
+}
+
+export function toMcpToolResult(result: unknown): McpToolResult {
+  const canonical: CanonicalOperationResult = isCanonicalOperationResult(result)
+    ? result
+    : {
+      status: "error",
+      operation: {},
+      context: {},
+      error: { code: "INTERNAL_ERROR" },
+    };
+
+  return {
+    content: [{ type: "text", text: resultSummary(canonical.status) }],
+    structuredContent: canonical,
+  };
+}
+
+function isCanonicalOperationResult(value: unknown): value is CanonicalOperationResult {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const status = (value as { status?: unknown }).status;
+  return status === "ok" ||
+    status === "authority_required" ||
+    status === "setup_required" ||
+    status === "error";
+}
+
+function resultSummary(status: CanonicalOperationResult["status"]): string {
+  switch (status) {
+    case "ok":
+      return "TinyCloud operation completed; use the structured result.";
+    case "authority_required":
+      return "TinyCloud authority is required; use the structured request and approval action.";
+    case "setup_required":
+      return "TinyCloud setup is required; use the structured setup action.";
+    case "error":
+      return "TinyCloud operation failed; use the structured error.";
+  }
+}
+import type { CallToolResult } from "@modelcontextprotocol/server";

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,25 @@
+import { McpServer } from "@modelcontextprotocol/server";
+import { serveStdio, type StdioServerHandle } from "@modelcontextprotocol/server/stdio";
+
+import { registerTinyCloudTools, type McpStartupSelection } from "./tools.js";
+
+export const MCP_SERVER_NAME = "tinycloud-mcp";
+export const MCP_VERSION = "0.1.0-beta.0";
+
+export function createTinyCloudMcpServer(selection: McpStartupSelection): McpServer {
+  const server = new McpServer({ name: MCP_SERVER_NAME, version: MCP_VERSION });
+  registerTinyCloudTools(server, selection);
+  return server;
+}
+
+/** Start the only supported MCP transport: local stdio. */
+export function serveTinyCloudMcp(selection: McpStartupSelection): StdioServerHandle {
+  return serveStdio(
+    () => createTinyCloudMcpServer(selection),
+    { onerror: () => writeBoundedDiagnostic("MCP transport error") },
+  );
+}
+
+function writeBoundedDiagnostic(message: string): void {
+  process.stderr.write(`[tinycloud-mcp] ${message}\n`);
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,14 +1,18 @@
 import { McpServer } from "@modelcontextprotocol/server";
 import { serveStdio, type StdioServerHandle } from "@modelcontextprotocol/server/stdio";
 
-import { registerTinyCloudTools, type McpStartupSelection } from "./tools.js";
+import { createJsonSchemaValidator, registerTinyCloudTools, type McpStartupSelection } from "./tools.js";
+import { MCP_VERSION } from "./version.js";
 
 export const MCP_SERVER_NAME = "tinycloud-mcp";
-export const MCP_VERSION = "0.1.0-beta.0";
-
+export { MCP_VERSION } from "./version.js";
 export function createTinyCloudMcpServer(selection: McpStartupSelection): McpServer {
-  const server = new McpServer({ name: MCP_SERVER_NAME, version: MCP_VERSION });
-  registerTinyCloudTools(server, selection);
+  const validator = createJsonSchemaValidator();
+  const server = new McpServer(
+    { name: MCP_SERVER_NAME, version: MCP_VERSION },
+    { jsonSchemaValidator: validator },
+  );
+  registerTinyCloudTools(server, selection, validator);
   return server;
 }
 

--- a/packages/mcp/src/stdio.test.ts
+++ b/packages/mcp/src/stdio.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -85,19 +85,16 @@ test("official v2 client lists exactly six generated-schema tools over stdio", a
       text: "TinyCloud operation completed; use the structured result.",
     }]);
 
-    for (const [name, arguments_] of [
-      ["tinycloud_auth_status", {}],
-      ["tinycloud_auth_capabilities", {}],
-      ["tinycloud_auth_request", {}],
-      ["tinycloud_auth_import", {}],
-      ["tinycloud_secrets_get", { name: "MCP_TEST_SECRET" }],
-    ] as const) {
+    const expectedToolResults = [
+      ["tinycloud_auth_status", {}, { status: "ok", operation: { operationId: "tinycloud.auth.status", operationVersion: 1 } }],
+      ["tinycloud_auth_capabilities", {}, { status: "error", operation: { operationId: "tinycloud.auth.capabilities", operationVersion: 1 }, error: { code: "SESSION_NOT_FOUND" } }],
+      ["tinycloud_auth_request", { requestId: "missing-request" }, { status: "error", operation: { operationId: "tinycloud.auth.request", operationVersion: 1 }, error: { code: "SESSION_NOT_FOUND" } }],
+      ["tinycloud_auth_import", validImportProbe(), { status: "error", operation: { operationId: "tinycloud.auth.import", operationVersion: 1 }, error: { code: "SESSION_NOT_FOUND" } }],
+      ["tinycloud_secrets_get", { name: "MCP_TEST_SECRET" }, { status: "error", operation: { operationId: "tinycloud.secrets.get", operationVersion: 1 }, error: { code: "PROFILE_OWNER_OPT_IN_REQUIRED" } }],
+    ] as const;
+    for (const [name, arguments_, expected] of expectedToolResults) {
       const result = await client.callTool({ name, arguments: arguments_ });
-      if (contentOf(result) === undefined) {
-        expect(result.isError).toBe(true);
-      } else {
-        expect(contentOf(result)!.status).toMatch(/^(ok|authority_required|setup_required|error)$/);
-      }
+      expect(contentOf(result)).toMatchObject(expected);
     }
 
     const unknownField = await client.callTool({
@@ -125,24 +122,13 @@ test("official v2 client lists exactly six generated-schema tools over stdio", a
   }
 });
 
-test("owner data requires explicit startup profile and opt-in while status stays callable", async () => {
-  const home = await fixtureHome();
-  const transport = new StdioClientTransport({
-    command: nodeBinary,
-    args: [cliPath],
-    env: { ...process.env, TC_HOME: home },
-  });
-  const ajv = new Ajv({ strict: false });
-  addFormats(ajv);
-  const client = new Client({ name: "tinycloud-mcp-owner-gate-test", version: "0.0.0" }, {
-    jsonSchemaValidator: new AjvJsonSchemaValidator(ajv),
-  });
+test("owner data requires opt-in and explicit opt-in passes the gate for both owner postures", async () => {
+  const defaultHome = await fixtureHome();
+  const defaultClient = await connectClient(defaultHome, []);
   try {
-    await client.connect(transport);
-    const status = await client.callTool({ name: "tinycloud_auth_status", arguments: {} });
+    const status = await defaultClient.client.callTool({ name: "tinycloud_auth_status", arguments: {} });
     expect(status.structuredContent).toMatchObject({ status: "ok" });
-
-    const secret = await client.callTool({
+    const secret = await defaultClient.client.callTool({
       name: "tinycloud_secrets_get",
       arguments: { name: "MCP_TEST_SECRET" },
     });
@@ -151,7 +137,32 @@ test("owner data requires explicit startup profile and opt-in while status stays
       error: { code: "PROFILE_OWNER_OPT_IN_REQUIRED" },
     });
   } finally {
-    await client.close();
+    await defaultClient.client.close();
+  }
+
+  for (const posture of ["owner-openkey", "local-owner-key"] as const) {
+    const home = await fixtureHome({
+      profile: posture,
+      posture,
+      ...(posture === "local-owner-key"
+        ? { authMethod: "local", privateKey: `0x${"1".repeat(64)}` }
+        : {}),
+    });
+    const connected = await connectClient(home, ["--profile", posture, "--allow-owner-profile"]);
+    try {
+      const result = await connected.client.callTool({
+        name: "tinycloud_secrets_get",
+        arguments: { name: "MCP_TEST_SECRET" },
+      });
+      const envelope = contentOf(result);
+      expect(envelope).toBeDefined();
+      expect(envelope?.error?.code).not.toBe("PROFILE_OWNER_OPT_IN_REQUIRED");
+      expect(connected.stderr()).not.toContain("MCP_TEST_SECRET");
+      expect(connected.stderr().length).toBeLessThanOrEqual(4096);
+    } finally {
+      await connected.client.close();
+      await rm(home, { recursive: true, force: true });
+    }
   }
 });
 
@@ -179,7 +190,7 @@ test("an explicitly pinned missing profile never falls back to config.defaultPro
   }
 });
 
-test("real MCP restarts preserve signed import/retry boundaries without owner fallback", async () => {
+test("three real MCP processes request, import, restart, and retry the original secret", async () => {
   const home = await mkdtemp(join(tmpdir(), "tinycloud-mcp-hermetic-"));
   const previousTcHome = process.env.TC_HOME;
   process.env.TC_HOME = home;
@@ -187,33 +198,31 @@ test("real MCP restarts preserve signed import/retry boundaries without owner fa
     "../../operations/test-support/auth-runtime.ts",
     import.meta.url,
   ).href) as {
-    createAuthRuntimeFixture: () => Promise<any>;
-    persistRuntimeDelegations: (fixture: any, delegations: readonly any[]) => Promise<void>;
+    createAuthRuntimeFixture: (options?: Record<string, unknown>) => Promise<any>;
   };
   const stateSupport = await import(new URL(
     "../../operations/src/state.ts",
     import.meta.url,
   ).href) as {
     readAuthRequests: (profile: string) => Promise<unknown[]>;
-    sessionPath: (profile: string) => string;
-    writeJsonAtomic: (path: string, value: unknown) => Promise<void>;
+    readAdditionalDelegations: (profile: string) => Promise<unknown[]>;
   };
-  const fixture = await authSupport.createAuthRuntimeFixture();
   const canary = "hermetic encrypted delegation proof";
-  let client: Client | undefined;
-  let importedClient: Client | undefined;
-  let retryClient: Client | undefined;
+  const fixture = await authSupport.createAuthRuntimeFixture({ secretPayloadValue: canary });
+  let client: ConnectedClient | undefined;
+  let importedClient: ConnectedClient | undefined;
+  let retryClient: ConnectedClient | undefined;
 
   try {
     client = await connectClient(home, ["--profile", fixture.profile]);
-    const invalid = await client.callTool({
+    const invalid = await client.client.callTool({
       name: "tinycloud_secrets_get",
       arguments: { name: 42 },
     });
     expect(invalid.isError).toBe(true);
     expect(await stateSupport.readAuthRequests(fixture.profile)).toEqual([]);
 
-    const authority = await client.callTool({
+    const authority = await client.client.callTool({
       name: "tinycloud_secrets_get",
       arguments: { name: "HERMETIC_DELEGATION_CANARY" },
     });
@@ -225,28 +234,18 @@ test("real MCP restarts preserve signed import/retry boundaries without owner fa
       throw new Error("expected a canonical authority result");
     }
     const requestId = (contentOf(authority)!.request as { requestId: string }).requestId;
-    await client.close();
+    expect((contentOf(authority)!.request as Record<string, unknown>).kind).toBe("tinycloud.auth.request");
+    await client.client.close();
     client = undefined;
 
     const delegation = await fixture.hermetic.mintDelegation();
     importedClient = await connectClient(home, ["--profile", fixture.profile]);
-    const request = await importedClient.callTool({
-      name: "tinycloud_auth_request",
-      arguments: {
-        operationId: "tinycloud.secrets.get",
-        operationVersion: 1,
-        input: { name: "HERMETIC_DELEGATION_CANARY" },
-      },
-    });
-    expect(contentOf(request)).toMatchObject({ status: "ok" });
-    if (contentOf(request)?.status !== "ok") throw new Error("expected an auth request result");
-    const importRequestId = (contentOf(request)!.output as { request: { requestId: string } }).request.requestId;
-    const imported = await importedClient.callTool({
+    const imported = await importedClient.client.callTool({
       name: "tinycloud_auth_import",
       arguments: {
         kind: "tinycloud.auth.delegation",
         version: 1,
-        requestId: importRequestId,
+        requestId,
         delegationCid: delegation.cid,
         delegation,
       },
@@ -256,50 +255,127 @@ test("real MCP restarts preserve signed import/retry boundaries without owner fa
       operation: { operationId: "tinycloud.auth.import", operationVersion: 1 },
       output: { cid: delegation.cid, activated: true },
     });
-    await importedClient.close();
+    expect(await stateSupport.readAdditionalDelegations(fixture.profile)).toEqual([
+      expect.objectContaining({ delegation: expect.objectContaining({ cid: delegation.cid }) }),
+    ]);
+    await importedClient.client.close();
     importedClient = undefined;
-    // Keep the exact compact artifact in the hermetic store for the fresh
-    // process read; the import response above proves the MCP import writer.
-    await authSupport.persistRuntimeDelegations(fixture, [delegation]);
 
     retryClient = await connectClient(home, ["--profile", fixture.profile]);
-    const afterRestart = await retryClient.callTool({ name: "tinycloud_status", arguments: {} });
-    expect(afterRestart.structuredContent).toMatchObject({ status: "ok" });
-    expect(afterRestart.content).toEqual([{
-      type: "text",
-      text: "TinyCloud operation completed; use the structured result.",
-    }]);
+    const afterRestart = await retryClient.client.callTool({
+      name: "tinycloud_secrets_get",
+      arguments: { name: "HERMETIC_DELEGATION_CANARY" },
+    });
+    expect(contentOf(afterRestart)).toMatchObject({
+      status: "ok",
+      output: { value: canary },
+    });
     expect(JSON.stringify(afterRestart.content)).not.toContain(canary);
-    await retryClient.close();
+    expect(JSON.stringify({ ...afterRestart, structuredContent: undefined })).not.toContain(canary);
+    expect(retryClient.stderr()).not.toContain(canary);
+    expect(retryClient.stderr().length).toBeLessThanOrEqual(4096);
+    fixture.hermetic.assertNarrowDelegatedReadAndDecrypt(delegation, fixture.sessionDid);
+    for (const file of ["profile.json", "session.json", "auth-requests.json", "additional-delegations.json"]) {
+      const persisted = await readFile(join(home, ".tinycloud/profiles", fixture.profile, file), "utf8");
+      expect(persisted).not.toContain(canary);
+    }
+    await retryClient.client.close();
     retryClient = undefined;
 
-    // A rotated persisted session cannot import the artifact minted for the
-    // prior audience. The MCP process must fail closed before persistence.
-    const sessionFile = stateSupport.sessionPath(fixture.profile);
-    const session = JSON.parse(await Bun.file(sessionFile).text()) as Record<string, unknown>;
-    await stateSupport.writeJsonAtomic(sessionFile, {
-      ...session,
-      verificationMethod: "did:key:z6Mki4RotatedSession#key-1",
-    });
+    // An artifact minted for another session audience must fail closed before
+    // persistence, as a stale artifact does after session rotation.
+    const rotatedDelegation = await fixture.hermetic.mintDelegationForAudience(
+      fixture.hermetic.unrelatedAudience,
+    );
     const rotatedClient = await connectClient(home, ["--profile", fixture.profile]);
-    const rotated = await rotatedClient.callTool({
+    const beforeRotatedImport = JSON.stringify(await stateSupport.readAdditionalDelegations(fixture.profile));
+    const rotated = await rotatedClient.client.callTool({
       name: "tinycloud_auth_import",
       arguments: {
         kind: "tinycloud.auth.delegation",
         version: 1,
-        requestId: importRequestId,
+        requestId,
+        delegationCid: rotatedDelegation.cid,
+        delegation: rotatedDelegation,
+      },
+    });
+    expect(contentOf(rotated)).toMatchObject({
+      status: "error",
+      error: { code: "DELEGATION_AUDIENCE_MISMATCH" },
+    });
+    expect(JSON.stringify(await stateSupport.readAdditionalDelegations(fixture.profile))).toBe(beforeRotatedImport);
+    expect(JSON.stringify(contentOf(rotated))).not.toContain(canary);
+    expect(rotatedClient.stderr()).not.toContain(canary);
+    await rotatedClient.client.close();
+
+  } finally {
+    await client?.client.close().catch(() => undefined);
+    await importedClient?.client.close().catch(() => undefined);
+    await retryClient?.client.close().catch(() => undefined);
+    fixture.hermetic.stop();
+    if (previousTcHome === undefined) delete process.env.TC_HOME;
+    else process.env.TC_HOME = previousTcHome;
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("an authorized missing secret returns only the value-free setup action", async () => {
+  const home = await mkdtemp(join(tmpdir(), "tinycloud-mcp-setup-"));
+  const previousTcHome = process.env.TC_HOME;
+  process.env.TC_HOME = home;
+  const authSupport = await import(new URL(
+    "../../operations/test-support/auth-runtime.ts",
+    import.meta.url,
+  ).href) as {
+    createAuthRuntimeFixture: (options?: Record<string, unknown>) => Promise<any>;
+  };
+  const fixture = await authSupport.createAuthRuntimeFixture({ secretPresent: false });
+  let requestClient: ConnectedClient | undefined;
+  let importClient: ConnectedClient | undefined;
+  try {
+    requestClient = await connectClient(home, ["--profile", fixture.profile]);
+    const authority = await requestClient.client.callTool({
+      name: "tinycloud_secrets_get",
+      arguments: { name: "HERMETIC_DELEGATION_CANARY" },
+    });
+    expect(contentOf(authority)?.status).toBe("authority_required");
+    const requestId = (contentOf(authority)!.request as { requestId: string }).requestId;
+    const delegation = await fixture.hermetic.mintDelegation();
+    await requestClient.client.close();
+    requestClient = undefined;
+
+    importClient = await connectClient(home, ["--profile", fixture.profile]);
+    const imported = await importClient.client.callTool({
+      name: "tinycloud_auth_import",
+      arguments: {
+        kind: "tinycloud.auth.delegation",
+        version: 1,
+        requestId,
         delegationCid: delegation.cid,
         delegation,
       },
     });
-    expect(contentOf(rotated)?.status).toBe("error");
-    expect(JSON.stringify(contentOf(rotated))).not.toContain(canary);
-    await rotatedClient.close();
-
+    expect(contentOf(imported)).toMatchObject({ status: "ok", output: { cid: delegation.cid } });
+    const absent = await importClient.client.callTool({
+      name: "tinycloud_secrets_get",
+      arguments: { name: "HERMETIC_DELEGATION_CANARY" },
+    });
+    expect(contentOf(absent)).toMatchObject({
+      status: "setup_required",
+      setup: {
+        kind: "secret_manager",
+        url: expect.stringMatching(/^https:\/\//),
+        message: expect.any(String),
+      },
+    });
+    const setup = contentOf(absent)!.setup as Record<string, any>;
+    expect(JSON.stringify(setup)).toContain("HERMETIC_DELEGATION_CANARY");
+    expect(JSON.stringify(setup)).not.toContain("value");
+    expect(JSON.stringify(absent.content)).not.toContain("HERMETIC_DELEGATION_CANARY");
+    expect(importClient.stderr()).not.toContain("HERMETIC_DELEGATION_CANARY");
   } finally {
-    await client?.close().catch(() => undefined);
-    await importedClient?.close().catch(() => undefined);
-    await retryClient?.close().catch(() => undefined);
+    await requestClient?.client.close().catch(() => undefined);
+    await importClient?.client.close().catch(() => undefined);
     fixture.hermetic.stop();
     if (previousTcHome === undefined) delete process.env.TC_HOME;
     else process.env.TC_HOME = previousTcHome;
@@ -311,7 +387,12 @@ function contentOf(result: { structuredContent?: unknown | null }): Record<strin
   return result.structuredContent as Record<string, any> | undefined;
 }
 
-async function connectClient(home: string, args: readonly string[]): Promise<Client> {
+interface ConnectedClient {
+  readonly client: Client;
+  readonly stderr: () => string;
+}
+
+async function connectClient(home: string, args: readonly string[]): Promise<ConnectedClient> {
   const transport = new StdioClientTransport({
     command: nodeBinary,
     args: [cliPath, ...args],
@@ -323,24 +404,54 @@ async function connectClient(home: string, args: readonly string[]): Promise<Cli
   const client = new Client({ name: "tinycloud-mcp-hermetic-test", version: "0.0.0" }, {
     jsonSchemaValidator: new AjvJsonSchemaValidator(ajv),
   });
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => { stderr += String(chunk); });
   await client.connect(transport);
-  return client;
+  return { client, stderr: () => stderr };
 }
 
-async function fixtureHome(): Promise<string> {
+function validImportProbe(): Record<string, unknown> {
+  return {
+    kind: "tinycloud.auth.delegation",
+    version: 1,
+    requestId: "missing-request",
+    delegationCid: "bafy-probe",
+    delegation: {
+      cid: "bafy-probe",
+      spaceId: "tinycloud:space",
+      path: "vault/secrets/MCP_TEST_SECRET",
+      actions: ["tinycloud.kv/get"],
+      delegateDID: "did:key:z6MkiSession",
+      ownerAddress: "0x0000000000000000000000000000000000000001",
+      chainId: 1,
+      expiry: "2030-01-01T00:00:00.000Z",
+      delegationHeader: { Authorization: "Bearer probe" },
+    },
+  };
+}
+
+async function fixtureHome(options: Readonly<{
+  profile?: string;
+  posture?: "owner-openkey" | "local-owner-key";
+  authMethod?: "openkey" | "local";
+  privateKey?: string;
+}> = {}): Promise<string> {
   const home = await mkdtemp(join(tmpdir(), "tinycloud-mcp-i4-"));
   homes.push(home);
-  const profileDirectory = join(home, ".tinycloud/profiles/default");
+  const profile = options.profile ?? "default";
+  const profileDirectory = join(home, ".tinycloud/profiles", profile);
   await Bun.write(join(profileDirectory, "profile.json"), JSON.stringify({
-    name: "default",
+    name: profile,
     host: "https://node.example",
     chainId: 1,
     spaceName: "secrets",
     did: "did:key:z6MkjMCPFixture",
     createdAt: "2026-07-16T00:00:00.000Z",
-    posture: "owner-openkey",
+    posture: options.posture ?? "owner-openkey",
     operatorType: "agent",
+    ...(options.authMethod === undefined ? {} : { authMethod: options.authMethod }),
+    ...(options.privateKey === undefined ? {} : { privateKey: options.privateKey }),
   }, null, 2));
-  await writeFile(join(home, ".tinycloud/config.json"), JSON.stringify({ defaultProfile: "default" }));
+  await writeFile(join(home, ".tinycloud/config.json"), JSON.stringify({ defaultProfile: profile }));
   return home;
 }

--- a/packages/mcp/src/stdio.test.ts
+++ b/packages/mcp/src/stdio.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { addFormats, Ajv, AjvJsonSchemaValidator } from "@modelcontextprotocol/client/validators/ajv";
+import catalog from "@tinycloud/operations/operations.json";
+
+const packageDirectory = new URL("..", import.meta.url).pathname;
+const cliPath = join(packageDirectory, "dist/cli.js");
+const nodeBinary = process.env.NODE_BINARY ?? "node";
+const homes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+test("official v2 client lists exactly six generated-schema tools over stdio", async () => {
+  const home = await fixtureHome();
+  const transport = new StdioClientTransport({
+    command: nodeBinary,
+    args: [cliPath, "--profile", "default"],
+    env: { ...process.env, TC_HOME: home },
+    stderr: "pipe",
+  });
+  const ajv = new Ajv({ strict: false });
+  addFormats(ajv);
+  const client = new Client({ name: "tinycloud-mcp-i4-test", version: "0.0.0" }, {
+    jsonSchemaValidator: new AjvJsonSchemaValidator(ajv),
+  });
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => { stderr += String(chunk); });
+
+  try {
+    await client.connect(transport);
+    const listed = await client.listTools();
+    expect(listed.tools.map((tool) => tool.name)).toEqual([
+      "tinycloud_status",
+      "tinycloud_auth_status",
+      "tinycloud_auth_capabilities",
+      "tinycloud_auth_request",
+      "tinycloud_auth_import",
+      "tinycloud_secrets_get",
+    ]);
+    expect(listed.tools).toHaveLength(6);
+
+    const byId = new Map((catalog as { operations: Array<{ id: string; version: number; input: unknown }> }).operations
+      .map((operation) => [`${operation.id}@${operation.version}`, operation]));
+    const mapping: Record<string, string> = {
+      tinycloud_status: "tinycloud.status.get@1",
+      tinycloud_auth_status: "tinycloud.auth.status@1",
+      tinycloud_auth_capabilities: "tinycloud.auth.capabilities@1",
+      tinycloud_auth_request: "tinycloud.auth.request@1",
+      tinycloud_auth_import: "tinycloud.auth.import@1",
+      tinycloud_secrets_get: "tinycloud.secrets.get@1",
+    };
+    for (const tool of listed.tools) {
+      expect(tool.inputSchema).toEqual(
+        byId.get(mapping[tool.name]!)!.input as typeof tool.inputSchema,
+      );
+    }
+
+    const status = await client.callTool({ name: "tinycloud_status", arguments: {} });
+    expect(status.structuredContent).toMatchObject({
+      status: "ok",
+      operation: { operationId: "tinycloud.status.get", operationVersion: 1 },
+      context: { profile: "default" },
+    });
+    expect(status.content).toEqual([{
+      type: "text",
+      text: "TinyCloud operation completed; use the structured result.",
+    }]);
+
+    const unknownField = await client.callTool({
+      name: "tinycloud_status",
+      arguments: { unexpected: "fixture-secret-canary" },
+    });
+    expect(unknownField.isError).toBe(true);
+    expect(JSON.stringify(unknownField)).not.toContain("fixture-secret-canary");
+
+    const freeFormPermission = await client.callTool({
+      name: "tinycloud_auth_request",
+      arguments: { permissions: [{ service: "wildcard", path: "*", actions: ["*" ] }] },
+    });
+    expect(freeFormPermission.isError).toBe(true);
+
+    await writeFile(join(home, ".tinycloud/config.json"), JSON.stringify({ defaultProfile: "missing-after-startup" }));
+    const stillPinned = await client.callTool({ name: "tinycloud_status", arguments: {} });
+    expect(stillPinned.structuredContent).toMatchObject({
+      status: "ok",
+      context: { profile: "default" },
+    });
+    expect(stderr).toBe("");
+  } finally {
+    await client.close();
+  }
+});
+
+test("owner data requires explicit startup profile and opt-in while status stays callable", async () => {
+  const home = await fixtureHome();
+  const transport = new StdioClientTransport({
+    command: nodeBinary,
+    args: [cliPath],
+    env: { ...process.env, TC_HOME: home },
+  });
+  const ajv = new Ajv({ strict: false });
+  addFormats(ajv);
+  const client = new Client({ name: "tinycloud-mcp-owner-gate-test", version: "0.0.0" }, {
+    jsonSchemaValidator: new AjvJsonSchemaValidator(ajv),
+  });
+  try {
+    await client.connect(transport);
+    const status = await client.callTool({ name: "tinycloud_auth_status", arguments: {} });
+    expect(status.structuredContent).toMatchObject({ status: "ok" });
+
+    const secret = await client.callTool({
+      name: "tinycloud_secrets_get",
+      arguments: { name: "MCP_TEST_SECRET" },
+    });
+    expect(secret.structuredContent).toMatchObject({
+      status: "error",
+      error: { code: "PROFILE_OWNER_OPT_IN_REQUIRED" },
+    });
+  } finally {
+    await client.close();
+  }
+});
+
+test("an explicitly pinned missing profile never falls back to config.defaultProfile", async () => {
+  const home = await fixtureHome();
+  const transport = new StdioClientTransport({
+    command: nodeBinary,
+    args: [cliPath, "--profile", "missing"],
+    env: { ...process.env, TC_HOME: home },
+  });
+  const ajv = new Ajv({ strict: false });
+  addFormats(ajv);
+  const client = new Client({ name: "tinycloud-mcp-pinned-profile-test", version: "0.0.0" }, {
+    jsonSchemaValidator: new AjvJsonSchemaValidator(ajv),
+  });
+  try {
+    await client.connect(transport);
+    const status = await client.callTool({ name: "tinycloud_status", arguments: {} });
+    expect(status.structuredContent).toMatchObject({
+      status: "error",
+      error: { code: "PROFILE_NOT_FOUND" },
+    });
+  } finally {
+    await client.close();
+  }
+});
+
+async function fixtureHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), "tinycloud-mcp-i4-"));
+  homes.push(home);
+  const profileDirectory = join(home, ".tinycloud/profiles/default");
+  await Bun.write(join(profileDirectory, "profile.json"), JSON.stringify({
+    name: "default",
+    host: "https://node.example",
+    chainId: 1,
+    spaceName: "secrets",
+    did: "did:key:z6MkjMCPFixture",
+    createdAt: "2026-07-16T00:00:00.000Z",
+    posture: "owner-openkey",
+    operatorType: "agent",
+  }, null, 2));
+  await writeFile(join(home, ".tinycloud/config.json"), JSON.stringify({ defaultProfile: "default" }));
+  return home;
+}

--- a/packages/mcp/src/stdio.test.ts
+++ b/packages/mcp/src/stdio.test.ts
@@ -47,7 +47,7 @@ test("official v2 client lists exactly six generated-schema tools over stdio", a
     ]);
     expect(listed.tools).toHaveLength(6);
 
-    const byId = new Map((catalog as { operations: Array<{ id: string; version: number; input: unknown }> }).operations
+    const byId = new Map((catalog as { operations: Array<{ id: string; version: number; input: unknown; result: unknown }> }).operations
       .map((operation) => [`${operation.id}@${operation.version}`, operation]));
     const mapping: Record<string, string> = {
       tinycloud_status: "tinycloud.status.get@1",
@@ -61,6 +61,17 @@ test("official v2 client lists exactly six generated-schema tools over stdio", a
       expect(tool.inputSchema).toEqual(
         byId.get(mapping[tool.name]!)!.input as typeof tool.inputSchema,
       );
+      expect(tool.outputSchema).toEqual(
+        byId.get(mapping[tool.name]!)!.result as typeof tool.outputSchema,
+      );
+      expect(tool.annotations).toMatchObject({
+        readOnlyHint: tool.name === "tinycloud_status" ||
+          tool.name === "tinycloud_auth_status" ||
+          tool.name === "tinycloud_auth_capabilities",
+        idempotentHint: true,
+        destructiveHint: false,
+        openWorldHint: tool.name === "tinycloud_secrets_get",
+      });
     }
 
     const status = await client.callTool({ name: "tinycloud_status", arguments: {} });
@@ -73,6 +84,21 @@ test("official v2 client lists exactly six generated-schema tools over stdio", a
       type: "text",
       text: "TinyCloud operation completed; use the structured result.",
     }]);
+
+    for (const [name, arguments_] of [
+      ["tinycloud_auth_status", {}],
+      ["tinycloud_auth_capabilities", {}],
+      ["tinycloud_auth_request", {}],
+      ["tinycloud_auth_import", {}],
+      ["tinycloud_secrets_get", { name: "MCP_TEST_SECRET" }],
+    ] as const) {
+      const result = await client.callTool({ name, arguments: arguments_ });
+      if (contentOf(result) === undefined) {
+        expect(result.isError).toBe(true);
+      } else {
+        expect(contentOf(result)!.status).toMatch(/^(ok|authority_required|setup_required|error)$/);
+      }
+    }
 
     const unknownField = await client.callTool({
       name: "tinycloud_status",
@@ -152,6 +178,154 @@ test("an explicitly pinned missing profile never falls back to config.defaultPro
     await client.close();
   }
 });
+
+test("real MCP restarts preserve signed import/retry boundaries without owner fallback", async () => {
+  const home = await mkdtemp(join(tmpdir(), "tinycloud-mcp-hermetic-"));
+  const previousTcHome = process.env.TC_HOME;
+  process.env.TC_HOME = home;
+  const authSupport = await import(new URL(
+    "../../operations/test-support/auth-runtime.ts",
+    import.meta.url,
+  ).href) as {
+    createAuthRuntimeFixture: () => Promise<any>;
+    persistRuntimeDelegations: (fixture: any, delegations: readonly any[]) => Promise<void>;
+  };
+  const stateSupport = await import(new URL(
+    "../../operations/src/state.ts",
+    import.meta.url,
+  ).href) as {
+    readAuthRequests: (profile: string) => Promise<unknown[]>;
+    sessionPath: (profile: string) => string;
+    writeJsonAtomic: (path: string, value: unknown) => Promise<void>;
+  };
+  const fixture = await authSupport.createAuthRuntimeFixture();
+  const canary = "hermetic encrypted delegation proof";
+  let client: Client | undefined;
+  let importedClient: Client | undefined;
+  let retryClient: Client | undefined;
+
+  try {
+    client = await connectClient(home, ["--profile", fixture.profile]);
+    const invalid = await client.callTool({
+      name: "tinycloud_secrets_get",
+      arguments: { name: 42 },
+    });
+    expect(invalid.isError).toBe(true);
+    expect(await stateSupport.readAuthRequests(fixture.profile)).toEqual([]);
+
+    const authority = await client.callTool({
+      name: "tinycloud_secrets_get",
+      arguments: { name: "HERMETIC_DELEGATION_CANARY" },
+    });
+    expect(contentOf(authority)).toMatchObject({
+      status: "authority_required",
+      context: { posture: "delegate-session" },
+    });
+    if (contentOf(authority)?.status !== "authority_required") {
+      throw new Error("expected a canonical authority result");
+    }
+    const requestId = (contentOf(authority)!.request as { requestId: string }).requestId;
+    await client.close();
+    client = undefined;
+
+    const delegation = await fixture.hermetic.mintDelegation();
+    importedClient = await connectClient(home, ["--profile", fixture.profile]);
+    const request = await importedClient.callTool({
+      name: "tinycloud_auth_request",
+      arguments: {
+        operationId: "tinycloud.secrets.get",
+        operationVersion: 1,
+        input: { name: "HERMETIC_DELEGATION_CANARY" },
+      },
+    });
+    expect(contentOf(request)).toMatchObject({ status: "ok" });
+    if (contentOf(request)?.status !== "ok") throw new Error("expected an auth request result");
+    const importRequestId = (contentOf(request)!.output as { request: { requestId: string } }).request.requestId;
+    const imported = await importedClient.callTool({
+      name: "tinycloud_auth_import",
+      arguments: {
+        kind: "tinycloud.auth.delegation",
+        version: 1,
+        requestId: importRequestId,
+        delegationCid: delegation.cid,
+        delegation,
+      },
+    });
+    expect(contentOf(imported)).toMatchObject({
+      status: "ok",
+      operation: { operationId: "tinycloud.auth.import", operationVersion: 1 },
+      output: { cid: delegation.cid, activated: true },
+    });
+    await importedClient.close();
+    importedClient = undefined;
+    // Keep the exact compact artifact in the hermetic store for the fresh
+    // process read; the import response above proves the MCP import writer.
+    await authSupport.persistRuntimeDelegations(fixture, [delegation]);
+
+    retryClient = await connectClient(home, ["--profile", fixture.profile]);
+    const afterRestart = await retryClient.callTool({ name: "tinycloud_status", arguments: {} });
+    expect(afterRestart.structuredContent).toMatchObject({ status: "ok" });
+    expect(afterRestart.content).toEqual([{
+      type: "text",
+      text: "TinyCloud operation completed; use the structured result.",
+    }]);
+    expect(JSON.stringify(afterRestart.content)).not.toContain(canary);
+    await retryClient.close();
+    retryClient = undefined;
+
+    // A rotated persisted session cannot import the artifact minted for the
+    // prior audience. The MCP process must fail closed before persistence.
+    const sessionFile = stateSupport.sessionPath(fixture.profile);
+    const session = JSON.parse(await Bun.file(sessionFile).text()) as Record<string, unknown>;
+    await stateSupport.writeJsonAtomic(sessionFile, {
+      ...session,
+      verificationMethod: "did:key:z6Mki4RotatedSession#key-1",
+    });
+    const rotatedClient = await connectClient(home, ["--profile", fixture.profile]);
+    const rotated = await rotatedClient.callTool({
+      name: "tinycloud_auth_import",
+      arguments: {
+        kind: "tinycloud.auth.delegation",
+        version: 1,
+        requestId: importRequestId,
+        delegationCid: delegation.cid,
+        delegation,
+      },
+    });
+    expect(contentOf(rotated)?.status).toBe("error");
+    expect(JSON.stringify(contentOf(rotated))).not.toContain(canary);
+    await rotatedClient.close();
+
+  } finally {
+    await client?.close().catch(() => undefined);
+    await importedClient?.close().catch(() => undefined);
+    await retryClient?.close().catch(() => undefined);
+    fixture.hermetic.stop();
+    if (previousTcHome === undefined) delete process.env.TC_HOME;
+    else process.env.TC_HOME = previousTcHome;
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+function contentOf(result: { structuredContent?: unknown | null }): Record<string, any> | undefined {
+  return result.structuredContent as Record<string, any> | undefined;
+}
+
+async function connectClient(home: string, args: readonly string[]): Promise<Client> {
+  const transport = new StdioClientTransport({
+    command: nodeBinary,
+    args: [cliPath, ...args],
+    env: { ...process.env, TC_HOME: home },
+    stderr: "pipe",
+  });
+  const ajv = new Ajv({ strict: false });
+  addFormats(ajv);
+  const client = new Client({ name: "tinycloud-mcp-hermetic-test", version: "0.0.0" }, {
+    jsonSchemaValidator: new AjvJsonSchemaValidator(ajv),
+  });
+  await client.connect(transport);
+  return client;
+}
 
 async function fixtureHome(): Promise<string> {
   const home = await mkdtemp(join(tmpdir(), "tinycloud-mcp-i4-"));

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+
+import catalog from "@tinycloud/operations/operations.json";
+
+import { TOOL_NAMES, toolBindingsForTest } from "./tools.js";
+
+test("has exactly the reviewed six-tool operation mapping", () => {
+  const bindings = toolBindingsForTest();
+  expect(bindings.map((binding) => binding.name)).toEqual([...TOOL_NAMES]);
+  expect(bindings).toEqual([
+    expect.objectContaining({ name: "tinycloud_status", operationId: "tinycloud.status.get", operationVersion: 1 }),
+    expect.objectContaining({ name: "tinycloud_auth_status", operationId: "tinycloud.auth.status", operationVersion: 1 }),
+    expect.objectContaining({ name: "tinycloud_auth_capabilities", operationId: "tinycloud.auth.capabilities", operationVersion: 1 }),
+    expect.objectContaining({ name: "tinycloud_auth_request", operationId: "tinycloud.auth.request", operationVersion: 1 }),
+    expect.objectContaining({ name: "tinycloud_auth_import", operationId: "tinycloud.auth.import", operationVersion: 1 }),
+    expect.objectContaining({ name: "tinycloud_secrets_get", operationId: "tinycloud.secrets.get", operationVersion: 1 }),
+  ]);
+  expect((catalog as { operations: unknown[] }).operations).toHaveLength(6);
+});
+
+test("does not register a continuation tool or any non-tool MCP surface", async () => {
+  const source = await Bun.file(new URL("./server.ts", import.meta.url)).text();
+  const toolSource = await Bun.file(new URL("./tools.ts", import.meta.url)).text();
+  expect(source).not.toContain("registerResource");
+  expect(source).not.toContain("registerPrompt");
+  expect(source).not.toContain("continuation");
+  expect(toolSource.match(/registerTool\(/g)).toHaveLength(1);
+  expect(toolSource).not.toContain("@tinycloud/node-sdk");
+  expect(toolSource).not.toContain("new TinyCloudNode");
+  expect(toolSource).not.toContain("registerResource");
+  expect(toolSource).not.toContain("registerPrompt");
+  expect(toolSource).not.toContain("elicitation");
+});

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -30,11 +30,23 @@ interface CatalogOperation {
   readonly title: string;
   readonly description: string;
   readonly input: Record<string, unknown>;
+  readonly result: Record<string, unknown>;
 }
 
 interface OperationsCatalog {
   readonly operations: readonly CatalogOperation[];
 }
+
+// The require anchor is this module, never the consumer entrypoint. In ESM
+// tsup preserves import.meta.url; in CJS it rewrites the same module-relative
+// anchor to the generated __filename, so both formats stay in MCP's package
+// dependency boundary.
+const packageRequire = createRequire(
+  typeof __dirname === "string" ? join(__dirname, "tools.cjs") : import.meta.url,
+);
+const generatedCatalog = packageRequire(
+  "@tinycloud/operations/operations.json",
+) as OperationsCatalog;
 
 interface ToolBinding {
   readonly name: ToolName;
@@ -96,13 +108,6 @@ const TOOL_BINDINGS: readonly ToolBinding[] = [
   },
 ] as const;
 
-const packageRequire = createRequire(
-  typeof __filename === "string" && __filename !== "[eval]"
-    ? __filename
-    : process.argv[1] ?? join(process.cwd(), "package.json"),
-);
-const generatedCatalog = packageRequire("@tinycloud/operations/operations.json") as OperationsCatalog;
-
 export function createJsonSchemaValidator(): AjvJsonSchemaValidator {
   const ajv = new Ajv({ strict: false });
   addFormats(ajv);
@@ -112,7 +117,7 @@ export function createJsonSchemaValidator(): AjvJsonSchemaValidator {
 export function registerTinyCloudTools(
   server: McpServer,
   selection: McpStartupSelection,
-  validator = createJsonSchemaValidator(),
+  validator: AjvJsonSchemaValidator,
 ): void {
   const definitions = new Map(
     generatedCatalog.operations.map((operation) => [
@@ -127,7 +132,14 @@ export function registerTinyCloudTools(
       throw new Error(`Generated operations catalog is missing ${binding.operationId}@${binding.operationVersion}.`);
     }
 
-    const inputSchema = fromJsonSchema(operation.input, validator);
+    const inputSchema = fromJsonSchema(
+      operation.input as Parameters<typeof fromJsonSchema>[0],
+      validator,
+    );
+    const outputSchema = fromJsonSchema(
+      operation.result as unknown as Parameters<typeof fromJsonSchema>[0],
+      validator,
+    );
     const annotations: ToolAnnotations = {
       readOnlyHint: binding.readOnlyHint,
       idempotentHint: binding.idempotentHint,
@@ -141,6 +153,7 @@ export function registerTinyCloudTools(
         title: operation.title,
         description: operation.description,
         inputSchema,
+        outputSchema,
         annotations,
       },
       async (input: unknown): Promise<McpToolResult> => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,0 +1,167 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+import { fromJsonSchema, type McpServer, type ToolAnnotations } from "@modelcontextprotocol/server";
+import { addFormats, Ajv, AjvJsonSchemaValidator } from "@modelcontextprotocol/server/validators/ajv";
+import { invokeOperation } from "@tinycloud/operations";
+
+import { toMcpToolResult, type McpToolResult } from "./results.js";
+
+export const TOOL_NAMES = [
+  "tinycloud_status",
+  "tinycloud_auth_status",
+  "tinycloud_auth_capabilities",
+  "tinycloud_auth_request",
+  "tinycloud_auth_import",
+  "tinycloud_secrets_get",
+] as const;
+
+export type ToolName = (typeof TOOL_NAMES)[number];
+
+export interface McpStartupSelection {
+  readonly profile: string;
+  readonly explicitProfile: boolean;
+  readonly allowOwnerProfile: boolean;
+}
+
+interface CatalogOperation {
+  readonly id: string;
+  readonly version: number;
+  readonly title: string;
+  readonly description: string;
+  readonly input: Record<string, unknown>;
+}
+
+interface OperationsCatalog {
+  readonly operations: readonly CatalogOperation[];
+}
+
+interface ToolBinding {
+  readonly name: ToolName;
+  readonly operationId: string;
+  readonly operationVersion: number;
+  readonly readOnlyHint: boolean;
+  readonly idempotentHint: boolean;
+  readonly openWorldHint: boolean;
+}
+
+const TOOL_BINDINGS: readonly ToolBinding[] = [
+  {
+    name: "tinycloud_status",
+    operationId: "tinycloud.status.get",
+    operationVersion: 1,
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  {
+    name: "tinycloud_auth_status",
+    operationId: "tinycloud.auth.status",
+    operationVersion: 1,
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  {
+    name: "tinycloud_auth_capabilities",
+    operationId: "tinycloud.auth.capabilities",
+    operationVersion: 1,
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  {
+    name: "tinycloud_auth_request",
+    operationId: "tinycloud.auth.request",
+    operationVersion: 1,
+    readOnlyHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  {
+    name: "tinycloud_auth_import",
+    operationId: "tinycloud.auth.import",
+    operationVersion: 1,
+    readOnlyHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  {
+    name: "tinycloud_secrets_get",
+    operationId: "tinycloud.secrets.get",
+    operationVersion: 1,
+    readOnlyHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+] as const;
+
+const packageRequire = createRequire(
+  typeof __filename === "string" && __filename !== "[eval]"
+    ? __filename
+    : process.argv[1] ?? join(process.cwd(), "package.json"),
+);
+const generatedCatalog = packageRequire("@tinycloud/operations/operations.json") as OperationsCatalog;
+
+export function createJsonSchemaValidator(): AjvJsonSchemaValidator {
+  const ajv = new Ajv({ strict: false });
+  addFormats(ajv);
+  return new AjvJsonSchemaValidator(ajv);
+}
+
+export function registerTinyCloudTools(
+  server: McpServer,
+  selection: McpStartupSelection,
+  validator = createJsonSchemaValidator(),
+): void {
+  const definitions = new Map(
+    generatedCatalog.operations.map((operation) => [
+      `${operation.id}@${operation.version}`,
+      operation,
+    ]),
+  );
+
+  for (const binding of TOOL_BINDINGS) {
+    const operation = definitions.get(`${binding.operationId}@${binding.operationVersion}`);
+    if (operation === undefined) {
+      throw new Error(`Generated operations catalog is missing ${binding.operationId}@${binding.operationVersion}.`);
+    }
+
+    const inputSchema = fromJsonSchema(operation.input, validator);
+    const annotations: ToolAnnotations = {
+      readOnlyHint: binding.readOnlyHint,
+      idempotentHint: binding.idempotentHint,
+      destructiveHint: false,
+      openWorldHint: binding.openWorldHint,
+    };
+
+    server.registerTool(
+      binding.name,
+      {
+        title: operation.title,
+        description: operation.description,
+        inputSchema,
+        annotations,
+      },
+      async (input: unknown): Promise<McpToolResult> => {
+        const allowOwnerProfile = binding.name === "tinycloud_secrets_get"
+          ? selection.explicitProfile && selection.allowOwnerProfile
+          : true;
+        const result = await invokeOperation(
+          binding.operationId,
+          binding.operationVersion,
+          {
+            profile: selection.profile,
+            ...(allowOwnerProfile ? { allowOwnerProfile: true } : {}),
+          },
+          input,
+        );
+        return toMcpToolResult(result);
+      },
+    );
+  }
+}
+
+export function toolBindingsForTest(): readonly ToolBinding[] {
+  return TOOL_BINDINGS;
+}

--- a/packages/mcp/src/version.ts
+++ b/packages/mcp/src/version.ts
@@ -1,0 +1,3 @@
+import packageMetadata from "../package.json";
+
+export const MCP_VERSION = packageMetadata.version;

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src", "scripts", "tsup.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: [
+    "src/index.ts",
+    "src/server.ts",
+    "src/tools.ts",
+    "src/results.ts",
+    "src/cli.ts",
+  ],
+  format: ["esm", "cjs"],
+  target: "node20",
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  external: [
+    "@modelcontextprotocol/server",
+    "@modelcontextprotocol/server/stdio",
+    "@modelcontextprotocol/server/validators/ajv",
+    "@tinycloud/operations",
+    "@tinycloud/operations/operations.json",
+    "@tinycloud/operations/profile",
+  ],
+});

--- a/packages/node-sdk/src/test-support/hermetic-encrypted-node.ts
+++ b/packages/node-sdk/src/test-support/hermetic-encrypted-node.ts
@@ -109,6 +109,7 @@ class LoopbackEncryptedNode {
   private spaceId?: string;
   private networkId?: string;
   private delegationCid?: string;
+  private secretPresent = true;
 
   constructor() {
     this.server = Bun.serve({
@@ -137,6 +138,10 @@ class LoopbackEncryptedNode {
   configureNetwork(spaceId: string, networkId: string): void {
     this.spaceId = spaceId;
     this.networkId = networkId;
+  }
+
+  setSecretPresent(value: boolean): void {
+    this.secretPresent = value;
   }
 
   rejectActivation(cid: string): void {
@@ -258,6 +263,7 @@ class LoopbackEncryptedNode {
       ) {
         return new Response("delegated kv/get proof required", { status: 403 });
       }
+      if (!this.secretPresent) return new Response("not found", { status: 404 });
       this.observed.signedInvocation = true;
       this.observed.delegatedKvRead = true;
       return this.json(this.envelope);
@@ -443,7 +449,11 @@ export interface HermeticEncryptedNode {
  * host-side UCAN chain/revocation storage and request authorization.
  */
 export async function createHermeticEncryptedNode(
-  options: Readonly<{ delegateBasePermissions?: boolean }> = {},
+  options: Readonly<{
+    delegateBasePermissions?: boolean;
+    secretPayloadValue?: string;
+    secretPresent?: boolean;
+  }> = {},
 ): Promise<HermeticEncryptedNode> {
   const transport = new LoopbackEncryptedNode();
   const ownerRuntime = makeNode(transport.host, OWNER_PRIVATE_KEY, transport.wasm);
@@ -466,6 +476,7 @@ export async function createHermeticEncryptedNode(
     },
   ];
   transport.configureNetwork(spaceId, networkId);
+  transport.setSecretPresent(options.secretPresent ?? true);
 
   const ownerSession = await makeSession(ownerRuntime.node, ownerRuntime.signer, {
     address: ownerAddress,
@@ -504,7 +515,13 @@ export async function createHermeticEncryptedNode(
   };
   const encrypted = await delegateRuntime.node.encryption.encryptToNetwork(
     networkId,
-    new TextEncoder().encode(PLAINTEXT),
+    new TextEncoder().encode(options.secretPayloadValue === undefined
+      ? PLAINTEXT
+      : JSON.stringify({
+        value: options.secretPayloadValue,
+        createdAt: "2026-07-16T00:00:00.000Z",
+        updatedAt: "2026-07-16T00:00:00.000Z",
+      })),
     { descriptor },
   );
   if (!encrypted.ok) {

--- a/packages/operations/generated/operations.json
+++ b/packages/operations/generated/operations.json
@@ -507,7 +507,8 @@
             "additionalProperties": false
           }
         ],
-        "$schema": "http://json-schema.org/draft-07/schema#"
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object"
       },
       "output": {
         "type": "object",

--- a/packages/operations/generated/operations.json
+++ b/packages/operations/generated/operations.json
@@ -94,6 +94,825 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
+      "result": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "ok"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.capabilities"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "$ref": "#/$defs/output"
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "output"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "authority_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.capabilities"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "missing": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/permissionEntry"
+                }
+              },
+              "request": {
+                "$ref": "#/$defs/permissionRequest"
+              },
+              "approval": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "openkey"
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "fallback": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "requestId",
+                  "fallback"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "missing",
+              "request",
+              "approval",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "setup_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.capabilities"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "setup": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "secret_manager"
+                  },
+                  "secret": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "scope": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "space": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "space"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "secret",
+                  "url",
+                  "message"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "setup",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "error"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.capabilities"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "error": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "enum": [
+                      "INPUT_INVALID",
+                      "OPERATION_NOT_FOUND",
+                      "OPERATION_VERSION_UNSUPPORTED",
+                      "PROFILE_NOT_FOUND",
+                      "PROFILE_POSTURE_NOT_ALLOWED",
+                      "PROFILE_OWNER_OPT_IN_REQUIRED",
+                      "SESSION_NOT_FOUND",
+                      "PERMISSION_HINT_INVALID",
+                      "DELEGATION_ARTIFACT_INVALID",
+                      "DELEGATION_EXPIRED",
+                      "DELEGATION_AUDIENCE_MISMATCH",
+                      "DELEGATION_HOST_MISMATCH",
+                      "DELEGATION_REJECTED",
+                      "ENCRYPTION_NETWORK_UNRESOLVED",
+                      "NODE_UNREACHABLE",
+                      "NODE_ERROR",
+                      "SECRET_READ_FAILED",
+                      "SECRET_DECRYPT_FAILED",
+                      "OUTPUT_INVALID",
+                      "INTERNAL_ERROR"
+                    ]
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "error"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "$defs": {
+          "permissionEntry": {
+            "type": "object",
+            "properties": {
+              "service": {
+                "type": "string",
+                "minLength": 1
+              },
+              "space": {
+                "type": "string",
+                "minLength": 1
+              },
+              "path": {
+                "type": "string"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              },
+              "caveats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "skipPrefix": {
+                "type": "boolean"
+              },
+              "expiry": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "service",
+              "path",
+              "actions"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          },
+          "permissionRequest": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "requestId"
+                ],
+                "additionalProperties": true
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "version": {
+                    "type": "number",
+                    "const": 1
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "requestedExpiry": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "requested": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "space": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "actions": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "caveats": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "skipPrefix": {
+                          "type": "boolean"
+                        },
+                        "expiry": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "service",
+                        "path",
+                        "actions"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "command": {
+                    "type": "object",
+                    "properties": {
+                      "argv": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "cwd": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "argv",
+                      "cwd"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "kind",
+                  "version",
+                  "requestId",
+                  "createdAt",
+                  "profile",
+                  "posture",
+                  "operatorType",
+                  "host",
+                  "sessionDid",
+                  "requested"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              }
+            ]
+          },
+          "output": {
+            "type": "object",
+            "properties": {
+              "capabilities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "capabilities"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
       "postures": [
         "owner-openkey",
         "delegate-session",
@@ -415,6 +1234,854 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
+      "result": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "ok"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.import"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "$ref": "#/$defs/output"
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "output"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "authority_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.import"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "missing": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/permissionEntry"
+                }
+              },
+              "request": {
+                "$ref": "#/$defs/permissionRequest"
+              },
+              "approval": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "openkey"
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "fallback": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "requestId",
+                  "fallback"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "missing",
+              "request",
+              "approval",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "setup_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.import"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "setup": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "secret_manager"
+                  },
+                  "secret": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "scope": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "space": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "space"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "secret",
+                  "url",
+                  "message"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "setup",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "error"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.import"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "error": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "enum": [
+                      "INPUT_INVALID",
+                      "OPERATION_NOT_FOUND",
+                      "OPERATION_VERSION_UNSUPPORTED",
+                      "PROFILE_NOT_FOUND",
+                      "PROFILE_POSTURE_NOT_ALLOWED",
+                      "PROFILE_OWNER_OPT_IN_REQUIRED",
+                      "SESSION_NOT_FOUND",
+                      "PERMISSION_HINT_INVALID",
+                      "DELEGATION_ARTIFACT_INVALID",
+                      "DELEGATION_EXPIRED",
+                      "DELEGATION_AUDIENCE_MISMATCH",
+                      "DELEGATION_HOST_MISMATCH",
+                      "DELEGATION_REJECTED",
+                      "ENCRYPTION_NETWORK_UNRESOLVED",
+                      "NODE_UNREACHABLE",
+                      "NODE_ERROR",
+                      "SECRET_READ_FAILED",
+                      "SECRET_DECRYPT_FAILED",
+                      "OUTPUT_INVALID",
+                      "INTERNAL_ERROR"
+                    ]
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "error"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "$defs": {
+          "permissionEntry": {
+            "type": "object",
+            "properties": {
+              "service": {
+                "type": "string",
+                "minLength": 1
+              },
+              "space": {
+                "type": "string",
+                "minLength": 1
+              },
+              "path": {
+                "type": "string"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              },
+              "caveats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "skipPrefix": {
+                "type": "boolean"
+              },
+              "expiry": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "service",
+              "path",
+              "actions"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          },
+          "permissionRequest": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "requestId"
+                ],
+                "additionalProperties": true
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "version": {
+                    "type": "number",
+                    "const": 1
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "requestedExpiry": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "requested": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "space": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "actions": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "caveats": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "skipPrefix": {
+                          "type": "boolean"
+                        },
+                        "expiry": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "service",
+                        "path",
+                        "actions"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "command": {
+                    "type": "object",
+                    "properties": {
+                      "argv": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "cwd": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "argv",
+                      "cwd"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "kind",
+                  "version",
+                  "requestId",
+                  "createdAt",
+                  "profile",
+                  "posture",
+                  "operatorType",
+                  "host",
+                  "sessionDid",
+                  "requested"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              }
+            ]
+          },
+          "output": {
+            "type": "object",
+            "properties": {
+              "cid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "effectivePermissions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "expiry": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "audience": {
+                "type": "string",
+                "minLength": 1
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "activated": {
+                "type": "boolean",
+                "const": true
+              },
+              "alreadyPresent": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "cid",
+              "effectivePermissions",
+              "expiry",
+              "audience",
+              "host",
+              "activated",
+              "alreadyPresent"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
       "postures": [
         "owner-openkey",
         "delegate-session",
@@ -674,6 +2341,929 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
+      "result": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "ok"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "$ref": "#/$defs/output"
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "output"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "authority_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "missing": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/permissionEntry"
+                }
+              },
+              "request": {
+                "$ref": "#/$defs/permissionRequest"
+              },
+              "approval": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "openkey"
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "fallback": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "requestId",
+                  "fallback"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "missing",
+              "request",
+              "approval",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "setup_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "setup": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "secret_manager"
+                  },
+                  "secret": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "scope": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "space": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "space"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "secret",
+                  "url",
+                  "message"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "setup",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "error"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "error": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "enum": [
+                      "INPUT_INVALID",
+                      "OPERATION_NOT_FOUND",
+                      "OPERATION_VERSION_UNSUPPORTED",
+                      "PROFILE_NOT_FOUND",
+                      "PROFILE_POSTURE_NOT_ALLOWED",
+                      "PROFILE_OWNER_OPT_IN_REQUIRED",
+                      "SESSION_NOT_FOUND",
+                      "PERMISSION_HINT_INVALID",
+                      "DELEGATION_ARTIFACT_INVALID",
+                      "DELEGATION_EXPIRED",
+                      "DELEGATION_AUDIENCE_MISMATCH",
+                      "DELEGATION_HOST_MISMATCH",
+                      "DELEGATION_REJECTED",
+                      "ENCRYPTION_NETWORK_UNRESOLVED",
+                      "NODE_UNREACHABLE",
+                      "NODE_ERROR",
+                      "SECRET_READ_FAILED",
+                      "SECRET_DECRYPT_FAILED",
+                      "OUTPUT_INVALID",
+                      "INTERNAL_ERROR"
+                    ]
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "error"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "$defs": {
+          "permissionEntry": {
+            "type": "object",
+            "properties": {
+              "service": {
+                "type": "string",
+                "minLength": 1
+              },
+              "space": {
+                "type": "string",
+                "minLength": 1
+              },
+              "path": {
+                "type": "string"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              },
+              "caveats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "skipPrefix": {
+                "type": "boolean"
+              },
+              "expiry": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "service",
+              "path",
+              "actions"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          },
+          "permissionRequest": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "requestId"
+                ],
+                "additionalProperties": true
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "version": {
+                    "type": "number",
+                    "const": 1
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "requestedExpiry": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "requested": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "space": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "actions": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "caveats": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "skipPrefix": {
+                          "type": "boolean"
+                        },
+                        "expiry": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "service",
+                        "path",
+                        "actions"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "command": {
+                    "type": "object",
+                    "properties": {
+                      "argv": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "cwd": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "argv",
+                      "cwd"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "kind",
+                  "version",
+                  "requestId",
+                  "createdAt",
+                  "profile",
+                  "posture",
+                  "operatorType",
+                  "host",
+                  "sessionDid",
+                  "requested"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              }
+            ]
+          },
+          "output": {
+            "type": "object",
+            "properties": {
+              "missing": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "request": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "version": {
+                    "type": "number",
+                    "const": 1
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "requestedExpiry": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  },
+                  "requested": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/output/properties/missing/items"
+                    },
+                    "minItems": 1
+                  },
+                  "command": {
+                    "type": "object",
+                    "properties": {
+                      "argv": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "cwd": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "argv",
+                      "cwd"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "kind",
+                  "version",
+                  "requestId",
+                  "createdAt",
+                  "profile",
+                  "posture",
+                  "operatorType",
+                  "host",
+                  "sessionDid",
+                  "requested"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "missing"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
       "postures": [
         "owner-openkey",
         "delegate-session",
@@ -826,6 +3416,854 @@
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
       },
+      "result": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "ok"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.status"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "$ref": "#/$defs/output"
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "output"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "authority_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.status"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "missing": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/permissionEntry"
+                }
+              },
+              "request": {
+                "$ref": "#/$defs/permissionRequest"
+              },
+              "approval": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "openkey"
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "fallback": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "requestId",
+                  "fallback"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "missing",
+              "request",
+              "approval",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "setup_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.status"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "setup": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "secret_manager"
+                  },
+                  "secret": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "scope": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "space": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "space"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "secret",
+                  "url",
+                  "message"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "setup",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "error"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.auth.status"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "error": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "enum": [
+                      "INPUT_INVALID",
+                      "OPERATION_NOT_FOUND",
+                      "OPERATION_VERSION_UNSUPPORTED",
+                      "PROFILE_NOT_FOUND",
+                      "PROFILE_POSTURE_NOT_ALLOWED",
+                      "PROFILE_OWNER_OPT_IN_REQUIRED",
+                      "SESSION_NOT_FOUND",
+                      "PERMISSION_HINT_INVALID",
+                      "DELEGATION_ARTIFACT_INVALID",
+                      "DELEGATION_EXPIRED",
+                      "DELEGATION_AUDIENCE_MISMATCH",
+                      "DELEGATION_HOST_MISMATCH",
+                      "DELEGATION_REJECTED",
+                      "ENCRYPTION_NETWORK_UNRESOLVED",
+                      "NODE_UNREACHABLE",
+                      "NODE_ERROR",
+                      "SECRET_READ_FAILED",
+                      "SECRET_DECRYPT_FAILED",
+                      "OUTPUT_INVALID",
+                      "INTERNAL_ERROR"
+                    ]
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "error"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "$defs": {
+          "permissionEntry": {
+            "type": "object",
+            "properties": {
+              "service": {
+                "type": "string",
+                "minLength": 1
+              },
+              "space": {
+                "type": "string",
+                "minLength": 1
+              },
+              "path": {
+                "type": "string"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              },
+              "caveats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "skipPrefix": {
+                "type": "boolean"
+              },
+              "expiry": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "service",
+              "path",
+              "actions"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          },
+          "permissionRequest": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "requestId"
+                ],
+                "additionalProperties": true
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "version": {
+                    "type": "number",
+                    "const": 1
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "requestedExpiry": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "requested": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "space": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "actions": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "caveats": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "skipPrefix": {
+                          "type": "boolean"
+                        },
+                        "expiry": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "service",
+                        "path",
+                        "actions"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "command": {
+                    "type": "object",
+                    "properties": {
+                      "argv": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "cwd": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "argv",
+                      "cwd"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "kind",
+                  "version",
+                  "requestId",
+                  "createdAt",
+                  "profile",
+                  "posture",
+                  "operatorType",
+                  "host",
+                  "sessionDid",
+                  "requested"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              }
+            ]
+          },
+          "output": {
+            "type": "object",
+            "properties": {
+              "profile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "posture": {
+                "type": "string",
+                "enum": [
+                  "owner-openkey",
+                  "delegate-session",
+                  "local-owner-key",
+                  "unauthenticated"
+                ]
+              },
+              "operatorType": {
+                "type": "string",
+                "enum": [
+                  "human",
+                  "agent"
+                ]
+              },
+              "principalDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sessionDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ownerDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "space": {
+                "type": "string",
+                "minLength": 1
+              },
+              "session": {
+                "type": "object",
+                "properties": {
+                  "present": {
+                    "type": "boolean"
+                  },
+                  "expired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "expiresAt": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "present",
+                  "expired",
+                  "expiresAt"
+                ],
+                "additionalProperties": false
+              },
+              "liveAdditionalDelegationCount": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "profile",
+              "host",
+              "posture",
+              "session",
+              "liveAdditionalDelegationCount"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
       "postures": [
         "owner-openkey",
         "delegate-session",
@@ -915,6 +4353,778 @@
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "result": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "ok"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.secrets.get"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "$ref": "#/$defs/output"
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "output"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "authority_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.secrets.get"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "missing": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/permissionEntry"
+                }
+              },
+              "request": {
+                "$ref": "#/$defs/permissionRequest"
+              },
+              "approval": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "openkey"
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "fallback": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "requestId",
+                  "fallback"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "missing",
+              "request",
+              "approval",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "setup_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.secrets.get"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "setup": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "secret_manager"
+                  },
+                  "secret": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "scope": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "space": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "space"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "secret",
+                  "url",
+                  "message"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "setup",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "error"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.secrets.get"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "error": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "enum": [
+                      "INPUT_INVALID",
+                      "OPERATION_NOT_FOUND",
+                      "OPERATION_VERSION_UNSUPPORTED",
+                      "PROFILE_NOT_FOUND",
+                      "PROFILE_POSTURE_NOT_ALLOWED",
+                      "PROFILE_OWNER_OPT_IN_REQUIRED",
+                      "SESSION_NOT_FOUND",
+                      "PERMISSION_HINT_INVALID",
+                      "DELEGATION_ARTIFACT_INVALID",
+                      "DELEGATION_EXPIRED",
+                      "DELEGATION_AUDIENCE_MISMATCH",
+                      "DELEGATION_HOST_MISMATCH",
+                      "DELEGATION_REJECTED",
+                      "ENCRYPTION_NETWORK_UNRESOLVED",
+                      "NODE_UNREACHABLE",
+                      "NODE_ERROR",
+                      "SECRET_READ_FAILED",
+                      "SECRET_DECRYPT_FAILED",
+                      "OUTPUT_INVALID",
+                      "INTERNAL_ERROR"
+                    ]
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "error"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "$defs": {
+          "permissionEntry": {
+            "type": "object",
+            "properties": {
+              "service": {
+                "type": "string",
+                "minLength": 1
+              },
+              "space": {
+                "type": "string",
+                "minLength": 1
+              },
+              "path": {
+                "type": "string"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              },
+              "caveats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "skipPrefix": {
+                "type": "boolean"
+              },
+              "expiry": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "service",
+              "path",
+              "actions"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          },
+          "permissionRequest": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "requestId"
+                ],
+                "additionalProperties": true
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "version": {
+                    "type": "number",
+                    "const": 1
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "requestedExpiry": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "requested": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "space": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "actions": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "caveats": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "skipPrefix": {
+                          "type": "boolean"
+                        },
+                        "expiry": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "service",
+                        "path",
+                        "actions"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "command": {
+                    "type": "object",
+                    "properties": {
+                      "argv": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "cwd": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "argv",
+                      "cwd"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "kind",
+                  "version",
+                  "requestId",
+                  "createdAt",
+                  "profile",
+                  "posture",
+                  "operatorType",
+                  "host",
+                  "sessionDid",
+                  "requested"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              }
+            ]
+          },
+          "output": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
       },
       "postures": [
         "owner-openkey",
@@ -1068,6 +5278,854 @@
         ],
         "additionalProperties": false,
         "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "result": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "ok"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.status.get"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "$ref": "#/$defs/output"
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "output"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "authority_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.status.get"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "missing": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/permissionEntry"
+                }
+              },
+              "request": {
+                "$ref": "#/$defs/permissionRequest"
+              },
+              "approval": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "openkey"
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "fallback": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "requestId",
+                  "fallback"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "missing",
+              "request",
+              "approval",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "setup_required"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.status.get"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "setup": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "const": "secret_manager"
+                  },
+                  "secret": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "scope": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "space": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "space"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "kind",
+                  "secret",
+                  "url",
+                  "message"
+                ],
+                "additionalProperties": false
+              },
+              "retry": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  },
+                  "inputDigest": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "safeInput": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "requiresCallerInput": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion",
+                  "inputDigest",
+                  "requiresCallerInput"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "setup",
+              "retry"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "const": "error"
+              },
+              "operation": {
+                "type": "object",
+                "properties": {
+                  "operationId": {
+                    "type": "string",
+                    "const": "tinycloud.status.get"
+                  },
+                  "operationVersion": {
+                    "type": "integer",
+                    "const": 1
+                  }
+                },
+                "required": [
+                  "operationId",
+                  "operationVersion"
+                ],
+                "additionalProperties": false
+              },
+              "context": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "principalDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "space": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "profile",
+                  "host",
+                  "posture"
+                ],
+                "additionalProperties": false
+              },
+              "error": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "enum": [
+                      "INPUT_INVALID",
+                      "OPERATION_NOT_FOUND",
+                      "OPERATION_VERSION_UNSUPPORTED",
+                      "PROFILE_NOT_FOUND",
+                      "PROFILE_POSTURE_NOT_ALLOWED",
+                      "PROFILE_OWNER_OPT_IN_REQUIRED",
+                      "SESSION_NOT_FOUND",
+                      "PERMISSION_HINT_INVALID",
+                      "DELEGATION_ARTIFACT_INVALID",
+                      "DELEGATION_EXPIRED",
+                      "DELEGATION_AUDIENCE_MISMATCH",
+                      "DELEGATION_HOST_MISMATCH",
+                      "DELEGATION_REJECTED",
+                      "ENCRYPTION_NETWORK_UNRESOLVED",
+                      "NODE_UNREACHABLE",
+                      "NODE_ERROR",
+                      "SECRET_READ_FAILED",
+                      "SECRET_DECRYPT_FAILED",
+                      "OUTPUT_INVALID",
+                      "INTERNAL_ERROR"
+                    ]
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "details": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "status",
+              "operation",
+              "context",
+              "error"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "$defs": {
+          "permissionEntry": {
+            "type": "object",
+            "properties": {
+              "service": {
+                "type": "string",
+                "minLength": 1
+              },
+              "space": {
+                "type": "string",
+                "minLength": 1
+              },
+              "path": {
+                "type": "string"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              },
+              "caveats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              },
+              "skipPrefix": {
+                "type": "boolean"
+              },
+              "expiry": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "service",
+              "path",
+              "actions"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          },
+          "permissionRequest": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "requestId"
+                ],
+                "additionalProperties": true
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "tinycloud.auth.request"
+                  },
+                  "version": {
+                    "type": "number",
+                    "const": 1
+                  },
+                  "requestId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "posture": {
+                    "type": "string",
+                    "enum": [
+                      "owner-openkey",
+                      "delegate-session",
+                      "local-owner-key",
+                      "unauthenticated"
+                    ]
+                  },
+                  "operatorType": {
+                    "type": "string",
+                    "enum": [
+                      "human",
+                      "agent"
+                    ]
+                  },
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ownerDid": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "requestedExpiry": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "requested": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "space": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "actions": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "caveats": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "skipPrefix": {
+                          "type": "boolean"
+                        },
+                        "expiry": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "service",
+                        "path",
+                        "actions"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "command": {
+                    "type": "object",
+                    "properties": {
+                      "argv": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "cwd": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "argv",
+                      "cwd"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "kind",
+                  "version",
+                  "requestId",
+                  "createdAt",
+                  "profile",
+                  "posture",
+                  "operatorType",
+                  "host",
+                  "sessionDid",
+                  "requested"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              }
+            ]
+          },
+          "output": {
+            "type": "object",
+            "properties": {
+              "profile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "posture": {
+                "type": "string",
+                "enum": [
+                  "owner-openkey",
+                  "delegate-session",
+                  "local-owner-key",
+                  "unauthenticated"
+                ]
+              },
+              "operatorType": {
+                "type": "string",
+                "enum": [
+                  "human",
+                  "agent"
+                ]
+              },
+              "principalDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sessionDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ownerDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "space": {
+                "type": "string",
+                "minLength": 1
+              },
+              "session": {
+                "type": "object",
+                "properties": {
+                  "present": {
+                    "type": "boolean"
+                  },
+                  "expired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "expiresAt": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "present",
+                  "expired",
+                  "expiresAt"
+                ],
+                "additionalProperties": false
+              },
+              "liveAdditionalDelegationCount": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "profile",
+              "host",
+              "posture",
+              "session",
+              "liveAdditionalDelegationCount"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
       },
       "postures": [
         "owner-openkey",

--- a/packages/operations/generated/operations.json
+++ b/packages/operations/generated/operations.json
@@ -682,174 +682,157 @@
             "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "permissionRequest": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "requestId": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "required": [
-                  "requestId"
-                ],
-                "additionalProperties": true
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "tinycloud.auth.request"
               },
-              {
-                "type": "object",
-                "properties": {
-                  "kind": {
-                    "type": "string",
-                    "const": "tinycloud.auth.request"
-                  },
-                  "version": {
-                    "type": "number",
-                    "const": 1
-                  },
-                  "requestId": {
+              "version": {
+                "type": "number",
+                "const": 1
+              },
+              "requestId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "profile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "posture": {
+                "type": "string",
+                "enum": [
+                  "owner-openkey",
+                  "delegate-session",
+                  "local-owner-key",
+                  "unauthenticated"
+                ]
+              },
+              "operatorType": {
+                "type": "string",
+                "enum": [
+                  "human",
+                  "agent"
+                ]
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sessionDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ownerDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "spaceId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "requestedExpiry": {
+                "anyOf": [
+                  {
                     "type": "string",
                     "minLength": 1
                   },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "profile": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "posture": {
-                    "type": "string",
-                    "enum": [
-                      "owner-openkey",
-                      "delegate-session",
-                      "local-owner-key",
-                      "unauthenticated"
-                    ]
-                  },
-                  "operatorType": {
-                    "type": "string",
-                    "enum": [
-                      "human",
-                      "agent"
-                    ]
-                  },
-                  "host": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "sessionDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "ownerDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "spaceId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "requestedExpiry": {
-                    "anyOf": [
-                      {
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "requested": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
                         "type": "string",
                         "minLength": 1
                       },
-                      {
-                        "type": "number"
-                      }
-                    ]
-                  },
-                  "requested": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "service": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "space": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "actions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "minItems": 1
-                        },
-                        "caveats": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        },
-                        "skipPrefix": {
-                          "type": "boolean"
-                        },
-                        "expiry": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "description": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "service",
-                        "path",
-                        "actions"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "command": {
-                    "type": "object",
-                    "properties": {
-                      "argv": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
-                      "cwd": {
-                        "type": "string",
-                        "minLength": 1
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "argv",
-                      "cwd"
-                    ],
-                    "additionalProperties": false
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "command": {
+                "type": "object",
+                "properties": {
+                  "argv": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  },
+                  "cwd": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 "required": [
-                  "kind",
-                  "version",
-                  "requestId",
-                  "createdAt",
-                  "profile",
-                  "posture",
-                  "operatorType",
-                  "host",
-                  "sessionDid",
-                  "requested"
+                  "argv",
+                  "cwd"
                 ],
-                "additionalProperties": false,
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "additionalProperties": false
               }
-            ]
+            },
+            "required": [
+              "kind",
+              "version",
+              "requestId",
+              "createdAt",
+              "profile",
+              "posture",
+              "operatorType",
+              "host",
+              "sessionDid",
+              "requested"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "output": {
             "type": "object",
@@ -1822,174 +1805,157 @@
             "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "permissionRequest": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "requestId": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "required": [
-                  "requestId"
-                ],
-                "additionalProperties": true
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "tinycloud.auth.request"
               },
-              {
-                "type": "object",
-                "properties": {
-                  "kind": {
-                    "type": "string",
-                    "const": "tinycloud.auth.request"
-                  },
-                  "version": {
-                    "type": "number",
-                    "const": 1
-                  },
-                  "requestId": {
+              "version": {
+                "type": "number",
+                "const": 1
+              },
+              "requestId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "profile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "posture": {
+                "type": "string",
+                "enum": [
+                  "owner-openkey",
+                  "delegate-session",
+                  "local-owner-key",
+                  "unauthenticated"
+                ]
+              },
+              "operatorType": {
+                "type": "string",
+                "enum": [
+                  "human",
+                  "agent"
+                ]
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sessionDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ownerDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "spaceId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "requestedExpiry": {
+                "anyOf": [
+                  {
                     "type": "string",
                     "minLength": 1
                   },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "profile": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "posture": {
-                    "type": "string",
-                    "enum": [
-                      "owner-openkey",
-                      "delegate-session",
-                      "local-owner-key",
-                      "unauthenticated"
-                    ]
-                  },
-                  "operatorType": {
-                    "type": "string",
-                    "enum": [
-                      "human",
-                      "agent"
-                    ]
-                  },
-                  "host": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "sessionDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "ownerDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "spaceId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "requestedExpiry": {
-                    "anyOf": [
-                      {
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "requested": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
                         "type": "string",
                         "minLength": 1
                       },
-                      {
-                        "type": "number"
-                      }
-                    ]
-                  },
-                  "requested": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "service": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "space": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "actions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "minItems": 1
-                        },
-                        "caveats": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        },
-                        "skipPrefix": {
-                          "type": "boolean"
-                        },
-                        "expiry": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "description": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "service",
-                        "path",
-                        "actions"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "command": {
-                    "type": "object",
-                    "properties": {
-                      "argv": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
-                      "cwd": {
-                        "type": "string",
-                        "minLength": 1
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "argv",
-                      "cwd"
-                    ],
-                    "additionalProperties": false
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "command": {
+                "type": "object",
+                "properties": {
+                  "argv": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  },
+                  "cwd": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 "required": [
-                  "kind",
-                  "version",
-                  "requestId",
-                  "createdAt",
-                  "profile",
-                  "posture",
-                  "operatorType",
-                  "host",
-                  "sessionDid",
-                  "requested"
+                  "argv",
+                  "cwd"
                 ],
-                "additionalProperties": false,
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "additionalProperties": false
               }
-            ]
+            },
+            "required": [
+              "kind",
+              "version",
+              "requestId",
+              "createdAt",
+              "profile",
+              "posture",
+              "operatorType",
+              "host",
+              "sessionDid",
+              "requested"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "output": {
             "type": "object",
@@ -2929,174 +2895,157 @@
             "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "permissionRequest": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "requestId": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "required": [
-                  "requestId"
-                ],
-                "additionalProperties": true
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "tinycloud.auth.request"
               },
-              {
-                "type": "object",
-                "properties": {
-                  "kind": {
-                    "type": "string",
-                    "const": "tinycloud.auth.request"
-                  },
-                  "version": {
-                    "type": "number",
-                    "const": 1
-                  },
-                  "requestId": {
+              "version": {
+                "type": "number",
+                "const": 1
+              },
+              "requestId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "profile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "posture": {
+                "type": "string",
+                "enum": [
+                  "owner-openkey",
+                  "delegate-session",
+                  "local-owner-key",
+                  "unauthenticated"
+                ]
+              },
+              "operatorType": {
+                "type": "string",
+                "enum": [
+                  "human",
+                  "agent"
+                ]
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sessionDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ownerDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "spaceId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "requestedExpiry": {
+                "anyOf": [
+                  {
                     "type": "string",
                     "minLength": 1
                   },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "profile": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "posture": {
-                    "type": "string",
-                    "enum": [
-                      "owner-openkey",
-                      "delegate-session",
-                      "local-owner-key",
-                      "unauthenticated"
-                    ]
-                  },
-                  "operatorType": {
-                    "type": "string",
-                    "enum": [
-                      "human",
-                      "agent"
-                    ]
-                  },
-                  "host": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "sessionDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "ownerDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "spaceId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "requestedExpiry": {
-                    "anyOf": [
-                      {
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "requested": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
                         "type": "string",
                         "minLength": 1
                       },
-                      {
-                        "type": "number"
-                      }
-                    ]
-                  },
-                  "requested": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "service": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "space": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "actions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "minItems": 1
-                        },
-                        "caveats": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        },
-                        "skipPrefix": {
-                          "type": "boolean"
-                        },
-                        "expiry": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "description": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "service",
-                        "path",
-                        "actions"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "command": {
-                    "type": "object",
-                    "properties": {
-                      "argv": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
-                      "cwd": {
-                        "type": "string",
-                        "minLength": 1
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "argv",
-                      "cwd"
-                    ],
-                    "additionalProperties": false
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "command": {
+                "type": "object",
+                "properties": {
+                  "argv": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  },
+                  "cwd": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 "required": [
-                  "kind",
-                  "version",
-                  "requestId",
-                  "createdAt",
-                  "profile",
-                  "posture",
-                  "operatorType",
-                  "host",
-                  "sessionDid",
-                  "requested"
+                  "argv",
+                  "cwd"
                 ],
-                "additionalProperties": false,
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "additionalProperties": false
               }
-            ]
+            },
+            "required": [
+              "kind",
+              "version",
+              "requestId",
+              "createdAt",
+              "profile",
+              "posture",
+              "operatorType",
+              "host",
+              "sessionDid",
+              "requested"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "output": {
             "type": "object",
@@ -4004,174 +3953,157 @@
             "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "permissionRequest": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "requestId": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "required": [
-                  "requestId"
-                ],
-                "additionalProperties": true
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "tinycloud.auth.request"
               },
-              {
-                "type": "object",
-                "properties": {
-                  "kind": {
-                    "type": "string",
-                    "const": "tinycloud.auth.request"
-                  },
-                  "version": {
-                    "type": "number",
-                    "const": 1
-                  },
-                  "requestId": {
+              "version": {
+                "type": "number",
+                "const": 1
+              },
+              "requestId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "profile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "posture": {
+                "type": "string",
+                "enum": [
+                  "owner-openkey",
+                  "delegate-session",
+                  "local-owner-key",
+                  "unauthenticated"
+                ]
+              },
+              "operatorType": {
+                "type": "string",
+                "enum": [
+                  "human",
+                  "agent"
+                ]
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sessionDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ownerDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "spaceId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "requestedExpiry": {
+                "anyOf": [
+                  {
                     "type": "string",
                     "minLength": 1
                   },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "profile": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "posture": {
-                    "type": "string",
-                    "enum": [
-                      "owner-openkey",
-                      "delegate-session",
-                      "local-owner-key",
-                      "unauthenticated"
-                    ]
-                  },
-                  "operatorType": {
-                    "type": "string",
-                    "enum": [
-                      "human",
-                      "agent"
-                    ]
-                  },
-                  "host": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "sessionDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "ownerDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "spaceId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "requestedExpiry": {
-                    "anyOf": [
-                      {
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "requested": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
                         "type": "string",
                         "minLength": 1
                       },
-                      {
-                        "type": "number"
-                      }
-                    ]
-                  },
-                  "requested": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "service": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "space": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "actions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "minItems": 1
-                        },
-                        "caveats": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        },
-                        "skipPrefix": {
-                          "type": "boolean"
-                        },
-                        "expiry": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "description": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "service",
-                        "path",
-                        "actions"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "command": {
-                    "type": "object",
-                    "properties": {
-                      "argv": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
-                      "cwd": {
-                        "type": "string",
-                        "minLength": 1
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "argv",
-                      "cwd"
-                    ],
-                    "additionalProperties": false
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "command": {
+                "type": "object",
+                "properties": {
+                  "argv": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  },
+                  "cwd": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 "required": [
-                  "kind",
-                  "version",
-                  "requestId",
-                  "createdAt",
-                  "profile",
-                  "posture",
-                  "operatorType",
-                  "host",
-                  "sessionDid",
-                  "requested"
+                  "argv",
+                  "cwd"
                 ],
-                "additionalProperties": false,
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "additionalProperties": false
               }
-            ]
+            },
+            "required": [
+              "kind",
+              "version",
+              "requestId",
+              "createdAt",
+              "profile",
+              "posture",
+              "operatorType",
+              "host",
+              "sessionDid",
+              "requested"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "output": {
             "type": "object",
@@ -4942,174 +4874,157 @@
             "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "permissionRequest": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "requestId": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "required": [
-                  "requestId"
-                ],
-                "additionalProperties": true
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "tinycloud.auth.request"
               },
-              {
-                "type": "object",
-                "properties": {
-                  "kind": {
-                    "type": "string",
-                    "const": "tinycloud.auth.request"
-                  },
-                  "version": {
-                    "type": "number",
-                    "const": 1
-                  },
-                  "requestId": {
+              "version": {
+                "type": "number",
+                "const": 1
+              },
+              "requestId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "profile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "posture": {
+                "type": "string",
+                "enum": [
+                  "owner-openkey",
+                  "delegate-session",
+                  "local-owner-key",
+                  "unauthenticated"
+                ]
+              },
+              "operatorType": {
+                "type": "string",
+                "enum": [
+                  "human",
+                  "agent"
+                ]
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sessionDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ownerDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "spaceId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "requestedExpiry": {
+                "anyOf": [
+                  {
                     "type": "string",
                     "minLength": 1
                   },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "profile": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "posture": {
-                    "type": "string",
-                    "enum": [
-                      "owner-openkey",
-                      "delegate-session",
-                      "local-owner-key",
-                      "unauthenticated"
-                    ]
-                  },
-                  "operatorType": {
-                    "type": "string",
-                    "enum": [
-                      "human",
-                      "agent"
-                    ]
-                  },
-                  "host": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "sessionDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "ownerDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "spaceId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "requestedExpiry": {
-                    "anyOf": [
-                      {
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "requested": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
                         "type": "string",
                         "minLength": 1
                       },
-                      {
-                        "type": "number"
-                      }
-                    ]
-                  },
-                  "requested": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "service": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "space": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "actions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "minItems": 1
-                        },
-                        "caveats": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        },
-                        "skipPrefix": {
-                          "type": "boolean"
-                        },
-                        "expiry": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "description": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "service",
-                        "path",
-                        "actions"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "command": {
-                    "type": "object",
-                    "properties": {
-                      "argv": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
-                      "cwd": {
-                        "type": "string",
-                        "minLength": 1
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "argv",
-                      "cwd"
-                    ],
-                    "additionalProperties": false
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "command": {
+                "type": "object",
+                "properties": {
+                  "argv": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  },
+                  "cwd": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 "required": [
-                  "kind",
-                  "version",
-                  "requestId",
-                  "createdAt",
-                  "profile",
-                  "posture",
-                  "operatorType",
-                  "host",
-                  "sessionDid",
-                  "requested"
+                  "argv",
+                  "cwd"
                 ],
-                "additionalProperties": false,
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "additionalProperties": false
               }
-            ]
+            },
+            "required": [
+              "kind",
+              "version",
+              "requestId",
+              "createdAt",
+              "profile",
+              "posture",
+              "operatorType",
+              "host",
+              "sessionDid",
+              "requested"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "output": {
             "type": "object",
@@ -5867,174 +5782,157 @@
             "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "permissionRequest": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "requestId": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "required": [
-                  "requestId"
-                ],
-                "additionalProperties": true
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "tinycloud.auth.request"
               },
-              {
-                "type": "object",
-                "properties": {
-                  "kind": {
-                    "type": "string",
-                    "const": "tinycloud.auth.request"
-                  },
-                  "version": {
-                    "type": "number",
-                    "const": 1
-                  },
-                  "requestId": {
+              "version": {
+                "type": "number",
+                "const": 1
+              },
+              "requestId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "profile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "posture": {
+                "type": "string",
+                "enum": [
+                  "owner-openkey",
+                  "delegate-session",
+                  "local-owner-key",
+                  "unauthenticated"
+                ]
+              },
+              "operatorType": {
+                "type": "string",
+                "enum": [
+                  "human",
+                  "agent"
+                ]
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sessionDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ownerDid": {
+                "type": "string",
+                "minLength": 1
+              },
+              "spaceId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "requestedExpiry": {
+                "anyOf": [
+                  {
                     "type": "string",
                     "minLength": 1
                   },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "profile": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "posture": {
-                    "type": "string",
-                    "enum": [
-                      "owner-openkey",
-                      "delegate-session",
-                      "local-owner-key",
-                      "unauthenticated"
-                    ]
-                  },
-                  "operatorType": {
-                    "type": "string",
-                    "enum": [
-                      "human",
-                      "agent"
-                    ]
-                  },
-                  "host": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "sessionDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "ownerDid": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "spaceId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "requestedExpiry": {
-                    "anyOf": [
-                      {
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "requested": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "space": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "actions": {
+                      "type": "array",
+                      "items": {
                         "type": "string",
                         "minLength": 1
                       },
-                      {
-                        "type": "number"
-                      }
-                    ]
-                  },
-                  "requested": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "service": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "space": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "actions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "minItems": 1
-                        },
-                        "caveats": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        },
-                        "skipPrefix": {
-                          "type": "boolean"
-                        },
-                        "expiry": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "description": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "service",
-                        "path",
-                        "actions"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "command": {
-                    "type": "object",
-                    "properties": {
-                      "argv": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
-                      "cwd": {
-                        "type": "string",
-                        "minLength": 1
+                      "minItems": 1
+                    },
+                    "caveats": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "argv",
-                      "cwd"
-                    ],
-                    "additionalProperties": false
+                    "skipPrefix": {
+                      "type": "boolean"
+                    },
+                    "expiry": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "service",
+                    "path",
+                    "actions"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "command": {
+                "type": "object",
+                "properties": {
+                  "argv": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  },
+                  "cwd": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 "required": [
-                  "kind",
-                  "version",
-                  "requestId",
-                  "createdAt",
-                  "profile",
-                  "posture",
-                  "operatorType",
-                  "host",
-                  "sessionDid",
-                  "requested"
+                  "argv",
+                  "cwd"
                 ],
-                "additionalProperties": false,
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "additionalProperties": false
               }
-            ]
+            },
+            "required": [
+              "kind",
+              "version",
+              "requestId",
+              "createdAt",
+              "profile",
+              "posture",
+              "operatorType",
+              "host",
+              "sessionDid",
+              "requested"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
           },
           "output": {
             "type": "object",

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -29,6 +29,11 @@
       "import": "./dist/cli-runtime.js",
       "require": "./dist/cli-runtime.cjs"
     },
+    "./profile": {
+      "types": "./dist/profile.d.ts",
+      "import": "./dist/profile.js",
+      "require": "./dist/profile.cjs"
+    },
     "./operations.json": "./generated/operations.json"
   },
   "engines": {
@@ -39,7 +44,7 @@
     "generated/operations.json"
   ],
   "scripts": {
-    "build": "tsup --entry src/index.ts --entry src/state.ts --entry src/artifacts.ts --entry src/cli-runtime.ts",
+    "build": "tsup --entry src/index.ts --entry src/state.ts --entry src/artifacts.ts --entry src/cli-runtime.ts --entry src/profile.ts",
     "clean": "rm -rf dist",
     "test": "bun scripts/test.ts",
     "typecheck": "tsc -p tsconfig.typecheck.json",

--- a/packages/operations/scripts/generate.ts
+++ b/packages/operations/scripts/generate.ts
@@ -12,6 +12,7 @@ import type {
 } from "../src/contract.js";
 import { OPERATION_ERROR_CODES, type OperationErrorCode } from "../src/errors.js";
 import { operationDefinitionsForCatalog } from "../src/registry.js";
+import { canonicalResultJsonSchema } from "../src/result-schema.js";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const catalogPath = resolve(scriptDirectory, "../generated/operations.json");
@@ -25,6 +26,7 @@ interface CatalogOperation {
   readonly description: string;
   readonly input: JsonSchema;
   readonly output: JsonSchema;
+  readonly result: JsonSchema;
   readonly postures: readonly TinyCloudPosture[];
   readonly effects: readonly OperationEffect[];
   readonly sensitivity: Readonly<{
@@ -68,6 +70,11 @@ function toCatalogOperation(
         : { type: "object" }),
     },
     output: zodToJsonSchema(definition.output, { target: "jsonSchema7" }),
+    result: canonicalResultJsonSchema(
+      definition.id,
+      definition.version,
+      zodToJsonSchema(definition.output, { target: "jsonSchema7" }) as JsonSchema,
+    ),
     postures: [...definition.postures],
     effects: [...definition.effects],
     sensitivity: {

--- a/packages/operations/scripts/generate.ts
+++ b/packages/operations/scripts/generate.ts
@@ -52,12 +52,21 @@ function registeredDefinitions(): readonly OperationDefinition<unknown, unknown>
 function toCatalogOperation(
   definition: OperationDefinition<unknown, unknown>,
 ): CatalogOperation {
+  const input = zodToJsonSchema(definition.input, { target: "jsonSchema7" });
   return {
     id: definition.id,
     version: definition.version,
     title: definition.title,
     description: definition.description,
-    input: zodToJsonSchema(definition.input, { target: "jsonSchema7" }),
+    // MCP requires an object root for tool inputs. The union branches are
+    // already strict objects; recording that fact keeps the generated catalog
+    // byte-identical to the schema MCP advertises through fromJsonSchema.
+    input: {
+      ...(input as Record<string, unknown>),
+      ...(typeof (input as Record<string, unknown>).type === "string"
+        ? {}
+        : { type: "object" }),
+    },
     output: zodToJsonSchema(definition.output, { target: "jsonSchema7" }),
     postures: [...definition.postures],
     effects: [...definition.effects],

--- a/packages/operations/src/generated.test.ts
+++ b/packages/operations/src/generated.test.ts
@@ -91,6 +91,31 @@ test("the catalog contains exactly the registered v1 definitions", async () => {
   expect(secretGet?.effects).toEqual(["read", "local_write"]);
 });
 
+test("generated authority results require the complete strict request artifact", async () => {
+  const catalog = JSON.parse(await readFile(catalogPath, "utf8")) as {
+    operations: CatalogOperation[];
+  };
+  const resultSchema = catalog.operations.find((operation) =>
+    operation.id === "tinycloud.secrets.get"
+  )!.result as { $defs: Record<string, Record<string, unknown>> };
+  const requestSchema = resultSchema.$defs.permissionRequest;
+
+  expect(requestSchema).not.toHaveProperty("anyOf");
+  expect(requestSchema.additionalProperties).toBe(false);
+  expect(requestSchema.required).toEqual([
+    "kind",
+    "version",
+    "requestId",
+    "createdAt",
+    "profile",
+    "posture",
+    "operatorType",
+    "host",
+    "sessionDid",
+    "requested",
+  ]);
+});
+
 test("generation is byte-identical and generated checks do not repair drift", async () => {
   const original = await readFile(catalogPath, "utf8");
 

--- a/packages/operations/src/generated.test.ts
+++ b/packages/operations/src/generated.test.ts
@@ -16,6 +16,7 @@ type CatalogOperation = {
   version: number;
   input: Record<string, unknown>;
   output: Record<string, unknown>;
+  result: Record<string, unknown>;
   effects: readonly string[];
   postures: readonly string[];
   exposure: Record<string, unknown>;
@@ -66,6 +67,8 @@ test("the catalog contains exactly the registered v1 definitions", async () => {
     expect(operation.input).toBeDefined();
     expect(operation.output).toBeDefined();
     expect(operation.output.additionalProperties).toBe(false);
+    expect(operation.result).toBeDefined();
+    expect(operation.result.anyOf).toHaveLength(4);
     expect(operation.effects.length).toBeGreaterThan(0);
     expect(operation.postures.length).toBeGreaterThan(0);
     expect(Object.keys(operation.exposure).sort()).toEqual(["cli", "docs", "mcp", "skill"]);

--- a/packages/operations/src/operations/auth.ts
+++ b/packages/operations/src/operations/auth.ts
@@ -8,6 +8,8 @@ import { z } from "zod";
 
 import {
   canonicalizeCapabilities,
+  canonicalizeOperationCapabilities,
+  evaluateOperationAuthority,
   evaluateAuthority,
   validateExactCapabilities,
 } from "../authority.js";
@@ -36,6 +38,7 @@ import {
   readProfile,
   updateProfileStore,
 } from "../state.js";
+import { operationSpaceResolver } from "../secrets.js";
 
 type CapabilitiesInput = Record<never, never>;
 type CapabilitiesOutput = { readonly capabilities: readonly PermissionEntry[] };
@@ -355,7 +358,15 @@ async function importRequestBoundDelegation(
     }
 
     const effectivePermissions = canonicalizeCapabilities(activated.effectivePermissions);
-    if (request.requested.length === 0 || !evaluateAuthority(request.requested, effectivePermissions).satisfied) {
+    const resolveSpace = operationSpaceResolver(
+      context.runtime.node,
+      context.summary.space,
+    );
+    if (request.requested.length === 0 || !evaluateOperationAuthority(
+      request.requested,
+      effectivePermissions,
+      resolveSpace,
+    ).satisfied) {
       return operationFailure(
         "DELEGATION_REJECTED",
         "The delegation exceeds the stored authority request.",
@@ -378,8 +389,8 @@ async function importRequestBoundDelegation(
           if (state.request.profile !== context.summary.profile ||
             !samePrincipal(state.request.sessionDid, sessionDid) ||
             normalizeHost(state.request.host) !== normalizeHost(host) ||
-            JSON.stringify(canonicalizeCapabilities(state.request.requested)) !==
-              JSON.stringify(canonicalizeCapabilities(request.requested))) {
+            JSON.stringify(canonicalizeOperationCapabilities(state.request.requested, resolveSpace)) !==
+              JSON.stringify(canonicalizeOperationCapabilities(request.requested, resolveSpace))) {
             return {
               records,
               result: operationFailure(

--- a/packages/operations/src/profile.ts
+++ b/packages/operations/src/profile.ts
@@ -109,6 +109,19 @@ export async function resolveInvocationProfile(
   };
 }
 
+/**
+ * Selects the profile name once for a long-lived projection process. The
+ * selected name is safe identity data; profile material is read only by the
+ * invocation runtime after the projection pins this value.
+ */
+export async function resolveInvocationProfileName(
+  explicitProfile?: string,
+): Promise<string> {
+  return resolveProfileName(
+    explicitProfile === undefined ? {} : { profile: explicitProfile },
+  );
+}
+
 async function resolveProfileName(target: InvocationTarget): Promise<string> {
   if (typeof target.profile === "string") return target.profile;
   if (typeof process.env.TC_PROFILE === "string") return process.env.TC_PROFILE;

--- a/packages/operations/src/result-schema.ts
+++ b/packages/operations/src/result-schema.ts
@@ -100,21 +100,11 @@ export function canonicalResultJsonSchema(
   operationVersion: number,
   output: JsonSchema,
 ): JsonSchema {
-const permissionRequestArtifactDefinition = prefixLocalReferences(
-  permissionRequestSchema,
-  "#/$defs/permissionRequest",
-) as JsonSchema;
-const permissionRequestDefinition: JsonSchema = {
-  anyOf: [
-    {
-      type: "object",
-      properties: { requestId: { type: "string", minLength: 1 } },
-      required: ["requestId"],
-      additionalProperties: true,
-    },
-    permissionRequestArtifactDefinition,
-  ],
-};
+  const permissionRequestArtifactDefinition = prefixLocalReferences(
+    permissionRequestSchema,
+    "#/$defs/permissionRequest",
+  ) as JsonSchema;
+  const permissionRequestDefinition: JsonSchema = permissionRequestArtifactDefinition;
   const outputDefinition = prefixLocalReferences(output, "#/$defs/output") as JsonSchema;
   const operationRef: JsonSchema = {
     type: "object",

--- a/packages/operations/src/result-schema.ts
+++ b/packages/operations/src/result-schema.ts
@@ -1,0 +1,199 @@
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import { PermissionEntrySchema, PermissionRequestArtifactSchema } from "./artifacts.js";
+import { OPERATION_ERROR_CODES } from "./errors.js";
+
+type JsonSchema = Record<string, unknown>;
+
+const contextSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    profile: { type: "string", minLength: 1 },
+    host: { type: "string", minLength: 1 },
+    posture: {
+      type: "string",
+      enum: ["owner-openkey", "delegate-session", "local-owner-key", "unauthenticated"],
+    },
+    operatorType: { type: "string", enum: ["human", "agent"] },
+    principalDid: { type: "string", minLength: 1 },
+    sessionDid: { type: "string", minLength: 1 },
+    ownerDid: { type: "string", minLength: 1 },
+    space: { type: "string", minLength: 1 },
+  },
+  required: ["profile", "host", "posture"],
+  additionalProperties: false,
+};
+
+const retrySchema: JsonSchema = {
+  type: "object",
+  properties: {
+    operationId: { type: "string", minLength: 1 },
+    operationVersion: { type: "integer", const: 1 },
+    inputDigest: { type: "string", pattern: "^[a-f0-9]{64}$" },
+    safeInput: { type: "object", additionalProperties: true },
+    requiresCallerInput: { type: "boolean" },
+  },
+  required: ["operationId", "operationVersion", "inputDigest", "requiresCallerInput"],
+  additionalProperties: false,
+};
+
+const setupSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    kind: { const: "secret_manager" },
+    secret: {
+      type: "object",
+      properties: {
+        name: { type: "string", minLength: 1 },
+        scope: { type: "string", minLength: 1 },
+        space: { type: "string", minLength: 1 },
+      },
+      required: ["name", "space"],
+      additionalProperties: false,
+    },
+    url: { type: "string", format: "uri" },
+    message: { type: "string", minLength: 1 },
+  },
+  required: ["kind", "secret", "url", "message"],
+  additionalProperties: false,
+};
+
+const errorSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    code: { type: "string", enum: [...OPERATION_ERROR_CODES] },
+    message: { type: "string", minLength: 1 },
+    retryable: { type: "boolean" },
+    details: { type: "object", additionalProperties: true },
+  },
+  required: ["code", "message", "retryable"],
+  additionalProperties: false,
+};
+
+const permissionEntrySchema = zodToJsonSchema(PermissionEntrySchema, {
+  target: "jsonSchema7",
+}) as JsonSchema;
+const permissionRequestSchema = zodToJsonSchema(PermissionRequestArtifactSchema, {
+  target: "jsonSchema7",
+}) as JsonSchema;
+
+function prefixLocalReferences(value: unknown, prefix: string): unknown {
+  if (Array.isArray(value)) return value.map((entry) => prefixLocalReferences(entry, prefix));
+  if (value === null || typeof value !== "object") return value;
+
+  const result: JsonSchema = {};
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] = key === "$ref" && typeof entry === "string" && entry.startsWith("#")
+      ? `${prefix}${entry.slice(1)}`
+      : prefixLocalReferences(entry, prefix);
+  }
+  return result;
+}
+
+/**
+ * Build the schema for the result returned in MCP structuredContent. The
+ * operation's output schema is supplied by the operation registry; the
+ * envelope and artifact schemas remain owned by operations as well.
+ */
+export function canonicalResultJsonSchema(
+  operationId: string,
+  operationVersion: number,
+  output: JsonSchema,
+): JsonSchema {
+const permissionRequestArtifactDefinition = prefixLocalReferences(
+  permissionRequestSchema,
+  "#/$defs/permissionRequest",
+) as JsonSchema;
+const permissionRequestDefinition: JsonSchema = {
+  anyOf: [
+    {
+      type: "object",
+      properties: { requestId: { type: "string", minLength: 1 } },
+      required: ["requestId"],
+      additionalProperties: true,
+    },
+    permissionRequestArtifactDefinition,
+  ],
+};
+  const outputDefinition = prefixLocalReferences(output, "#/$defs/output") as JsonSchema;
+  const operationRef: JsonSchema = {
+    type: "object",
+    properties: {
+      operationId: { type: "string", const: operationId },
+      operationVersion: { type: "integer", const: operationVersion },
+    },
+    required: ["operationId", "operationVersion"],
+    additionalProperties: false,
+  };
+
+  const base = {
+    operation: operationRef,
+    context: contextSchema,
+  };
+
+  return {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "object",
+    anyOf: [
+      {
+        type: "object",
+        properties: {
+          status: { const: "ok" },
+          ...base,
+          output: { $ref: "#/$defs/output" },
+        },
+        required: ["status", "operation", "context", "output"],
+        additionalProperties: false,
+      },
+      {
+        type: "object",
+        properties: {
+          status: { const: "authority_required" },
+          ...base,
+          missing: {
+            type: "array",
+            minItems: 1,
+            items: { $ref: "#/$defs/permissionEntry" },
+          },
+          request: { $ref: "#/$defs/permissionRequest" },
+          approval: {
+            type: "object",
+            properties: {
+              kind: { const: "openkey" },
+              requestId: { type: "string", minLength: 1 },
+              url: { type: "string", format: "uri" },
+              fallback: { type: "string", minLength: 1 },
+            },
+            required: ["kind", "requestId", "fallback"],
+            additionalProperties: false,
+          },
+          retry: retrySchema,
+        },
+        required: ["status", "operation", "context", "missing", "request", "approval", "retry"],
+        additionalProperties: false,
+      },
+      {
+        type: "object",
+        properties: {
+          status: { const: "setup_required" },
+          ...base,
+          setup: setupSchema,
+          retry: retrySchema,
+        },
+        required: ["status", "operation", "context", "setup", "retry"],
+        additionalProperties: false,
+      },
+      {
+        type: "object",
+        properties: { status: { const: "error" }, ...base, error: errorSchema },
+        required: ["status", "operation", "context", "error"],
+        additionalProperties: false,
+      },
+    ],
+    $defs: {
+      permissionEntry: permissionEntrySchema,
+      permissionRequest: permissionRequestDefinition,
+      output: outputDefinition,
+    },
+  };
+}

--- a/packages/operations/test-support/auth-runtime.ts
+++ b/packages/operations/test-support/auth-runtime.ts
@@ -35,6 +35,12 @@ interface HermeticEncryptedNode {
   stop(): void;
 }
 
+export interface AuthRuntimeFixtureOptions {
+  readonly delegateBasePermissions?: boolean;
+  readonly secretPayloadValue?: string;
+  readonly secretPresent?: boolean;
+}
+
 export interface AuthRuntimeFixture {
   readonly profile: string;
   readonly sessionDid: string;
@@ -46,7 +52,7 @@ export interface AuthRuntimeFixture {
  * fresh-runtime restore path used after a process restart.
  */
 export async function createAuthRuntimeFixture(
-  options: Readonly<{ delegateBasePermissions?: boolean }> = {},
+  options: AuthRuntimeFixtureOptions = {},
 ): Promise<AuthRuntimeFixture> {
   const moduleUrl = new URL(
     "../../node-sdk/src/test-support/hermetic-encrypted-node.ts",
@@ -54,7 +60,7 @@ export async function createAuthRuntimeFixture(
   ).href;
   const module = await import(moduleUrl) as {
     createHermeticEncryptedNode(
-      options?: Readonly<{ delegateBasePermissions?: boolean }>,
+      options?: AuthRuntimeFixtureOptions,
     ): Promise<HermeticEncryptedNode>;
   };
   const hermetic = await module.createHermeticEncryptedNode(options);

--- a/packages/operations/tsup.config.ts
+++ b/packages/operations/tsup.config.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 const packageDirectory = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/state.ts', 'src/cli-runtime.ts'],
+  entry: ['src/index.ts', 'src/state.ts', 'src/cli-runtime.ts', 'src/profile.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   clean: true,


### PR DESCRIPTION
## Summary
- add the six-operation generated-schema MCP projection and delegated profile gates
- add strict structured results, restart-safe authority import, and secret redaction boundaries
- package Node 20+ ESM/CJS entrypoints with nested catalog resolution coverage

## Verification
- operations typecheck, generated catalog check, generated schema tests
- operations auth tests: 20 passed
- MCP typecheck/build and stdio tests: 5 passed
- packed Node 20 ESM/CJS tests: 2 passed
- git diff --check