### PR TITLE
fix(tests): align KV delete mock response

### DIFF
--- a/tests/sdk-services/src/MockKVService.ts
+++ b/tests/sdk-services/src/MockKVService.ts
@@ -320,7 +320,10 @@ export class MockKVService implements IKVService {
     return ok({ keys });
   }
 
-  async delete(key: string, options?: KVDeleteOptions): Promise<Result<void>> {
+  async delete(
+    key: string,
+    options?: KVDeleteOptions
+  ): Promise<Result<KVResponse<void>>> {
     this.recordOperation("delete", key, undefined, options);
 
     const fullKey = this.getFullKey(key, options?.prefix);
@@ -338,14 +341,18 @@ export class MockKVService implements IKVService {
       return err(serviceError(ErrorCodes.ABORTED, "Request aborted", "kv"));
     }
 
-    if (!this._store.has(fullKey)) {
+    const stored = this._store.get(fullKey);
+    if (!stored) {
       return err(
         serviceError(ErrorCodes.KV_NOT_FOUND, `Key not found: ${key}`, "kv")
       );
     }
 
     this._store.delete(fullKey);
-    return ok(undefined);
+    return ok({
+      data: undefined as void,
+      headers: this.createHeaders(stored),
+    });
   }
 
   async head(


### PR DESCRIPTION
## Summary\n- update MockKVService.delete to implement the current IKVService response contract\n- preserve the deleted value's response headers in the mock result\n\n## Verification\n- built @tinycloud/sdk-services\n- built @tinycloud/sdk-services-test\n\nUnblocks the beta/stable release pipeline after #340.