### PR TITLE
TC-272: batch KV reads and memoize descriptors

### DIFF
--- a/.changeset/fast-batch-reads.md
+++ b/.changeset/fast-batch-reads.md
@@ -1,0 +1,7 @@
+---
+"@tinycloud/node-sdk": minor
+"@tinycloud/sdk-core": minor
+"@tinycloud/sdk-services": minor
+---
+
+Add batch KV reads and memoize TinyCloud node descriptor lookups to reduce SDK round trips.

--- a/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.restoreSession.test.ts
@@ -111,6 +111,64 @@ function legacyBindings(): IWasmBindings {
 }
 
 describe("TinyCloudNode.restoreSession session-key lifecycle", () => {
+  test("memoizes encryption descriptors within one session graph and refreshes after restore", async () => {
+    const originalFetch = globalThis.fetch;
+    const networkId = "urn:tinycloud:encryption:did:key:zTest:default";
+    let descriptorFetches = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (!url.includes("/encryption/networks/")) {
+        throw new Error(`Unexpected fetch: ${url}`);
+      }
+      descriptorFetches++;
+      return new Response(JSON.stringify({
+        networkId,
+        ownerDid: "did:key:zTest",
+        name: "default",
+        members: [{ nodeId: "did:key:zNode", role: "primary" }],
+        threshold: { n: 1, t: 1 },
+        state: "active",
+        publicEncryptionKey: "AQ==",
+        alg: "x25519-aes256gcm/v1",
+        keyVersion: descriptorFetches,
+        keyBackend: "local-one-of-one",
+        createdAt: "2026-07-24T00:00:00.000Z",
+        updatedAt: "2026-07-24T00:00:00.000Z",
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    try {
+      const proof = await signedRestorableSession();
+      const node = new TinyCloudNode({
+        signer: new PrivateKeySigner(PROOF_PRIVATE_KEY),
+        wasmBindings: new NodeWasmBindings(),
+      });
+      await node.restoreSession({ ...proof, tinycloudHosts: ["https://one.example"] });
+
+      const firstService = node.encryption;
+      const [first, concurrent] = await Promise.all([
+        (firstService as any).config.node.fetchByNetworkId(networkId),
+        (firstService as any).config.node.fetchByNetworkId(networkId),
+      ]);
+      const cached = await (firstService as any).config.node.fetchByNetworkId(networkId);
+      expect(descriptorFetches).toBe(1);
+      expect(concurrent).toEqual(first);
+      expect(cached).toEqual(first);
+
+      await node.restoreSession({ ...proof, tinycloudHosts: ["https://two.example"] });
+      const refreshed = await (node.encryption as any).config.node.fetchByNetworkId(
+        networkId,
+      );
+      expect(descriptorFetches).toBe(2);
+      expect(refreshed.keyVersion).toBe(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("exposes cryptographically restored base-session ReCap authority through the public API", async () => {
     const proof = await signedRestorableSession({
       abilities: { kv: { "vault/secrets/API_KEY": ["tinycloud.kv/get"] } },

--- a/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.runtimePermissions.test.ts
@@ -1558,10 +1558,10 @@ describe("TinyCloudNode runtime permission delegations", () => {
       expect(new TextDecoder().decode(decryptResult.data)).toBe(
         "hello tinycloud encryption",
       );
-      expect(fetchCalls.map((call) => call.method)).toEqual(["GET", "GET", "POST"]);
+      expect(fetchCalls.map((call) => call.method)).toEqual(["GET", "POST"]);
       expect(signRawNetworkAuthorization).toHaveBeenCalledTimes(1);
 
-      const postCall = fetchCalls[2];
+      const postCall = fetchCalls[1];
       expect(postCall.url).toBe(
         `https://tinycloud.test/encryption/networks/${encodeURIComponent(networkId)}/decrypt`,
       );

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -3205,6 +3205,10 @@ export class TinyCloudNode {
     const address = binding?.address ?? this._address;
     const chainId = binding?.chainId ?? this._chainId;
     const crypto = this.createEncryptionCrypto();
+    // Successful descriptor lookups are immutable for a key version. Cache
+    // and coalesce them for this session graph; replacing the graph replaces
+    // this cache. Misses and failures remain retryable.
+    const descriptorCache = new Map<string, Promise<NetworkDescriptor | null>>();
     const transport: DecryptTransport = {
       postDecrypt: async ({ networkId, authorization, canonicalBody, signal }) => {
         graph.assertActive();
@@ -3270,7 +3274,20 @@ export class TinyCloudNode {
       node: {
         fetchByNetworkId: async (networkId) => {
           graph.assertActive();
-          const descriptor = await this.fetchEncryptionNetworkAt(host, networkId, graph.fetch);
+          let pending = descriptorCache.get(networkId);
+          if (!pending) {
+            pending = this.fetchEncryptionNetworkAt(host, networkId, graph.fetch)
+              .then((descriptor) => {
+                if (descriptor === null) descriptorCache.delete(networkId);
+                return descriptor;
+              })
+              .catch((error) => {
+                descriptorCache.delete(networkId);
+                throw error;
+              });
+            descriptorCache.set(networkId, pending);
+          }
+          const descriptor = await pending;
           graph.assertActive();
           return descriptor;
         },

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -190,6 +190,7 @@ export type {
   KVServiceConfig,
   KVCreateSignedReadUrlOptions,
   KVResponse,
+  KVBatchReadResponse,
   KVSignedReadUrlResponse,
   IPrefixedKVService,
 } from "@tinycloud/sdk-core";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -232,6 +232,7 @@ export type {
   KVServiceConfig,
   KVCreateSignedReadUrlOptions,
   KVResponse,
+  KVBatchReadResponse,
   KVSignedReadUrlResponse,
   IPrefixedKVService,
 } from "@tinycloud/sdk-core";

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -169,6 +169,7 @@ export {
   type KVHeadOptions,
   type KVCreateSignedReadUrlOptions,
   type KVResponse,
+  type KVBatchReadResponse,
   type KVListResponse,
   type KVSignedReadUrlResponse,
   type KVResponseHeaders,

--- a/packages/sdk-services/src/index.ts
+++ b/packages/sdk-services/src/index.ts
@@ -183,6 +183,7 @@ export type {
   KVBatchPutItem,
   KVBatchPutOptions,
   KVBatchPutResponse,
+  KVBatchReadResponse,
   KVListOptions,
   KVDeleteOptions,
   KVHeadOptions,

--- a/packages/sdk-services/src/kv/IKVService.ts
+++ b/packages/sdk-services/src/kv/IKVService.ts
@@ -14,6 +14,7 @@ import {
   KVBatchPutItem,
   KVBatchPutOptions,
   KVBatchPutResponse,
+  KVBatchReadResponse,
   KVListOptions,
   KVDeleteOptions,
   KVHeadOptions,
@@ -63,6 +64,11 @@ export interface IKVService extends IService {
     key: string,
     options?: KVGetOptions
   ): Promise<Result<KVResponse<T>>>;
+
+  batchGet<T = unknown>(
+    keys: string[],
+    options?: KVGetOptions
+  ): Promise<Result<KVBatchReadResponse<T>>>;
 
   /**
    * Store a value at a key.
@@ -158,6 +164,11 @@ export interface IKVService extends IService {
    * ```
    */
   head(key: string, options?: KVHeadOptions): Promise<Result<KVResponse<void>>>;
+
+  batchHead(
+    keys: string[],
+    options?: KVHeadOptions
+  ): Promise<Result<KVBatchReadResponse<void>>>;
 
   /**
    * Create a short-lived signed URL for reading a KV object.

--- a/packages/sdk-services/src/kv/KVService.test.ts
+++ b/packages/sdk-services/src/kv/KVService.test.ts
@@ -95,6 +95,141 @@ function createContext(
   };
 }
 
+describe("KVService batch reads", () => {
+  test("reduces three gets from three signatures and requests to one", async () => {
+    const individualInvocations: Array<{
+      service: string;
+      path: string;
+      action: string;
+    }> = [];
+    let individualFetches = 0;
+    const individual = new KVService({ prefix: "app" });
+    individual.initialize(
+      createContext(async () => {
+        individualFetches++;
+        return response(true, 200, { value: 1 });
+      }, individualInvocations)
+    );
+    await Promise.all(["a", "b", "c"].map((key) => individual.get(key)));
+
+    const batchInvocations: Array<{ entries: InvokeAnyEntry[] }> = [];
+    let batchFetches = 0;
+    const batch = new KVService({ prefix: "app" });
+    batch.initialize(
+      createContext(async () => {
+        batchFetches++;
+        return response(true, 200, {
+          results: ["a", "b", "c"].map((key) => ({
+            key: `app/${key}`,
+            ok: true,
+            dataBase64: btoa(JSON.stringify({ key })),
+            headers: { "content-type": "application/json" },
+          })),
+        });
+      }, [], batchInvocations)
+    );
+    const result = await batch.batchGet<{ key: string }>(["a", "b", "c"]);
+
+    expect([individualInvocations.length, individualFetches]).toEqual([3, 3]);
+    expect([batchInvocations.length, batchFetches]).toEqual([1, 1]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(
+        result.data.results.map((item) =>
+          item.result.ok ? item.result.data.data.key : "failed"
+        )
+      ).toEqual(["a", "b", "c"]);
+    }
+  });
+
+  test("returns missing keys as explicit per-item failures", async () => {
+    const invokeAnyCalls: Array<{ entries: InvokeAnyEntry[] }> = [];
+    const service = new KVService({ prefix: "app" });
+    service.initialize(
+      createContext(async () =>
+        response(true, 200, {
+          results: [
+            {
+              key: "app/found",
+              ok: true,
+              dataBase64: btoa("hello"),
+              headers: { "content-type": "text/plain" },
+            },
+            {
+              key: "app/missing",
+              ok: false,
+              error: {
+                code: ErrorCodes.KV_NOT_FOUND,
+                message: "Key not found: app/missing",
+              },
+            },
+          ],
+        }), [], invokeAnyCalls)
+    );
+
+    const result = await service.batchGet<string>(["found", "missing"]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.results[0]!.result).toMatchObject({
+        ok: true,
+        data: { data: "hello" },
+      });
+      expect(result.data.results[1]!.result).toMatchObject({
+        ok: false,
+        error: { code: ErrorCodes.KV_NOT_FOUND },
+      });
+    }
+  });
+
+  test("batchHead and prefixed batchGet preserve caller keys", async () => {
+    const invokeAnyCalls: Array<{ entries: InvokeAnyEntry[] }> = [];
+    let call = 0;
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () => {
+        call++;
+        return response(true, 200, {
+          results: ["one", "two"].map((key) => ({
+            key: `/audio/${key}`,
+            ok: true,
+            ...(call === 2 ? { dataBase64: btoa(key) } : {}),
+            headers: {
+              "content-type": "text/plain",
+              "content-length": String(key.length),
+            },
+          })),
+        });
+      }, [], invokeAnyCalls)
+    );
+
+    const prefixed = service.withPrefix("/audio");
+    const head = await prefixed.batchHead(["one", "two"]);
+    const get = await prefixed.batchGet<string>(["one", "two"]);
+    expect(head.ok && head.data.results[0]!.key).toBe("one");
+    expect(get.ok && get.data.results[0]!.key).toBe("one");
+    expect(invokeAnyCalls.map((entry) => entry.entries[0]!.path)).toEqual([
+      "/audio/one",
+      "/audio/one",
+    ]);
+  });
+
+  test("rejects duplicate resolved keys before signing", async () => {
+    const invokeAnyCalls: Array<{ entries: InvokeAnyEntry[] }> = [];
+    let fetches = 0;
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () => {
+        fetches++;
+        return response(true, 200, {});
+      }, [], invokeAnyCalls)
+    );
+    const result = await service.batchGet(["same", "same"]);
+    expect(result.ok).toBe(false);
+    expect(invokeAnyCalls).toHaveLength(0);
+    expect(fetches).toBe(0);
+  });
+});
+
 describe("KVService.batchPut", () => {
   test("writes multiple keys with one invokeAny multipart request", async () => {
     const invokeAnyCalls: Array<{ entries: InvokeAnyEntry[] }> = [];

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -34,6 +34,7 @@ import {
   KVBatchPutItem,
   KVBatchPutOptions,
   KVBatchPutResponse,
+  KVBatchReadResponse,
   KVListOptions,
   KVDeleteOptions,
   KVHeadOptions,
@@ -50,6 +51,20 @@ interface SignedKvUrlNodeResponse {
   ticketId: string;
   expiresAt: string;
 }
+
+interface KvBatchNodeItem {
+  key: string;
+  ok: boolean;
+  dataBase64?: string;
+  headers?: Record<string, string>;
+  error?: { code: string; message: string };
+}
+
+interface KvBatchNodeResponse {
+  results: KvBatchNodeItem[];
+}
+
+const MAX_KV_BATCH_READ_ITEMS = 100;
 
 function encodeKvBatchPartName(path: string): string {
   return encodeURIComponent(path).replace(/[!'()*]/g, (char) =>
@@ -381,6 +396,228 @@ export class KVService extends BaseService implements IKVService {
     };
   }
 
+  private createBatchResponseHeaders(
+    values: Record<string, string>
+  ): KVResponseHeaders {
+    const normalized = new Map(
+      Object.entries(values).map(([name, value]) => [name.toLowerCase(), value])
+    );
+    return this.createResponseHeaders({
+      get: (name) => normalized.get(name.toLowerCase()) ?? null,
+    });
+  }
+
+  private parseBatchValue<T>(
+    dataBase64: string,
+    headers: Record<string, string>,
+    raw: boolean = false,
+    binary: boolean = false
+  ): T {
+    const encoded = globalThis.atob(dataBase64);
+    const bytes = Uint8Array.from(encoded, (character) => character.charCodeAt(0));
+    if (binary) return bytes as unknown as T;
+
+    const text = new TextDecoder().decode(bytes);
+    if (raw) return text as unknown as T;
+    const contentType = Object.entries(headers).find(
+      ([name]) => name.toLowerCase() === "content-type"
+    )?.[1];
+    return (contentType?.includes("application/json")
+      ? JSON.parse(text)
+      : text) as T;
+  }
+
+  private normalizeBatchReadResponse(
+    data: unknown,
+    paths: string[],
+    requireData: boolean
+  ): KvBatchNodeResponse | undefined {
+    if (!data || typeof data !== "object") return undefined;
+    const response = data as Partial<KvBatchNodeResponse>;
+    if (!Array.isArray(response.results) || response.results.length !== paths.length) {
+      return undefined;
+    }
+
+    for (let index = 0; index < response.results.length; index++) {
+      const item = response.results[index];
+      if (
+        !item ||
+        typeof item !== "object" ||
+        item.key !== paths[index] ||
+        typeof item.ok !== "boolean"
+      ) {
+        return undefined;
+      }
+      if (
+        item.ok &&
+        (!item.headers ||
+          typeof item.headers !== "object" ||
+          Object.values(item.headers).some((value) => typeof value !== "string") ||
+          (requireData && typeof item.dataBase64 !== "string"))
+      ) {
+        return undefined;
+      }
+      if (
+        !item.ok &&
+        (!item.error ||
+          typeof item.error.code !== "string" ||
+          typeof item.error.message !== "string")
+      ) {
+        return undefined;
+      }
+    }
+    return response as KvBatchNodeResponse;
+  }
+
+  private async batchRead<T>(
+    keys: string[],
+    action: typeof KVAction.GET | typeof KVAction.HEAD,
+    options?: KVGetOptions | KVHeadOptions
+  ): Promise<Result<KVBatchReadResponse<T>>> {
+    if (!this.requireAuth()) return err(authRequiredError("kv"));
+    if (keys.length === 0) return ok({ results: [], count: 0 });
+    if (keys.length > MAX_KV_BATCH_READ_ITEMS) {
+      return err(serviceError(
+        ErrorCodes.INVALID_INPUT,
+        `KV batch reads accept at most ${MAX_KV_BATCH_READ_ITEMS} keys`,
+        "kv"
+      ));
+    }
+    if (keys.length === 1) {
+      const key = keys[0]!;
+      const result = action === KVAction.GET
+        ? await this.get<T>(key, options as KVGetOptions)
+        : await this.head(key, options as KVHeadOptions);
+      return ok({
+        results: [{ key, result: result as Result<KVResponse<T>> }],
+        count: 1,
+      });
+    }
+    if (!this.context.invokeAny) {
+      return err(serviceError(
+        ErrorCodes.INVALID_INPUT,
+        "KV batch reads require SDK runtime support for multi-resource invocations",
+        "kv"
+      ));
+    }
+
+    const getOptions = action === KVAction.GET ? options as KVGetOptions : undefined;
+    if (
+      getOptions?.maxResponseBytes !== undefined &&
+      (!Number.isSafeInteger(getOptions.maxResponseBytes) ||
+        getOptions.maxResponseBytes <= 0)
+    ) {
+      return err(serviceError(
+        ErrorCodes.INVALID_INPUT,
+        "KV maxResponseBytes must be a positive safe integer",
+        "kv"
+      ));
+    }
+
+    const paths = keys.map((key) => this.getFullPath(key, options?.prefix));
+    if (new Set(paths).size !== paths.length) {
+      return err(serviceError(
+        ErrorCodes.INVALID_INPUT,
+        "KV batch read received duplicate keys after prefix resolution",
+        "kv"
+      ));
+    }
+
+    try {
+      const session = this.context.session!;
+      const invocationHeaders = this.context.invokeAny(
+        session,
+        paths.map((path) => ({
+          spaceId: session.spaceId,
+          service: "kv",
+          path,
+          action,
+        }))
+      );
+      const limitHeaders: Record<string, string> = {};
+      if (getOptions?.maxResponseBytes !== undefined) {
+        limitHeaders["x-tinycloud-max-response-bytes"] = String(
+          getOptions.maxResponseBytes
+        );
+      }
+      const headers: ServiceHeaders = Array.isArray(invocationHeaders)
+        ? [...invocationHeaders, ...Object.entries(limitHeaders)]
+        : { ...invocationHeaders, ...limitHeaders };
+      const response = await this.context.fetch(`${this.host}/invoke`, {
+        method: "POST",
+        headers,
+        signal: this.combineSignals(options?.signal),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        if (response.status === 401 || response.status === 403) {
+          const { resource, action: requiredAction } = parseAuthError(errorText);
+          return err(authUnauthorizedError("kv", errorText, {
+            status: response.status,
+            ...(requiredAction && { requiredAction }),
+            ...(resource && { resource }),
+          }));
+        }
+        if (response.status === 413) {
+          return err(serviceError(
+            ErrorCodes.KV_RESPONSE_TOO_LARGE,
+            "A KV batch value exceeds the requested response limit",
+            "kv",
+            { meta: { status: response.status, statusText: response.statusText } }
+          ));
+        }
+        return err(serviceError(
+          ErrorCodes.NETWORK_ERROR,
+          `Failed to batch read ${keys.length} key(s): ${response.status} - ${errorText}`,
+          "kv",
+          { meta: { status: response.status, statusText: response.statusText } }
+        ));
+      }
+
+      const payload = this.normalizeBatchReadResponse(
+        await response.json(),
+        paths,
+        action === KVAction.GET
+      );
+      if (!payload) {
+        return err(serviceError(
+          ErrorCodes.NETWORK_ERROR,
+          "KV batch read response did not match the requested keys",
+          "kv"
+        ));
+      }
+
+      const results = payload.results.map((item, index) => {
+        if (!item.ok) {
+          return {
+            key: keys[index]!,
+            result: err(serviceError(item.error!.code, item.error!.message, "kv")),
+          };
+        }
+        const headers = item.headers!;
+        const data = action === KVAction.HEAD
+          ? undefined
+          : this.parseBatchValue<T>(
+              item.dataBase64!,
+              headers,
+              getOptions?.raw,
+              getOptions?.binary
+            );
+        return {
+          key: keys[index]!,
+          result: ok({
+            data: data as T,
+            headers: this.createBatchResponseHeaders(headers),
+          }),
+        };
+      });
+      return ok({ results, count: results.length });
+    } catch (error) {
+      return err(wrapError("kv", error));
+    }
+  }
+
   /**
    * Parse response body based on content type.
    *
@@ -568,6 +805,15 @@ export class KVService extends BaseService implements IKVService {
         return err(wrapError("kv", error));
       }
     });
+  }
+
+  async batchGet<T = unknown>(
+    keys: string[],
+    options?: KVGetOptions
+  ): Promise<Result<KVBatchReadResponse<T>>> {
+    return this.withTelemetry("batchGet", String(keys.length), () =>
+      this.batchRead<T>(keys, KVAction.GET, options)
+    );
   }
 
   /**
@@ -1010,6 +1256,15 @@ export class KVService extends BaseService implements IKVService {
         return err(wrapError("kv", error));
       }
     });
+  }
+
+  async batchHead(
+    keys: string[],
+    options?: KVHeadOptions
+  ): Promise<Result<KVBatchReadResponse<void>>> {
+    return this.withTelemetry("batchHead", String(keys.length), () =>
+      this.batchRead<void>(keys, KVAction.HEAD, options)
+    );
   }
 
   /**

--- a/packages/sdk-services/src/kv/PrefixedKVService.ts
+++ b/packages/sdk-services/src/kv/PrefixedKVService.ts
@@ -29,13 +29,14 @@
  * ```
  */
 
-import { Result } from "../types";
+import { Result, ok } from "../types";
 import {
   KVGetOptions,
   KVPutOptions,
   KVBatchPutItem,
   KVBatchPutOptions,
   KVBatchPutResponse,
+  KVBatchReadResponse,
   KVListOptions,
   KVDeleteOptions,
   KVHeadOptions,
@@ -77,6 +78,11 @@ export interface IPrefixedKVService {
     key: string,
     options?: Omit<KVGetOptions, 'prefix'>
   ): Promise<Result<KVResponse<T>>>;
+
+  batchGet<T = unknown>(
+    keys: string[],
+    options?: Omit<KVGetOptions, 'prefix'>
+  ): Promise<Result<KVBatchReadResponse<T>>>;
 
   /**
    * Store a value at a key.
@@ -167,6 +173,11 @@ export interface IPrefixedKVService {
    */
   head(key: string, options?: Omit<KVHeadOptions, 'prefix'>): Promise<Result<KVResponse<void>>>;
 
+  batchHead(
+    keys: string[],
+    options?: Omit<KVHeadOptions, 'prefix'>
+  ): Promise<Result<KVBatchReadResponse<void>>>;
+
   /**
    * Create a short-lived signed URL for reading a KV object.
    *
@@ -211,6 +222,11 @@ interface IKVServiceLike {
     options?: KVGetOptions
   ): Promise<Result<KVResponse<T>>>;
 
+  batchGet<T = unknown>(
+    keys: string[],
+    options?: KVGetOptions
+  ): Promise<Result<KVBatchReadResponse<T>>>;
+
   put(
     key: string,
     value: unknown,
@@ -227,6 +243,11 @@ interface IKVServiceLike {
   delete(key: string, options?: KVDeleteOptions): Promise<Result<KVResponse<void>>>;
 
   head(key: string, options?: KVHeadOptions): Promise<Result<KVResponse<void>>>;
+
+  batchHead(
+    keys: string[],
+    options?: KVHeadOptions
+  ): Promise<Result<KVBatchReadResponse<void>>>;
 
   createSignedReadUrl(
     key: string,
@@ -320,6 +341,24 @@ export class PrefixedKVService implements IPrefixedKVService {
     return this._kv.get<T>(fullKey, { ...options, prefix: '' });
   }
 
+  async batchGet<T = unknown>(
+    keys: string[],
+    options?: Omit<KVGetOptions, 'prefix'>
+  ): Promise<Result<KVBatchReadResponse<T>>> {
+    const response = await this._kv.batchGet<T>(
+      keys.map((key) => this.getFullKey(key)),
+      { ...options, prefix: '' }
+    );
+    if (!response.ok) return response;
+    return ok({
+      ...response.data,
+      results: response.data.results.map((item, index) => ({
+        ...item,
+        key: keys[index]!,
+      })),
+    });
+  }
+
   /**
    * Store a value at a key.
    */
@@ -381,6 +420,24 @@ export class PrefixedKVService implements IPrefixedKVService {
   ): Promise<Result<KVResponse<void>>> {
     const fullKey = this.getFullKey(key);
     return this._kv.head(fullKey, { ...options, prefix: '' });
+  }
+
+  async batchHead(
+    keys: string[],
+    options?: Omit<KVHeadOptions, 'prefix'>
+  ): Promise<Result<KVBatchReadResponse<void>>> {
+    const response = await this._kv.batchHead(
+      keys.map((key) => this.getFullKey(key)),
+      { ...options, prefix: '' }
+    );
+    if (!response.ok) return response;
+    return ok({
+      ...response.data,
+      results: response.data.results.map((item, index) => ({
+        ...item,
+        key: keys[index]!,
+      })),
+    });
   }
 
   /**

--- a/packages/sdk-services/src/kv/index.ts
+++ b/packages/sdk-services/src/kv/index.ts
@@ -22,6 +22,7 @@ export {
   KVBatchPutItem,
   KVBatchPutOptions,
   KVBatchPutResponse,
+  KVBatchReadResponse,
   KVListOptions,
   KVDeleteOptions,
   KVHeadOptions,

--- a/packages/sdk-services/src/kv/types.ts
+++ b/packages/sdk-services/src/kv/types.ts
@@ -4,6 +4,8 @@
  * Type definitions for the KV (Key-Value) service operations.
  */
 
+import type { Result } from "../types";
+
 /**
  * Configuration for KVService.
  */
@@ -162,6 +164,19 @@ export interface KVBatchPutResponse {
   /**
    * Number of written keys.
    */
+  count: number;
+}
+
+/**
+ * Response from a KV batch read. Transport or authorization failures are
+ * returned by the outer Result; each requested key has its own Result so a
+ * missing key does not discard successful siblings.
+ */
+export interface KVBatchReadResponse<T = unknown> {
+  results: Array<{
+    key: string;
+    result: Result<KVResponse<T>>;
+  }>;
   count: number;
 }
 


### PR DESCRIPTION
## Summary

- Add batchGet and batchHead with ordered per-key Result values.
- Sign and fetch multi-key reads once, while keeping partial failures explicit.
- Cache successful encryption network descriptors for one session graph and coalesce concurrent lookups.

## Performance

- 3-key trace: 3 signatures / 3 requests -> 1 signature / 1 request.
- Repeated descriptor reads: N network fetches -> 1 per session graph.

## Verification

- @tinycloud/sdk-services tests: 189 passed
- KV focused tests: 27 passed
- restore-session tests: 18 passed
- sdk-services, sdk-core, and node-sdk builds pass

Linear: TC-272

Requires the tinycloud-node TC-272 batch response PR.