### PR TITLE
chore: add changeset for TC-106 localhost-first resolution

### DIFF
--- a/.changeset/tc-106-localhost-first.md
+++ b/.changeset/tc-106-localhost-first.md
@@ -1,0 +1,8 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/web-sdk": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/cli": minor
+---
+
+Add localhost-first node resolution with identity pinning. Before falling back to registry/hosted resolution, `resolveTinyCloudHosts` now probes for a locally-running TinyCloud node (loopback, then `*.local.tinycloud.link`) and uses it if it answers and passes DID identity verification (trust-on-first-use, pinned per consumer). New opt-out and config knobs: `autoDiscoverLocalNode` (default true), `localNodeUrl`, `localLinkName`, `expectedNodeDid`, surfaced on node-sdk, web-sdk, and the CLI. Explicit host configuration (`host`, `--host`/`TC_HOST`) continues to skip discovery entirely.


### PR DESCRIPTION
## Summary
- PR #346 (TC-106: localhost-first node resolution with identity pinning) merged to master without a changeset, so the next beta/stable release would not pick up a version bump for the new SDK surface.
- Adds a minor-bump changeset for `@tinycloud/sdk-core`, `@tinycloud/web-sdk`, `@tinycloud/node-sdk`, and `@tinycloud/cli` (localhost-first discovery is additive/opt-out, so minor per the linked-package convention in `.changeset/config.json`).
- Verified with `bunx @changesets/cli status --verbose`: this changeset resolves to `sdk-core`/`web-sdk`/`node-sdk` → `2.9.0-beta.0` and `cli` → `0.8.0-beta.0` (repo is currently in changesets pre/beta mode). `@tinycloud/sdk-services` is linked to the same version group and will sync automatically at release time even without its own changeset.

## Test plan
- [x] `bunx --bun @changesets/cli status --verbose` shows the expected minor bumps consuming this changeset
- [ ] Merge to master triggers the `beta` job in `.github/workflows/changesets.yml`, which should version/build/publish beta packages containing the TC-106 localhost-first exports