### PR TITLE
PROOF/DO-NOT-MERGE (TC-380): control — planted failures under the OLD paths filters

### DIFF
--- a/packages/vfs/src/index.ts
+++ b/packages/vfs/src/index.ts
@@ -1,3 +1,6 @@
+// TC-380 PROOF: deliberate type error planted in a package no old filter covered.
+export const tc380PlantedFailure: number = "this is not a number";
+
 export {
   TinyCloudVfsProvider,
   createTinyCloudVfs,

--- a/tests/packed-runtime/tinycloud-entrypoints.ts
+++ b/tests/packed-runtime/tinycloud-entrypoints.ts
@@ -28,6 +28,8 @@ const publishedPackageNames = {
 } as const;
 
 export function tinycloudPackages(root = repositoryDirectory) {
+  // TC-380 PROOF: deliberate break in the harness tc-191 tests import.
+  throw new Error("TC-380 planted failure in the packed-runtime harness");
   return [
     ["bootstrap", join(root, "packages/bootstrap")],
     ["sdk-services", join(root, "packages/sdk-services")],


### PR DESCRIPTION
Temporary control experiment for TC-380 / PR #366. **Do not merge — will be closed and deleted.**

This branch is cut from `master` (old, `paths:`-filtered config) and plants two deliberate, obvious failures:

1. `packages/vfs/src/index.ts` — a type error (`const x: number = "string"`) in a package **no workflow builds at all**
2. `tests/packed-runtime/tinycloud-entrypoints.ts` — an unconditional `throw` in the harness that `tc-191-i0-gate` imports via `cli.test.ts` and `entrypoints.test.ts`, but which is **absent from tc-191's `paths:` filter**

**Expected result: zero checks run, PR shows as green//no-checks despite being visibly broken.**

Compare against #366, where the same two failures are caught.