### PR TITLE
fix(mcp): continue deploy after image publish

### DIFF
--- a/.github/workflows/mcp-image.yml
+++ b/.github/workflows/mcp-image.yml
@@ -31,14 +31,6 @@ jobs:
           tags: |
             ghcr.io/tinycloudlabs/tinycloud-mcp:${{ inputs.package_version }}
             ghcr.io/tinycloudlabs/tinycloud-mcp:latest
-      - name: Make image public
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh api --method PATCH
-          /orgs/TinyCloudLabs/packages/container/tinycloud-mcp
-          -f visibility=public
-
   deploy:
     needs: image
     runs-on: ubuntu-latest


### PR DESCRIPTION
The hosted image is already public through the repository package settings. Remove the redundant package-visibility API call, which the workflow token cannot administer and which prevented the Phala deploy job from running after a successful image push.

Verification: `gh api /orgs/TinyCloudLabs/packages/container/tinycloud-mcp` reports `visibility: public`.