### PR TITLE
feat(sharing): add owner-rooted policy SDK boundary

### DIFF
--- a/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.sharing.test.ts
@@ -6,6 +6,10 @@ import {
   type EncodedShareData,
   type ISessionManager,
   type IWasmBindings,
+  canonicalOwnerSharePolicy,
+  computeOwnerShareRegistrationCid,
+  type OwnerDelegationReceipt,
+  type OwnerSharePolicyRegistration,
 } from "@tinycloud/sdk-core";
 import { Wallet } from "ethers";
 
@@ -498,5 +502,51 @@ describe("TinyCloudNode sharing", () => {
       wasmBindings: makeWasmBindings(),
     });
     await expect(withoutSession.createOwnerDelegation(params)).rejects.toThrow("Owner session is required");
+  });
+
+  test("registerOwnerSharePolicy posts only after the caller supplies the activated owner receipt", async () => {
+    const policy = await canonicalOwnerSharePolicy({
+      type: "TinyCloudSharePolicy",
+      version: 2,
+      shareId: "share-1",
+      ownerDid: "did:pkh:eip155:1:0xowner",
+      shareKeyDid: "did:key:z6MkShare",
+      recipientMatcher: { kind: "exactEmail", value: "alice@example.com" },
+      target: { origin: "https://share.tinycloud.xyz", nodeAudience: "did:web:tee.node.tinycloud.xyz", enforcerDid: "did:key:z6MkEnforcer", spaceId: SPACE },
+      resource: { kind: "exact", path: "shares/share-1/document.md" },
+      actions: ["tinycloud.kv/get", "tinycloud.kv/metadata"],
+      contentSource: { kind: "kv", space: SPACE, path: "shares/share-1/document.md" },
+      contentSourceDigest: "content-digest",
+      ownerDelegationCid: "bafy-owner",
+      expiresAt: "2030-01-01T00:00:00.000Z",
+    });
+    const ownerDelegation = { delegationCid: "bafy-owner", signedDagCbor: new Uint8Array([1]), delegation: { delegateDID: "did:key:z6MkShare", spaceId: SPACE, path: "shares/share-1/document.md", actions: ["tinycloud.kv/get"], expiry: new Date("2030-01-01T00:00:00.000Z") } } satisfies OwnerDelegationReceipt;
+    const enforcement = { cid: "bafy-enforcement", dagCbor: "bytes", issuerDid: "did:key:z6MkShare", audienceDid: "did:key:z6MkEnforcer", facts: {}, signature: "sig" } as const;
+    const registrationCore = {
+      policyCid: policy.cid,
+      ownerDelegationCid: ownerDelegation.delegationCid,
+      enforcementDelegationCid: enforcement.cid,
+      ownerDid: "did:pkh:eip155:1:0xowner",
+      shareKeyDid: "did:key:z6MkShare",
+      enforcerDid: "did:key:z6MkEnforcer",
+      target: { origin: "https://share.tinycloud.xyz", nodeAudience: "did:web:tee.node.tinycloud.xyz", enforcerDid: "did:key:z6MkEnforcer", spaceId: SPACE },
+      resource: { kind: "exact" as const, path: "shares/share-1/document.md" },
+      actions: ["tinycloud.kv/get", "tinycloud.kv/metadata"],
+      contentSourceDigest: "content-digest",
+      registeredAt: "2029-01-01T00:00:00.000Z",
+      expiresAt: "2030-01-01T00:00:00.000Z",
+    } satisfies Omit<OwnerSharePolicyRegistration, "registrationCid">;
+    const responseBody = { registration: { registrationCid: computeOwnerShareRegistrationCid(registrationCore), ...registrationCore }, proof: { alg: "EdDSA", kid: "did:web:tee.node.tinycloud.xyz#key", signature: "sig" } };
+    const fetchMock = mock(async (input: string, init?: RequestInit) => {
+      expect(input).toBe("https://node.example/share/v2/policies");
+      expect(init?.method).toBe("POST");
+      expect(typeof init?.body).toBe("string");
+      return new Response(JSON.stringify(responseBody), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const node = new TinyCloudNode({ host: "https://node.example", wasmBindings: makeWasmBindings() });
+    const receipt = await node.registerOwnerSharePolicy({ policy: { ...policy, proof: "policy-proof" }, ownerDelegation, enforcementDelegation: enforcement, contentSourceDigest: "content-digest" });
+    expect(receipt.registration.registrationCid).toBe(responseBody.registration.registrationCid);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -139,6 +139,9 @@ import {
   type DecryptTransport,
   type EncryptionCrypto,
   type NetworkDescriptor,
+  type RegisterOwnerSharePolicyParams,
+  type OwnerSharePolicyRegistrationReceipt,
+  validateOwnerSharePolicyRegistration,
 } from "@tinycloud/sdk-core";
 import {
   parsePermissionHint,
@@ -158,6 +161,11 @@ import {
   extractSiweExpiration,
 } from "./delegateToHelpers";
 import { NodeSecretsService } from "./NodeSecretsService";
+
+export type {
+  RegisterOwnerSharePolicyParams,
+  OwnerSharePolicyRegistrationReceipt,
+} from "@tinycloud/sdk-core";
 
 /** Default TinyCloud host */
 const DEFAULT_HOST = "https://node.tinycloud.xyz";
@@ -3714,6 +3722,26 @@ export class TinyCloudNode {
         skipped: activation.skipped ?? [],
       },
     };
+  }
+
+  /** Register a policy that is already bound to an activated owner delegation. */
+  async registerOwnerSharePolicy(
+    params: RegisterOwnerSharePolicyParams,
+  ): Promise<OwnerSharePolicyRegistrationReceipt> {
+    this._serviceGraph.assertActive();
+    if (params.policy.bytes.byteLength > 2 * 1024 * 1024) throw new Error("Owner share policy is too large");
+    const response = await fetch(`${this.config.host!}/share/v2/policies`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({
+        policy: { bytes: Buffer.from(params.policy.bytes).toString("base64url"), cid: params.policy.cid, proof: params.policy.proof },
+        ownerDelegation: { cid: params.ownerDelegation.delegationCid, dagCbor: Buffer.from(params.ownerDelegation.signedDagCbor).toString("base64url") },
+        enforcementDelegation: params.enforcementDelegation,
+        contentSourceDigest: params.contentSourceDigest,
+      }),
+    });
+    if (!response.ok) throw new Error(`Owner share policy registration failed: ${response.status}`);
+    return validateOwnerSharePolicyRegistration(await response.json(), params);
   }
 
   private async createRootDelegationForSharing(params: {

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -116,6 +116,10 @@ export {
   type SecretReadInput,
   type SecretPermissionHint,
   type SecretReadResult,
+  type CreateOwnerDelegationParams,
+  type OwnerDelegationReceipt,
+  type RegisterOwnerSharePolicyParams,
+  type OwnerSharePolicyRegistrationReceipt,
 } from "./TinyCloudNode";
 
 export { AccountService } from "./account/AccountService";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -142,6 +142,8 @@ export {
   type RuntimePermissionGrantOptions,
   type CreateOwnerDelegationParams,
   type OwnerDelegationReceipt,
+  type RegisterOwnerSharePolicyParams,
+  type OwnerSharePolicyRegistrationReceipt,
   type SecretReadInput,
   type SecretPermissionHint,
   type SecretReadResult,

--- a/packages/sdk-core/src/delegations/index.ts
+++ b/packages/sdk-core/src/delegations/index.ts
@@ -139,6 +139,27 @@ export type {
   ShareResource,
   VerifyShareEnvelopeOptions,
 } from "./share-envelope";
+
+export {
+  createDelegatedShareKey,
+  createPolicyEnforcementDelegation,
+  canonicalOwnerSharePolicy,
+  computeOwnerShareRegistrationCid,
+  validateOwnerSharePolicyRegistration,
+  MAX_CONTENT_BYTES,
+} from "./owner-policy";
+export type {
+  OwnerDelegationReceipt,
+  CreateOwnerDelegationParams,
+  OwnerShareAction,
+  OwnerShareMatcher,
+  OwnerSharePolicyV2,
+  DelegatedShareKey,
+  SignedDelegation,
+  RegisterOwnerSharePolicyParams,
+  OwnerSharePolicyRegistration,
+  OwnerSharePolicyRegistrationReceipt,
+} from "./owner-policy";
 export type {
   ShareAccessV2,
   ShareListResult,

--- a/packages/sdk-core/src/delegations/owner-policy.test.ts
+++ b/packages/sdk-core/src/delegations/owner-policy.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalOwnerSharePolicy,
+  createDelegatedShareKey,
+  createPolicyEnforcementDelegation,
+  validateOwnerSharePolicyRegistration,
+  type OwnerDelegationReceipt,
+} from "./owner-policy";
+
+const ownerDelegation: OwnerDelegationReceipt = {
+  delegationCid: "bafy-owner-delegation",
+  signedDagCbor: new Uint8Array([1, 2, 3]),
+  delegation: {
+    delegateDID: "did:key:z6MkwOwnerShareKey",
+    spaceId: "tinycloud:pkh:eip155:1:0xowner:applications",
+    path: "shares/share-1/document.md",
+    actions: ["tinycloud.kv/get", "tinycloud.kv/metadata"],
+    expiry: new Date("2030-01-01T00:00:00.000Z"),
+  },
+};
+
+describe("owner share policy primitives", () => {
+  test("keeps addressed private key material non-extractable", async () => {
+    const key = createDelegatedShareKey({ extractable: false });
+    expect(key.did).toMatch(/^did:key:z/);
+    expect(key.privateJwk).toBeUndefined();
+    const signature = await key.sign(new TextEncoder().encode("owner-share-test"));
+    expect(signature).toHaveLength(64);
+    key.clear();
+    await expect(key.sign(new Uint8Array([1]))).rejects.toThrow("cleared");
+  });
+
+  test("binds enforcement facts to the activated owner delegation", async () => {
+    const key = createDelegatedShareKey({ extractable: false });
+    const enforcement = await createPolicyEnforcementDelegation({
+      ownerDelegation,
+      shareKey: key,
+      enforcerDid: "did:key:z6MkEnforcer",
+      policyCid: "bafy-policy",
+      shareId: "share-1",
+      spaceId: ownerDelegation.delegation.spaceId,
+      path: ownerDelegation.delegation.path,
+      actions: ["tinycloud.kv/get", "tinycloud.kv/metadata"],
+      contentSourceDigest: "digest",
+      expiresAt: "2030-01-01T00:00:00.000Z",
+    });
+    expect(enforcement.issuerDid).toBe(key.did);
+    expect(enforcement.facts.ownerDelegationCid).toBe(ownerDelegation.delegationCid);
+    expect(enforcement.facts.policyCid).toBe("bafy-policy");
+    expect(enforcement.dagCbor).not.toContain("digest");
+  });
+
+  test("computes a canonical SHA-256 raw CID for policy bytes", async () => {
+    const result = await canonicalOwnerSharePolicy({
+      type: "TinyCloudSharePolicy",
+      version: 2,
+      shareId: "share-1",
+      ownerDid: "did:pkh:eip155:1:0xowner",
+      shareKeyDid: "did:key:z6MkShare",
+      recipientMatcher: { kind: "emailDomain", value: "example.com" },
+      target: { origin: "https://share.tinycloud.xyz", nodeAudience: "did:web:tee.node.tinycloud.xyz", enforcerDid: "did:key:z6MkEnforcer", spaceId: ownerDelegation.delegation.spaceId },
+      resource: { kind: "exact", path: ownerDelegation.delegation.path },
+      actions: ["tinycloud.kv/get", "tinycloud.kv/metadata"],
+      contentSource: { kind: "kv", space: ownerDelegation.delegation.spaceId, path: ownerDelegation.delegation.path },
+      contentSourceDigest: "digest",
+      ownerDelegationCid: ownerDelegation.delegationCid,
+      expiresAt: "2030-01-01T00:00:00.000Z",
+    });
+    expect(result.cid).toMatch(/^bafkrei/);
+    expect(result.digest).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("rejects a receipt that substitutes any chain identity", () => {
+    expect(() => validateOwnerSharePolicyRegistration({
+      registration: {
+        registrationCid: "bafy-registration",
+        policyCid: "bafy-other-policy",
+        ownerDelegationCid: ownerDelegation.delegationCid,
+        enforcementDelegationCid: "bafy-enforcement",
+        ownerDid: "did:pkh:eip155:1:0xowner",
+        shareKeyDid: "did:key:z6MkShare",
+        enforcerDid: "did:key:z6MkEnforcer",
+        target: { origin: "https://share.tinycloud.xyz", nodeAudience: "did:web:tee.node.tinycloud.xyz", enforcerDid: "did:key:z6MkEnforcer", spaceId: ownerDelegation.delegation.spaceId },
+        resource: { kind: "exact", path: ownerDelegation.delegation.path },
+        actions: ["tinycloud.kv/get"],
+        contentSourceDigest: "digest",
+        registeredAt: "2029-01-01T00:00:00.000Z",
+        expiresAt: "2030-01-01T00:00:00.000Z",
+      },
+      proof: { alg: "EdDSA", kid: "did:web:tee.node.tinycloud.xyz#key", signature: "sig" },
+    }, {
+      policy: { bytes: new Uint8Array([1]), cid: "bafy-policy", proof: "proof" },
+      ownerDelegation,
+      enforcementDelegation: { cid: "bafy-enforcement", dagCbor: "bytes", issuerDid: "did:key:z6MkShare", audienceDid: "did:key:z6MkEnforcer", facts: {}, signature: "sig" },
+      contentSourceDigest: "digest",
+    })).toThrow("policy bytes");
+  });
+});

--- a/packages/sdk-core/src/delegations/owner-policy.ts
+++ b/packages/sdk-core/src/delegations/owner-policy.ts
@@ -1,0 +1,211 @@
+import { ed25519 } from "@noble/curves/ed25519";
+import { sha256 } from "@noble/hashes/sha256";
+import { base32 } from "multiformats/bases/base32";
+import { CID } from "multiformats/cid";
+import { create as createDigest } from "multiformats/hashes/digest";
+import { sha256 as sha256Cid } from "multiformats/hashes/sha2";
+import * as raw from "multiformats/codecs/raw";
+import { base58btc } from "multiformats/bases/base58";
+import { canonicalizeSignedObjectUnsigned as canonicalize } from "../policy/signed-object.js";
+
+export interface OwnerDelegationReceipt {
+  readonly delegationCid: string;
+  readonly signedDagCbor: Uint8Array;
+  readonly delegation: { readonly delegateDID: string; readonly spaceId: string; readonly path: string; readonly actions: readonly string[]; readonly expiry: Date };
+}
+
+export interface CreateOwnerDelegationParams {
+  readonly delegateDid: string;
+  readonly spaceId: string;
+  readonly path: string;
+  readonly actions: readonly string[];
+  readonly expiresAt: Date;
+}
+
+const MAX_CONTENT_BYTES = 100 * 1024 * 1024;
+const ENFORCEMENT_DOMAIN = "xyz.tinycloud.share/policy-enforcement/v2\\0";
+const POLICY_DOMAIN = "xyz.tinycloud.share/policy/v2\\0";
+
+export type OwnerShareAction = "tinycloud.kv/get" | "tinycloud.kv/metadata" | "tinycloud.kv/put";
+export type OwnerShareMatcher =
+  | { readonly kind: "exactEmail"; readonly value: string }
+  | { readonly kind: "emailDomain"; readonly value: string };
+
+export interface OwnerSharePolicyV2 {
+  readonly type: "TinyCloudSharePolicy";
+  readonly version: 2;
+  readonly shareId: string;
+  readonly ownerDid: string;
+  readonly shareKeyDid: string;
+  readonly recipientMatcher: OwnerShareMatcher;
+  readonly target: { readonly origin: string; readonly nodeAudience: string; readonly enforcerDid: string; readonly spaceId: string };
+  readonly resource: { readonly kind: "exact"; readonly path: string };
+  readonly actions: readonly OwnerShareAction[];
+  readonly contentSource: { readonly kind: "kv"; readonly space: string; readonly path: string };
+  readonly contentSourceDigest: string;
+  readonly ownerDelegationCid: string;
+  readonly expiresAt: string;
+}
+
+export interface DelegatedShareKey {
+  readonly did: string;
+  readonly publicKey: Uint8Array;
+  readonly extractable: boolean;
+  readonly privateJwk?: Record<string, string>;
+  sign(bytes: Uint8Array): Promise<Uint8Array>;
+  clear(): void;
+}
+
+export interface SignedDelegation {
+  readonly cid: string;
+  readonly dagCbor: string;
+  readonly issuerDid: string;
+  readonly audienceDid: string;
+  readonly facts: Record<string, string | readonly string[]>;
+  readonly signature: string;
+}
+
+export interface RegisterOwnerSharePolicyParams {
+  readonly policy: { readonly bytes: Uint8Array; readonly cid: string; readonly proof: string };
+  readonly ownerDelegation: OwnerDelegationReceipt;
+  readonly enforcementDelegation: SignedDelegation;
+  readonly contentSourceDigest: string;
+}
+
+export interface OwnerSharePolicyRegistration {
+  readonly registrationCid: string;
+  readonly policyCid: string;
+  readonly ownerDelegationCid: string;
+  readonly enforcementDelegationCid: string;
+  readonly ownerDid: string;
+  readonly shareKeyDid: string;
+  readonly enforcerDid: string;
+  readonly target: { readonly origin: string; readonly nodeAudience: string; readonly spaceId: string };
+  readonly resource: { readonly kind: "exact"; readonly path: string };
+  readonly actions: readonly OwnerShareAction[];
+  readonly contentSourceDigest: string;
+  readonly registeredAt: string;
+  readonly expiresAt: string;
+}
+
+export interface OwnerSharePolicyRegistrationReceipt {
+  readonly registration: OwnerSharePolicyRegistration;
+  readonly proof: { readonly alg: "EdDSA"; readonly kid: string; readonly signature: string };
+}
+
+function bytes(value: Uint8Array): Uint8Array { return new Uint8Array(value); }
+
+function b64(value: Uint8Array): string {
+  if (typeof Buffer !== "undefined") return Buffer.from(value).toString("base64url");
+  let binary = "";
+  for (const byte of value) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function fromB64(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error("owner-share value is not canonical base64url");
+  if (typeof Buffer !== "undefined") return new Uint8Array(Buffer.from(value, "base64url"));
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - value.length % 4) % 4);
+  return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+}
+
+function cid(bytesValue: Uint8Array): string {
+  return CID.createV1(raw.code, createDigest(sha256Cid.code, sha256(bytesValue))).toString(base32.encoder);
+}
+
+function digest(bytesValue: Uint8Array): string { return b64(sha256(bytesValue)); }
+
+function didKeyFromEd25519PublicKey(publicKey: Uint8Array): string {
+  if (publicKey.length !== 32) throw new Error("share key public key must be 32 bytes");
+  const prefixed = new Uint8Array(34);
+  prefixed.set([0xed, 0x01]);
+  prefixed.set(publicKey, 2);
+  return `did:key:${base58btc.encode(prefixed)}`;
+}
+
+function assertCanonical(value: string, label: string): void {
+  if (value !== canonicalize(JSON.parse(value))) throw new Error(`${label} is not canonical JSON`);
+}
+
+function assertObject(value: unknown, keys: readonly string[], label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${label} is invalid`);
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).length !== keys.length || keys.some((key) => !Object.prototype.hasOwnProperty.call(record, key))) throw new Error(`${label} has unknown or missing fields`);
+  return record;
+}
+
+export function createDelegatedShareKey(options: { readonly extractable: boolean }): DelegatedShareKey {
+  const seed = crypto.getRandomValues(new Uint8Array(32));
+  const publicKey = ed25519.getPublicKey(seed);
+  let cleared = false;
+  const key: DelegatedShareKey = {
+    did: didKeyFromEd25519PublicKey(publicKey),
+    publicKey: bytes(publicKey),
+    extractable: options.extractable,
+    ...(options.extractable ? { privateJwk: { kty: "OKP", crv: "Ed25519", x: b64(publicKey), d: b64(seed) } } : {}),
+    async sign(input) {
+      if (cleared) throw new Error("share key has been cleared");
+      return bytes(ed25519.sign(input, seed));
+    },
+    clear() { seed.fill(0); cleared = true; },
+  };
+  return key;
+}
+
+export async function createPolicyEnforcementDelegation(input: {
+  readonly ownerDelegation: OwnerDelegationReceipt;
+  readonly shareKey: DelegatedShareKey;
+  readonly enforcerDid: string;
+  readonly policyCid: string;
+  readonly shareId: string;
+  readonly spaceId: string;
+  readonly path: string;
+  readonly actions: readonly OwnerShareAction[];
+  readonly contentSourceDigest: string;
+  readonly expiresAt: string;
+}): Promise<SignedDelegation> {
+  if (input.shareKey.did.length === 0 || input.ownerDelegation.delegationCid.length === 0) throw new Error("owner delegation and share key are required");
+  const facts = {
+    ownerDelegationCid: input.ownerDelegation.delegationCid,
+    policyCid: input.policyCid,
+    shareId: input.shareId,
+    shareKeyDid: input.shareKey.did,
+    enforcerDid: input.enforcerDid,
+    nodeAudience: "did:web:tee.node.tinycloud.xyz",
+    spaceId: input.spaceId,
+    path: input.path,
+    actions: [...input.actions],
+    contentSourceDigest: input.contentSourceDigest,
+    expiresAt: input.expiresAt,
+  } satisfies Record<string, string | readonly string[]>;
+  const unsigned = { type: "TinyCloudSharePolicyEnforcement", version: 2, issuerDid: input.shareKey.did, audienceDid: input.enforcerDid, facts };
+  const dagCbor = canonicalize({ domain: ENFORCEMENT_DOMAIN, unsigned });
+  const signature = b64(await input.shareKey.sign(new TextEncoder().encode(dagCbor)));
+  return { cid: cid(new TextEncoder().encode(`${dagCbor}.${signature}`)), dagCbor: b64(new TextEncoder().encode(dagCbor)), issuerDid: input.shareKey.did, audienceDid: input.enforcerDid, facts, signature };
+}
+
+export async function canonicalOwnerSharePolicy(policy: OwnerSharePolicyV2): Promise<{ readonly bytes: Uint8Array; readonly cid: string; readonly digest: string }> {
+  const text = canonicalize({ domain: POLICY_DOMAIN, policy });
+  const policyBytes = new TextEncoder().encode(text);
+  return { bytes: policyBytes, cid: cid(policyBytes), digest: digest(policyBytes) };
+}
+
+export function computeOwnerShareRegistrationCid(registration: Omit<OwnerSharePolicyRegistration, "registrationCid">): string {
+  return cid(new TextEncoder().encode(canonicalize(registration)));
+}
+
+export function validateOwnerSharePolicyRegistration(value: unknown, expected: RegisterOwnerSharePolicyParams): OwnerSharePolicyRegistrationReceipt {
+  const root = assertObject(value, ["registration", "proof"], "owner-share registration response");
+  const registration = assertObject(root.registration, ["registrationCid", "policyCid", "ownerDelegationCid", "enforcementDelegationCid", "ownerDid", "shareKeyDid", "enforcerDid", "target", "resource", "actions", "contentSourceDigest", "registeredAt", "expiresAt"], "owner-share registration");
+  const proof = assertObject(root.proof, ["alg", "kid", "signature"], "owner-share registration proof");
+  if (proof.alg !== "EdDSA" || typeof proof.kid !== "string" || typeof proof.signature !== "string") throw new Error("owner-share registration proof is invalid");
+  if (cid(expected.policy.bytes) !== expected.policy.cid) throw new Error("submitted owner-share policy bytes do not match its CID");
+  if (registration.policyCid !== expected.policy.cid || registration.ownerDelegationCid !== expected.ownerDelegation.delegationCid || registration.enforcementDelegationCid !== expected.enforcementDelegation.cid || registration.contentSourceDigest !== expected.contentSourceDigest) throw new Error("owner-share registration is not bound to the submitted chain");
+  if (typeof registration.registrationCid !== "string" || typeof registration.expiresAt !== "string" || typeof registration.registeredAt !== "string") throw new Error("owner-share registration timestamps are invalid");
+  if (new Date(registration.expiresAt).toISOString() !== registration.expiresAt || Date.parse(registration.expiresAt) <= Date.now()) throw new Error("owner-share registration is expired or non-canonical");
+  const { registrationCid: _registrationCid, ...registrationCore } = registration;
+  if (computeOwnerShareRegistrationCid(registrationCore as unknown as Omit<OwnerSharePolicyRegistration, "registrationCid">) !== registration.registrationCid) throw new Error("owner-share registration CID does not match its canonical core");
+  return { registration: registration as unknown as OwnerSharePolicyRegistration, proof: proof as unknown as OwnerSharePolicyRegistrationReceipt["proof"] };
+}
+
+export { MAX_CONTENT_BYTES };

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -132,6 +132,12 @@ export {
   ShareAddressedDelegationRequestV2Schema,
   ShareAddressedDelegationEnvelopeV2Schema,
   ShareAddressedDelegationResponseV2Schema,
+  createDelegatedShareKey,
+  createPolicyEnforcementDelegation,
+  canonicalOwnerSharePolicy,
+  computeOwnerShareRegistrationCid,
+  validateOwnerSharePolicyRegistration,
+  MAX_CONTENT_BYTES,
 } from "./delegations";
 export type {
   ShareAccessV2,
@@ -180,6 +186,16 @@ export type {
   ShareResource,
   ShareSaveOptions,
   VerifyShareEnvelopeOptions,
+  OwnerDelegationReceipt,
+  CreateOwnerDelegationParams,
+  OwnerShareAction,
+  OwnerShareMatcher,
+  OwnerSharePolicyV2,
+  DelegatedShareKey,
+  SignedDelegation,
+  RegisterOwnerSharePolicyParams,
+  OwnerSharePolicyRegistration,
+  OwnerSharePolicyRegistrationReceipt,
 } from "./delegations";
 
 // Encryption network identity helpers

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -7,6 +7,12 @@ export {
   SessionRestoreStatus,
 } from "./modules/tcw";
 export type { SecretReadInput, SecretReadResult } from "@tinycloud/node-sdk";
+export type {
+  CreateOwnerDelegationParams,
+  OwnerDelegationReceipt,
+  RegisterOwnerSharePolicyParams,
+  OwnerSharePolicyRegistrationReceipt,
+} from "@tinycloud/sdk-core";
 
 // Browser Adapters
 export {
@@ -84,6 +90,12 @@ export {
   installTinyCloudDebugGlobals,
 } from "@tinycloud/sdk-core";
 export type {
+  OwnerShareAction,
+  OwnerShareMatcher,
+  OwnerSharePolicyV2,
+  DelegatedShareKey,
+  SignedDelegation,
+  OwnerSharePolicyRegistration,
   AccountApplication,
   AccountApplicationListOptions,
   AccountDelegation,
@@ -169,6 +181,12 @@ export {
   ShareLinkData,
   IngestOptions,
   GenerateShareParams,
+  createDelegatedShareKey,
+  createPolicyEnforcementDelegation,
+  canonicalOwnerSharePolicy,
+  computeOwnerShareRegistrationCid,
+  validateOwnerSharePolicyRegistration,
+  MAX_CONTENT_BYTES,
 } from "@tinycloud/sdk-core";
 
 // Re-export CapabilityKeyRegistry from sdk-core

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -52,6 +52,10 @@ import {
   type ResolvedDelegate,
   type PermissionEntry,
   type NetworkDescriptor,
+  type CreateOwnerDelegationParams,
+  type OwnerDelegationReceipt,
+  type RegisterOwnerSharePolicyParams,
+  type OwnerSharePolicyRegistrationReceipt,
   type LocalNodeIdentityStore,
   SignInOptions,
   composeManifestRequest,
@@ -734,6 +738,24 @@ export class TinyCloudWeb {
   }): Promise<PortableDelegation> {
     const node = await this.ensureNode();
     return node.createDelegation(params);
+  }
+
+  /** Create and activate a wallet-rooted delegation for an ephemeral share key. */
+  async createOwnerDelegation(
+    params: Omit<CreateOwnerDelegationParams, "spaceId"> & { readonly spaceId?: string },
+  ): Promise<OwnerDelegationReceipt> {
+    const node = await this.ensureNode();
+    const spaceId = params.spaceId ?? this.spaceId;
+    if (spaceId === undefined) throw new Error("Owner share delegation requires an authenticated space.");
+    return node.createOwnerDelegation({ ...params, spaceId });
+  }
+
+  /** Register an owner-bound addressed sharing policy through TinyCloud Node. */
+  async registerOwnerSharePolicy(
+    params: RegisterOwnerSharePolicyParams,
+  ): Promise<OwnerSharePolicyRegistrationReceipt> {
+    const node = await this.ensureNode();
+    return node.registerOwnerSharePolicy(params);
   }
 
   /**


### PR DESCRIPTION
## Summary

- expose the existing wallet-rooted owner delegation through TinyCloudWeb
- add strict owner-share policy, enforcement delegation, canonical CID, and registration receipt primitives
- reject substituted policy/chain identities and keep addressed private keys non-extractable

## Verification

- bun test packages/sdk-core/src/delegations/owner-policy.test.ts packages/node-sdk/src/TinyCloudNode.sharing.test.ts
- sdk-core, node-sdk, and web-sdk production builds

The service-side v2 policy and recipient routes remain a follow-up coordinated change; Share PR #26 remains the safe fallback while those dependencies are unavailable.