### PR TITLE
TC-293: trim the cold sign-in critical path

### DIFF
--- a/packages/node-sdk/src/TinyCloudNode.encryptionNetwork.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.encryptionNetwork.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Encryption-network round-trip guards (TC-293 P6).
+ *
+ * Two cold-path requests removed:
+ *   (a) `GET /info` is already performed during sign-in for the protocol
+ *       check, and that response carries `nodeId` — so encryption-network
+ *       admin invocations reuse it instead of fetching `/info` again.
+ *   (b) `ensureEncryptionNetwork` no longer probes
+ *       `GET /encryption/networks/{id}` when the caller knows the account was
+ *       just bootstrapped (a guaranteed 404). Creating without the probe is
+ *       safe because the server answers 409 for an existing network, which is
+ *       resolved to the existing descriptor.
+ */
+import { expect, mock, test } from "bun:test";
+
+import type { ISessionManager, IWasmBindings } from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+const ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+const HOST = "https://tinycloud.test";
+const NODE_DID = "did:key:z6MkNodeUnderTest111111111111111111111111111";
+const DID = `did:pkh:eip155:1:${ADDRESS}`;
+const NETWORK_ID = `urn:tinycloud:encryption:${DID}:default`;
+
+const DESCRIPTOR = {
+  networkId: NETWORK_ID,
+  ownerDid: DID,
+  name: "default",
+  alg: "x25519",
+  keyVersion: 1,
+  publicKey: "AAAA",
+  state: "active",
+};
+
+function makeWasmBindings(): IWasmBindings {
+  return {
+    invoke: async () => undefined,
+    invokeAny: async () => ({}),
+    makeSpaceId: (address: string, chainId: number, name: string) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${name}`,
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_sha256: mock(() => new Uint8Array(32)),
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array(32)),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(32),
+      privateKey: new Uint8Array(32),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array(32)),
+    createSessionManager: (): ISessionManager =>
+      ({
+        createSessionKey: (id: string) => id,
+        replaceSessionKey: (_jwk: object, keyId: string) => keyId,
+        renameSessionKeyId: () => {},
+        getDID: (keyId: string) => `did:key:${keyId}`,
+        jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+      }) as unknown as ISessionManager,
+  } as unknown as IWasmBindings;
+}
+
+function makeNode(options: { cachedNodeIdHost?: string } = {}): TinyCloudNode {
+  const node = new TinyCloudNode({
+    host: HOST,
+    signer: {
+      getAddress: async () => ADDRESS,
+      getChainId: async () => 1,
+      signMessage: mock(async () => "0xsig"),
+    } as any,
+    wasmBindings: makeWasmBindings(),
+  });
+  (node as any)._address = ADDRESS;
+  (node as any)._chainId = 1;
+  (node as any).auth = {
+    tinyCloudSession: {
+      address: ADDRESS,
+      chainId: 1,
+      delegationHeader: { Authorization: "token" },
+      spaceId: `tinycloud:pkh:eip155:1:${ADDRESS}:default`,
+    },
+    // Mirrors NodeUserAuthorization.nodeIdForHost: only answers for the host
+    // whose /info produced the value.
+    nodeIdForHost: (host: string) =>
+      host === options.cachedNodeIdHost ? NODE_DID : undefined,
+  };
+  // Signing an admin invocation is a WASM concern; this suite is about the
+  // request sequence, so stub it out.
+  (node as any).signRawNetworkAuthorization = mock(async () => ({
+    authorization: "Bearer signed-admin-invocation",
+    invocationCid: "bafy-invocation",
+  }));
+  return node;
+}
+
+interface Recorded {
+  method: string;
+  url: string;
+}
+
+/**
+ * Stub `fetch` with a small router and record every request, so tests assert
+ * on the exact wire sequence rather than on internal call counts.
+ */
+function withRecordedFetch<T>(
+  handler: (method: string, url: string) => Response | undefined,
+  fn: (recorded: Recorded[]) => Promise<T>,
+): Promise<T> {
+  const original = globalThis.fetch;
+  const recorded: Recorded[] = [];
+  globalThis.fetch = mock(async (input: any, init?: any) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    recorded.push({ method, url });
+    const response = handler(method, url);
+    if (!response) throw new Error(`unexpected fetch: ${method} ${url}`);
+    return response;
+  }) as unknown as typeof fetch;
+  return fn(recorded).finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+// ---------------------------------------------------------------------------
+// (a) nodeId reuse
+// ---------------------------------------------------------------------------
+
+test("fetchNodeId reuses the nodeId that sign-in already read from /info", async () => {
+  const node = makeNode({ cachedNodeIdHost: HOST });
+
+  await withRecordedFetch(
+    () => undefined, // any request at all is a failure
+    async (recorded) => {
+      const nodeId = await (node as any).fetchNodeId();
+      expect(nodeId).toBe(NODE_DID);
+      expect(recorded).toEqual([]);
+    },
+  );
+});
+
+test("fetchNodeId falls back to GET /info when sign-in recorded a different host", async () => {
+  // Sign-in targeted another node: the cached DID must not be reused here.
+  const node = makeNode({ cachedNodeIdHost: "https://other.tinycloud.test" });
+
+  await withRecordedFetch(
+    (method, url) =>
+      method === "GET" && url === `${HOST}/info`
+        ? json({ nodeId: NODE_DID, protocol: 1, version: "1.0.0", features: [] })
+        : undefined,
+    async (recorded) => {
+      const nodeId = await (node as any).fetchNodeId();
+      expect(nodeId).toBe(NODE_DID);
+      expect(recorded).toEqual([{ method: "GET", url: `${HOST}/info` }]);
+    },
+  );
+});
+
+test("fetchNodeId falls back to GET /info when the node reported no nodeId", async () => {
+  // No cached host at all — the auth layer stores nothing when /info omits nodeId.
+  const node = makeNode();
+
+  await withRecordedFetch(
+    (method, url) =>
+      method === "GET" && url === `${HOST}/info`
+        ? json({ nodeId: NODE_DID, protocol: 1, version: "1.0.0", features: [] })
+        : undefined,
+    async (recorded) => {
+      expect(await (node as any).fetchNodeId()).toBe(NODE_DID);
+      expect(recorded).toHaveLength(1);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (b) POST-first / 409 handling
+// ---------------------------------------------------------------------------
+
+test("assumeMissing skips the existence probe: create is the only request", async () => {
+  const node = makeNode({ cachedNodeIdHost: HOST });
+
+  await withRecordedFetch(
+    (method, url) =>
+      method === "POST" && url === `${HOST}/encryption/networks`
+        ? json({ descriptor: DESCRIPTOR }, 201)
+        : undefined,
+    async (recorded) => {
+      const descriptor = await node.ensureEncryptionNetwork(NETWORK_ID, {
+        assumeMissing: true,
+      });
+
+      expect(descriptor).toEqual(DESCRIPTOR as any);
+      // No GET /info and no GET /encryption/networks/{id}: one request total.
+      expect(recorded).toEqual([
+        { method: "POST", url: `${HOST}/encryption/networks` },
+      ]);
+    },
+  );
+});
+
+test("409 Conflict is treated as success and resolved to the existing network", async () => {
+  const node = makeNode({ cachedNodeIdHost: HOST });
+
+  await withRecordedFetch(
+    (method, url) => {
+      if (method === "POST" && url === `${HOST}/encryption/networks`) {
+        // The only Conflict this route produces is NetworkAlreadyExists.
+        return new Response("network already exists", { status: 409 });
+      }
+      if (method === "GET" && url.startsWith(`${HOST}/encryption/networks/`)) {
+        return json({ descriptor: DESCRIPTOR });
+      }
+      return undefined;
+    },
+    async (recorded) => {
+      const descriptor = await node.ensureEncryptionNetwork(NETWORK_ID, {
+        assumeMissing: true,
+      });
+
+      expect(descriptor).toEqual(DESCRIPTOR as any);
+      expect(recorded.map((r) => r.method)).toEqual(["POST", "GET"]);
+    },
+  );
+});
+
+test("a non-409 create failure still throws", async () => {
+  const node = makeNode({ cachedNodeIdHost: HOST });
+
+  await withRecordedFetch(
+    (method, url) =>
+      method === "POST" && url === `${HOST}/encryption/networks`
+        ? new Response("not authorized", { status: 401 })
+        : undefined,
+    async () => {
+      await expect(
+        node.ensureEncryptionNetwork(NETWORK_ID, { assumeMissing: true }),
+      ).rejects.toThrow(/Failed to create encryption network .*HTTP 401/);
+    },
+  );
+});
+
+test("without assumeMissing the warm path is unchanged: one GET, no create", async () => {
+  const node = makeNode({ cachedNodeIdHost: HOST });
+
+  await withRecordedFetch(
+    (method, url) =>
+      method === "GET" && url.startsWith(`${HOST}/encryption/networks/`)
+        ? json({ descriptor: DESCRIPTOR })
+        : undefined,
+    async (recorded) => {
+      const descriptor = await node.ensureEncryptionNetwork(NETWORK_ID);
+
+      expect(descriptor).toEqual(DESCRIPTOR as any);
+      expect(recorded).toEqual([
+        {
+          method: "GET",
+          url: `${HOST}/encryption/networks/${encodeURIComponent(NETWORK_ID)}`,
+        },
+      ]);
+    },
+  );
+});
+
+test("without assumeMissing a 404 probe still falls through to create", async () => {
+  const node = makeNode({ cachedNodeIdHost: HOST });
+
+  await withRecordedFetch(
+    (method, url) => {
+      if (method === "GET" && url.startsWith(`${HOST}/encryption/networks/`)) {
+        return new Response("", { status: 404 });
+      }
+      if (method === "POST" && url === `${HOST}/encryption/networks`) {
+        return json({ descriptor: DESCRIPTOR }, 201);
+      }
+      return undefined;
+    },
+    async (recorded) => {
+      const descriptor = await node.ensureEncryptionNetwork(NETWORK_ID);
+
+      expect(descriptor).toEqual(DESCRIPTOR as any);
+      expect(recorded.map((r) => r.method)).toEqual(["GET", "POST"]);
+    },
+  );
+});
+
+test("ensureEncryptionNetwork still refuses to create a network owned by someone else", async () => {
+  const node = makeNode({ cachedNodeIdHost: HOST });
+  const foreign = "urn:tinycloud:encryption:did:pkh:eip155:1:0x00000000000000000000000000000000000000ff:default";
+
+  await withRecordedFetch(
+    () => undefined,
+    async () => {
+      // assumeMissing must not bypass the ownership check.
+      await expect(
+        node.ensureEncryptionNetwork(foreign, { assumeMissing: true }),
+      ).rejects.toThrow(/does not match signed-in DID/);
+    },
+  );
+});

--- a/packages/node-sdk/src/TinyCloudNode.ensureOwnedSpaceHostedById.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ensureOwnedSpaceHostedById.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Per-sign-in hosting memo for the private `ensureOwnedSpaceHostedById`
+ * (TC-293 P3).
+ *
+ * `AccountService.ensureAccountSpaceHosted` funnels six calls through this
+ * method during account bootstrap. Each one POSTs `/delegate` with the primary
+ * session, whose recap covers only `default` + `secrets` — so the account space
+ * appears in neither `activated` nor `skipped`, the guard returns immediately,
+ * and the repeat calls cannot change the outcome. These tests pin that the
+ * delegate submission happens once per space per sign-in, and that `signIn`
+ * resets the memo.
+ */
+import { expect, mock, test } from "bun:test";
+
+import type { ISessionManager, IWasmBindings } from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+const ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+const HOST = "https://tinycloud.test";
+const ACCOUNT_SPACE = `tinycloud:pkh:eip155:1:${ADDRESS}:account`;
+const SECRETS_SPACE = `tinycloud:pkh:eip155:1:${ADDRESS}:secrets`;
+
+function makeSessionManager(): ISessionManager {
+  return {
+    createSessionKey: (id: string) => id,
+    replaceSessionKey: (_jwk: object, keyId: string) => keyId,
+    renameSessionKeyId: () => {},
+    getDID: (keyId: string) => `did:key:${keyId}`,
+    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+  } as unknown as ISessionManager;
+}
+
+function makeWasmBindings(): IWasmBindings {
+  return {
+    invoke: async () => undefined,
+    makeSpaceId: (address: string, chainId: number, name: string) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${name}`,
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    createSessionManager: makeSessionManager,
+  } as unknown as IWasmBindings;
+}
+
+function makeNode(): TinyCloudNode {
+  const node = new TinyCloudNode({
+    host: HOST,
+    signer: {
+      getAddress: async () => ADDRESS,
+      getChainId: async () => 1,
+      signMessage: mock(async () => "0xsig"),
+    } as any,
+    wasmBindings: makeWasmBindings(),
+  });
+  // Simulate post-signIn state.
+  (node as any)._address = ADDRESS;
+  (node as any)._chainId = 1;
+  (node as any).auth = {
+    tinyCloudSession: {
+      address: ADDRESS,
+      chainId: 1,
+      // Unique per node so sdk-core's in-flight activation dedupe (keyed on
+      // host + header) can never mask a repeated submission across tests.
+      delegationHeader: { Authorization: `token-${Math.random()}` },
+      spaceId: `tinycloud:pkh:eip155:1:${ADDRESS}:default`,
+    },
+    hostOwnedSpace: mock(async (spaceId: string) => spaceId),
+  };
+  return node;
+}
+
+/**
+ * Stub `fetch` and count POSTs to `/delegate`. `activated`/`skipped` default to
+ * empty, which is the real production shape for a space the primary session's
+ * recap never mentions.
+ */
+function withDelegateFetch<T>(
+  body: { activated?: string[]; skipped?: string[] },
+  fn: (calls: () => number) => Promise<T>,
+): Promise<T> {
+  const original = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = mock(async (input: any, init?: any) => {
+    const url = String(input);
+    if (url.endsWith("/delegate") && init?.method === "POST") {
+      calls += 1;
+      return new Response(
+        JSON.stringify({
+          cid: "bafy-activation",
+          activated: body.activated ?? [],
+          skipped: body.skipped ?? [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    throw new Error(`unexpected fetch: ${init?.method ?? "GET"} ${url}`);
+  }) as unknown as typeof fetch;
+  return fn(() => calls).finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+test("ensureOwnedSpaceHostedById submits /delegate ONCE across the six bootstrap calls", async () => {
+  const node = makeNode();
+
+  await withDelegateFetch({}, async (calls) => {
+    for (let i = 0; i < 6; i += 1) {
+      await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    }
+    expect(calls()).toBe(1);
+  });
+});
+
+test("the memo is per space, not global", async () => {
+  const node = makeNode();
+
+  await withDelegateFetch({}, async (calls) => {
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    await (node as any).ensureOwnedSpaceHostedById(SECRETS_SPACE);
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    await (node as any).ensureOwnedSpaceHostedById(SECRETS_SPACE);
+
+    expect(calls()).toBe(2);
+  });
+});
+
+test("a skipped space is NOT memoized as hosted", async () => {
+  const node = makeNode();
+
+  // `skipped` includes the space => the guard does not return early, so the
+  // create path runs and only the post-create activation may confirm hosting.
+  await withDelegateFetch({ skipped: [ACCOUNT_SPACE] }, async (calls) => {
+    await expect(
+      (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE),
+    ).rejects.toThrow(/Failed to activate session after creating owned space/);
+    // Initial probe + post-create retry.
+    expect(calls()).toBe(2);
+  });
+
+  // The failure must not have poisoned the memo into "hosted".
+  await withDelegateFetch({}, async (calls) => {
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    expect(calls()).toBe(1);
+  });
+});
+
+test("hosting confirmed after a create is memoized too", async () => {
+  const node = makeNode();
+
+  // First activation reports the space as skipped, so the space is created and
+  // the retry activation (empty skipped) confirms it.
+  let firstCall = true;
+  const original = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = mock(async (input: any, init?: any) => {
+    const url = String(input);
+    if (url.endsWith("/delegate") && init?.method === "POST") {
+      calls += 1;
+      const skipped = firstCall ? [ACCOUNT_SPACE] : [];
+      firstCall = false;
+      return new Response(JSON.stringify({ cid: "bafy", activated: [], skipped }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+
+  try {
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    expect(calls).toBe(2);
+
+    // Already confirmed: no further /delegate submissions.
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    expect(calls).toBe(2);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("signIn clears the memo so the next session re-confirms hosting", async () => {
+  const node = makeNode();
+
+  // Confirm hosting under the current session.
+  await withDelegateFetch({}, async (calls) => {
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    expect(calls()).toBe(1);
+  });
+  expect((node as any).confirmedHostedSpaceIds.has(ACCOUNT_SPACE)).toBe(true);
+
+  // Drive the real signIn() with its network layers stubbed out.
+  const tc = (node as any).tc;
+  tc.signIn = mock(async () => ({
+    address: ADDRESS,
+    walletAddress: ADDRESS,
+    chainId: 1,
+    sessionKey: "session-test",
+    siwe: "fake-siwe",
+    signature: `0x${"ff".repeat(65)}`,
+  }));
+  (node as any).syncResolvedHostFromAuth = () => {};
+  (node as any).initializeServices = () => {};
+  (node as any).isFreshBootstrapAccount = async () => false;
+  (node as any).ensureRequestedEncryptionNetworks = async () => {};
+  (node as any).scheduleAccountRegistrySync = () => {};
+
+  // signIn itself ensures the `secrets` space is hosted, so keep the delegate
+  // stub in place and let that real call run.
+  await withDelegateFetch({}, async () => {
+    await node.signIn();
+  });
+
+  // The pre-signIn confirmation is gone; only what THIS session confirmed
+  // remains.
+  expect((node as any).confirmedHostedSpaceIds.has(ACCOUNT_SPACE)).toBe(false);
+  expect((node as any).confirmedHostedSpaceIds.has(SECRETS_SPACE)).toBe(true);
+
+  // The new session therefore re-submits /delegate for the account space.
+  await withDelegateFetch({}, async (calls) => {
+    await (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE);
+    expect(calls()).toBe(1);
+  });
+});
+
+test("ensureOwnedSpaceHostedById still requires an active session", async () => {
+  const node = makeNode();
+  (node as any).auth = { tinyCloudSession: undefined };
+
+  await expect(
+    (node as any).ensureOwnedSpaceHostedById(ACCOUNT_SPACE),
+  ).rejects.toThrow("Owned space hosting requires an active session");
+});

--- a/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.signInManifest.test.ts
@@ -34,16 +34,6 @@ import { TinyCloudNode } from "./TinyCloudNode";
 // keep this file self-contained and easy to read in isolation)
 // ---------------------------------------------------------------------------
 
-async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
-  const started = Date.now();
-  while (!predicate()) {
-    if (Date.now() - started > timeoutMs) {
-      throw new Error("Timed out waiting for predicate");
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-}
-
 function makeFakeSessionManager(): ISessionManager {
   // Pre-seed with "default" since that's the key name the
   // TinyCloudNode constructor uses on the WASM side; the real
@@ -77,9 +67,39 @@ function makeFakeSessionManager(): ISessionManager {
   };
 }
 
+// Each fake WASM-bindings instance gets a unique, file-scoped activation
+// delegation header (`Bearer signInManifest-<n>`) instead of a constant
+// "Bearer fake". The prefix is file-specific — not just "fake-N" — so it
+// can't collide with another test file's own counter if bun ever runs
+// multiple files in one process. Per-instance uniqueness makes cross-test
+// single-flight joins in `activateSessionWithHost`
+// (sdk-core/src/space.ts, keyed on host + the full delegation header)
+// impossible for this file's sessions: two different headers can never
+// coalesce into the same in-flight request. See TC-372.
+let signInManifestAuthorizationSeq = 0;
+
+// Tracks the activation Authorization header each fake bindings instance
+// will present, so `withFetchResponses` can confirm an incoming
+// `POST .../delegate` actually belongs to the test that installed the
+// current fetch mock — not a same-shaped request leaked from an earlier
+// test's detached account-registry-sync retry.
+const expectedActivationAuthorizationByBindings = new WeakMap<IWasmBindings, string>();
+
+function expectedActivationAuthorizationFor(wasm: IWasmBindings): string {
+  const authorization = expectedActivationAuthorizationByBindings.get(wasm);
+  if (authorization === undefined) {
+    throw new Error(
+      "expectedActivationAuthorizationFor: these wasm bindings were not created by " +
+        "makeFakeWasmBindings, so withFetchResponses has no expected header to match",
+    );
+  }
+  return authorization;
+}
+
 function makeFakeWasmBindings(
   overrides: Partial<IWasmBindings> = {},
 ): IWasmBindings {
+  const authorization = `Bearer signInManifest-${++signInManifestAuthorizationSeq}`;
   const base: IWasmBindings = {
     invoke: mock(() => Promise.resolve({} as any)) as any,
     invokeAny: mock(() => Promise.resolve({} as any)) as any,
@@ -90,7 +110,7 @@ function makeFakeWasmBindings(
       verificationMethod: "did:key:z6MkTestSession",
     })),
     completeSessionSetup: mock(() => ({
-      delegationHeader: { Authorization: "Bearer fake" },
+      delegationHeader: { Authorization: authorization },
       delegationCid: "bafyfake",
       jwk: { kty: "OKP" },
       spaceId: "space://test",
@@ -115,7 +135,9 @@ function makeFakeWasmBindings(
     vault_sha256: mock(() => new Uint8Array()),
     createSessionManager: makeFakeSessionManager,
   };
-  return { ...base, ...overrides };
+  const bindings = { ...base, ...overrides };
+  expectedActivationAuthorizationByBindings.set(bindings, authorization);
+  return bindings;
 }
 
 /**
@@ -125,33 +147,99 @@ function makeFakeWasmBindings(
  * needs: getAddress, getChainId, signMessage. We don't reach the network
  * calls (checkNodeInfo, ensureSpaceExists) because we override those via
  * monkey-patching the auth instance after construction.
+ *
+ * `scheduleAccountRegistrySync` is stubbed to a no-op by default — the same
+ * idiom the `bootstrapGate`/`accountRegistrySync` test fixtures already use.
+ * A full `signIn()` in this file otherwise ends with a *detached* background
+ * registry sync (retries at 250ms/1s/3s) that easily outlives the calling
+ * test's own `withFetchResponses` window and leaks into whichever test runs
+ * next (TC-372). Pass `{ realRegistrySync: true }` for the one test that
+ * asserts on the sync's own effects.
  */
 function makeNodeWithSigner(
   wasm: IWasmBindings,
   config: Partial<ConstructorParameters<typeof TinyCloudNode>[0]> = {},
+  opts: { realRegistrySync?: boolean } = {},
 ): TinyCloudNode {
   const fakeSigner = {
     signMessage: async () => "0x" + "ff".repeat(65),
     getAddress: async () => "0x0000000000000000000000000000000000000001",
     getChainId: async () => 1,
   };
-  return new TinyCloudNode({
+  const node = new TinyCloudNode({
     wasmBindings: wasm,
     signer: fakeSigner as any,
     host: "https://tinycloud.test",
     ...config,
   });
+  if (!opts.realRegistrySync) {
+    (node as any).scheduleAccountRegistrySync = () => {};
+  }
+  return node;
 }
 
+/**
+ * Serve fixed `Response`s to fetch calls made during `fn`, but only to the
+ * calls this test actually expects.
+ *
+ * Every signIn / ensureOwnedSpaceHostedById flow in this file makes at most
+ * two kinds of request, always in this order: an unauthenticated
+ * `GET .../info` (checkNodeInfo) and an authenticated `POST .../delegate`
+ * (activateSessionWithHost). Two queued responses means [info, activate];
+ * one means [activate] alone — every call site below uses one of those two
+ * shapes, so the expected sequence can be derived from `responses.length`.
+ *
+ * Matching is deliberately strict and *positional* rather than "shift the
+ * queue for anything that shows up": a leaked fetch from an earlier test's
+ * detached account-registry-sync retry (TC-372) must never silently consume
+ * this test's queued response — whether it's a differently-shaped request
+ * (e.g. a SQL `/invoke` from `indexHasApplicationHash`) or a same-shaped
+ * `POST /delegate` whose Authorization header proves it belongs to a
+ * *different* session. `expectedAuthorization` is normally
+ * `expectedActivationAuthorizationFor(wasm)` for the wasm bindings this
+ * test's node was built with (unique per instance — see
+ * `makeFakeWasmBindings`); tests that install a delegation header directly
+ * (bypassing `completeSessionSetup`) pass the literal string instead.
+ *
+ * An unmatched request throws synchronously with the URL/method/position it
+ * failed to match, rather than falling through to the real network — a leak
+ * fails loudly at its source instead of silently hitting the network or
+ * stealing a neighboring test's response.
+ */
 async function withFetchResponses(
   responses: Response[],
   fn: (fetchMock: any) => Promise<void>,
+  expectedAuthorization: string,
 ): Promise<void> {
   const originalFetch = globalThis.fetch;
-  const fetchMock = mock(async () => {
+  const expectedSequence: Array<"info" | "delegate"> =
+    responses.length >= 2 ? ["info", "delegate"] : ["delegate"];
+  let position = 0;
+
+  const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const expectedKind = expectedSequence[position];
+    const authorization = new Headers(init?.headers).get("authorization");
+
+    const matches =
+      expectedKind === "info"
+        ? method === "GET" && url.endsWith("/info")
+        : method === "POST" && url.endsWith("/delegate") && authorization === expectedAuthorization;
+
+    if (!matches) {
+      throw new Error(
+        `unexpected fetch: ${method} ${url} (expected this test's ${expectedKind} ` +
+          `request at position ${position}${
+            expectedKind === "delegate" ? `, authorization "${authorization}"` : ""
+          })`,
+      );
+    }
+
+    position += 1;
     const response = responses.shift();
     if (!response) {
-      throw new Error("unexpected fetch");
+      throw new Error(`unexpected fetch: ${method} ${url} (response queue already empty)`);
     }
     return response;
   });
@@ -225,7 +313,8 @@ function stubAuthNetworkCalls(node: TinyCloudNode): void {
 
 describe("TinyCloudNode.signIn — manifest-driven recap", () => {
   test("sessionDid follows the active key across repeated signIn calls", async () => {
-    const node = makeNodeWithSigner(makeFakeWasmBindings(), {
+    const wasm = makeFakeWasmBindings();
+    const node = makeNodeWithSigner(wasm, {
       autoBootstrapAccount: false,
       includeAccountRegistryPermissions: false,
       manifest: {
@@ -255,6 +344,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
       async () => {
         await node.signIn();
       },
+      expectedActivationAuthorizationFor(wasm),
     );
 
     const firstKeyId = node.session?.sessionKey;
@@ -282,6 +372,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
       async () => {
         await node.signIn();
       },
+      expectedActivationAuthorizationFor(wasm),
     );
 
     const secondKeyId = node.session?.sessionKey;
@@ -639,6 +730,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
       async () => {
         await node.signIn();
       },
+      expectedActivationAuthorizationFor(wasm),
     );
 
     expect(ensureEncryptionNetwork).toHaveBeenCalledTimes(1);
@@ -651,6 +743,22 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
     });
   });
 
+  /**
+   * Narrow property: signIn's *implicit* create-grant synthesis (the
+   * `didPrincipalMatches` owner check in
+   * NodeUserAuthorization.resolveSignInCapabilities, guarded again by the
+   * same check in TinyCloudNode.ensureRequestedEncryptionNetworks before
+   * ensureEncryptionNetwork runs) does not auto-add
+   * `tinycloud.encryption/network.create` for a network owned by someone
+   * else.
+   *
+   * This does NOT prove the broader "signIn never composes a foreign
+   * network.create" invariant. An explicitly-requested foreign
+   * `network.create` permission is copied into `rawAbilities` before either
+   * owner guard runs (both guards only gate the *implicit* add), and
+   * manifests can request `network.create` explicitly — that path is
+   * untested here and tracked separately as TC-391.
+   */
   test("signIn does not add a create grant for another owner's encryption network", async () => {
     const networkId =
       "urn:tinycloud:encryption:did:pkh:eip155:1:0x0000000000000000000000000000000000000002:default";
@@ -694,6 +802,7 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
       async () => {
         await node.signIn();
       },
+      expectedActivationAuthorizationFor(wasm),
     );
 
     expect(ensureEncryptionNetwork).not.toHaveBeenCalled();
@@ -722,6 +831,10 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
           "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:account",
         );
       },
+      // This test bypasses completeSessionSetup and installs the delegation
+      // header directly, so the expected header is this literal rather than
+      // expectedActivationAuthorizationFor(wasm).
+      "Bearer fake",
     );
 
     expect(auth.hostOwnedSpace).not.toHaveBeenCalled();
@@ -772,11 +885,16 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
         },
       ],
     };
-    const node = makeNodeWithSigner(makeFakeWasmBindings(), { manifest });
+    const wasm = makeFakeWasmBindings();
+    // This is the one test in the file that asserts on the account-registry
+    // sync's own effects, so it opts back into the real (non-stubbed)
+    // scheduleAccountRegistrySync — see makeNodeWithSigner.
+    const node = makeNodeWithSigner(wasm, { manifest }, { realRegistrySync: true });
     const accountSpaceId =
       "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:account";
     const ensureOwnedSpaceHostedById = mock(async () => {});
     const put = mock(async () => ({ ok: true, data: undefined, headers: {} }));
+    const spacesList = mock(async () => ({ ok: true, data: [] }));
 
     (node as any).ensureOwnedSpaceHostedById = ensureOwnedSpaceHostedById;
     Object.defineProperty(node, "spaces", {
@@ -786,8 +904,40 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
           expect(spaceId).toBe(accountSpaceId);
           return { kv: { put } };
         },
+        // syncAccessible() (part of the real registry sync this test opts
+        // into) reads this via `config.getSpaces().list()`.
+        list: spacesList,
       },
     });
+
+    // The real registry sync also runs `index.ensure()` (fire-and-forget)
+    // and, via `applications.register()`, an `indexHasApplicationHash()`
+    // SQL pre-read before every write. None of that has a real server to
+    // answer it here — stub it away so no `/invoke` escapes this test's
+    // fetch mock and forces the retry backoff in withAccountRegistryRetry
+    // (250ms/1s/3s), which would otherwise make this test slow and still
+    // timing-dependent.
+    (node.account as any).indexHasApplicationHash = async () => false;
+    (node.account as any).index.ensure = async () => ({
+      ok: true,
+      data: { database: "account" },
+    });
+    (node.account as any).upsertApplicationIndexQuietly = async () => {};
+
+    // scheduleAccountRegistrySync fires `withAccountRegistryRetry(...)`
+    // detached (`void`) so signIn() can return without waiting on it.
+    // Capture the promise it returns so this test can await the *entire*
+    // retry-wrapped chain settling before its own withFetchResponses window
+    // closes — waiting only for `put` to have been called proves the write
+    // happened, but not that the scheduler is done, and any part of it that
+    // runs after this test's fetch mock is torn down is exactly the leak
+    // this fix (TC-372) exists to prevent.
+    let registrySync: Promise<void> | undefined;
+    const originalWithAccountRegistryRetry = (node as any).withAccountRegistryRetry.bind(node);
+    (node as any).withAccountRegistryRetry = (task: () => Promise<void>) => {
+      registrySync = originalWithAccountRegistryRetry(task);
+      return registrySync;
+    };
 
     await withFetchResponses(
       [
@@ -807,10 +957,11 @@ describe("TinyCloudNode.signIn — manifest-driven recap", () => {
       ],
       async () => {
         await node.signIn();
+        await registrySync;
       },
+      expectedActivationAuthorizationFor(wasm),
     );
 
-    await waitFor(() => put.mock.calls.length > 0);
     expect(ensureOwnedSpaceHostedById).toHaveBeenCalledWith(accountSpaceId);
     expect(put).toHaveBeenCalledTimes(1);
     expect(put).toHaveBeenCalledWith("applications/com.listen.app", {

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -642,6 +642,22 @@ export interface RuntimePermissionGrantOptions {
   expiry?: string | number;
 }
 
+export interface EnsureEncryptionNetworkOptions {
+  /**
+   * Skip the `GET /encryption/networks/{id}` existence probe and go straight
+   * to the create.
+   *
+   * The probe pays for itself only when the network already exists. On a
+   * freshly bootstrapped account it is a guaranteed 404, so it costs a round
+   * trip on the cold sign-in path and saves nothing. Creating without it is
+   * safe: the server answers `409 Conflict` if the network is already there,
+   * which {@link TinyCloudNode.createEncryptionNetwork} resolves by reading the
+   * existing descriptor. Set this only when the caller knows the account was
+   * just provisioned.
+   */
+  assumeMissing?: boolean;
+}
+
 interface RuntimePermissionOperation {
   spaceId?: string;
   resource?: string;
@@ -833,6 +849,13 @@ export class TinyCloudNode {
    * so this avoids re-parsing the recap on every registration.
    */
   private _recapOperationsCache?: { siwe: string; operations: RuntimePermissionOperation[] };
+
+  /**
+   * Owned space ids this sign-in has already confirmed are hosted. Consulted by
+   * {@link ensureOwnedSpaceHostedById}; cleared on every {@link signIn} because
+   * hosting is confirmed against the session that was active at the time.
+   */
+  private readonly confirmedHostedSpaceIds = new Set<string>();
 
   /**
    * TinyCloudSession captured by {@link restoreSession} when there's no
@@ -1365,6 +1388,7 @@ export class TinyCloudNode {
     this._spaceService = undefined;
     this._serviceContext = undefined;
     this.runtimePermissionGrants = [];
+    this.confirmedHostedSpaceIds.clear();
 
     await this.tc.signIn(options);
     this.syncResolvedHostFromAuth();
@@ -1615,6 +1639,10 @@ export class TinyCloudNode {
           step.manifests.length > 0
             ? [...step.manifests]
             : TINYCLOUD_SECRETS_BOOTSTRAP_MANIFEST,
+          // Bootstrap only runs on an account with no registry records, so the
+          // manifest-hash pre-read is definitionally a miss. Skip it; the write
+          // it guards is an INSERT OR REPLACE and is safe to repeat.
+          { assumeUnregistered: true },
         );
         if (!registered.ok) {
           throw new Error(`Failed to seed bootstrap applications: ${registered.error.message}`);
@@ -1622,7 +1650,10 @@ export class TinyCloudNode {
       }
 
       if (step.kind === "encryption-network-create") {
-        await this.ensureEncryptionNetwork(step.networkId);
+        // Bootstrap only runs on a fresh account, so the existence probe is a
+        // guaranteed 404. Create directly; a 409 is resolved to the existing
+        // descriptor.
+        await this.ensureEncryptionNetwork(step.networkId, { assumeMissing: true });
       }
 
       if (step.kind === "secret-records-schema") {
@@ -1957,6 +1988,22 @@ export class TinyCloudNode {
     }
   }
 
+  /**
+   * Ensure one of this user's owned spaces is hosted, at most once per space
+   * per sign-in.
+   *
+   * Account bootstrap funnels six calls through here (via
+   * `AccountService.ensureAccountSpaceHosted`), and each one re-submits
+   * `activateSessionWithHost` with the *primary* session. That session's recap
+   * covers only `default` and `secrets`, so the account space appears in
+   * neither `activated` nor `skipped` and the guard below returns immediately
+   * — the repeat calls cannot change the outcome, they only cost round trips.
+   *
+   * The memo is per sign-in ({@link confirmedHostedSpaceIds} is cleared in
+   * `signIn`) and only records confirmed successes. A wrong skip is
+   * self-revealing: the next write to the space fails immediately and loudly
+   * with `404 Space not found`.
+   */
   private async ensureOwnedSpaceHostedById(spaceId: string): Promise<void> {
     if (!this.auth) {
       throw new Error("Owned space hosting requires wallet mode");
@@ -1967,6 +2014,10 @@ export class TinyCloudNode {
       throw new Error("Owned space hosting requires an active session");
     }
 
+    if (this.confirmedHostedSpaceIds.has(spaceId)) {
+      return;
+    }
+
     const host = this.hosts[0] ?? this.config.host;
     if (!host) {
       throw new Error("Owned space hosting requires a TinyCloud host");
@@ -1974,6 +2025,7 @@ export class TinyCloudNode {
 
     const activation = await activateSessionWithHost(host, session.delegationHeader);
     if (activation.success && !activation.skipped?.includes(spaceId)) {
+      this.confirmedHostedSpaceIds.add(spaceId);
       return;
     }
 
@@ -1998,6 +2050,7 @@ export class TinyCloudNode {
         }`,
       );
     }
+    this.confirmedHostedSpaceIds.add(spaceId);
   }
 
   /**
@@ -2427,6 +2480,7 @@ export class TinyCloudNode {
     this.tc = stagedGraph.core;
     this._recapOperationsCache = stagedPrimary.cache;
     this.runtimePermissionGrants = stagedPrimary.grants;
+    this.confirmedHostedSpaceIds.clear();
     if (this.auth) {
       this.auth.installRestoredSession(stagedManager, stagedTcSession, [stagedHost]);
       this._restoredTcSession = undefined;
@@ -3119,7 +3173,18 @@ export class TinyCloudNode {
     };
   }
 
+  /**
+   * The node DID for {@link config.host}.
+   *
+   * Sign-in already performs `GET /info` for the protocol-version check, and
+   * that response carries `nodeId`, so reuse it rather than fetching `/info` a
+   * second time. Only a value recorded for this exact host qualifies; older
+   * nodes that omit `nodeId` fall through to the fetch.
+   */
   private async fetchNodeId(): Promise<string> {
+    const cached = this.auth?.nodeIdForHost(this.config.host!);
+    if (cached) return cached;
+
     const response = await fetch(`${this.config.host}/info`);
     if (!response.ok) {
       throw new Error(`Failed to fetch node info: HTTP ${response.status}`);
@@ -4029,6 +4094,18 @@ export class TinyCloudNode {
         body as unknown as CanonicalizableEncryptionJson,
       ),
     });
+    // `NetworkAlreadyExists` is the only error this route maps to Conflict
+    // (`NetworkNotActive`, the other Conflict in the shared error mapper, is
+    // reachable only from the decrypt routes). So a 409 means the network is
+    // already there — which is exactly the post-condition `create` promises.
+    // Read it back rather than failing an otherwise-successful ensure.
+    if (response.status === 409) {
+      const existing = await this.getEncryptionNetwork(networkId);
+      if (existing) return existing;
+      throw new Error(
+        `Encryption network ${networkId} already exists but could not be read back`,
+      );
+    }
     if (!response.ok) {
       throw new Error(
         `Failed to create encryption network ${networkId}: HTTP ${response.status} ${await response.text()}`,
@@ -4038,15 +4115,28 @@ export class TinyCloudNode {
     return created.descriptor;
   }
 
+  /**
+   * Ensure an encryption network exists, creating it if necessary.
+   *
+   * @param nameOrNetworkId - Network name or full `urn:tinycloud:encryption:` id.
+   * @param options - See {@link EnsureEncryptionNetworkOptions}.
+   */
   async ensureEncryptionNetwork(
     nameOrNetworkId = DEFAULT_ENCRYPTION_NETWORK_NAME,
+    options: EnsureEncryptionNetworkOptions = {},
   ): Promise<NetworkDescriptor> {
     const networkId = nameOrNetworkId.startsWith("urn:tinycloud:encryption:")
       ? nameOrNetworkId
       : this.getDefaultEncryptionNetworkId(nameOrNetworkId);
-    const existing = await this.getEncryptionNetwork(networkId);
-    if (existing) {
-      return existing;
+    // The existence probe is worth a round trip only when the network is
+    // likely to be there. On a freshly bootstrapped account it always 404s,
+    // so callers that know the account is new skip straight to the create —
+    // which is itself safe to race, since 409 is handled above.
+    if (!options.assumeMissing) {
+      const existing = await this.getEncryptionNetwork(networkId);
+      if (existing) {
+        return existing;
+      }
     }
     const parsed = parseNetworkId(networkId);
     if (!didPrincipalMatches(parsed.ownerDid, this.did)) {

--- a/packages/node-sdk/src/account/AccountService.coldSignIn.test.ts
+++ b/packages/node-sdk/src/account/AccountService.coldSignIn.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Cold sign-in request-count guards for AccountService (TC-293).
+ *
+ * Account bootstrap touches the materialized index eight times and registers
+ * the bootstrap manifest once. These tests pin the two behaviours that keep
+ * that from costing ~17 avoidable round trips:
+ *
+ *   - the index schema migration is applied at most once per account space
+ *     (P1), and a failure is never cached;
+ *   - the bootstrap manifest write skips the `application_state` pre-read
+ *     that can only ever miss on a fresh account (P5), without weakening the
+ *     dedupe on the normal re-registration path.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { Manifest } from "@tinycloud/sdk-core";
+
+import { AccountService } from "./AccountService";
+
+const ACCOUNT_SPACE = "tinycloud:pkh:eip155:1:0xabc:account";
+const OTHER_ACCOUNT_SPACE = "tinycloud:pkh:eip155:1:0xdef:account";
+
+const MANIFEST: Manifest = {
+  app_id: "com.notes.app",
+  name: "Notes",
+  defaults: false,
+};
+
+function makeHarness(
+  options: {
+    /** Number of leading `migrations.apply` calls that should fail. */
+    migrationFailures?: number;
+    /** Make the `application_state` pre-read report the manifest as current. */
+    indexReportsCurrent?: boolean;
+  } = {},
+) {
+  let remainingFailures = options.migrationFailures ?? 0;
+  let accountSpaceId = ACCOUNT_SPACE;
+
+  const queries: string[] = [];
+  const batches: Array<Array<{ sql: string; params?: unknown[] }>> = [];
+  const puts: Array<{ key: string; value: any }> = [];
+
+  const apply = mock(async (migrationOptions: any) => {
+    if (remainingFailures > 0) {
+      remainingFailures -= 1;
+      return {
+        ok: false,
+        error: {
+          code: "SQL_PERMISSION_DENIED",
+          message: "SQL migration failed: 403 - not authorized",
+          service: "sql",
+        },
+      };
+    }
+    return {
+      ok: true,
+      data: {
+        database: "account",
+        namespace: migrationOptions.namespace,
+        status: "already_current",
+        applied: [],
+        skipped: migrationOptions.migrations.map((m: any) => m.id),
+      },
+    };
+  });
+
+  const query = mock(async (sql: string, _params?: unknown[]) => {
+    queries.push(sql);
+    if (sql.includes("FROM application_state")) {
+      return {
+        ok: true,
+        data: {
+          columns: ["matched"],
+          rows: options.indexReportsCurrent ? [["1"]] : [],
+          rowCount: options.indexReportsCurrent ? 1 : 0,
+        },
+      };
+    }
+    return { ok: true, data: { columns: [], rows: [], rowCount: 0 } };
+  });
+
+  const batch = mock(async (statements: Array<{ sql: string; params?: unknown[] }>) => {
+    batches.push(statements);
+    return {
+      ok: true,
+      data: { results: statements.map(() => ({ changes: 1, lastInsertRowId: 0 })) },
+    };
+  });
+
+  // A *fresh* handle per call, exactly like TinyCloudNode.getAccountDb, which
+  // builds a new SQLService + ServiceContext every time. This is why
+  // SQLService's own in-flight migration lock never helps here, and why the
+  // memo must live on AccountService rather than on the handle.
+  let handleCount = 0;
+  const getAccountDb = () => {
+    handleCount += 1;
+    return { migrations: { apply }, query, batch } as any;
+  };
+
+  const put = mock(async (key: string, value: unknown) => {
+    puts.push({ key, value });
+    return { ok: true, data: { data: undefined, headers: {} } };
+  });
+
+  const service = new AccountService({
+    getDid: () => "did:pkh:eip155:1:0xabc",
+    getHost: () => "https://node.tinycloud.xyz",
+    getPrimarySpaceId: () => "tinycloud:pkh:eip155:1:0xabc:default",
+    getAccountSpaceId: () => accountSpaceId,
+    ensureAccountSpaceHosted: mock(async () => {}),
+    getSpaces: () =>
+      ({
+        list: async () => ({ ok: true, data: [] }),
+        get: () => ({
+          kv: {
+            list: async () => ({ ok: true, data: { keys: [] } }),
+            get: async () => ({
+              ok: false,
+              error: { code: "KV_NOT_FOUND", message: "Key not found", service: "kv" },
+            }),
+            put,
+            delete: async () => ({ ok: true, data: undefined }),
+          },
+          delegations: {
+            list: async () => ({ ok: true, data: [] }),
+            listReceived: async () => ({ ok: true, data: [] }),
+            revoke: async () => ({ ok: true, data: undefined }),
+          },
+        }),
+      }) as any,
+    getAccountDb,
+  });
+
+  return {
+    apply,
+    batches,
+    put,
+    puts,
+    queries,
+    service,
+    handleCount: () => handleCount,
+    useAccountSpace: (spaceId: string) => {
+      accountSpaceId = spaceId;
+    },
+    applicationStateReads: () =>
+      queries.filter((sql) => sql.includes("FROM application_state")),
+  };
+}
+
+describe("AccountService account-index memo (P1)", () => {
+  test("applies the index migration ONCE across the eight bootstrap index touches", async () => {
+    const { apply, handleCount, service } = makeHarness();
+
+    for (let i = 0; i < 8; i += 1) {
+      const result = await service.index.ensure();
+      expect(result.ok).toBe(true);
+    }
+
+    // Every touch still asked for a fresh db handle...
+    expect(handleCount()).toBe(8);
+    // ...but only the first paid the two-request migration probe.
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  test("shares the memo across different index entry points", async () => {
+    const { apply, service } = makeHarness();
+
+    await service.index.ensure();
+    // Goes through upsertApplicationIndexQuietly -> ensureAccountIndex.
+    await service.applications.register(MANIFEST);
+    await service.applications.remove("com.notes.app");
+
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  test("coalesces concurrent index touches into a single migration", async () => {
+    const { apply, service } = makeHarness();
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () => service.index.ensure()),
+    );
+
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  test("does NOT cache a failure: a later touch retries and can succeed", async () => {
+    const { apply, service } = makeHarness({ migrationFailures: 1 });
+
+    const first = await service.index.ensure();
+    expect(first.ok).toBe(false);
+
+    const second = await service.index.ensure();
+    expect(second.ok).toBe(true);
+
+    // The failure was evicted, so the retry really re-applied.
+    expect(apply).toHaveBeenCalledTimes(2);
+
+    // ...and the now-successful result IS memoized.
+    await service.index.ensure();
+    expect(apply).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not cache a failure shared by concurrent callers", async () => {
+    const { apply, service } = makeHarness({ migrationFailures: 1 });
+
+    const [a, b] = await Promise.all([service.index.ensure(), service.index.ensure()]);
+    expect(a.ok).toBe(false);
+    expect(b.ok).toBe(false);
+    expect(apply).toHaveBeenCalledTimes(1);
+
+    const retried = await service.index.ensure();
+    expect(retried.ok).toBe(true);
+    expect(apply).toHaveBeenCalledTimes(2);
+  });
+
+  test("keys the memo by account space, so a different account re-applies", async () => {
+    const { apply, service, useAccountSpace } = makeHarness();
+
+    await service.index.ensure();
+    expect(apply).toHaveBeenCalledTimes(1);
+
+    useAccountSpace(OTHER_ACCOUNT_SPACE);
+    await service.index.ensure();
+    expect(apply).toHaveBeenCalledTimes(2);
+
+    // Back to the first account: still memoized.
+    useAccountSpace(ACCOUNT_SPACE);
+    await service.index.ensure();
+    expect(apply).toHaveBeenCalledTimes(2);
+  });
+
+  test("index.rebuild re-applies the schema instead of trusting the memo", async () => {
+    const { apply, service } = makeHarness();
+
+    await service.index.ensure();
+    expect(apply).toHaveBeenCalledTimes(1);
+
+    const rebuilt = await service.index.rebuild();
+    expect(rebuilt.ok).toBe(true);
+    // rebuild is the explicit repair path: it must re-verify server-side.
+    expect(apply).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("AccountService bootstrap manifest write (P5)", () => {
+  test("assumeUnregistered skips the application_state pre-read", async () => {
+    // The index would claim the manifest is already current; the bootstrap
+    // path must not even ask.
+    const { applicationStateReads, put, service } = makeHarness({
+      indexReportsCurrent: true,
+    });
+
+    const result = await service.applications.register(MANIFEST, {
+      assumeUnregistered: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(applicationStateReads()).toEqual([]);
+    expect(put).toHaveBeenCalledTimes(1);
+  });
+
+  test("without the flag the pre-read still short-circuits a redundant write", async () => {
+    const { applicationStateReads, put, service } = makeHarness({
+      indexReportsCurrent: true,
+    });
+
+    const result = await service.applications.register(MANIFEST);
+
+    expect(result.ok).toBe(true);
+    // The warm dedupe is intact: one pre-read, zero writes.
+    expect(applicationStateReads()).toHaveLength(1);
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  test("re-registering the same manifest with assumeUnregistered is idempotent", async () => {
+    const { batches, put, puts, service } = makeHarness({ indexReportsCurrent: true });
+
+    const first = await service.applications.register(MANIFEST, {
+      assumeUnregistered: true,
+    });
+    const second = await service.applications.register(MANIFEST, {
+      assumeUnregistered: true,
+    });
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(put).toHaveBeenCalledTimes(2);
+
+    // Same key, same content (modulo the updated_at stamp): repeating the
+    // write cannot change what is stored.
+    expect(puts[0]!.key).toBe(puts[1]!.key);
+    expect(puts[0]!.value.app_id).toBe(puts[1]!.value.app_id);
+    expect(puts[0]!.value.manifests).toEqual(puts[1]!.value.manifests);
+    expect(puts[0]!.value.manifest_hash).toBe(puts[1]!.value.manifest_hash);
+
+    // Both index updates are one batch of INSERT OR REPLACE statements, so
+    // they are replayable too — and cost one request, not two.
+    expect(batches).toHaveLength(2);
+    for (const statements of batches) {
+      expect(statements).toHaveLength(2);
+      expect(statements.every((s) => s.sql.startsWith("INSERT OR REPLACE"))).toBe(true);
+    }
+  });
+
+  test("register still reports the existing record when the pre-read hits", async () => {
+    const { service } = makeHarness({ indexReportsCurrent: true });
+
+    const result = await service.applications.register(MANIFEST);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.data.appId).toBe("com.notes.app");
+    expect(result.ok && result.data.manifests).toEqual([MANIFEST]);
+  });
+});

--- a/packages/node-sdk/src/account/AccountService.ts
+++ b/packages/node-sdk/src/account/AccountService.ts
@@ -2,6 +2,7 @@ export { AccountService } from "@tinycloud/sdk-core";
 export type {
   AccountApplication,
   AccountApplicationListOptions,
+  AccountApplicationRegisterOptions,
   AccountDelegation,
   AccountDelegationListOptions,
   AccountDelegationRevokeOptions,

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -234,6 +234,12 @@ export class NodeUserAuthorization implements IUserAuthorization {
   private _address?: string;
   private _chainId?: number;
   private _nodeFeatures: string[] = [];
+  /**
+   * `nodeId` from the `GET /info` performed during sign-in/restore, tagged with
+   * the host it came from. Callers that need the node DID (encryption-network
+   * admin invocations) reuse this instead of re-fetching `/info`.
+   */
+  private _nodeInfoIdentity?: { host: string; nodeId: string };
   private _lastActivationSkippedSpaceIds: string[] = [];
 
   constructor(config: NodeUserAuthorizationConfig) {
@@ -474,6 +480,18 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
   get nodeFeatures(): string[] {
     return this._nodeFeatures;
+  }
+
+  /**
+   * The node DID reported by `GET /info` for `host`, if the sign-in (or
+   * restore) that populated it targeted that same host. Returns `undefined`
+   * for any other host, and for nodes whose `/info` omits `nodeId`, so callers
+   * fall back to fetching it themselves rather than using a foreign node's DID.
+   */
+  nodeIdForHost(host: string): string | undefined {
+    return this._nodeInfoIdentity?.host === host
+      ? this._nodeInfoIdentity.nodeId
+      : undefined;
   }
 
   get lastActivationSkippedSpaceIds(): string[] {
@@ -1094,11 +1112,17 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this._chainId = chainId;
 
     // Verify SDK-node protocol compatibility and discover supported features
+    const infoHost = this.primaryTinyCloudHost;
     const nodeInfo = await checkNodeInfo(
-      this.primaryTinyCloudHost,
+      infoHost,
       this.wasm.protocolVersion(),
     );
     this._nodeFeatures = nodeInfo.features;
+    // `/info` already told us the node DID. Keep it so encryption-network
+    // admin invocations do not re-fetch `/info` just to learn it.
+    this._nodeInfoIdentity = nodeInfo.nodeId
+      ? { host: infoHost, nodeId: nodeInfo.nodeId }
+      : undefined;
 
     // Call extension hooks
     for (const ext of this.extensions) {
@@ -1344,11 +1368,17 @@ export class NodeUserAuthorization implements IUserAuthorization {
     this._chainId = chainId;
 
     // Verify SDK-node protocol compatibility and discover supported features
+    const infoHost = this.primaryTinyCloudHost;
     const nodeInfo = await checkNodeInfo(
-      this.primaryTinyCloudHost,
+      infoHost,
       this.wasm.protocolVersion(),
     );
     this._nodeFeatures = nodeInfo.features;
+    // `/info` already told us the node DID. Keep it so encryption-network
+    // admin invocations do not re-fetch `/info` just to learn it.
+    this._nodeInfoIdentity = nodeInfo.nodeId
+      ? { host: infoHost, nodeId: nodeInfo.nodeId }
+      : undefined;
 
     // Call extension hooks
     for (const ext of this.extensions) {

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -113,6 +113,7 @@ export {
   type DelegateToOptions,
   type DelegateToResult,
   type RuntimePermissionGrantOptions,
+  type EnsureEncryptionNetworkOptions,
   type SecretReadInput,
   type SecretPermissionHint,
   type SecretReadResult,
@@ -126,6 +127,7 @@ export { AccountService } from "./account/AccountService";
 export type {
   AccountApplication,
   AccountApplicationListOptions,
+  AccountApplicationRegisterOptions,
   AccountDelegation,
   AccountDelegationListOptions,
   AccountDelegationRevokeOptions,

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -140,6 +140,7 @@ export {
   type DelegateToOptions,
   type DelegateToResult,
   type RuntimePermissionGrantOptions,
+  type EnsureEncryptionNetworkOptions,
   type CreateOwnerDelegationParams,
   type OwnerDelegationReceipt,
   type RegisterOwnerSharePolicyParams,
@@ -153,6 +154,7 @@ export { AccountService } from "./account/AccountService";
 export type {
   AccountApplication,
   AccountApplicationListOptions,
+  AccountApplicationRegisterOptions,
   AccountDelegation,
   AccountDelegationListOptions,
   AccountDelegationRevokeOptions,

--- a/packages/sdk-core/src/account/AccountService.ts
+++ b/packages/sdk-core/src/account/AccountService.ts
@@ -96,6 +96,21 @@ export interface AccountIndexedReadOptions {
 
 export type AccountApplicationListOptions = AccountIndexedReadOptions;
 
+export interface AccountApplicationRegisterOptions {
+  /**
+   * Skip the `application_state` manifest-hash pre-read that normally
+   * short-circuits a redundant write.
+   *
+   * The pre-read is a saving only when the application is already registered
+   * with the same manifest hash. On a freshly bootstrapped account it is
+   * definitionally a miss, so it costs a round trip and buys nothing — and the
+   * write it guards is an `INSERT OR REPLACE`, so performing it unconditionally
+   * is idempotent. Set this only when the caller knows the record cannot
+   * already be current (i.e. the account bootstrap path).
+   */
+  assumeUnregistered?: boolean;
+}
+
 export type AccountSpaceListOptions = AccountIndexedReadOptions;
 
 export interface AccountDelegationListOptions {
@@ -122,6 +137,23 @@ export interface AccountServiceConfig {
 }
 
 export class AccountService {
+  /**
+   * Per-account-space memo for {@link ensureAccountIndex}.
+   *
+   * Applying the index migration is a no-op once the schema exists, but the
+   * SQL service still spends two round trips discovering that (create the
+   * migrations table, then read the applied-migration rows). Account bootstrap
+   * touches the index eight times, so without a memo that is ~14 wasted
+   * requests on the cold sign-in path. The in-flight dedupe inside SQLService
+   * never helps here: the node SDK builds a fresh SQLService per
+   * `getAccountDb()` call, so its lock map is always empty.
+   *
+   * Keyed by account space id, so a different account never reuses this entry.
+   * Failures are evicted so a later call retries instead of inheriting a
+   * permanently poisoned result.
+   */
+  private readonly accountIndexReady = new Map<string, Promise<Result<void>>>();
+
   constructor(private readonly config: AccountServiceConfig) {}
 
   async status(): Promise<Result<AccountStatus>> {
@@ -187,7 +219,10 @@ export class AccountService {
       return ok(applicationFromRecord(key, loaded.data.data));
     },
 
-    register: async (manifest: Manifest | Manifest[]): Promise<Result<AccountApplication>> => {
+    register: async (
+      manifest: Manifest | Manifest[],
+      options: AccountApplicationRegisterOptions = {},
+    ): Promise<Result<AccountApplication>> => {
       const manifests = Array.isArray(manifest) ? manifest : [manifest];
       const request = composeManifestRequest(manifests);
       if (request.registryRecords.length === 0) {
@@ -208,7 +243,10 @@ export class AccountService {
       let registered: AccountApplication | undefined;
       for (const record of request.registryRecords) {
         const manifestHash = hashJson(record.manifests);
-        if (await this.indexHasApplicationHash(record.app_id, manifestHash)) {
+        if (
+          !options.assumeUnregistered &&
+          (await this.indexHasApplicationHash(record.app_id, manifestHash))
+        ) {
           registered = {
             appId: record.app_id,
             manifests: record.manifests,
@@ -437,6 +475,9 @@ export class AccountService {
       if (!delegations.ok) return delegations;
 
       const syncedAt = new Date().toISOString();
+      // `rebuild` is the explicit repair entry point: re-verify the schema
+      // server-side instead of trusting the per-space memo.
+      this.invalidateAccountIndexMemo();
       const schema = await this.ensureAccountIndex(dbResult.data);
       if (!schema.ok) return schema;
 
@@ -877,7 +918,48 @@ export class AccountService {
     });
   }
 
+  /**
+   * Apply the account index schema at most once per account space.
+   *
+   * The index is a cache over canonical KV state, and every caller already
+   * tolerates it being absent (`ignoreIndexFailure` / `isMissingIndexError`),
+   * so a memo that is wrong in the "already applied" direction degrades to a
+   * `no such table` read that the caller handles. A memo that is wrong in the
+   * other direction would be a real bug, so failures are never cached.
+   */
   private async ensureAccountIndex(db: IDatabaseHandle): Promise<Result<void>> {
+    const key = this.config.getAccountSpaceId() ?? "";
+    const cached = this.accountIndexReady.get(key);
+    if (cached) return cached;
+
+    const pending = this.applyAccountIndex(db);
+    this.accountIndexReady.set(key, pending);
+
+    // Only evict our own entry: a concurrent caller may already have installed
+    // a fresh attempt by the time this one settles.
+    const evict = () => {
+      if (this.accountIndexReady.get(key) === pending) {
+        this.accountIndexReady.delete(key);
+      }
+    };
+
+    let settled: Result<void>;
+    try {
+      settled = await pending;
+    } catch (error) {
+      evict();
+      throw error;
+    }
+    if (!settled.ok) evict();
+    return settled;
+  }
+
+  /** Drop the memo so the next {@link ensureAccountIndex} re-applies the schema. */
+  private invalidateAccountIndexMemo(): void {
+    this.accountIndexReady.delete(this.config.getAccountSpaceId() ?? "");
+  }
+
+  private async applyAccountIndex(db: IDatabaseHandle): Promise<Result<void>> {
     const migrated = await db.migrations.apply({
       namespace: ACCOUNT_INDEX_NAMESPACE,
       migrations: [

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -251,6 +251,7 @@ export { AccountService } from "./account/AccountService";
 export type {
   AccountApplication,
   AccountApplicationListOptions,
+  AccountApplicationRegisterOptions,
   AccountDelegation,
   AccountDelegationListOptions,
   AccountDelegationRevokeOptions,

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -98,6 +98,7 @@ export type {
   OwnerSharePolicyRegistration,
   AccountApplication,
   AccountApplicationListOptions,
+  AccountApplicationRegisterOptions,
   AccountDelegation,
   AccountDelegationListOptions,
   AccountDelegationRevokeOptions,


### PR DESCRIPTION
## Baseline

Measured against production 2026-07-29 (node-sdk, fresh key, `autoCreateSpace`):

| | requests | wall clock |
|---|---|---|
| **Cold** first-account sign-in | **62** sequential | **76-110s** |
| **Warm** sign-in | 6-7 | 4.4s |

No individual request is slow (~1.8-3.5s each). The cost is **count x latency**, so the only lever that matters is removing round trips.

This PR removes **~24 requests, taking cold sign-in to roughly 38**. It is the subset of the trace analysis that can be changed *without* revisiting auth semantics.

> **Please review carefully rather than rubber-stamping** — this is the product's most critical path. Not merging until a human has signed off.

## What landed

### P1 — memoize the account-index schema check (~14 requests)

`AccountService.ensureAccountIndex` called `db.migrations.apply(...)` on **every** index touch. Each call spends two requests before it can conclude "already current" (`ensureMigrationsTable` batch, then `SELECT` from `__tinycloud_sql_migrations`). Bootstrap touches the index 8 times.

The existing in-flight dedupe (`SQLService.migrationLocks`) never helped: `TinyCloudNode.getAccountDb` builds a **fresh** `SQLService` + `ServiceContext` per call, so that map is always empty. The memo has to live on `AccountService`, which is the object that actually survives.

Keyed by `getAccountSpaceId()`. **Failures are evicted**, so a later call retries rather than inheriting a poisoned result — and only the entry we installed is evicted, so a concurrent retry isn't clobbered. `index.rebuild()` invalidates the memo, keeping the explicit repair path honest.

Safety: the index is a cache over canonical KV, and every caller already tolerates it being absent (`ignoreIndexFailure` / `isMissingIndexError`). A stale memo degrades to `no such table`, which is already handled.

### P3 — memoize `ensureOwnedSpaceHostedById` per sign-in (~5 requests)

Called 6x during bootstrap via `AccountService.ensureAccountSpaceHosted`. In this configuration it provably cannot do anything useful: it submits `activateSessionWithHost` with the **primary** session, whose recap covers only `default` + `secrets`, so the account space appears in neither `activated` nor `skipped` and the guard returns immediately.

Tracks confirmed space ids in a `Set` cleared by `signIn()` (alongside the other per-sign-in resets) and by `restoreSession()`. Only *confirmed successes* are recorded — a skipped or failed activation is never memoized.

Safety: a wrong skip fails loudly and immediately as `404 Space not found` on the next write. Self-revealing, not silent.

### P5 — drop the bootstrap-manifest hash pre-read (~3 requests)

`applications.register` pre-reads `application_state` to short-circuit a redundant write. For the bootstrap manifest on a cold account that is *definitionally* a miss, and the write it guards is an `INSERT OR REPLACE` anyway.

New `assumeUnregistered` option skips the pre-read. **Only the bootstrap call site passes it** — `writeManifestRegistryRecords` (the warm re-registration path) still pre-reads, because there the probe genuinely saves a KV put plus an index batch. Skipping it unconditionally would have *regressed* warm sign-in.

The two index writes were already folded into a single `batch` of `INSERT OR REPLACE` statements; there's now a test pinning that.

### P6 — reuse `nodeId`, and POST-first for encryption networks (~2 requests)

**(a)** `checkNodeInfo` already returns `nodeId`, but `NodeUserAuthorization` kept only `features`, so `fetchNodeId` re-fetched `GET /info`. Now stored **tagged with the host it came from** and reused only for that exact host — a session against a different node must not reuse a foreign node's DID. Nodes whose `/info` omits `nodeId` fall through to the fetch.

**(b)** `ensureEncryptionNetwork` probed `GET /encryption/networks/{id}` (always 404 on a cold account) before POSTing. The bootstrap path now skips the probe via `assumeMissing`, and `createEncryptionNetwork` treats **409 as success** by reading back the existing descriptor — which also makes create race-safe.

I verified the 409 claim against the node rather than taking it on faith: `map_service_err` maps *two* variants to `Conflict`, but `NetworkNotActive` is only reachable from `decrypt` / `decrypt_authorized`. On `POST /encryption/networks` the only Conflict is `NetworkAlreadyExists`.

**Note on scope:** I did *not* make POST-first unconditional. `ensureRequestedEncryptionNetworks` runs on **every** sign-in, so an unconditional POST-first would turn the warm path from one `GET` (200) into `POST` (409) + `GET` — a request *and* a WASM signature worse on the everyday path. Gating on the cold signal makes this a strict improvement. There is a test asserting the warm path is byte-for-byte unchanged.

## Deliberately deferred

| | why |
|---|---|
| **P9 / P10** — multi-space sessions, host delegations | Need an auth-model review. Both change what a session is authorized for, which is exactly the line this PR stays behind. |
| **P8** — sleep removal | The 100ms sleep guards a create -> activate race. Removing it needs evidence about node-side visibility, not just a measurement that it's usually unnecessary. |
| **P2 / P4** — batching, parallelism | Need live-node verification. Both change request *shape* rather than count, so unit tests can't establish they're safe. |

## Testing

26 new unit tests across three files, using the repo's existing `bun:test` + stubbed-`fetch` patterns. The encryption and hosting tests assert on the **recorded wire sequence** (method + URL) rather than internal call counts, so they measure the thing this PR is actually about.

Every test was **mutation-checked**: I reverted each optimization and confirmed the tests fail.

- `AccountService.coldSignIn.test.ts` — 11 tests, 8 fail when reverted
- `TinyCloudNode.ensureOwnedSpaceHostedById.test.ts` — 6 tests, 4 fail when reverted
- `TinyCloudNode.encryptionNetwork.test.ts` — 9 tests, 6 fail when reverted

The tests that still pass under mutation are the intended guards asserting warm-path behaviour is *unchanged*.

### Gates run

| command | result |
|---|---|
| `bun run build` (turbo, full workspace) | 15/15 successful — includes `.d.ts` emit, which is the effective typecheck |
| `bun run lint` (turbo) | 12/12 successful |
| `bun test src/` in `packages/node-sdk` | **234 pass, 0 fail** (208 before) |
| `bun test` in `packages/sdk-core` | **807 pass, 0 fail** |

`@tinycloud/node-sdk-tests` (the `tests/node-sdk` live suite) fails in `bun run test` with 28 `checkServerHealth` connection-refused errors against `localhost:9000`. That's environmental — it aborts before any SDK code runs and requires a running tinycloud-node.

`packages/cli/dist/index.js.map` is regenerated by the build and is tracked in git; it is deliberately **not** included in this commit.

Part of TC-318 (scaling review wave)