### PR TITLE
fix(mcp): let Phala select deployment region

### DIFF
--- a/.github/workflows/mcp-image.yml
+++ b/.github/workflows/mcp-image.yml
@@ -53,7 +53,7 @@ jobs:
           if phala cvms ls --json | jq -e '.items[] | select(.cvmName == "tinycloud-mcp")' >/dev/null; then
             target=(--cvm-id tinycloud-mcp)
           else
-            target=(--name tinycloud-mcp --instance-type tdx.small --region us-west)
+            target=(--name tinycloud-mcp --instance-type tdx.small)
           fi
           phala deploy \
             --api-token "$PHALA_CLOUD_API_KEY" \


### PR DESCRIPTION
Remove the hard-coded `us-west` placement preference. The first production deploy found no matching `tdx.small` capacity there; Phala can select an available region automatically.