### PR TITLE
ci: allow package-only stable releases

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -218,9 +218,13 @@ jobs:
       - name: Create GitHub Release
         run: |
           VERSION=$(node -e "console.log(require('./packages/web-sdk/package.json').version)")
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
-            --generate-notes \
-            --target master
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "GitHub release v${VERSION} already exists; package-only release is complete."
+          else
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes \
+              --target master
+          fi
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- make the final GitHub release step idempotent when the web SDK tag already exists
- allow package-only stable publishes, such as @tinycloud/mcp 0.2.1, to finish cleanly

## Verification
- YAML parses
- git diff --check passes
- actionlint reports only the two pre-existing SC2015 findings at lines 116 and 209; the changed step is clean