### PR TITLE
fix(sdk-core): single-flight concurrent session activations (TC-332)

### DIFF
--- a/.changeset/single-flight-session-activation.md
+++ b/.changeset/single-flight-session-activation.md
@@ -1,0 +1,19 @@
+---
+"@tinycloud/sdk-core": patch
+---
+
+Coalesce concurrent identical session activations into a single `POST /delegate` (TC-332).
+
+`activateSessionWithHost` had no de-duplication, so the ~17 call sites that replay a
+byte-identical session delegation header — registry sync, space-hosting hooks and their
+retry wrappers, several of which fire without awaiting each other — could issue the same
+request concurrently. A parentless root session delegation acquires no chain guard locks on
+the node, and PostgreSQL deployments have no `writer_lock` to serialize writes, so two
+identical concurrent requests compute the same `epoch_hash`, both insert into `epoch`, and
+the loser fails with a unique-constraint violation surfaced as HTTP 500.
+
+Concurrent callers with the same host and header now share one in-flight request. Only
+in-flight promises are shared, never completed results, so sequential calls still issue a
+fresh request and a revoked session is never masked by a cached success. A caller that
+joins a request which then fails at the network level gets its own second attempt rather
+than inheriting a failure it did not cause.

--- a/packages/sdk-core/src/space.test.ts
+++ b/packages/sdk-core/src/space.test.ts
@@ -2,8 +2,15 @@
  * Tests for activateSessionWithHost in space.ts.
  */
 
-import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
 import { activateSessionWithHost } from "./space";
+
+/**
+ * The real `fetch`, captured at import time before any test replaces it.
+ * Bun shares one process across test files, so a stubbed global must always be
+ * put back or it leaks into unrelated suites.
+ */
+const REAL_FETCH = globalThis.fetch;
 
 // =============================================================================
 // Test Helpers
@@ -130,5 +137,332 @@ describe("activateSessionWithHost", () => {
         headers: TEST_DELEGATION_HEADER,
       }
     );
+  });
+});
+
+// =============================================================================
+// TC-332: single-flight / de-duplication of concurrent identical activations
+//
+// A parentless *root* session delegation acquires zero guard locks on the node
+// (`delegate()` derives guard roots from parents only). On PostgreSQL there is
+// no `writer_lock`, so two byte-identical concurrent POST /delegate requests
+// race into the same `epoch_hash`; the loser takes SQLSTATE 23505 on the
+// `pk-epoch` constraint and the SDK sees an HTTP 500.
+//
+// The SDK-side fix is to coalesce concurrent identical activations into a
+// single in-flight request.
+// =============================================================================
+
+/**
+ * A distinct delegation token per call.
+ *
+ * Real delegation headers are minted per SIWE signature and are unique per
+ * session; reusing one literal across tests would couple them through the
+ * module-level in-flight map.
+ */
+let tokenCounter = 0;
+function uniqueHeader(): { Authorization: string } {
+  tokenCounter += 1;
+  return { Authorization: `Bearer root-delegation-${tokenCounter}` };
+}
+
+/** A promise plus its resolve/reject handles. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * Installs a `fetch` that records every call and hands control of each
+ * response back to the test via a deferred.
+ */
+function installControllableFetch() {
+  const calls: string[] = [];
+  const pending: Array<ReturnType<typeof deferred<Response>>> = [];
+
+  globalThis.fetch = ((url: string) => {
+    calls.push(url);
+    const d = deferred<Response>();
+    pending.push(d);
+    return d.promise;
+  }) as unknown as typeof fetch;
+
+  return {
+    calls,
+    pending,
+    /** Resolve every outstanding fetch with a 200 JSON activation receipt. */
+    settleAllOk(cid = "bafyreiactivated") {
+      for (const d of pending.splice(0)) {
+        d.resolve(
+          mockFetchResponse({ cid, activated: ["space-1"], skipped: [] }, { status: 200 })
+        );
+      }
+    },
+    /** Reject every outstanding fetch as a network-level failure. */
+    rejectAll(error: Error) {
+      for (const d of pending.splice(0)) {
+        d.reject(error);
+      }
+    },
+  };
+}
+
+describe("activateSessionWithHost single-flight (TC-332)", () => {
+  beforeEach(() => {
+    globalThis.fetch = mock() as any;
+  });
+
+  afterEach(() => {
+    // `installControllableFetch` installs a `fetch` that never settles on its
+    // own. Leaving it in place would hang any later suite that does real I/O.
+    globalThis.fetch = REAL_FETCH;
+  });
+
+  it("coalesces N concurrent identical activations into exactly one fetch", async () => {
+    const controller = installControllableFetch();
+    const header = uniqueHeader();
+
+    const flights = Array.from({ length: 7 }, () =>
+      activateSessionWithHost(TEST_HOST, header)
+    );
+
+    // Let every caller reach its `await` before any response lands.
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(1);
+
+    controller.settleAllOk();
+    const results = await Promise.all(flights);
+
+    expect(controller.calls).toEqual([`${TEST_HOST}/delegate`]);
+    for (const result of results) {
+      expect(result.success).toBe(true);
+      expect(result.status).toBe(200);
+      expect(result.activated).toEqual(["space-1"]);
+      expect(result.commitEventCid).toBe("bafyreiactivated");
+    }
+  });
+
+  it("coalesces identical activations passed as distinct but equal header objects", async () => {
+    const controller = installControllableFetch();
+
+    // Real call sites pass `session.delegationHeader` by reference, but a
+    // structurally equal object must coalesce too — the node only sees bytes.
+    const flights = Array.from({ length: 5 }, () =>
+      activateSessionWithHost(TEST_HOST, { Authorization: "Bearer same-bytes" })
+    );
+
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(1);
+
+    controller.settleAllOk();
+    await Promise.all(flights);
+    expect(controller.calls.length).toBe(1);
+  });
+
+  it("does not coalesce concurrent activations with distinct headers", async () => {
+    const controller = installControllableFetch();
+
+    const flights = Array.from({ length: 5 }, (_, i) =>
+      activateSessionWithHost(TEST_HOST, { Authorization: `Bearer delegation-${i}` })
+    );
+
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(5);
+
+    controller.settleAllOk();
+    await Promise.all(flights);
+    expect(controller.calls.length).toBe(5);
+  });
+
+  it("keys on the whole header, not a prefix of it", async () => {
+    const controller = installControllableFetch();
+
+    // Two tokens sharing a long common prefix and differing only in the final
+    // characters. A truncated cache key would wrongly coalesce these.
+    const prefix = `Bearer ${"u".repeat(512)}`;
+    const flights = [
+      activateSessionWithHost(TEST_HOST, { Authorization: `${prefix}AAAA` }),
+      activateSessionWithHost(TEST_HOST, { Authorization: `${prefix}BBBB` }),
+    ];
+
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(2);
+
+    controller.settleAllOk();
+    await Promise.all(flights);
+    expect(controller.calls.length).toBe(2);
+  });
+
+  it("does not coalesce the same header across different hosts", async () => {
+    const controller = installControllableFetch();
+    const header = uniqueHeader();
+
+    const flights = [
+      activateSessionWithHost("https://node.tinycloud.xyz", header),
+      activateSessionWithHost("http://127.0.0.1:54108", header),
+    ];
+
+    await Promise.resolve();
+    expect(controller.calls).toEqual([
+      "https://node.tinycloud.xyz/delegate",
+      "http://127.0.0.1:54108/delegate",
+    ]);
+
+    controller.settleAllOk();
+    await Promise.all(flights);
+    expect(controller.calls.length).toBe(2);
+  });
+
+  it("issues a fresh request for a sequential call after the flight settles", async () => {
+    const controller = installControllableFetch();
+    const header = uniqueHeader();
+
+    const first = activateSessionWithHost(TEST_HOST, header);
+    await Promise.resolve();
+    controller.settleAllOk();
+    await first;
+
+    // Activation is a server-side mutation whose response reflects live space
+    // state; completed results must never be replayed from cache.
+    const second = activateSessionWithHost(TEST_HOST, header);
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(2);
+
+    controller.settleAllOk();
+    await second;
+    expect(controller.calls.length).toBe(2);
+  });
+
+  it("lets a joining caller recover on its own when the shared flight fails at the network level", async () => {
+    const controller = installControllableFetch();
+    const header = uniqueHeader();
+
+    // A caller that joins an in-flight request must never end up worse off than
+    // it would have been issuing its own request. A background activation that
+    // dies on a transient network error must not take a legitimate concurrent
+    // caller down with it.
+    const originator = activateSessionWithHost(TEST_HOST, header);
+    const joiner = activateSessionWithHost(TEST_HOST, header);
+
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(1);
+
+    controller.rejectAll(new Error("network down"));
+
+    // The originator genuinely failed, so it rejects.
+    await expect(originator).rejects.toThrow("network down");
+
+    // The joiner gets a second, independent attempt.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(controller.calls.length).toBe(2);
+    controller.settleAllOk();
+    expect((await joiner).success).toBe(true);
+  });
+
+  it("bounds the network-failure path at two requests however many callers coalesce", async () => {
+    const controller = installControllableFetch();
+    const header = uniqueHeader();
+
+    const flights = Array.from({ length: 6 }, () =>
+      activateSessionWithHost(TEST_HOST, header)
+    );
+    // Attach handlers up front so the rejections below are never "unhandled".
+    const settledPromise = Promise.allSettled(flights);
+
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(1);
+    controller.rejectAll(new Error("network down"));
+
+    // The five displaced joiners share one replacement request, not five.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(controller.calls.length).toBe(2);
+
+    // When the replacement also fails, everyone rejects — no further attempts.
+    controller.rejectAll(new Error("still down"));
+    const settled = await settledPromise;
+
+    expect(settled.every((s) => s.status === "rejected")).toBe(true);
+    expect(controller.calls.length).toBe(2);
+  });
+
+  it("does not poison later retries after a rejected flight", async () => {
+    const controller = installControllableFetch();
+    const header = uniqueHeader();
+
+    // `withAccountRegistryRetry` reruns the whole task, sequentially, with the
+    // same header. A rejected flight must be evicted so the next attempt is a
+    // real request rather than the cached failure.
+    const first = activateSessionWithHost(TEST_HOST, header);
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(1);
+    controller.rejectAll(new Error("network down"));
+    await expect(first).rejects.toThrow("network down");
+
+    const retry = activateSessionWithHost(TEST_HOST, header);
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(2);
+
+    controller.settleAllOk();
+    expect((await retry).success).toBe(true);
+  });
+
+  it("evicts the flight before callers observe the rejection, so a retry in the catch handler is fresh", async () => {
+    const controller = installControllableFetch();
+    const header = uniqueHeader();
+
+    // A caller that retries synchronously from its own rejection handler must
+    // not be handed back the already-rejected shared promise.
+    const chained = activateSessionWithHost(TEST_HOST, header).catch(() =>
+      activateSessionWithHost(TEST_HOST, header)
+    );
+
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(1);
+    controller.rejectAll(new Error("network down"));
+
+    // Give the rejection handler a chance to fire and issue the retry.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(controller.calls.length).toBe(2);
+
+    controller.settleAllOk();
+    const result = await chained;
+    expect(result.success).toBe(true);
+  });
+
+  it("does not coalesce a failed HTTP result into later calls", async () => {
+    const controller = installControllableFetch();
+    const header = uniqueHeader();
+
+    const flights = Array.from({ length: 3 }, () =>
+      activateSessionWithHost(TEST_HOST, header)
+    );
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(1);
+
+    for (const d of controller.pending.splice(0)) {
+      d.resolve(mockFetchResponse("Internal server error", { status: 500 }));
+    }
+    const results = await Promise.all(flights);
+    for (const result of results) {
+      expect(result.success).toBe(false);
+      expect(result.status).toBe(500);
+    }
+
+    // A 500 is a resolved (not rejected) result; the entry must still be gone.
+    const retry = activateSessionWithHost(TEST_HOST, header);
+    await Promise.resolve();
+    expect(controller.calls.length).toBe(2);
+
+    controller.settleAllOk();
+    expect((await retry).success).toBe(true);
   });
 });

--- a/packages/sdk-core/src/space.ts
+++ b/packages/sdk-core/src/space.ts
@@ -90,16 +90,131 @@ export async function submitHostDelegation(
 }
 
 /**
+ * In-flight `POST /delegate` activations, keyed by host + full delegation header.
+ *
+ * Why this exists (TC-332): a session delegation is replayed byte-for-byte by
+ * many call sites (registry sync, space-hosting hooks, retry wrappers), and
+ * several of them fire without awaiting each other. On the node, a *root*
+ * session delegation has no parents, so `delegate()` derives an empty guard-root
+ * set and acquires no chain locks; on PostgreSQL there is also no `writer_lock`
+ * to serialize writes. Two byte-identical concurrent POSTs therefore compute the
+ * same `epoch_hash`, both INSERT into `epoch`, and the loser takes SQLSTATE
+ * 23505 on `pk-epoch`, surfacing as HTTP 500. Coalescing identical concurrent
+ * activations into one request removes the trigger client-side.
+ *
+ * Scope is module-level, not per-client, deliberately:
+ *   - `activateSessionWithHost` is a free function with no owning instance, and
+ *     every one of its call sites imports this same module instance.
+ *   - The collision is on the node's `(space, epoch_hash)` primary key, which is
+ *     indifferent to which client object issued the POST. Two `TinyCloudNode`
+ *     instances in one realm holding the same session would still collide, so
+ *     per-instance state would not cover the race.
+ *
+ * Only *in-flight* promises are stored, never settled results. Activation is a
+ * server-side mutation whose response reflects live space state (`activated` /
+ * `skipped`) and whose session can be revoked, so replaying a completed result
+ * would hand callers stale data and suppress legitimate re-activation. Entries
+ * are evicted the moment the request settles, so sequential calls behave exactly
+ * as they did before this change and the map cannot grow without bound.
+ */
+const inFlightActivations = new Map<string, Promise<SpaceHostResult>>();
+
+/**
+ * Build a collision-free single-flight key from the host and the *complete*
+ * delegation header.
+ *
+ * The header is serialized in full (never truncated or hashed) as a sorted array
+ * of entries, so two headers coalesce only if every name/value pair matches.
+ * JSON encoding keeps the key unambiguous regardless of what characters appear
+ * in a token.
+ */
+function activationFlightKey(
+  host: string,
+  delegationHeader: Record<string, string>
+): string {
+  const entries = Object.entries(delegationHeader).sort(([a], [b]) =>
+    a < b ? -1 : a > b ? 1 : 0
+  );
+  return JSON.stringify([host, entries]);
+}
+
+/**
  * Activate a session with TinyCloud server.
  *
  * This submits the session delegation to the server, enabling the session
  * key to perform operations on behalf of the user.
+ *
+ * Concurrent calls with the same host and a byte-identical delegation header
+ * share a single `POST /delegate`; see {@link inFlightActivations}. Sequential
+ * calls always issue a fresh request.
  *
  * @param host - TinyCloud server URL
  * @param delegationHeader - Session delegation header (from session.delegationHeader)
  * @returns Result indicating success/failure (404 means space doesn't exist)
  */
 export async function activateSessionWithHost(
+  host: string,
+  delegationHeader: { Authorization: string }
+): Promise<SpaceHostResult> {
+  const key = activationFlightKey(host, delegationHeader as Record<string, string>);
+
+  const existing = inFlightActivations.get(key);
+  if (!existing) return startActivationFlight(key, host, delegationHeader);
+
+  try {
+    return await existing;
+  } catch {
+    // Join the in-flight request, but never leave a joining caller worse off
+    // than it would have been without de-duplication. If the shared request
+    // fails at the *network* level (`fetch` threw), the joiner attempts once on
+    // its own rather than inheriting a failure it never caused. HTTP error
+    // *results* — including the 500 this change exists to prevent — are shared
+    // as-is: they are the server's verdict on these exact bytes, and re-POSTing
+    // them would reintroduce the fan-out. Callers keep their own retry policies
+    // on top of this.
+    return joinOrStartActivationFlight(key, host, delegationHeader);
+  }
+}
+
+/**
+ * Second and final attempt for callers displaced by a failed shared flight.
+ *
+ * Never retries again, which bounds the failure path at two requests no matter
+ * how many callers were coalesced: whichever displaced caller runs first starts
+ * the replacement flight, and the rest join it.
+ */
+function joinOrStartActivationFlight(
+  key: string,
+  host: string,
+  delegationHeader: { Authorization: string }
+): Promise<SpaceHostResult> {
+  return (
+    inFlightActivations.get(key) ?? startActivationFlight(key, host, delegationHeader)
+  );
+}
+
+function startActivationFlight(
+  key: string,
+  host: string,
+  delegationHeader: { Authorization: string }
+): Promise<SpaceHostResult> {
+  const flight = postSessionActivation(host, delegationHeader);
+  inFlightActivations.set(key, flight);
+
+  // Evict on settle, for both fulfilment and rejection, so a rejected flight
+  // never poisons a later retry. This handler is attached before any caller's
+  // continuation, so the entry is already gone by the time a caller resumes —
+  // even one that retries synchronously from its own `catch`. The identity check
+  // avoids evicting a newer flight registered under the same key.
+  const evict = () => {
+    if (inFlightActivations.get(key) === flight) inFlightActivations.delete(key);
+  };
+  flight.then(evict, evict);
+
+  return flight;
+}
+
+async function postSessionActivation(
   host: string,
   delegationHeader: { Authorization: string }
 ): Promise<SpaceHostResult> {


### PR DESCRIPTION
## The bug

`activateSessionWithHost` (`packages/sdk-core/src/space.ts`) was a bare `fetch` POST to `/delegate` with **no dedupe, no single-flight, no in-flight promise cache**. It has ~17 call sites across `TinyCloudNode.ts` and `NodeUserAuthorization.ts`, several of which fire without awaiting each other:

- `scheduleAccountRegistrySync` uses a double `void`, so activation POSTs outlive `signIn()`
- `hostOwnedSpace` fires `void this.account.spaces.register(...)`, whose hook triggers another activation after the function returns
- `withAccountRegistryRetry` reruns the whole task 3× with the same header

The `Authorization` value is a frozen pre-encoded token minted once per SIWE signature and passed by reference, so it is byte-identical on every replay. Observed telemetry from a real browser run: `distinctDelegateAuthorizationCount: 2`, `sameAuthorizationCount: 7`.

**This is a live production fault, not a test artifact.** On PostgreSQL a parentless *root* session delegation acquires **zero** guard locks — `delegate()` builds guard roots from parents only, and a root delegation has no parents — and there is no `writer_lock` (that is SQLite-only). Two byte-identical concurrent POSTs therefore read the same tip, compute the same `epoch_hash`, both `INSERT INTO epoch`, and the loser takes SQLSTATE 23505 on constraint `pk-epoch` → HTTP 500. SQLite hides this because `writer_lock` serializes writes, which is why it went undiagnosed.

## The fix

Concurrent callers sharing a host and a byte-identical delegation header now share one request.

**Cache lifetime — in-flight only.** Only pending promises are stored, never settled results. Activation is a server-side mutation whose response reflects live space state (`activated` / `skipped`) and whose session can be revoked; replaying a completed result would return stale data and mask legitimate re-activation. Entries are evicted the moment the request settles, so sequential calls behave exactly as before and the map cannot grow without bound.

**Key correctness.** The key is the host plus the *complete* header, serialized as sorted `[name, value]` entries via `JSON.stringify` — never truncated, never hashed. A test covers two tokens sharing a 512-character common prefix and differing only in the last four characters; they must not coalesce. Host is part of the key too.

**Failure semantics.** The eviction handler is attached before any caller's continuation, so a rejected flight is already gone by the time a caller resumes — even one retrying synchronously from its own `catch`. Additionally, a caller that *joins* a request which then fails at the network level gets its own second attempt rather than inheriting a failure it never caused, so de-duplication never leaves a caller worse off than the un-deduplicated code. That fallback never retries again, bounding the failure path at two requests however many callers coalesced. HTTP error *results* — including the 500 this change exists to prevent — are shared as-is rather than re-POSTed, since they are the server's verdict on those exact bytes.

**Scope — module-level.** `activateSessionWithHost` is a free function with no owning instance, and every call site imports the same module instance. More importantly the collision is on the node's `(space, epoch_hash)` primary key, which is indifferent to which client object issued the POST: two `TinyCloudNode` instances in one realm holding the same session would still collide, so per-instance state would not cover the race.

The function remains `async`, preserving the original error-propagation contract.

## Verification

11 regression tests added in `packages/sdk-core/src/space.test.ts`, written first and confirmed **red** against the previous implementation (5 fail / 13 pass) and **green** after (18 pass / 0 fail). They cover: N concurrent identical activations producing exactly one `fetch`; distinct headers producing N; whole-header key correctness; host separation; a fresh request for sequential calls after settle; a joiner recovering from a network-level failure; the two-request bound on the failure path; retry-after-rejection; and that a failed HTTP result is not coalesced into later calls.

Suites, verbatim:

```
packages/sdk-core   807 pass / 0 fail   (baseline 796 / 0; +11 new tests)
packages/node-sdk   208 pass / 0 fail   (baseline 208 / 0)
turbo build         15 successful, 15 total
```

`turbo test --continue --force` across the monorepo produces a failing-task set that is a strict **subset** of baseline's — no new failures. The remaining failures are pre-existing and environmental (Playwright e2e requiring live servers; `tests/vfs-node` needs `node:sqlite`, i.e. Node ≥22.5, while `.nvmrc` pins 20.19.4).

Typecheck (`tsc --noEmit`) reports 35 errors both before and after, all pre-existing in unrelated test files that `tsconfig.json` includes but the tsup build excludes. Zero in `space.ts` / `space.test.ts`.

Changeset added (`@tinycloud/sdk-core`, patch); the repo is in changesets pre/beta mode.

## Notes

- Server-side behaviour is unchanged; this is purely an SDK-side fix. It removes the *trigger*. The server-side defenses (`delegation_guard_roots` including `retained_hash`, the fast-path `find_by_id`, `is_pk_epoch_conflict`) exist in node v1.9.0 but production runs v1.8.0 — that fix is a deploy, tracked separately.
- `submitHostDelegation` in the same file is also an undeduplicated `POST /delegate`. It was left alone as out of scope for TC-332, but it is worth a look.

TC-332
