### PR TITLE
docs(mcp): publish complete npm discovery surface

### DIFF
--- a/.changeset/fresh-mcp-discovery.md
+++ b/.changeset/fresh-mcp-discovery.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/mcp": patch
+---
+
+Publish the stable 16-tool MCP setup, delegated workflow, KV CRUD, and SQLite
+surface in the npm README and package discovery metadata.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,23 +1,87 @@
 # @tinycloud/mcp
 
-Experimental local stdio MCP projection for the canonical TinyCloud operations
-package. It starts in `delegate-session` posture and pins one profile at
-startup. Owner-profile data execution requires an explicit profile selection
-and `--allow-owner-profile`; there is no silent owner fallback.
+Local stdio MCP server for delegated TinyCloud operations. It pins one
+TinyCloud profile at startup, defaults to `delegate-session` posture, and never
+silently falls back to owner authority.
 
-The tools expose generated operation schemas and canonical structured
-envelopes. An agent can inspect account spaces and applications, then request
-exact delegated access to list or read KV data in a selected non-secrets
-space. Permission requests contain only exact capabilities and redacted
-context. Secret values are not written to TinyCloud logs, errors,
-stderr, request/delegation files, audit records, generated artifacts, or the
-MCP text content channel. MCP hosts may retain structured results in their own
-transcripts, which is outside this package’s control.
+## Requirements
 
-The package is published as a beta and requires Node.js 20 or newer.
+- Node.js 20 or newer
+- `@tinycloud/cli`
+- A delegated TinyCloud profile
+- A TinyCloud node running 1.6.0 or newer
 
-A new `delegate-session` profile has a key but no TinyCloud session. Bootstrap
-it once with the CLI by creating an exact `tc auth request --cap ...` artifact,
-having the owner grant that request, and importing the result with
-`tc auth import`. Start MCP after that import; subsequent exact requests and
-imports can use the MCP tools.
+## Install and configure
+
+```bash
+npm install --global @tinycloud/cli @tinycloud/mcp
+```
+
+Configure a local stdio server in your MCP client:
+
+```json
+{
+  "mcpServers": {
+    "tinycloud": {
+      "command": "tinycloud-mcp",
+      "args": ["--profile", "agent"]
+    }
+  }
+}
+```
+
+The selected profile is fixed for the life of the process. Restart the server
+to select another profile.
+
+## Tools
+
+The server exposes 16 tools:
+
+- Local and authorization state: `tinycloud_status`,
+  `tinycloud_auth_status`, `tinycloud_auth_capabilities`
+- Exact permission flow: `tinycloud_auth_request`, `tinycloud_auth_import`
+- Account discovery: `tinycloud_account_spaces_list`,
+  `tinycloud_account_applications_list`
+- Bounded KV CRUD: `tinycloud_kv_list`, `tinycloud_kv_get`,
+  `tinycloud_kv_head`, `tinycloud_kv_put`, `tinycloud_kv_delete`
+- Bounded SQLite: `tinycloud_sql_schema_inspect`, `tinycloud_sql_query`,
+  `tinycloud_sql_execute`
+- Delegated secrets: `tinycloud_secrets_get`
+
+Results use canonical structured envelopes with `ok`, `authority_required`,
+`setup_required`, or `error` status. Data operations plan authority for the
+exact space and key, prefix, or database supplied by the caller. Missing
+authority returns an exact, resumable request instead of widening access.
+
+KV values support text, JSON, and lossless base64 content. Conditional replace
+and delete use the strong ETag returned by `tinycloud_kv_head`. SQLite queries
+are read-only and bounded; SQL execution accepts one parameterized `INSERT`,
+`UPDATE`, or `DELETE` and requires explicit acknowledgement that the delegated
+SQL write capability is database-wide.
+
+## Delegate bootstrap
+
+A new `delegate-session` profile has a key but no TinyCloud authority. Complete
+the one-time bootstrap flow before starting MCP:
+
+1. Create an exact request with `tc auth request --cap ...`.
+2. Have the owner grant that request.
+3. Import the returned delegation with `tc auth import`.
+
+After bootstrap, MCP tools can create exact permission requests and import the
+request-bound delegations. Requests and imports persist, so approval and retry
+can happen in separate processes.
+
+Owner-profile data execution is disabled by default. It requires both an
+explicit owner profile and `--allow-owner-profile`.
+
+## Documentation
+
+- [TinyCloud MCP setup and tool reference](https://docs.tinycloud.xyz/cli/mcp)
+- [Access and explore my TinyCloud](https://docs.tinycloud.xyz/guides/access-and-explore-my-tinycloud)
+- [Agent-readable documentation index](https://docs.tinycloud.xyz/llms.txt)
+
+Secret values are excluded from TinyCloud text output, logs, errors, request
+files, delegation files, and generated artifacts. MCP hosts may retain
+structured tool results in their own transcripts, so use a client and retention
+policy appropriate for secrets.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,6 +2,16 @@
   "name": "@tinycloud/mcp",
   "version": "0.2.0",
   "description": "TinyCloud delegated operations MCP server",
+  "keywords": [
+    "tinycloud",
+    "mcp",
+    "model-context-protocol",
+    "agents",
+    "delegation",
+    "ucan",
+    "kv",
+    "sqlite"
+  ],
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
   "type": "module",
@@ -63,6 +73,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tinycloudlabs/web-sdk"
-  }
+    "url": "https://github.com/TinyCloudLabs/js-sdk"
+  },
+  "homepage": "https://docs.tinycloud.xyz/cli/mcp"
 }


### PR DESCRIPTION
## Summary
- replace the stale experimental/beta npm README with the stable 16-tool MCP setup
- document exact delegated bootstrap, KV CRUD, bounded SQLite, secrets, and owner opt-in behavior
- point npm metadata at the current js-sdk repository and MCP docs, with discovery keywords
- add an MCP-only patch changeset for 0.2.1

## Verification
- Prettier check passes for all changed files
- package.json parses
- changesets resolves only @tinycloud/mcp, 0.2.0 -> 0.2.1-beta.0
- git diff --check passes

This corrects the README currently published with @tinycloud/mcp@0.2.0, which still describes the package as beta and omits KV mutation and SQLite tools.