### PR TITLE
fix(web-sdk): bound the space-creation dialog wait and honour autoCreateSpace (TC-362)

### DIFF
--- a/.changeset/tc-362-space-modal-timeout.md
+++ b/.changeset/tc-362-space-modal-timeout.md
@@ -1,0 +1,35 @@
+---
+"@tinycloud/web-sdk": minor
+"@tinycloud/sdk-core": minor
+---
+
+Stop browser sign-in hanging forever on an invisible space-creation dialog (TC-362).
+
+`ModalSpaceCreationHandler.confirmSpaceCreation` returned a promise that only ever
+settled on a click inside a shadow-DOM `<tinycloud-space-modal>`. When that dialog
+was not reachable — for example hidden behind an app's own full-screen "Connecting…"
+overlay — `ensureSpaceExists` awaited it forever and sign-in looked permanently stuck,
+with nothing in the light DOM to explain why.
+
+- The wait is now bounded (default 2 minutes, configurable via the new
+  `TinyCloudWeb` config option `spaceCreationTimeoutMs` or
+  `new ModalSpaceCreationHandler({ timeoutMs })`; `0` restores the unbounded wait).
+  On expiry the handler closes the dialog and rejects with a `SpaceCreationTimeoutError`
+  whose message names the element, the likely cause, and the three ways out.
+- **Behaviour change:** `autoCreateSpace` is now honoured in the browser. `TinyCloudWeb`
+  used to install the modal handler unconditionally, and node-sdk gives an explicit
+  handler precedence over `autoCreateSpace`, so the option was dead config in the browser.
+  `autoCreateSpace: true` now creates the space with no dialog, `autoCreateSpace: false`
+  skips creation entirely, and leaving it unset keeps today's modal confirmation.
+  An explicit `spaceCreationHandler` still wins over both.
+- While the SDK is blocked on the user it sets
+  `data-tinycloud-awaiting-user-input="space-creation"` on `<html>`, fires
+  `tinycloud:awaiting-user-input` / `tinycloud:awaiting-user-input-resolved` on `window`,
+  and logs an explanatory warning — so a stuck sign-in is diagnosable from outside
+  the shadow root. New helper `pendingUserInputKind()` reports the same state.
+- The owner-policy sharing path signs mid-compose by re-opening the wallet/OpenKey
+  signing surface. An unanswered or cancelled prompt there used to surface the same
+  `PERMISSION_DENIED` "the active session ReCap does not authorize this sharing
+  delegation" message as a genuine HTTP 403. It is now reported as `TIMEOUT` or
+  `ABORTED` with a message that says what to do, and the underlying error is kept
+  as `cause`.

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.signIn.test.ts
@@ -454,3 +454,46 @@ test("createBootstrapSession mints a signed single-space bootstrap session", asy
     ],
   });
 });
+
+// TC-362: the browser's modal handler now gives up on an unanswered dialog and
+// rejects. That is only useful if the rejection actually reaches the caller of
+// signIn() instead of being swallowed inside ensureSpaceExists.
+test("ensureSpaceExists surfaces a space-creation handler rejection", async () => {
+  const primarySpaceId = restoredTinyCloudSession().spaceId;
+  const captured: Array<Record<string, unknown>> = [];
+  const signedMessages: string[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).__originalFetch = originalFetch;
+  globalThis.fetch = async (input: any, init?: any) => {
+    const url = String(input);
+    if (url.endsWith("/delegate") && init?.method === "POST") {
+      // The primary space does not exist yet, so the handler is consulted.
+      return new Response(
+        JSON.stringify({ activated: [], skipped: [primarySpaceId] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  const auth = new NodeUserAuthorization({
+    signer: createSigner(signedMessages),
+    wasmBindings: createWasmBindings(captured),
+    signStrategy: { type: "auto-sign" },
+    domain: "example.com",
+    tinycloudHosts: ["https://tinycloud.test"],
+    sessionStorage: new MemorySessionStorage(),
+    spaceCreationHandler: {
+      confirmSpaceCreation: async () => {
+        throw new Error("TinyCloud waited 120s for you to confirm");
+      },
+    },
+  });
+  auth.setRestoredTinyCloudSession(restoredTinyCloudSession());
+
+  await expect(auth.ensureSpaceExists()).rejects.toThrow(
+    "TinyCloud waited 120s for you to confirm",
+  );
+  // The space was never hosted, so no wallet signature was requested.
+  expect(signedMessages.length).toBe(0);
+});

--- a/packages/sdk-core/src/delegations/SharingService.test.ts
+++ b/packages/sdk-core/src/delegations/SharingService.test.ts
@@ -635,3 +635,92 @@ describe("SharingService.delegateReceivedShare", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 });
+
+describe("SharingService.generate root-delegation signing failures", () => {
+  // TC-362 follow-on: the owner-policy path re-opens the wallet/OpenKey signing
+  // surface mid-compose. An unanswered prompt and a genuine authorization
+  // refusal used to collapse into the same PERMISSION_DENIED message, so a
+  // user who simply missed a signing popup was told they lacked permission.
+  function makeGeneratingService(
+    onRootDelegationNeeded: NonNullable<
+      ConstructorParameters<typeof SharingService>[0]["onRootDelegationNeeded"]
+    >,
+  ): SharingService {
+    const shareJwk = { kty: "OKP", crv: "Ed25519", x: SHARE_X, d: SHARE_D };
+    return new SharingService({
+      hosts: [HOST],
+      invoke: mock(async () => ({ ok: true, data: undefined })) as never,
+      fetch: mock(async () => new Response(null, { status: 200 })),
+      keyProvider: {
+        createSessionKey: (name: string) => name,
+        getDID: () => `${SHARE_DID}#${SHARE_DID.slice("did:key:".length)}`,
+        getJWK: () => shareJwk,
+      } as unknown as KeyProvider,
+      registry: new CapabilityKeyRegistry(),
+      createKVService: mock(() => ({})) as never,
+      createDelegationWasm: mock(() => {
+        throw new Error("should not be reached");
+      }) as never,
+      computeCid: () => "bafy-child",
+      session: {
+        spaceId: SPACE,
+        delegationCid: "bafy-session",
+        verificationMethod: "did:key:zSession#zSession",
+        jwk: shareJwk,
+      } as unknown as ServiceSession,
+      onRootDelegationNeeded,
+    });
+  }
+
+  test("reports an unanswered signing prompt as TIMEOUT, not PERMISSION_DENIED", async () => {
+    const service = makeGeneratingService(async () => {
+      throw Object.assign(new Error("Request timed out."), { code: "TIMEOUT" });
+    });
+
+    const result = await service.generate({
+      path: "shared",
+      actions: ["tinycloud.kv/get"],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("TIMEOUT");
+    expect(result.error.message).toContain("Timed out waiting for the signature");
+    expect(result.error.cause).toBeInstanceOf(Error);
+  });
+
+  test("reports a cancelled signing prompt as ABORTED", async () => {
+    const service = makeGeneratingService(async () => {
+      throw Object.assign(new Error("User rejected the request"), {
+        name: "AbortError",
+      });
+    });
+
+    const result = await service.generate({
+      path: "shared",
+      actions: ["tinycloud.kv/get"],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("ABORTED");
+  });
+
+  test("still reports a genuine authorization failure as PERMISSION_DENIED", async () => {
+    const service = makeGeneratingService(async () => {
+      throw Object.assign(new Error("Request failed"), { code: "403" });
+    });
+
+    const result = await service.generate({
+      path: "shared",
+      actions: ["tinycloud.kv/get"],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PERMISSION_DENIED");
+    expect(result.error.message).toContain(
+      "The active session ReCap does not authorize",
+    );
+  });
+});

--- a/packages/sdk-core/src/delegations/SharingService.ts
+++ b/packages/sdk-core/src/delegations/SharingService.ts
@@ -131,6 +131,59 @@ function createError(
 }
 
 /**
+ * Classify a failure thrown by the root-delegation signing callback.
+ *
+ * The callback drives a wallet / OpenKey signing surface. "The signer never
+ * answered" and "the server said you may not do this" both used to collapse
+ * into a single `PERMISSION_DENIED` with an authorization-flavoured message,
+ * which is wrong for the user (retrying the signature would have worked) and
+ * useless for whoever is debugging it.
+ */
+function rootDelegationSigningError(err: unknown): DelegationError {
+  const cause = err instanceof Error ? err : undefined;
+  const code =
+    err && typeof err === "object" && "code" in err
+      ? String((err as { code?: unknown }).code ?? "")
+      : "";
+  const name = err instanceof Error ? err.name : "";
+  const message = err instanceof Error ? err.message : String(err ?? "");
+
+  const aborted =
+    code === DelegationErrorCodes.ABORTED ||
+    name === "AbortError" ||
+    /\bcancell?ed\b|\brejected\b|user denied/i.test(message);
+  if (aborted) {
+    return createError(
+      DelegationErrorCodes.ABORTED,
+      "The signature that authorizes this sharing link was cancelled. " +
+        "Approve the signing prompt to finish creating the link.",
+      cause,
+    );
+  }
+
+  const timedOut =
+    code === DelegationErrorCodes.TIMEOUT ||
+    name === "TimeoutError" ||
+    /timed out|timeout/i.test(message);
+  if (timedOut) {
+    return createError(
+      DelegationErrorCodes.TIMEOUT,
+      "Timed out waiting for the signature that authorizes this sharing link. " +
+        "Creating a long-lived link re-opens the signing prompt after sign-in; " +
+        "if you did not see one, check for a blocked popup or a hidden signing " +
+        "frame, then try again.",
+      cause,
+    );
+  }
+
+  return createError(
+    DelegationErrorCodes.PERMISSION_DENIED,
+    "The active session ReCap does not authorize this sharing delegation.",
+    cause,
+  );
+}
+
+/**
  * Base64 encode for URLs (URL-safe base64).
  */
 function base64UrlEncode(data: string): string {
@@ -708,14 +761,11 @@ export class SharingService implements ISharingService {
           };
         }
       } catch (err) {
-        return {
-          ok: false,
-          error: createError(
-            DelegationErrorCodes.PERMISSION_DENIED,
-            "The active session ReCap does not authorize this sharing delegation.",
-            err instanceof Error ? err : undefined,
-          ),
-        };
+        // `onRootDelegationNeeded` re-opens the wallet/OpenKey signing surface
+        // mid-compose, long after sign-in. An unanswered or cancelled signature
+        // is a completely different problem from "you are not authorized", and
+        // must not be reported as the same thing.
+        return { ok: false, error: rootDelegationSigningError(err) };
       }
     } else {
       return {

--- a/packages/web-sdk/src/authorization/WebSpaceCreationHandler.ts
+++ b/packages/web-sdk/src/authorization/WebSpaceCreationHandler.ts
@@ -5,11 +5,71 @@
  */
 
 import {
+  AutoApproveSpaceCreationHandler,
   ISpaceCreationHandler,
   SpaceCreationContext,
 } from "@tinycloud/sdk-core";
-import { showSpaceCreationModal } from "../notifications/ModalManager";
+import {
+  ModalManager,
+  showSpaceCreationModal,
+} from "../notifications/ModalManager";
 import { dispatchSDKEvent } from "../notifications/ErrorHandler";
+import {
+  beginAwaitingUserInput,
+  formatDuration,
+} from "../notifications/awaitingUserInput";
+
+/**
+ * How long {@link ModalSpaceCreationHandler} waits for the user to answer the
+ * space-creation dialog before failing sign-in.
+ *
+ * Two minutes is long enough for a first-time user to read the dialog and
+ * decide, and short enough that a dialog nobody can see surfaces as an error
+ * instead of an apparently frozen app.
+ */
+export const DEFAULT_SPACE_CREATION_TIMEOUT_MS = 120_000;
+
+/**
+ * Thrown when the space-creation dialog is never answered.
+ *
+ * This is what users experience as "sign-in hangs forever": the SDK is not
+ * stuck, it is blocked on a click in a shadow-DOM dialog that may be invisible
+ * behind the app's own loading overlay.
+ */
+export class SpaceCreationTimeoutError extends Error {
+  /** Stable, matchable error code. */
+  readonly code = "SPACE_CREATION_TIMEOUT";
+
+  /** The timeout that elapsed, in milliseconds. */
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(
+      `TinyCloud waited ${formatDuration(timeoutMs)} for you to confirm creating your ` +
+        `TinyCloud Space and got no answer. The confirmation dialog is a ` +
+        `<tinycloud-space-modal> element appended to <body>; because it renders in a shadow ` +
+        `root it can sit behind a full-screen loading overlay and never be seen. ` +
+        `Fixes: dismiss or lower the z-index of any overlay shown during sign-in and retry; ` +
+        `or set autoCreateSpace: true on TinyCloudWeb to create the space without a dialog; ` +
+        `or pass your own spaceCreationHandler to prompt in your own UI.`
+    );
+    this.name = "SpaceCreationTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Options for {@link ModalSpaceCreationHandler}.
+ */
+export interface ModalSpaceCreationHandlerOptions {
+  /**
+   * How long to wait for the user to answer the dialog, in milliseconds.
+   * Defaults to {@link DEFAULT_SPACE_CREATION_TIMEOUT_MS}. Pass `0` (or a
+   * negative value) to wait forever — only sensible when you have verified the
+   * dialog is actually reachable in your UI.
+   */
+  timeoutMs?: number;
+}
 
 /**
  * Space creation handler that shows a modal for user confirmation.
@@ -17,21 +77,45 @@ import { dispatchSDKEvent } from "../notifications/ErrorHandler";
  * This is the default handler for web applications, providing a
  * user-friendly confirmation dialog before creating a new space.
  *
+ * The wait for the user is bounded: if the dialog is not answered within
+ * {@link ModalSpaceCreationHandlerOptions.timeoutMs} the handler rejects with a
+ * {@link SpaceCreationTimeoutError} rather than blocking sign-in forever.
+ *
  * @example
  * ```typescript
  * const auth = new WebUserAuthorization({
  *   provider: window.ethereum,
- *   spaceCreationHandler: new ModalSpaceCreationHandler(),
+ *   spaceCreationHandler: new ModalSpaceCreationHandler({ timeoutMs: 60_000 }),
  * });
  * ```
  */
 export class ModalSpaceCreationHandler implements ISpaceCreationHandler {
+  private readonly timeoutMs: number;
+
+  constructor(options: ModalSpaceCreationHandlerOptions = {}) {
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_SPACE_CREATION_TIMEOUT_MS;
+  }
+
   /**
    * Show a modal to confirm space creation.
    * Returns true if user confirms, false if dismissed.
+   *
+   * @throws {@link SpaceCreationTimeoutError} if the dialog is never answered.
    */
   async confirmSpaceCreation(context: SpaceCreationContext): Promise<boolean> {
-    return new Promise((resolve) => {
+    const timeoutMs = this.timeoutMs;
+    const bounded = timeoutMs > 0;
+
+    const endBeacon = beginAwaitingUserInput({
+      kind: "space-creation",
+      message: `confirm creating your TinyCloud Space (${context.spaceId}) on ${context.host}.`,
+      timeoutMs: bounded ? timeoutMs : null,
+      element: "tinycloud-space-modal",
+    });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const decision = new Promise<boolean>((resolve) => {
       showSpaceCreationModal({
         onCreateSpace: async () => {
           // Just resolve true - actual creation happens in WebUserAuthorization
@@ -42,6 +126,42 @@ export class ModalSpaceCreationHandler implements ISpaceCreationHandler {
         },
       });
     });
+
+    try {
+      if (!bounded) {
+        const confirmed = await decision;
+        endBeacon(confirmed ? "confirmed" : "dismissed");
+        return confirmed;
+      }
+
+      const expiry = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new SpaceCreationTimeoutError(timeoutMs)),
+          timeoutMs
+        );
+      });
+
+      const confirmed = await Promise.race([decision, expiry]);
+      endBeacon(confirmed ? "confirmed" : "dismissed");
+      return confirmed;
+    } catch (error) {
+      if (error instanceof SpaceCreationTimeoutError) {
+        // Nothing is going to answer this dialog. Take it down so the page is
+        // not left with an invisible modal trapping scroll and focus.
+        ModalManager.getInstance().closeActiveModal();
+        endBeacon("timeout");
+        dispatchSDKEvent.error(
+          "storage.space_creation_timeout",
+          "Setting up your TinyCloud Space timed out",
+          error.message
+        );
+      } else {
+        endBeacon("error");
+      }
+      throw error;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   /**
@@ -68,3 +188,44 @@ export class ModalSpaceCreationHandler implements ISpaceCreationHandler {
  */
 export const defaultWebSpaceCreationHandler: ISpaceCreationHandler =
   new ModalSpaceCreationHandler();
+
+/**
+ * Configuration subset that decides how the browser confirms space creation.
+ */
+export interface SpaceCreationHandlerConfig {
+  /** See `TinyCloudWeb.Config.autoCreateSpace`. */
+  autoCreateSpace?: boolean;
+  /** See `TinyCloudWeb.Config.spaceCreationHandler`. */
+  spaceCreationHandler?: ISpaceCreationHandler;
+  /** See `TinyCloudWeb.Config.spaceCreationTimeoutMs`. */
+  spaceCreationTimeoutMs?: number;
+}
+
+/**
+ * Pick the space-creation handler a browser app should run with.
+ *
+ * The precedence is deliberate, and is the reason `autoCreateSpace: true` is
+ * honoured in the browser rather than being silently overridden:
+ *
+ * - An explicit `spaceCreationHandler` always wins — the caller asked for a
+ *   specific UX.
+ * - `autoCreateSpace: true` means "create it, don't ask me". Returning the
+ *   modal handler here would contradict the documented option and leave callers
+ *   blocked on a dialog they explicitly opted out of.
+ * - `autoCreateSpace: false` means "don't create it". No handler at all, so
+ *   `ensureSpaceExists` skips creation silently.
+ * - Unset is the default browser experience: confirm in a modal first, because
+ *   creating a space costs the user a wallet signature.
+ */
+export function resolveSpaceCreationHandler(
+  config: SpaceCreationHandlerConfig
+): ISpaceCreationHandler | undefined {
+  if (config.spaceCreationHandler) return config.spaceCreationHandler;
+  if (config.autoCreateSpace === true) {
+    return new AutoApproveSpaceCreationHandler();
+  }
+  if (config.autoCreateSpace === false) return undefined;
+  return new ModalSpaceCreationHandler({
+    timeoutMs: config.spaceCreationTimeoutMs,
+  });
+}

--- a/packages/web-sdk/src/authorization/index.ts
+++ b/packages/web-sdk/src/authorization/index.ts
@@ -8,7 +8,12 @@
 
 export {
   ModalSpaceCreationHandler,
+  ModalSpaceCreationHandlerOptions,
+  SpaceCreationHandlerConfig,
+  SpaceCreationTimeoutError,
+  DEFAULT_SPACE_CREATION_TIMEOUT_MS,
   defaultWebSpaceCreationHandler,
+  resolveSpaceCreationHandler,
 } from "./WebSpaceCreationHandler";
 
 // Re-export sdk-core authorization types for convenience

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -31,8 +31,24 @@ export type {
 // Auth module (browser-specific strategies)
 export {
   ModalSpaceCreationHandler,
+  ModalSpaceCreationHandlerOptions,
+  SpaceCreationHandlerConfig,
+  SpaceCreationTimeoutError,
+  DEFAULT_SPACE_CREATION_TIMEOUT_MS,
   defaultWebSpaceCreationHandler,
+  resolveSpaceCreationHandler,
 } from "./authorization";
+
+// Observability for prompts the SDK is blocked on
+export {
+  AWAITING_USER_INPUT_ATTRIBUTE,
+  AWAITING_USER_INPUT_EVENT,
+  AWAITING_USER_INPUT_RESOLVED_EVENT,
+  AwaitingUserInputDetail,
+  AwaitingUserInputOutcome,
+  AwaitingUserInputResolvedDetail,
+  pendingUserInputKind,
+} from "./notifications/awaitingUserInput";
 
 // Re-export sdk-core authorization types used by the new auth module
 export {

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -86,10 +86,7 @@ import {
   type BrowserSessionLoadResult,
 } from "../adapters/BrowserSessionStorage";
 import { RPCProviders, ClientConfig, Extension as ExtensionType } from "../providers";
-import {
-  ModalSpaceCreationHandler,
-  defaultWebSpaceCreationHandler,
-} from "../authorization/WebSpaceCreationHandler";
+import { resolveSpaceCreationHandler } from "../authorization/WebSpaceCreationHandler";
 import type { NotificationConfig } from "../notifications/types";
 import { WasmInitializer } from "./WasmInitializer";
 import { invoke } from "./Storage/tinycloud/module";
@@ -139,11 +136,28 @@ export interface Config extends ClientConfig {
    */
   localNodeIdentityStore?: LocalNodeIdentityStore;
 
-  /** Whether to auto-create space on sign-in (default: true) */
+  /**
+   * How the user's space is created on sign-in when it does not exist yet.
+   *
+   * - unset (default): confirm in a `<tinycloud-space-modal>` dialog first.
+   * - `true`: create it without asking. No dialog is shown, so sign-in cannot
+   *   block on one.
+   * - `false`: never create it. Sign-in continues without a primary space,
+   *   which is what you want when the app only ever uses delegated spaces.
+   *
+   * Ignored when {@link Config.spaceCreationHandler} is set.
+   */
   autoCreateSpace?: boolean;
 
   /** Space creation handler (default: ModalSpaceCreationHandler) */
   spaceCreationHandler?: ISpaceCreationHandler;
+
+  /**
+   * How long the default space-creation dialog waits for the user before
+   * failing sign-in, in milliseconds (default: 120000). Only applies when the
+   * modal handler is in use.
+   */
+  spaceCreationTimeoutMs?: number;
 
   /** Session expiration time in milliseconds (default: 1 hour) */
   sessionExpirationMs?: number;
@@ -409,9 +423,13 @@ export class TinyCloudWeb {
       nodeConfig.ensResolver = new BrowserENSResolver(this.provider);
     }
 
-    // Space creation handler
-    nodeConfig.spaceCreationHandler =
-      this.config.spaceCreationHandler ?? new ModalSpaceCreationHandler();
+    // Space creation handler.
+    //
+    // Do NOT unconditionally install the modal handler here: node-sdk gives an
+    // explicit handler precedence over `autoCreateSpace`, so always setting one
+    // made `autoCreateSpace` dead config in the browser and forced every app
+    // through a dialog it may have opted out of.
+    nodeConfig.spaceCreationHandler = resolveSpaceCreationHandler(this.config);
 
     this._node = new TinyCloudNode(nodeConfig);
   }

--- a/packages/web-sdk/src/notifications/SpaceCreationModal.ts
+++ b/packages/web-sdk/src/notifications/SpaceCreationModal.ts
@@ -39,7 +39,12 @@ export class TinyCloudSpaceModal extends HTMLElement {
   }
 
   disconnectedCallback() {
+    // The modal can now be torn down programmatically (e.g. when the
+    // confirmation times out), not just via hide(), so all document-level
+    // state has to be released here too.
+    this.isVisible = false;
     document.body.style.overflow = '';
+    document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   private render() {
@@ -354,8 +359,10 @@ export class TinyCloudSpaceModal extends HTMLElement {
       }
     });
 
-    // Handle escape key
-    document.addEventListener('keydown', this.handleKeyDown.bind(this));
+    // Handle escape key. `handleKeyDown` is already an instance-bound arrow
+    // function — binding again here would create a new reference that
+    // removeEventListener could never match, leaking the listener.
+    document.addEventListener('keydown', this.handleKeyDown);
   }
 
   private handleKeyDown = (e: KeyboardEvent) => {

--- a/packages/web-sdk/src/notifications/awaitingUserInput.ts
+++ b/packages/web-sdk/src/notifications/awaitingUserInput.ts
@@ -1,0 +1,144 @@
+/**
+ * Light-DOM beacon for "the SDK is blocked waiting on the user".
+ *
+ * TinyCloud's blocking prompts are shadow-DOM custom elements
+ * (`<tinycloud-space-modal>`, `<tinycloud-permission-modal>`, …). Nothing
+ * about them is visible to the host page, to an automated test, or to a
+ * support engineer poking at a stuck tab — so a prompt the user cannot see
+ * (hidden behind an app loading overlay, rendered off-screen, suppressed by
+ * a `z-index` war) is indistinguishable from a hung SDK.
+ *
+ * This module makes that state observable without changing the prompt UX:
+ *
+ * - `document.documentElement` gets `data-tinycloud-awaiting-user-input="<kind>"`
+ *   for as long as the SDK is blocked. Visible to CSS, to `document.querySelector`,
+ *   and to any DOM-driving harness.
+ * - A `tinycloud:awaiting-user-input` event fires on `window` when the wait
+ *   starts, and `tinycloud:awaiting-user-input-resolved` when it ends. Apps can
+ *   subscribe to swap their own "Connecting…" spinner for a "check the dialog"
+ *   message.
+ * - A `console.warn` explains what is being waited on and what to do about it.
+ *
+ * @packageDocumentation
+ */
+
+/** Attribute set on `<html>` while the SDK is blocked on user input. */
+export const AWAITING_USER_INPUT_ATTRIBUTE =
+  "data-tinycloud-awaiting-user-input";
+
+/** Window event fired when the SDK starts waiting on the user. */
+export const AWAITING_USER_INPUT_EVENT = "tinycloud:awaiting-user-input";
+
+/** Window event fired when the SDK stops waiting on the user. */
+export const AWAITING_USER_INPUT_RESOLVED_EVENT =
+  "tinycloud:awaiting-user-input-resolved";
+
+/** How a wait for user input ended. */
+export type AwaitingUserInputOutcome =
+  | "confirmed"
+  | "dismissed"
+  | "timeout"
+  | "error";
+
+/** Payload of the awaiting-user-input events. */
+export interface AwaitingUserInputDetail {
+  /** Stable identifier for what is being waited on, e.g. `"space-creation"`. */
+  kind: string;
+  /** Human-readable description of what the SDK needs. */
+  message: string;
+  /** Milliseconds before the wait gives up, or `null` when it never does. */
+  timeoutMs: number | null;
+  /** Tag name of the prompt element, when there is one. */
+  element?: string;
+}
+
+/** Payload of the awaiting-user-input-resolved event. */
+export interface AwaitingUserInputResolvedDetail extends AwaitingUserInputDetail {
+  outcome: AwaitingUserInputOutcome;
+  /** Milliseconds the SDK spent blocked. */
+  waitedMs: number;
+}
+
+/** Render a millisecond duration without collapsing short waits to "0s". */
+export function formatDuration(ms: number): string {
+  return ms >= 1000 ? `${Math.round(ms / 1000)}s` : `${Math.round(ms)}ms`;
+}
+
+function dispatch(type: string, detail: unknown): void {
+  if (typeof window === "undefined" || typeof CustomEvent === "undefined") {
+    return;
+  }
+  try {
+    window.dispatchEvent(new CustomEvent(type, { detail }));
+  } catch {
+    // A page that has torn down `window` mid-flight must not turn an
+    // observability beacon into the actual failure.
+  }
+}
+
+function documentRoot(): { setAttribute: Function; removeAttribute: Function } | undefined {
+  if (typeof document === "undefined") return undefined;
+  const root = document.documentElement as unknown as
+    | { setAttribute?: Function; removeAttribute?: Function }
+    | undefined;
+  if (
+    !root ||
+    typeof root.setAttribute !== "function" ||
+    typeof root.removeAttribute !== "function"
+  ) {
+    return undefined;
+  }
+  return root as { setAttribute: Function; removeAttribute: Function };
+}
+
+/**
+ * Mark the SDK as blocked on user input.
+ *
+ * @returns A function that clears the marker. Safe to call more than once.
+ */
+export function beginAwaitingUserInput(
+  detail: AwaitingUserInputDetail
+): (outcome: AwaitingUserInputOutcome) => void {
+  const startedAt = Date.now();
+
+  documentRoot()?.setAttribute(AWAITING_USER_INPUT_ATTRIBUTE, detail.kind);
+  dispatch(AWAITING_USER_INPUT_EVENT, detail);
+
+  const timeoutNote =
+    detail.timeoutMs === null
+      ? ""
+      : ` It fails after ${formatDuration(detail.timeoutMs)} if it is not answered.`;
+  console.warn(
+    `[TinyCloud] Waiting for you: ${detail.message}` +
+      (detail.element
+        ? ` The prompt is a <${detail.element}> element appended to <body>; it uses a shadow root, so it will not appear in the page's own DOM tree and may be hidden behind a full-screen loading overlay.`
+        : "") +
+      timeoutNote
+  );
+
+  let ended = false;
+  return (outcome: AwaitingUserInputOutcome) => {
+    if (ended) return;
+    ended = true;
+    documentRoot()?.removeAttribute(AWAITING_USER_INPUT_ATTRIBUTE);
+    dispatch(AWAITING_USER_INPUT_RESOLVED_EVENT, {
+      ...detail,
+      outcome,
+      waitedMs: Date.now() - startedAt,
+    } satisfies AwaitingUserInputResolvedDetail);
+  };
+}
+
+/**
+ * Whether the SDK is currently blocked on user input.
+ *
+ * @returns The `kind` of the pending prompt, or `undefined` when nothing is pending.
+ */
+export function pendingUserInputKind(): string | undefined {
+  if (typeof document === "undefined") return undefined;
+  const root = document.documentElement as unknown as
+    | { getAttribute?: (name: string) => string | null }
+    | undefined;
+  if (!root || typeof root.getAttribute !== "function") return undefined;
+  return root.getAttribute(AWAITING_USER_INPUT_ATTRIBUTE) ?? undefined;
+}

--- a/packages/web-sdk/tests/WebSpaceCreationHandler.test.ts
+++ b/packages/web-sdk/tests/WebSpaceCreationHandler.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Regression tests for TC-362: sign-in hanging forever on an invisible
+ * space-creation dialog.
+ *
+ * `ModalSpaceCreationHandler.confirmSpaceCreation` used to return a promise
+ * that only ever settled on a DOM click inside a shadow root. When that dialog
+ * was not reachable — hidden behind the app's own "Connecting to your encrypted
+ * TinyCloud…" overlay — `ensureSpaceExists` awaited it forever and sign-in
+ * appeared frozen with nothing in the light DOM to explain why.
+ *
+ * These tests drive the real modal through the real ModalManager against a
+ * minimal DOM shim (same approach as PermissionRequestModal.test.ts), so the
+ * "nobody clicks" case is exercised end to end rather than against a stub.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Minimal DOM shim
+// ---------------------------------------------------------------------------
+
+class FakeElement {
+  private attrs = new Map<string, string>();
+  private listeners = new Map<string, Array<(e: any) => void>>();
+  private bySelector = new Map<string, FakeElement>();
+  public innerHTML = "";
+  public children: FakeElement[] = [];
+  public removed = false;
+
+  setAttribute(name: string, value: string): void {
+    this.attrs.set(name, value);
+  }
+  getAttribute(name: string): string | null {
+    return this.attrs.get(name) ?? null;
+  }
+  removeAttribute(name: string): void {
+    this.attrs.delete(name);
+  }
+  addEventListener(name: string, cb: (e: any) => void): void {
+    const list = this.listeners.get(name);
+    if (list === undefined) {
+      this.listeners.set(name, [cb]);
+    } else {
+      list.push(cb);
+    }
+  }
+  removeEventListener(name: string, cb: (e: any) => void): void {
+    const list = this.listeners.get(name);
+    if (list !== undefined) {
+      const idx = list.indexOf(cb);
+      if (idx >= 0) list.splice(idx, 1);
+    }
+  }
+  dispatchEvent(event: { type: string; target?: any; key?: string }): boolean {
+    const list = this.listeners.get(event.type);
+    if (list !== undefined) {
+      for (const cb of [...list]) cb(event);
+    }
+    return true;
+  }
+  /** Stable element per selector, so `[data-action="create"]` and `.modal-backdrop` differ. */
+  querySelector(sel: string): FakeElement {
+    let found = this.bySelector.get(sel);
+    if (found === undefined) {
+      found = new FakeElement();
+      this.bySelector.set(sel, found);
+    }
+    return found;
+  }
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+  remove(): void {
+    this.removed = true;
+  }
+}
+
+class FakeShadowRoot extends FakeElement {}
+
+class FakeHTMLElement extends FakeElement {
+  public shadowRoot: FakeShadowRoot | null = null;
+  attachShadow(_opts: { mode: "open" | "closed" }): FakeShadowRoot {
+    this.shadowRoot = new FakeShadowRoot();
+    return this.shadowRoot;
+  }
+}
+
+class FakeCustomEvent<T> {
+  readonly type: string;
+  readonly detail: T | undefined;
+  constructor(type: string, init?: { detail?: T }) {
+    this.type = type;
+    this.detail = init?.detail;
+  }
+}
+
+const dispatchedWindowEvents: Array<{ type: string; detail: any }> = [];
+
+const originalGlobals = {
+  HTMLElement: (globalThis as any).HTMLElement,
+  customElements: (globalThis as any).customElements,
+  document: (globalThis as any).document,
+  window: (globalThis as any).window,
+  CustomEvent: (globalThis as any).CustomEvent,
+  requestAnimationFrame: (globalThis as any).requestAnimationFrame,
+  consoleWarn: console.warn,
+};
+
+let documentElement: FakeElement;
+
+beforeAll(() => {
+  (globalThis as any).HTMLElement = FakeHTMLElement;
+  (globalThis as any).customElements = { define: () => {}, get: () => undefined };
+  const body: any = new FakeElement();
+  body.style = {};
+  documentElement = new FakeElement();
+  (globalThis as any).document = {
+    body,
+    documentElement,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  (globalThis as any).CustomEvent = FakeCustomEvent;
+  (globalThis as any).window = {
+    dispatchEvent: (event: any) => {
+      dispatchedWindowEvents.push({ type: event.type, detail: event.detail });
+      return true;
+    },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  (globalThis as any).requestAnimationFrame = (cb: () => void) => {
+    cb();
+    return 0;
+  };
+  // The handler intentionally warns when it starts blocking on the user.
+  // Keep the test output readable while still recording the calls.
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+});
+
+afterAll(async () => {
+  // The modal's hide() animation runs on a 200ms timer that touches `document`.
+  // Let it drain before the globals are restored.
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  (globalThis as any).HTMLElement = originalGlobals.HTMLElement;
+  (globalThis as any).customElements = originalGlobals.customElements;
+  (globalThis as any).document = originalGlobals.document;
+  (globalThis as any).window = originalGlobals.window;
+  (globalThis as any).CustomEvent = originalGlobals.CustomEvent;
+  (globalThis as any).requestAnimationFrame = originalGlobals.requestAnimationFrame;
+  console.warn = originalGlobals.consoleWarn;
+});
+
+const warnings: string[] = [];
+
+beforeEach(() => {
+  dispatchedWindowEvents.length = 0;
+  warnings.length = 0;
+});
+
+// Dynamic import so the shim is in place before module evaluation
+// (SpaceCreationModal does `class ... extends HTMLElement` at module scope).
+async function loadHandlerModule(): Promise<any> {
+  return await import("../src/authorization/WebSpaceCreationHandler");
+}
+
+async function loadModalManager(): Promise<any> {
+  return await import("../src/notifications/ModalManager");
+}
+
+async function loadBeacon(): Promise<any> {
+  return await import("../src/notifications/awaitingUserInput");
+}
+
+const context = {
+  spaceId: "tinycloud:pkh:eip155:1:0xabc:default",
+  address: "0xabc",
+  chainId: 1,
+  host: "https://node.tinycloud.test",
+};
+
+/**
+ * The dialog that is currently on screen, as ModalManager sees it.
+ *
+ * Note: the modal's own shadow tree is not asserted on here. Bun shares the
+ * module registry across test files, and `signInManifestRestore.test.ts` may
+ * evaluate `SpaceCreationModal` first under its own (much thinner) HTMLElement
+ * stub, so the shadow root's shape is not ours to rely on. What matters for
+ * this regression is the handler's contract with the modal's callbacks.
+ */
+function activeModal(manager: any): any {
+  return (manager.ModalManager.getInstance() as any).activeModal;
+}
+
+describe("ModalSpaceCreationHandler", () => {
+  test("rejects instead of hanging when nobody answers the dialog", async () => {
+    const { ModalSpaceCreationHandler, SpaceCreationTimeoutError } =
+      await loadHandlerModule();
+    const modals = await loadModalManager();
+    const { AWAITING_USER_INPUT_ATTRIBUTE, pendingUserInputKind } =
+      await loadBeacon();
+
+    const handler = new ModalSpaceCreationHandler({ timeoutMs: 40 });
+    const pending = handler.confirmSpaceCreation(context);
+
+    // While blocked, the wait is observable from the light DOM.
+    expect(pendingUserInputKind()).toBe("space-creation");
+    expect(documentElement.getAttribute(AWAITING_USER_INPUT_ATTRIBUTE)).toBe(
+      "space-creation",
+    );
+    expect(
+      dispatchedWindowEvents.some(
+        (e) => e.type === "tinycloud:awaiting-user-input",
+      ),
+    ).toBe(true);
+    expect(warnings.join("\n")).toContain("tinycloud-space-modal");
+
+    // No click ever happens. Before the fix this promise never settled.
+    let caught: unknown;
+    try {
+      await pending;
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(SpaceCreationTimeoutError);
+    expect((caught as Error).name).toBe("SpaceCreationTimeoutError");
+    expect((caught as any).code).toBe("SPACE_CREATION_TIMEOUT");
+    // Actionable, not generic.
+    expect((caught as Error).message).toContain("autoCreateSpace: true");
+    expect((caught as Error).message).toContain("tinycloud-space-modal");
+
+    // The wait is no longer advertised, and the unanswerable dialog is gone.
+    expect(pendingUserInputKind()).toBeUndefined();
+    expect(modals.ModalManager.getInstance().hasActiveModal()).toBe(false);
+    const resolved = dispatchedWindowEvents.find(
+      (e) => e.type === "tinycloud:awaiting-user-input-resolved",
+    );
+    expect(resolved?.detail?.outcome).toBe("timeout");
+  });
+
+  test("resolves true when the user clicks Create", async () => {
+    const { ModalSpaceCreationHandler } = await loadHandlerModule();
+    const modals = await loadModalManager();
+    const { pendingUserInputKind } = await loadBeacon();
+
+    const handler = new ModalSpaceCreationHandler({ timeoutMs: 5_000 });
+    const pending = handler.confirmSpaceCreation(context);
+
+    // Exactly what the modal's Create button invokes.
+    await activeModal(modals).options.onCreateSpace();
+
+    expect(await pending).toBe(true);
+    expect(pendingUserInputKind()).toBeUndefined();
+    const resolved = dispatchedWindowEvents.find(
+      (e) => e.type === "tinycloud:awaiting-user-input-resolved",
+    );
+    expect(resolved?.detail?.outcome).toBe("confirmed");
+  });
+
+  test("resolves false when the user dismisses the dialog", async () => {
+    const { ModalSpaceCreationHandler } = await loadHandlerModule();
+    const modals = await loadModalManager();
+    const { pendingUserInputKind } = await loadBeacon();
+
+    const handler = new ModalSpaceCreationHandler({ timeoutMs: 5_000 });
+    const pending = handler.confirmSpaceCreation(context);
+
+    activeModal(modals).dismiss();
+
+    expect(await pending).toBe(false);
+    expect(pendingUserInputKind()).toBeUndefined();
+  });
+
+  test("timeoutMs: 0 restores the unbounded wait for callers who opt in", async () => {
+    const { ModalSpaceCreationHandler } = await loadHandlerModule();
+    const modals = await loadModalManager();
+
+    const handler = new ModalSpaceCreationHandler({ timeoutMs: 0 });
+    const pending = handler.confirmSpaceCreation(context);
+
+    const settled = await Promise.race([
+      pending.then(() => "settled"),
+      new Promise((resolve) => setTimeout(() => resolve("still waiting"), 60)),
+    ]);
+    expect(settled).toBe("still waiting");
+
+    // Do not leave a dangling promise behind.
+    activeModal(modals).dismiss();
+    expect(await pending).toBe(false);
+  });
+});
+
+describe("resolveSpaceCreationHandler", () => {
+  test("autoCreateSpace: true creates the space without showing a dialog", async () => {
+    const { resolveSpaceCreationHandler, ModalSpaceCreationHandler } =
+      await loadHandlerModule();
+    const modals = await loadModalManager();
+
+    const handler = resolveSpaceCreationHandler({ autoCreateSpace: true });
+    expect(handler).toBeDefined();
+    expect(handler).not.toBeInstanceOf(ModalSpaceCreationHandler);
+
+    // The whole point: it confirms immediately, with no modal to click.
+    expect(await handler!.confirmSpaceCreation(context)).toBe(true);
+    expect(modals.ModalManager.getInstance().hasActiveModal()).toBe(false);
+  });
+
+  test("autoCreateSpace: false skips creation entirely (no handler)", async () => {
+    const { resolveSpaceCreationHandler } = await loadHandlerModule();
+    expect(resolveSpaceCreationHandler({ autoCreateSpace: false })).toBeUndefined();
+  });
+
+  test("unset autoCreateSpace keeps the modal confirmation default", async () => {
+    const { resolveSpaceCreationHandler, ModalSpaceCreationHandler } =
+      await loadHandlerModule();
+    expect(resolveSpaceCreationHandler({})).toBeInstanceOf(
+      ModalSpaceCreationHandler,
+    );
+  });
+
+  test("an explicit handler wins over autoCreateSpace", async () => {
+    const { resolveSpaceCreationHandler } = await loadHandlerModule();
+    const custom = { confirmSpaceCreation: async () => true };
+    expect(
+      resolveSpaceCreationHandler({
+        autoCreateSpace: true,
+        spaceCreationHandler: custom,
+      }),
+    ).toBe(custom);
+  });
+
+  test("spaceCreationTimeoutMs is forwarded to the modal handler", async () => {
+    const { resolveSpaceCreationHandler, SpaceCreationTimeoutError } =
+      await loadHandlerModule();
+
+    const handler = resolveSpaceCreationHandler({ spaceCreationTimeoutMs: 30 });
+    let caught: unknown;
+    try {
+      await handler!.confirmSpaceCreation(context);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SpaceCreationTimeoutError);
+    expect((caught as any).timeoutMs).toBe(30);
+  });
+});


### PR DESCRIPTION
## The bug

Sign-in appeared to hang permanently at *"Connecting to your encrypted TinyCloud…"*. It was not hung — it was waiting on a click nobody could see.

`TinyCloudWeb` always installed `ModalSpaceCreationHandler`, whose `confirmSpaceCreation` returned a promise that **only** ever settled on a DOM click, with no timeout. The dialog is a shadow-DOM custom element (`<tinycloud-space-modal>`), so nothing in the light DOM indicated it existed — a full-screen app overlay could sit on top of it and the SDK would wait forever. Clicking `shadowRoot [data-action="create"]` unblocked it instantly.

## What changed

**1. The infinite wait is now bounded.**
Default 2 minutes, configurable via the new `TinyCloudWeb` config option `spaceCreationTimeoutMs` or `new ModalSpaceCreationHandler({ timeoutMs })`; `0` restores the unbounded wait for callers who have verified their dialog is reachable. On expiry the handler closes the dialog, fires an SDK error event, and rejects with `SpaceCreationTimeoutError` (`code: "SPACE_CREATION_TIMEOUT"`) whose message names the element, the likely cause, and the three ways out:

> TinyCloud waited 120s for you to confirm creating your TinyCloud Space and got no answer. The confirmation dialog is a `<tinycloud-space-modal>` element appended to `<body>`; because it renders in a shadow root it can sit behind a full-screen loading overlay and never be seen. Fixes: dismiss or lower the z-index of any overlay shown during sign-in and retry; or set `autoCreateSpace: true` on TinyCloudWeb to create the space without a dialog; or pass your own `spaceCreationHandler` to prompt in your own UI.

**2. `autoCreateSpace` is honoured in the browser** (behaviour change).
`TinyCloudWeb` set `nodeConfig.spaceCreationHandler` unconditionally, and node-sdk gives an explicit handler precedence over `autoCreateSpace` — so `autoCreateSpace: true` was dead config in the browser. **Honouring it** rather than removing it: it is a documented, public option, callers reasonably expect it to work, and it is also the escape hatch the timeout message points at. New precedence, in `resolveSpaceCreationHandler`:

| config | handler | effect |
|---|---|---|
| explicit `spaceCreationHandler` | that handler | caller asked for a specific UX |
| `autoCreateSpace: true` | `AutoApproveSpaceCreationHandler` | create it, no dialog |
| `autoCreateSpace: false` | none | never create; sign-in continues without a primary space |
| unset (default) | `ModalSpaceCreationHandler` | today's confirm-first UX, unchanged |

Only apps that *explicitly* set `autoCreateSpace` see a change — and they see what the option always said it did.

**3. Discoverability.**
While the SDK is blocked on the user it sets `data-tinycloud-awaiting-user-input="space-creation"` on `<html>`, fires `tinycloud:awaiting-user-input` / `tinycloud:awaiting-user-input-resolved` on `window` (with kind, message, timeout, outcome and waited-ms), and logs an explanatory `console.warn`. `pendingUserInputKind()` reports the same state. A stuck sign-in is now visible to CSS, to `document.querySelector`, to a support engineer in devtools, and to any DOM-driving harness.

**Also fixed** (the related item): the owner-policy path signs mid-compose by re-opening the OpenKey/wallet signing surface long after sign-in. An unanswered or cancelled prompt there produced the *same* `PERMISSION_DENIED` "the active session ReCap does not authorize this sharing delegation" message as an unrelated HTTP 403. `SharingService` now classifies it as `TIMEOUT` or `ABORTED` with an actionable message, and keeps the original error as `cause`.

**Incidental, in scope:** `SpaceCreationModal.disconnectedCallback` now releases document-level state, and `handleKeyDown` is no longer re-bound at `addEventListener` time (which made the matching `removeEventListener` a no-op). Both matter now that the modal can be torn down programmatically on timeout.

## Verification

Red-then-green on the must-fix, using a bound of 40ms so the proof is fast (pre-fix the option does not exist and the wait is unbounded):

<pre>
=== RED (pre-fix handler) ===
  expect(outcome).toBe("rejected");
error: expect(received).toBe(expected)
Expected: "rejected"
Received: "HUNG: still waiting on a click"
(fail) TC-362: a skipped primary space with no click must not hang forever [2748.13ms]
 0 pass
 1 fail

=== GREEN (post-fix handler) ===
 1 pass
 0 fail
</pre>

Functional check against a **real DOM** (jsdom), driving the actual shadow-DOM dialog:

<pre>
[1] real DOM, user clicks the create button
  modal element in light DOM: true
  modal is a shadow host (invisible to page DOM queries): true
  page can see the SDK is blocked: space-creation
  confirmSpaceCreation resolved: true
  attribute cleared: null
  modal removed from DOM: true

[2] real DOM, nobody clicks (the reported hang)
  outcome: SpaceCreationTimeoutError / SPACE_CREATION_TIMEOUT
  elapsed ms: 310
  modal removed from DOM: true
  attribute cleared: null

[3] autoCreateSpace: true never opens a dialog
  confirmSpaceCreation: true
  no modal in the DOM: true
  handler for autoCreateSpace:false: undefined
  handler when unset: ModalSpaceCreationHandler

window events observed: awaiting(space-creation), resolved(confirmed), awaiting(space-creation), resolved(timeout)
</pre>

Committed tests: `packages/web-sdk/tests/WebSpaceCreationHandler.test.ts` (9 tests: timeout, confirm, dismiss, `timeoutMs: 0`, and the full `resolveSpaceCreationHandler` matrix), a node-sdk test that `ensureSpaceExists` actually surfaces a handler rejection rather than swallowing it, and three `SharingService` tests for the TIMEOUT / ABORTED / PERMISSION_DENIED split.

## Gates

<pre>
##### bun run --cwd packages/sdk-core test
 810 pass
 0 fail
 2639 expect() calls
Ran 810 tests across 34 files. [17.23s]

##### bun run --cwd packages/node-sdk test
 209 pass
 0 fail
 696 expect() calls
Ran 209 tests across 19 files. [2.15s]

##### bun test (cwd packages/web-sdk)
 175 pass
 5 fail
 2 errors
 306 expect() calls
Ran 180 tests across 14 files. [837.00ms]

##### tsc --noEmit (web-sdk)
exit=0

##### bun run build (turbo, all packages)
 Tasks:    15 successful, 15 total
Cached:    0 cached, 15 total
  Time:    1m39.346s
</pre>

The 5 web-sdk failures + 2 errors are **pre-existing on master** — legacy jest-style `.test.js` files that bun picks up but that are not in any CI gate. Same command on a clean `origin/master` tree with the same build: `166 pass, 5 fail, 2 errors`. This branch: `175 pass, 5 fail, 2 errors` (+9 new passing).

Also green: `bun test tests/mcp-sdk-contract/{contract,prerequisites}.test.ts` (6 pass), `bun run --cwd tests/mcp-sdk-contract test:public-api` (exit 0), eslint on all changed web-sdk files (exit 0).

## Changeset

`.changeset/tc-362-space-modal-timeout.md` — minor for `@tinycloud/web-sdk` and `@tinycloud/sdk-core` (new public option + behaviour change on `autoCreateSpace`; the four SDK packages are `linked` so they move together).

Linear: TC-362