### PR TITLE
TC-373: batch the account-bootstrap seed-spaces writes

### DIFF
--- a/.changeset/tc-373-batch-seed-spaces-classifier.md
+++ b/.changeset/tc-373-batch-seed-spaces-classifier.md
@@ -1,0 +1,14 @@
+---
+"@tinycloud/sdk-core": minor
+"@tinycloud/web-sdk": minor
+"@tinycloud/node-sdk": minor
+"@tinycloud/sdk-services": minor
+---
+
+TC-373: fix two blockers found in review of the batched account-bootstrap seed-spaces write.
+
+- `KVService.batchPut` now attaches structured metadata (`requestMayHaveDispatched`, and on the two unconfirmed-2xx response paths, `responseReceived` / `status` / `outcome: "batch-unconfirmed"`) to `NETWORK_ERROR`/`TIMEOUT` failures instead of leaving them unclassified. No new `ErrorCodes` member is added — the ambiguity is carried entirely in `meta` to avoid widening the exported `ErrorCode` union.
+- `AccountService.spaces.registerBatch`'s internal ambiguous-failure classifier is now a strict allow-list (previously a deny-list that defaulted to "retry", so deterministic failures like 400/409/422, `INVALID_INPUT`, and 501/505 triggered five pointless per-space reconcile puts). `registerBatch` now returns `RegisterBatchSuccess` (`{ spaces, recoveredFromBatchError? }`) instead of a bare array, so a batch write that recovers via per-space reconciliation is visible on the success payload, not only via `console.warn`.
+- `TinyCloudNode.bootstrapStatus` gains an optional `warnings?: BootstrapWarning[]` field: bootstrap that completes via a recovered ambiguous write is now programmatically distinguishable from a clean run (both were previously `{ skipped: false }`).
+
+Both changes are additive; nothing published is broken.

--- a/apps/node-demo/src/tc-373-live-verify.ts
+++ b/apps/node-demo/src/tc-373-live-verify.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+/**
+ * TC-373 live verification: proves the account-bootstrap seed-spaces
+ * batching end-to-end against a real node, using a throwaway key.
+ *
+ * Wraps global fetch to count/log every request made during a cold
+ * signIn(), classifying each /invoke call's body shape (multipart batch vs
+ * single JSON/text) so the collapsed KV batch write and the collapsed SQL
+ * index write are visible in the trace. Then reads all 5 seeded space
+ * records back through the canonical (non-index) read path to confirm they
+ * are readable and correct.
+ *
+ * Usage:
+ *   bun run src/tc-373-live-verify.ts
+ *   TINYCLOUD_HOST=https://... bun run src/tc-373-live-verify.ts
+ */
+import { TinyCloudNode } from "@tinycloud/node-sdk";
+import { randomBytes } from "crypto";
+
+const HOST = process.env.TINYCLOUD_HOST ?? "https://node.tinycloud.xyz";
+const original = globalThis.fetch;
+let n = 0;
+
+interface RequestLog {
+  method: string;
+  path: string;
+  status: number;
+  ms: number;
+  bodyKind: string;
+}
+const requests: RequestLog[] = [];
+
+function bodyKind(init?: RequestInit): string {
+  const body = init?.body;
+  if (!body) return "none";
+  if (body instanceof FormData) {
+    const parts = [...body.keys()];
+    return `multipart(${parts.length} part${parts.length === 1 ? "" : "s"})`;
+  }
+  if (typeof body === "string") {
+    try {
+      const parsed = JSON.parse(body);
+      if (parsed && typeof parsed === "object" && Array.isArray(parsed.statements)) {
+        return `json-batch(${parsed.statements.length} stmt${parsed.statements.length === 1 ? "" : "s"})`;
+      }
+      if (parsed && typeof parsed === "object" && typeof parsed.action === "string") {
+        return `json-${parsed.action}`;
+      }
+      return "json";
+    } catch {
+      return "text";
+    }
+  }
+  return "binary";
+}
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = init?.method ?? (typeof input === "object" ? input?.method : "GET") ?? "GET";
+  const kind = bodyKind(init);
+  const i = ++n;
+  const started = Date.now();
+  try {
+    const res = await original(input as any, init);
+    const ms = Date.now() - started;
+    requests.push({ method, path: url.replace(HOST, ""), status: res.status, ms, bodyKind: kind });
+    console.log(
+      `  [${String(i).padStart(2)}] ${String(method).padEnd(5)} ${String(ms).padStart(6)}ms  ${res.status}  ${kind.padEnd(18)}  ${url.replace(HOST, "")}`,
+    );
+    return res;
+  } catch (error) {
+    const ms = Date.now() - started;
+    requests.push({ method, path: url.replace(HOST, ""), status: -1, ms, bodyKind: kind });
+    console.log(
+      `  [${String(i).padStart(2)}] ${String(method).padEnd(5)} ${String(ms).padStart(6)}ms  ERR   ${kind.padEnd(18)}  ${url.replace(HOST, "")}  ${error}`,
+    );
+    throw error;
+  }
+}) as typeof fetch;
+
+console.log(`=== TC-373 live verify against ${HOST} ===\n`);
+
+const key = `0x${randomBytes(32).toString("hex")}`;
+const node = new TinyCloudNode({
+  privateKey: key,
+  host: HOST,
+  prefix: "tc-373-verify",
+  autoCreateSpace: true,
+});
+
+const started = Date.now();
+await node.signIn();
+const signInMs = Date.now() - started;
+
+console.log(`\ntotal signIn: ${signInMs}ms, ${requests.length} requests`);
+console.log(`bootstrap skipped: ${node.bootstrapSkipped}`);
+if (node.bootstrapSkipped) {
+  console.log(`bootstrap status:`, node.bootstrapStatus);
+}
+
+const invokeRequests = requests.filter((r) => r.path === "/invoke" && r.method === "POST");
+const multipartBatch = invokeRequests.filter((r) => r.bodyKind.startsWith("multipart"));
+const jsonBatchSql = invokeRequests.filter((r) => r.bodyKind.startsWith("json-batch"));
+
+console.log(`\n/invoke POST calls: ${invokeRequests.length}`);
+console.log(`  multipart KV batch writes: ${multipartBatch.length} (expect 1, covering all 5 spaces)`);
+console.log(`  multi-statement SQL batch calls: ${jsonBatchSql.length}`);
+
+let failed = false;
+function assert(name: string, cond: boolean, detail = "") {
+  console.log(`  ${cond ? "ok  " : "FAIL"}  ${name}${detail ? `  (${detail})` : ""}`);
+  if (!cond) failed = true;
+}
+
+console.log("\n=== verifying all 5 seeded spaces ===");
+assert(
+  "bootstrap did not skip",
+  node.bootstrapSkipped === false,
+  JSON.stringify(node.bootstrapStatus),
+);
+assert(
+  "exactly one multipart KV batch write",
+  multipartBatch.length === 1,
+  `got ${multipartBatch.length}`,
+);
+if (multipartBatch.length === 1) {
+  assert(
+    "batch write covers exactly 5 parts",
+    multipartBatch[0]!.bodyKind === "multipart(5 parts)",
+    multipartBatch[0]!.bodyKind,
+  );
+}
+
+const expectedNames = ["default", "applications", "account", "secrets", "public"];
+const spacesResult = await node.account.spaces.list();
+assert(
+  "account.spaces.list() ok (canonical KV read, not the SQL index)",
+  spacesResult.ok,
+  spacesResult.ok ? "" : JSON.stringify((spacesResult as any).error),
+);
+if (spacesResult.ok) {
+  assert(
+    "all 5 spaces present",
+    spacesResult.data.length === 5,
+    `got ${spacesResult.data.length}: ${spacesResult.data.map((s) => s.name).join(",")}`,
+  );
+  for (const name of expectedNames) {
+    const found = spacesResult.data.find((s) => s.name === name);
+    assert(`space "${name}" registered`, Boolean(found), found ? `spaceId=${found.spaceId}` : "missing");
+    if (found) {
+      assert(
+        `space "${name}" ownerDid matches signed-in identity`,
+        found.ownerDid === node.did,
+        `${found.ownerDid} vs ${node.did}`,
+      );
+      assert(`space "${name}" status active`, found.status === "active");
+    }
+  }
+}
+
+// Index status: the multi-row index write should have landed too (best
+// effort, but expected to succeed on a healthy node).
+const indexStatus = await node.account.index.status();
+console.log(`\nindex status:`, indexStatus.ok ? indexStatus.data : (indexStatus as any).error);
+
+console.log(`\nRESULT: ${failed ? "FAIL" : "PASS"}`);
+process.exit(failed ? 1 : 0);

--- a/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.bootstrapGate.test.ts
@@ -158,7 +158,7 @@ function stubNodeForSignIn(
  * Returns the mock for assertions.
  */
 function stubRunAccountBootstrap(node: TinyCloudNode): ReturnType<typeof mock> {
-  const bootstrapMock = mock(async () => {});
+  const bootstrapMock = mock(async () => []);
   (node as any).runAccountBootstrap = bootstrapMock;
   return bootstrapMock;
 }

--- a/packages/node-sdk/src/TinyCloudNode.bootstrapWarnings.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.bootstrapWarnings.test.ts
@@ -11,7 +11,12 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
-import type { IWasmBindings, ISessionManager, ClientSession } from "@tinycloud/sdk-core";
+import type {
+  IWasmBindings,
+  ISessionManager,
+  ClientSession,
+  BootstrapSeedSpacesStep,
+} from "@tinycloud/sdk-core";
 import { createOpenKeyCallbackSigningStrategy } from "@tinycloud/sdk-core";
 import { TinyCloudNode, type BootstrapWarning } from "./TinyCloudNode";
 
@@ -180,5 +185,56 @@ describe("bootstrapStatus.warnings — recovered ambiguous batch write (TC-373 /
     expect(node.bootstrapStatus.skipped).toBe(true);
     expect(node.bootstrapStatus.reason).toBe("boom");
     expect(node.bootstrapStatus.warnings).toBeUndefined();
+  });
+
+  // Sol B3 (round 2): the three tests above all replace `runAccountBootstrap`
+  // itself with a mock, so they only assert that TinyCloudNode plumbs
+  // whatever `runAccountBootstrap` returns onto `bootstrapStatus` — they would
+  // still pass even if the mapping from `recoveredFromBatchError` to a
+  // `BootstrapWarning` at TinyCloudNode.ts:1667-1675 were deleted entirely.
+  // This test drives the REAL `runAccountBootstrap` and only stubs the KV
+  // layer it calls (`account.spaces.registerBatch`), so it actually guards
+  // the mapping code itself.
+  test("the REAL runAccountBootstrap seed-spaces path maps recoveredFromBatchError to a BootstrapWarning", async () => {
+    const warningSpy = mock(() => {});
+    const node = makeNode(warningSpy);
+
+    // runAccountBootstrap() only requires `this.auth` (set synchronously in
+    // the constructor via setupAuth) and `this._address` (normally set
+    // inside signIn()). Set the address directly instead of calling
+    // signIn(), so the *only* real bootstrap step that runs is the
+    // seed-spaces one under test.
+    (node as any)._address = FAKE_ADDRESS;
+
+    const batchError = {
+      code: "KV_WRITE_FAILED",
+      message: "500 - internal error after commit, reconciled",
+      service: "kv",
+    };
+
+    // Stub only the KV batch outcome. Everything downstream of it —
+    // including the `if (batchError) warnings.push(...)` mapping — is the
+    // real production code.
+    node.account.spaces.registerBatch = mock(async () => ({
+      ok: true as const,
+      data: { spaces: [], recoveredFromBatchError: batchError },
+    }));
+
+    const seedSpacesStep: BootstrapSeedSpacesStep = {
+      id: "account:seed-spaces",
+      kind: "seed-spaces",
+      spaces: [],
+    };
+
+    const warnings = await (node as any).runAccountBootstrap([seedSpacesStep]);
+
+    expect(warnings).toEqual([
+      {
+        stepId: "account:seed-spaces",
+        kind: "batch-write-reconciled",
+        code: "KV_WRITE_FAILED",
+        message: "500 - internal error after commit, reconciled",
+      },
+    ]);
   });
 });

--- a/packages/node-sdk/src/TinyCloudNode.bootstrapWarnings.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.bootstrapWarnings.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for TC-373 Sol blocker #2: a recovered ambiguous batch-write
+ * failure must be surfaced structurally on `bootstrapStatus`, not only via
+ * `console.warn` (Sol B5/B6e).
+ *
+ * These drive the PUBLIC contract — `bootstrapAccountIfNeeded()` via
+ * `signIn()` — rather than inspecting `runAccountBootstrap`'s private return
+ * value directly, using the same stubbing style as
+ * `TinyCloudNode.bootstrapGate.test.ts`.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { IWasmBindings, ISessionManager, ClientSession } from "@tinycloud/sdk-core";
+import { createOpenKeyCallbackSigningStrategy } from "@tinycloud/sdk-core";
+import { TinyCloudNode, type BootstrapWarning } from "./TinyCloudNode";
+
+function makeFakeSessionManager(): ISessionManager {
+  const keys = new Set<string>(["default"]);
+  return {
+    createSessionKey(id: string): string {
+      keys.add(id);
+      return id;
+    },
+    replaceSessionKey(_jwk: object, keyId: string): string {
+      keys.add(keyId);
+      return keyId;
+    },
+    renameSessionKeyId(oldId: string, newId: string): void {
+      if (keys.has(oldId)) {
+        keys.delete(oldId);
+        keys.add(newId);
+      }
+    },
+    getDID(keyId: string): string {
+      return `did:key:z6MkTest-${keyId}`;
+    },
+    jwk(keyId: string): string | undefined {
+      if (!keys.has(keyId)) return undefined;
+      return JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" });
+    },
+  };
+}
+
+function makeFakeWasmBindings(): IWasmBindings {
+  return {
+    invoke: mock(() => Promise.resolve({} as any)) as any,
+    invokeAny: mock(() => Promise.resolve({} as any)) as any,
+    prepareSession: mock(() => ({
+      siwe: "fake-siwe",
+      jwk: { kty: "OKP" },
+      spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      verificationMethod: "did:key:z6MkTestSession",
+    })),
+    completeSessionSetup: mock(() => ({
+      delegationHeader: { Authorization: "Bearer fake" },
+      delegationCid: "bafyfake",
+      jwk: { kty: "OKP" },
+      spaceId: "tinycloud:pkh:eip155:1:0x0000000000000000000000000000000000000001:default",
+      verificationMethod: "did:key:z6MkTestSession",
+    })),
+    ensureEip55: (a: string) => a,
+    makeSpaceId: (a: string, c: number, p: string) => `tinycloud:pkh:eip155:${c}:${a}:${p}`,
+    createDelegation: mock(() => ({})),
+    parseRecapFromSiwe: mock(() => [] as any[]),
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    vault_encrypt: mock(() => new Uint8Array()),
+    vault_decrypt: mock(() => new Uint8Array()),
+    vault_derive_key: mock(() => new Uint8Array()),
+    vault_x25519_from_seed: mock(() => ({
+      publicKey: new Uint8Array(),
+      privateKey: new Uint8Array(),
+    })),
+    vault_x25519_dh: mock(() => new Uint8Array()),
+    vault_random_bytes: mock(() => new Uint8Array()),
+    vault_sha256: mock(() => new Uint8Array()),
+    createSessionManager: makeFakeSessionManager,
+  };
+}
+
+const FAKE_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+const FAKE_SESSION: ClientSession = {
+  address: FAKE_ADDRESS,
+  walletAddress: FAKE_ADDRESS,
+  chainId: 1,
+  sessionKey: "session-test",
+  siwe: "fake-siwe",
+  signature: "0x" + "ff".repeat(65),
+};
+
+function makeExternalSigner() {
+  return {
+    signMessage: mock(async () => "0x" + "ff".repeat(65)),
+    getAddress: async () => FAKE_ADDRESS,
+    getChainId: async () => 1,
+  };
+}
+
+function stubNodeForSignIn(node: TinyCloudNode): void {
+  const tc = (node as any).tc;
+  if (!tc) throw new Error("expected tc to be present (node needs signer)");
+  tc.signIn = mock(async () => FAKE_SESSION);
+
+  (node as any).syncResolvedHostFromAuth = () => {};
+  (node as any).initializeServices = () => {};
+  (node as any).isFreshBootstrapAccount = async () => true;
+  (node as any).ensureRequestedEncryptionNetworks = async () => {};
+  (node as any).ensureOwnedSpaceHostedById = async () => {};
+  (node as any).scheduleAccountRegistrySync = () => {};
+}
+
+function makeNode(warningSpy: ReturnType<typeof mock>) {
+  const openKeyStrategy = createOpenKeyCallbackSigningStrategy({
+    endpoint: "https://openkey.test/api/delegate/sign",
+  });
+  const node = new TinyCloudNode({
+    wasmBindings: makeFakeWasmBindings(),
+    signer: makeExternalSigner() as any,
+    signStrategy: openKeyStrategy,
+    host: "https://tinycloud.test",
+    notificationHandler: {
+      success: () => {},
+      warning: warningSpy,
+      error: () => {},
+    },
+  });
+  stubNodeForSignIn(node);
+  return node;
+}
+
+describe("bootstrapStatus.warnings — recovered ambiguous batch write (TC-373 / TC-361)", () => {
+  test("a recovered registerBatch surfaces a structured warning on bootstrapStatus", async () => {
+    const warningSpy = mock(() => {});
+    const node = makeNode(warningSpy);
+
+    const warning: BootstrapWarning = {
+      stepId: "account:seed-spaces",
+      kind: "batch-write-reconciled",
+      code: "KV_WRITE_FAILED",
+      message: "500 - internal error after commit, reconciled",
+    };
+    (node as any).runAccountBootstrap = mock(async () => [warning]);
+
+    await node.signIn();
+
+    expect(node.bootstrapSkipped).toBe(false);
+    expect(node.bootstrapStatus).toEqual({ skipped: false, warnings: [warning] });
+    expect(warningSpy).toHaveBeenCalledTimes(1);
+    expect(String(warningSpy.mock.calls[0]![0])).toContain("account:seed-spaces");
+  });
+
+  test("a clean registerBatch leaves bootstrapStatus.warnings undefined (clean vs. recovered are distinguishable)", async () => {
+    const warningSpy = mock(() => {});
+    const node = makeNode(warningSpy);
+
+    (node as any).runAccountBootstrap = mock(async () => []);
+
+    await node.signIn();
+
+    expect(node.bootstrapSkipped).toBe(false);
+    expect(node.bootstrapStatus.skipped).toBe(false);
+    expect(node.bootstrapStatus.warnings).toBeUndefined();
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  test("bootstrap failure path is unchanged: { skipped: true, reason } with no warnings key", async () => {
+    const warningSpy = mock(() => {});
+    const node = makeNode(warningSpy);
+
+    (node as any).runAccountBootstrap = mock(async () => {
+      throw new Error("boom");
+    });
+
+    await node.signIn();
+
+    expect(node.bootstrapSkipped).toBe(true);
+    expect(node.bootstrapStatus.skipped).toBe(true);
+    expect(node.bootstrapStatus.reason).toBe("boom");
+    expect(node.bootstrapStatus.warnings).toBeUndefined();
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.seedSpacesBatch.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.seedSpacesBatch.test.ts
@@ -1,0 +1,113 @@
+/**
+ * TC-373: the account-bootstrap "seed-spaces" step must batch all 5 spaces
+ * into ONE `account.spaces.registerBatch()` call instead of looping 5 times
+ * over `account.spaces.register()`.
+ *
+ * This exercises `runAccountBootstrap` directly with a `steps` array
+ * containing only a `seed-spaces` step, isolating the seeding branch from
+ * the session/host/activate machinery (which no-op when their step kinds
+ * are absent from the array).
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { IWasmBindings, ISessionManager } from "@tinycloud/sdk-core";
+import { TinyCloudNode } from "./TinyCloudNode";
+
+const ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+
+function makeSessionManager(): ISessionManager {
+  return {
+    createSessionKey: (id: string) => id,
+    replaceSessionKey: (_jwk: object, keyId: string) => keyId,
+    renameSessionKeyId: () => {},
+    getDID: (keyId: string) => `did:key:${keyId}`,
+    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+  };
+}
+
+function makeWasmBindings(): IWasmBindings {
+  return {
+    invoke: async () => undefined,
+    makeSpaceId: (address: string, chainId: number, name: string) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${name}`,
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    createSessionManager: makeSessionManager,
+  } as unknown as IWasmBindings;
+}
+
+function makeNode() {
+  const signer = {
+    getAddress: async () => ADDRESS,
+    getChainId: async () => 1,
+    signMessage: mock(async () => "0xsig"),
+  };
+  const node = new TinyCloudNode({
+    host: "https://tinycloud.test",
+    signer: signer as any,
+    wasmBindings: makeWasmBindings(),
+  });
+  (node as any)._address = ADDRESS;
+  (node as any)._chainId = 1;
+  // runAccountBootstrap only needs a truthy `auth` with the two properties
+  // it reads (tinyCloudSession, capabilityRequest) — no session/host steps
+  // are present in this test's `steps` array, so nothing else is read.
+  (node as any).auth = { tinyCloudSession: undefined, capabilityRequest: undefined };
+  return node;
+}
+
+const SPACE_NAMES = ["default", "applications", "account", "secrets", "public"] as const;
+
+function seedSpacesStep() {
+  return {
+    id: "account:seed-spaces",
+    kind: "seed-spaces" as const,
+    spaces: SPACE_NAMES.map((name) => ({
+      name,
+      spaceId: `tinycloud:pkh:eip155:1:${ADDRESS}:${name}`,
+    })),
+  };
+}
+
+describe("seed-spaces bootstrap step batches all 5 spaces in ONE call (TC-373)", () => {
+  test("calls account.spaces.registerBatch once with all 5 spaces, never register()", async () => {
+    const node = makeNode();
+
+    const registerBatch = mock(async (spaces: any[]) => ({
+      ok: true,
+      data: spaces.map((s) => ({ ...s })),
+    }));
+    const register = mock(async () => ({ ok: true, data: {} }));
+    (node as any)._account = { spaces: { registerBatch, register } };
+
+    await (node as any).runAccountBootstrap([seedSpacesStep()]);
+
+    expect(registerBatch).toHaveBeenCalledTimes(1);
+    expect(register).not.toHaveBeenCalled();
+
+    const [passedSpaces] = registerBatch.mock.calls[0] as [Array<{ spaceId: string; ownerDid: string }>];
+    expect(passedSpaces).toHaveLength(5);
+    expect(passedSpaces.map((s) => s.spaceId).sort()).toEqual(
+      SPACE_NAMES.map((name) => `tinycloud:pkh:eip155:1:${ADDRESS}:${name}`).sort(),
+    );
+    // Every entry carries the signed-in owner DID.
+    for (const space of passedSpaces) {
+      expect(space.ownerDid).toBe((node as any).did);
+    }
+  });
+
+  test("throws with all space ids named when registerBatch fails", async () => {
+    const node = makeNode();
+
+    const registerBatch = mock(async () => ({
+      ok: false,
+      error: { code: "KV_WRITE_FAILED", message: "boom", service: "kv" },
+    }));
+    (node as any)._account = { spaces: { registerBatch, register: mock(async () => ({ ok: true, data: {} })) } };
+
+    await expect((node as any).runAccountBootstrap([seedSpacesStep()])).rejects.toThrow(
+      "Failed to seed account spaces: boom",
+    );
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.seedSpacesBatch.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.seedSpacesBatch.test.ts
@@ -76,7 +76,7 @@ describe("seed-spaces bootstrap step batches all 5 spaces in ONE call (TC-373)",
 
     const registerBatch = mock(async (spaces: any[]) => ({
       ok: true,
-      data: spaces.map((s) => ({ ...s })),
+      data: { spaces: spaces.map((s) => ({ ...s })) },
     }));
     const register = mock(async () => ({ ok: true, data: {} }));
     (node as any)._account = { spaces: { registerBatch, register } };

--- a/packages/node-sdk/src/TinyCloudNode.spaceScopedKV.test.ts
+++ b/packages/node-sdk/src/TinyCloudNode.spaceScopedKV.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression test for TC-373 corrected-design point 1: `createSpaceScopedKVService`
+ * previously omitted `invokeAny` when constructing the space-scoped
+ * `ServiceContext`, so any `space.kv.batch*` call synchronously rejected
+ * with INVALID_INPUT ("KV batchPut requires SDK runtime support for
+ * multi-resource invocations") before ever signing or fetching. This made
+ * batching a no-op for every space-scoped KV surface, including the account
+ * bootstrap seeding path (`node.account.spaces.get(accountSpaceId).kv`).
+ *
+ * This drives the fix directly at the public surface named in the TC-373
+ * spec: `node.spaces.get(accountSpaceId).kv.batchPut()` must actually reach
+ * `invokeAny` and the network, not reject before either.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ISessionManager, IWasmBindings, ServiceSession } from "@tinycloud/sdk-core";
+import { ServiceContext, SpaceService } from "@tinycloud/sdk-core";
+
+import { TinyCloudNode } from "./TinyCloudNode";
+
+const ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+
+function makeSessionManager(): ISessionManager {
+  return {
+    createSessionKey: (id: string) => id,
+    replaceSessionKey: (_jwk: object, keyId: string) => keyId,
+    renameSessionKeyId: () => {},
+    getDID: (keyId: string) => `did:key:${keyId}`,
+    jwk: () => JSON.stringify({ kty: "OKP", crv: "Ed25519", x: "test" }),
+  };
+}
+
+function makeWasmBindings(): IWasmBindings {
+  return {
+    invoke: async () => undefined,
+    makeSpaceId: (address: string, chainId: number, name: string) =>
+      `tinycloud:pkh:eip155:${chainId}:${address}:${name}`,
+    generateHostSIWEMessage: mock(() => ""),
+    siweToDelegationHeaders: mock(() => ({})),
+    protocolVersion: () => 1,
+    createSessionManager: makeSessionManager,
+  } as unknown as IWasmBindings;
+}
+
+describe("createSpaceScopedKVService threads invokeAny (TC-373 point 1)", () => {
+  test("node.spaces.get(accountSpaceId).kv.batchPut() reaches invokeAny and the network, not INVALID_INPUT", async () => {
+    const signer = {
+      getAddress: async () => ADDRESS,
+      getChainId: async () => 1,
+      signMessage: mock(async () => "0xsig"),
+    };
+    const node = new TinyCloudNode({
+      host: "https://tinycloud.test",
+      signer: signer as any,
+      wasmBindings: makeWasmBindings(),
+    });
+
+    // Simulate post-signIn identity state without running the network dance.
+    (node as any)._address = ADDRESS;
+    (node as any)._chainId = 1;
+    const accountSpaceId: string = (node as any).accountSpaceId;
+    expect(accountSpaceId).toContain(":account");
+
+    const session: ServiceSession = {
+      delegationHeader: { Authorization: "Bearer primary" },
+      delegationCid: "bafyprimary",
+      spaceId: accountSpaceId,
+      verificationMethod: "did:key:z6MkTestSession",
+      jwk: { kty: "OKP" },
+    };
+
+    const invokeAnySpy = mock((_session: ServiceSession, _entries: unknown[]) => ({
+      Authorization: "Bearer batch",
+    }));
+    const fetchSpy = mock(
+      async () =>
+        new Response(JSON.stringify({ written: ["a", "b"], count: 2 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    // Build the primary ServiceContext exactly as initializeServices() does:
+    // both invoke AND invokeAny wired. This is the object
+    // createSpaceScopedKVService reads `invokeAny` from.
+    const ctx = new ServiceContext({
+      invoke: () => ({ Authorization: "Bearer single" }),
+      invokeAny: invokeAnySpy as any,
+      fetch: fetchSpy as any,
+      hosts: ["https://tinycloud.test"],
+    });
+    ctx.setSession(session);
+    (node as any)._serviceContext = ctx;
+
+    // Wire SpaceService exactly like production's initializeServices() does:
+    // createKVService delegates to the private createSpaceScopedKVService.
+    (node as any)._spaceService = new SpaceService({
+      hosts: ["https://tinycloud.test"],
+      session,
+      invoke: ctx.invoke,
+      fetch: ctx.fetch,
+      userDid: (node as any).did,
+      createKVService: (spaceId: string) => (node as any).createSpaceScopedKVService(spaceId),
+    });
+
+    const result = await node.spaces.get(accountSpaceId).kv.batchPut([
+      { key: "a", value: "one" },
+      { key: "b", value: "two" },
+    ]);
+
+    // FAILS before the fix: the space-scoped ServiceContext had no
+    // invokeAny, so batchPut rejected synchronously with INVALID_INPUT and
+    // neither invokeAnySpy nor fetchSpy were ever reached.
+    expect(result.ok).toBe(true);
+    expect(invokeAnySpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // And the invocation actually named both resources (one invocation
+    // proving both capabilities, not two separate ones).
+    const [, entries] = invokeAnySpy.mock.calls[0] as [unknown, Array<{ path: string }>];
+    expect(entries).toHaveLength(2);
+  });
+
+  test("without the fix (invokeAny omitted from the space-scoped context), batchPut rejects with INVALID_INPUT before signing or fetching", async () => {
+    const signer = {
+      getAddress: async () => ADDRESS,
+      getChainId: async () => 1,
+      signMessage: mock(async () => "0xsig"),
+    };
+    const node = new TinyCloudNode({
+      host: "https://tinycloud.test",
+      signer: signer as any,
+      wasmBindings: makeWasmBindings(),
+    });
+
+    (node as any)._address = ADDRESS;
+    (node as any)._chainId = 1;
+    const accountSpaceId: string = (node as any).accountSpaceId;
+
+    const session: ServiceSession = {
+      delegationHeader: { Authorization: "Bearer primary" },
+      delegationCid: "bafyprimary",
+      spaceId: accountSpaceId,
+      verificationMethod: "did:key:z6MkTestSession",
+      jwk: { kty: "OKP" },
+    };
+
+    const invokeAnySpy = mock((_session: ServiceSession, _entries: unknown[]) => ({
+      Authorization: "Bearer batch",
+    }));
+    const fetchSpy = mock(
+      async () =>
+        new Response(JSON.stringify({ written: ["a", "b"], count: 2 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    // Same context as above, but the primary ServiceContext itself has no
+    // invokeAny — mirrors a node whose top-level graph wiring never
+    // threaded one through in the first place. createSpaceScopedKVService
+    // reads `this._serviceContext.invokeAny`, so `undefined` here is
+    // sufficient to reproduce the pre-fix regression without needing to
+    // revert TinyCloudNode.ts itself.
+    const ctx = new ServiceContext({
+      invoke: () => ({ Authorization: "Bearer single" }),
+      fetch: fetchSpy as any,
+      hosts: ["https://tinycloud.test"],
+    });
+    ctx.setSession(session);
+    (node as any)._serviceContext = ctx;
+
+    (node as any)._spaceService = new SpaceService({
+      hosts: ["https://tinycloud.test"],
+      session,
+      invoke: ctx.invoke,
+      fetch: ctx.fetch,
+      userDid: (node as any).did,
+      createKVService: (spaceId: string) => (node as any).createSpaceScopedKVService(spaceId),
+    });
+
+    const result = await node.spaces.get(accountSpaceId).kv.batchPut([
+      { key: "a", value: "one" },
+      { key: "b", value: "two" },
+    ]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_INPUT");
+    }
+    expect(invokeAnySpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -875,6 +875,24 @@ export interface NodeDefaults {
   createSigner: (privateKey: string, chainId?: number) => ISigner;
 }
 
+/**
+ * A bootstrap step that COMPLETED but did so in a degraded way — e.g. a KV
+ * batch write that failed ambiguously and was recovered by per-space
+ * reconciliation. Structured (not prose) so callers can branch on `kind` and
+ * `code` without parsing messages (TC-361).
+ */
+export interface BootstrapWarning {
+  /** The BootstrapStep.id that degraded, e.g. "account:seed-spaces"
+   *  (BootstrapStepBase.id — packages/bootstrap/src/index.ts:642-645). */
+  stepId: string;
+  /** What kind of degradation. Additive union; one member today. */
+  kind: "batch-write-reconciled";
+  /** ServiceError.code of the underlying failure that was recovered from. */
+  code: string;
+  /** Human-readable detail. Diagnostics only — never parse this. */
+  message: string;
+}
+
 export class TinyCloudNode {
   /** @internal Registered by importing @tinycloud/node-sdk (not /core) */
   private static nodeDefaults?: NodeDefaults;
@@ -957,9 +975,12 @@ export class TinyCloudNode {
    * Outcome of the last signIn()'s account-bootstrap attempt. `skipped` is
    * true when bootstrap did not complete (interactive signer, auto-sign
    * denied, or a bootstrap step failed); `reason` carries the cause so apps
-   * can surface a "finish account setup" call-to-action.
+   * can surface a "finish account setup" call-to-action. `warnings` is
+   * present when bootstrap completed, but one or more steps recovered from
+   * an ambiguous failure (e.g. a KV batch write reconciled via per-space
+   * fallback) — clean vs. recovered runs are otherwise byte-identical.
    */
-  private _bootstrapStatus: { skipped: boolean; reason?: string } = {
+  private _bootstrapStatus: { skipped: boolean; reason?: string; warnings?: BootstrapWarning[] } = {
     skipped: false,
   };
 
@@ -970,7 +991,7 @@ export class TinyCloudNode {
   }
 
   /** Outcome of the last signIn()'s account-bootstrap attempt. */
-  get bootstrapStatus(): { skipped: boolean; reason?: string } {
+  get bootstrapStatus(): { skipped: boolean; reason?: string; warnings?: BootstrapWarning[] } {
     return this._bootstrapStatus;
   }
 
@@ -1565,7 +1586,15 @@ export class TinyCloudNode {
     }
 
     try {
-      await this.runAccountBootstrap(steps);
+      const warnings = await this.runAccountBootstrap(steps);
+      if (warnings.length > 0) {
+        this._bootstrapStatus = { skipped: false, warnings };
+        this.notificationHandler.warning(
+          `Account bootstrap completed with warnings: ${warnings
+            .map((w) => `${w.stepId} (${w.kind}: ${w.code})`)
+            .join("; ")}`,
+        );
+      }
     } catch (err) {
       // Bootstrap is provisioning, not a precondition of the session the
       // user just signed: never fail signIn() because of it. Surface the
@@ -1611,7 +1640,7 @@ export class TinyCloudNode {
     }
   }
 
-  private async runAccountBootstrap(steps: BootstrapStep[]): Promise<void> {
+  private async runAccountBootstrap(steps: BootstrapStep[]): Promise<BootstrapWarning[]> {
     if (!this.auth || !this._address) {
       throw new Error("Account bootstrap requires an active wallet session");
     }
@@ -1624,6 +1653,7 @@ export class TinyCloudNode {
     const auth = this.auth as NodeUserAuthorization;
     const sessions = new Map<BootstrapSpaceName, TinyCloudSession>();
     const rawAbilitiesBySpace = new Map<BootstrapSpaceName, Record<string, string[]>>();
+    const warnings: BootstrapWarning[] = [];
     const primarySession = auth.tinyCloudSession;
     const defaultSpaceId = this.ownedSpaceId("default");
     const canReusePrimaryBootstrapSession =
@@ -1715,6 +1745,15 @@ export class TinyCloudNode {
             `Failed to seed account spaces: ${registered.error.message}`,
           );
         }
+        const batchError = registered.data.recoveredFromBatchError;
+        if (batchError) {
+          warnings.push({
+            stepId: step.id,
+            kind: "batch-write-reconciled",
+            code: batchError.code,
+            message: batchError.message,
+          });
+        }
       }
 
       if (step.kind === "seed-applications") {
@@ -1757,6 +1796,8 @@ export class TinyCloudNode {
         }
       }
     }
+
+    return warnings;
   }
 
   private registerBootstrapRuntimeGrant(

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -1698,20 +1698,22 @@ export class TinyCloudNode {
       }
 
       if (step.kind === "seed-spaces") {
-        for (const space of step.spaces) {
-          const registered = await this.account.spaces.register({
+        // One batched KV write + one multi-row index write instead of 5
+        // sequential register() calls (TC-373).
+        const registered = await this.account.spaces.registerBatch(
+          step.spaces.map((space) => ({
             spaceId: space.spaceId,
             name: space.name,
             ownerDid: this.did,
             type: "owned",
             permissions: ["*"],
             status: "active",
-          });
-          if (!registered.ok) {
-            throw new Error(
-              `Failed to seed account space ${space.spaceId}: ${registered.error.message}`,
-            );
-          }
+          })),
+        );
+        if (!registered.ok) {
+          throw new Error(
+            `Failed to seed account spaces: ${registered.error.message}`,
+          );
         }
       }
 
@@ -3150,6 +3152,7 @@ export class TinyCloudNode {
     if (this._serviceContext) {
       const spaceScopedContext = this._serviceGraph.track(new ServiceContext({
         invoke: this._serviceContext.invoke,
+        invokeAny: this._serviceContext.invokeAny,
         fetch: this._serviceContext.fetch,
         hosts: this._serviceContext.hosts,
         telemetry: this.config.telemetry,

--- a/packages/node-sdk/src/account/AccountService.registerBatch.test.ts
+++ b/packages/node-sdk/src/account/AccountService.registerBatch.test.ts
@@ -184,11 +184,11 @@ describe("AccountService.spaces.registerBatch", () => {
     ["KV_WRITE_FAILED 429", { code: "KV_WRITE_FAILED", message: "429 - Too Many Requests", service: "kv", meta: { status: 429 } }],
     ["KV_WRITE_FAILED 501", { code: "KV_WRITE_FAILED", message: "501 - Not Implemented", service: "kv", meta: { status: 501 } }],
     ["KV_WRITE_FAILED 505", { code: "KV_WRITE_FAILED", message: "505 - HTTP Version Not Supported", service: "kv", meta: { status: 505 } }],
-    // Sol B1: Cloudflare 52x family, excluded members — the request never
-    // reached the origin (connection refused / connect timeout / routing
-    // failure), so nothing was written.
+    // Sol B1 (round 2): Cloudflare 52x family, excluded members — the
+    // request never reached the origin (connection refused / routing
+    // failure), so nothing was written. 522 moved to the include matrix
+    // below: it has a post-connection mode where the origin was reached.
     ["KV_WRITE_FAILED 521 (Cloudflare: web server is down)", { code: "KV_WRITE_FAILED", message: "521 - Web Server Is Down", service: "kv", meta: { status: 521 } }],
-    ["KV_WRITE_FAILED 522 (Cloudflare: connection timed out)", { code: "KV_WRITE_FAILED", message: "522 - Connection Timed Out", service: "kv", meta: { status: 522 } }],
     ["KV_WRITE_FAILED 523 (Cloudflare: origin is unreachable)", { code: "KV_WRITE_FAILED", message: "523 - Origin Is Unreachable", service: "kv", meta: { status: 523 } }],
     ["NETWORK_ERROR with no meta at all", { code: ErrorCodes.NETWORK_ERROR, message: "fetch failed", service: "kv" }],
     ["NETWORK_ERROR with requestMayHaveDispatched: false (pre-dispatch throw)", { code: ErrorCodes.NETWORK_ERROR, message: "fetch failed", service: "kv", meta: { requestMayHaveDispatched: false } }],
@@ -339,6 +339,11 @@ describe("AccountService.spaces.registerBatch", () => {
     // reached (some response, or the origin received the request and
     // processed it before the timeout), so the write may have landed.
     ["KV_WRITE_FAILED 520 (Cloudflare: unknown origin error)", { code: "KV_WRITE_FAILED", message: "520 - Web Server Returned An Unknown Error", service: "kv", meta: { status: 520 } }],
+    // Sol B1 (round 2): 522 has a post-connection mode — the TCP connection
+    // to the origin was established and the request sent, but the origin
+    // never ACKs the response — so the origin may already have processed
+    // the write.
+    ["KV_WRITE_FAILED 522 (Cloudflare: connection timed out)", { code: "KV_WRITE_FAILED", message: "522 - Connection Timed Out", service: "kv", meta: { status: 522 } }],
     ["KV_WRITE_FAILED 524 (Cloudflare: a timeout occurred)", { code: "KV_WRITE_FAILED", message: "524 - A Timeout Occurred", service: "kv", meta: { status: 524 } }],
   ])("reconciles via per-space puts for %s (one row per include decision)", async (_label, error) => {
     const { service, put } = makeHarness({

--- a/packages/node-sdk/src/account/AccountService.registerBatch.test.ts
+++ b/packages/node-sdk/src/account/AccountService.registerBatch.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for TC-373 (P2): batch the account-bootstrap seed-spaces writes.
+ *
+ * `AccountService.spaces.registerBatch()` replaces 5 sequential
+ * `register()` calls (5 KV puts + 5 index writes) with ONE KV batch write +
+ * ONE multi-row index write. These tests pin the six corrected-design points
+ * from the Sol plan review (2026-07-29):
+ *
+ *   1. invokeAny is threaded so batchPut is reachable at all (covered
+ *      separately in TinyCloudNode.spaceScopedKV.test.ts, since that wiring
+ *      lives in TinyCloudNode, not AccountService).
+ *   2. the stored records are precomputed ONCE and reused byte-for-byte in
+ *      any reconciliation fallback (no fresh timestamps).
+ *   3. the index write is ONE multi-row statement, not N statements in one
+ *      `db.batch` call.
+ *   4. an index-write failure is best-effort and must never trigger a KV
+ *      rewrite.
+ *   5. the fallback is narrow: no retry on 401/403/402/413/404/abort, and an
+ *      ambiguous failure's own error must survive even after a successful
+ *      reconciliation.
+ *   6. (validated in KVService.test.ts, since that's where the check lives)
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { ErrorCodes } from "@tinycloud/sdk-services";
+import { AccountService } from "./AccountService";
+
+const ACCOUNT_SPACE = "tinycloud:pkh:eip155:1:0xabc:account";
+
+function makeSpace(name: string) {
+  return {
+    spaceId: `tinycloud:pkh:eip155:1:0xabc:${name}`,
+    name,
+    ownerDid: "did:pkh:eip155:1:0xabc",
+    type: "owned" as const,
+    permissions: ["*"],
+    status: "active" as const,
+  };
+}
+
+const FIVE_SPACES = ["default", "applications", "account", "secrets", "public"].map(makeSpace);
+
+interface HarnessOptions {
+  batchPutImpl?: (items: Array<{ key: string; value: unknown }>) => Promise<any>;
+  putImpl?: (key: string, value: unknown) => Promise<any>;
+  dbBatchImpl?: (statements: Array<{ sql: string; params?: unknown[] }>) => Promise<any>;
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const batchPutCalls: Array<Array<{ key: string; value: unknown }>> = [];
+  const putCalls: Array<{ key: string; value: unknown }> = [];
+  const dbBatchCalls: Array<Array<{ sql: string; params?: unknown[] }>> = [];
+
+  const batchPut = mock(async (items: Array<{ key: string; value: unknown }>) => {
+    batchPutCalls.push(items);
+    if (options.batchPutImpl) return options.batchPutImpl(items);
+    return { ok: true, data: { written: items.map((i) => i.key), count: items.length } };
+  });
+
+  const put = mock(async (key: string, value: unknown) => {
+    putCalls.push({ key, value });
+    if (options.putImpl) return options.putImpl(key, value);
+    return { ok: true, data: { data: undefined, headers: {} } };
+  });
+
+  const dbBatch = mock(async (statements: Array<{ sql: string; params?: unknown[] }>) => {
+    dbBatchCalls.push(statements);
+    if (options.dbBatchImpl) return options.dbBatchImpl(statements);
+    return { ok: true, data: { results: statements.map(() => ({ changes: 1, lastInsertRowId: 0 })) } };
+  });
+
+  const db = {
+    migrations: {
+      apply: mock(async (migrationOptions: any) => ({
+        ok: true,
+        data: {
+          database: "account",
+          namespace: migrationOptions.namespace,
+          status: "already_current",
+          applied: [],
+          skipped: migrationOptions.migrations.map((m: any) => m.id),
+        },
+      })),
+    },
+    batch: dbBatch,
+    query: mock(async () => ({ ok: true, data: { columns: [], rows: [], rowCount: 0 } })),
+  };
+
+  const ensureAccountSpaceHosted = mock(async () => {});
+
+  const service = new AccountService({
+    getDid: () => "did:pkh:eip155:1:0xabc",
+    getHost: () => "https://node.tinycloud.xyz",
+    getPrimarySpaceId: () => "tinycloud:pkh:eip155:1:0xabc:default",
+    getAccountSpaceId: () => ACCOUNT_SPACE,
+    ensureAccountSpaceHosted,
+    getSpaces: () =>
+      ({
+        list: async () => ({ ok: true, data: [] }),
+        get: () => ({
+          kv: {
+            batchPut,
+            put,
+            list: async () => ({ ok: true, data: { keys: [] } }),
+            get: async () => ({
+              ok: false,
+              error: { code: "KV_NOT_FOUND", message: "n/a", service: "kv" },
+            }),
+            delete: async () => ({ ok: true, data: undefined }),
+          },
+          delegations: {
+            list: async () => ({ ok: true, data: [] }),
+            listReceived: async () => ({ ok: true, data: [] }),
+            revoke: async () => ({ ok: true, data: undefined }),
+          },
+        }),
+      }) as any,
+    getAccountDb: () => db as any,
+  });
+
+  return { service, batchPut, batchPutCalls, put, putCalls, dbBatch, dbBatchCalls, ensureAccountSpaceHosted };
+}
+
+describe("AccountService.spaces.registerBatch", () => {
+  test("writes all 5 spaces in ONE batchPut call, never falling back to per-space put", async () => {
+    const { service, batchPut, put } = makeHarness();
+
+    const result = await service.spaces.registerBatch(FIVE_SPACES);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.data).toHaveLength(5);
+    expect(batchPut).toHaveBeenCalledTimes(1);
+    expect(put).not.toHaveBeenCalled();
+    const [items] = batchPut.mock.calls[0] as [Array<{ key: string }>];
+    expect(items).toHaveLength(5);
+    expect(items.map((i) => i.key).sort()).toEqual(
+      FIVE_SPACES.map((s) => `spaces/${s.spaceId}`).sort(),
+    );
+  });
+
+  test("returns [] without touching KV or the index for an empty input", async () => {
+    const { service, batchPut, put, dbBatch } = makeHarness();
+
+    const result = await service.spaces.registerBatch([]);
+
+    expect(result).toEqual({ ok: true, data: [] });
+    expect(batchPut).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+    expect(dbBatch).not.toHaveBeenCalled();
+  });
+
+  test("upserts the index in ONE multi-row INSERT OR REPLACE statement, not 5 statements", async () => {
+    const { service, dbBatch, dbBatchCalls } = makeHarness();
+
+    await service.spaces.registerBatch(FIVE_SPACES);
+
+    expect(dbBatch).toHaveBeenCalledTimes(1);
+    const statements = dbBatchCalls[0]!;
+    // ONE statement in the batch array (SQLite statement atomicity), not 5.
+    expect(statements).toHaveLength(1);
+    expect(statements[0]!.sql).toStartWith("INSERT OR REPLACE INTO spaces");
+    // 5 value-groups of 9 columns each.
+    const valueGroups = statements[0]!.sql.match(/\(\?, \?, \?, \?, \?, \?, \?, \?, \?\)/g) ?? [];
+    expect(valueGroups).toHaveLength(5);
+    expect(statements[0]!.params).toHaveLength(45);
+  });
+
+  test.each([
+    ["auth (401/403)", { code: ErrorCodes.AUTH_UNAUTHORIZED, message: "Unauthorized Action: spaces// / tinycloud.kv/put", service: "kv" }],
+    ["quota (402)", { code: ErrorCodes.STORAGE_QUOTA_EXCEEDED, message: "Storage quota exceeded", service: "kv" }],
+    ["quota (413)", { code: ErrorCodes.STORAGE_LIMIT_REACHED, message: "Storage limit reached", service: "kv" }],
+    ["space not hosted (404)", { code: "KV_WRITE_FAILED", message: "404 - Space not found", service: "kv", meta: { status: 404 } }],
+    ["caller abort", { code: ErrorCodes.ABORTED, message: "Request was aborted.", service: "kv" }],
+  ])("never falls back to per-space put for %s", async (_label, error) => {
+    const { service, put, batchPut } = makeHarness({
+      batchPutImpl: async () => ({ ok: false, error }),
+    });
+
+    const result = await service.spaces.registerBatch(FIVE_SPACES);
+
+    expect(result.ok).toBe(false);
+    expect(batchPut).toHaveBeenCalledTimes(1);
+    expect(put).not.toHaveBeenCalled();
+    if (!result.ok) {
+      expect(result.error.code).toBe(error.code);
+    }
+  });
+
+  test("reconciles an ambiguous failure via per-space puts using IDENTICAL bytes, and preserves the original error", async () => {
+    const warnCalls: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = ((...args: unknown[]) => {
+      warnCalls.push(args);
+    }) as typeof console.warn;
+
+    try {
+      const { service, put, putCalls, batchPutCalls } = makeHarness({
+        batchPutImpl: async () => ({
+          ok: false,
+          error: {
+            code: "KV_WRITE_FAILED",
+            message: "500 - internal error after commit",
+            service: "kv",
+            meta: { status: 500 },
+          },
+        }),
+      });
+
+      const result = await service.spaces.registerBatch(FIVE_SPACES);
+
+      expect(result.ok).toBe(true);
+      expect(put).toHaveBeenCalledTimes(5);
+
+      // The fallback must reuse the EXACT SAME record objects computed for
+      // the batch attempt, not regenerate them via a second
+      // spaceRecordFromInput call. Assert reference identity (`toBe`), not
+      // deep equality: two independently-computed timestamps could
+      // coincidentally land in the same millisecond in a fast test, which
+      // would make a deep-equality check pass even for a regenerated
+      // object. Reference identity can only hold if the value was truly
+      // reused, so it is immune to that coincidence.
+      //
+      // Read from our own harness arrays (batchPutCalls / putCalls), not
+      // bun's `mock.calls` snapshot — bun's own call recording does not
+      // preserve object identity across calls and would silently defeat
+      // this exact check regardless of what the production code does.
+      const batchItems = batchPutCalls[0]!;
+      expect(batchItems).toHaveLength(5);
+      for (const item of batchItems) {
+        const fallback = putCalls.find((call) => call.key === item.key);
+        expect(fallback?.value).toBe(item.value);
+      }
+
+      // The original batch error must not vanish just because the fallback
+      // succeeded — a silent swallow here is exactly how ambiguous failures
+      // turn into undiagnosable half-provisioned accounts.
+      expect(warnCalls).toHaveLength(1);
+      expect(String(warnCalls[0]![0])).toContain("500 - internal error after commit");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("surfaces BOTH errors when the ambiguous-failure reconciliation itself fails", async () => {
+    const { service } = makeHarness({
+      batchPutImpl: async () => ({
+        ok: false,
+        error: { code: "KV_WRITE_FAILED", message: "502 bad gateway", service: "kv", meta: { status: 502 } },
+      }),
+      putImpl: async (key: string) => ({
+        ok: false,
+        error: { code: "KV_WRITE_FAILED", message: `write failed for ${key}`, service: "kv" },
+      }),
+    });
+
+    const result = await service.spaces.registerBatch(FIVE_SPACES);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("502 bad gateway");
+      expect(result.error.message).toContain("write failed for");
+    }
+  });
+
+  test("an index-write failure does not trigger a KV rewrite, and the canonical write still succeeds", async () => {
+    const { service, batchPut, put, dbBatch } = makeHarness({
+      dbBatchImpl: async () => ({
+        ok: false,
+        error: { code: "SQL_PERMISSION_DENIED", message: "403 - not authorized", service: "sql" },
+      }),
+    });
+
+    const result = await service.spaces.registerBatch(FIVE_SPACES);
+
+    // Index failure is best-effort: it must not fail the canonical KV write.
+    expect(result.ok).toBe(true);
+    expect(batchPut).toHaveBeenCalledTimes(1);
+    // Crucially: the index failure must not cause a retry/rewrite of the KV data.
+    expect(put).not.toHaveBeenCalled();
+    expect(dbBatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node-sdk/src/account/AccountService.registerBatch.test.ts
+++ b/packages/node-sdk/src/account/AccountService.registerBatch.test.ts
@@ -122,13 +122,18 @@ function makeHarness(options: HarnessOptions = {}) {
 
 describe("AccountService.spaces.registerBatch", () => {
   test("writes all 5 spaces in ONE batchPut call, never falling back to per-space put", async () => {
-    const { service, batchPut, put } = makeHarness();
+    const { service, batchPut, put, dbBatch } = makeHarness();
 
     const result = await service.spaces.registerBatch(FIVE_SPACES);
 
     expect(result.ok).toBe(true);
-    expect(result.ok && result.data).toHaveLength(5);
+    expect(result.ok && result.data.spaces).toHaveLength(5);
+    expect(result.ok && result.data.recoveredFromBatchError).toBeUndefined();
+    // Clean-path regression guard (TC-373): exactly one batchPut, exactly
+    // one index write, zero per-space put calls. Any future change that
+    // trades a request for convenience must fail this loudly.
     expect(batchPut).toHaveBeenCalledTimes(1);
+    expect(dbBatch).toHaveBeenCalledTimes(1);
     expect(put).not.toHaveBeenCalled();
     const [items] = batchPut.mock.calls[0] as [Array<{ key: string }>];
     expect(items).toHaveLength(5);
@@ -142,7 +147,7 @@ describe("AccountService.spaces.registerBatch", () => {
 
     const result = await service.spaces.registerBatch([]);
 
-    expect(result).toEqual({ ok: true, data: [] });
+    expect(result).toEqual({ ok: true, data: { spaces: [] } });
     expect(batchPut).not.toHaveBeenCalled();
     expect(put).not.toHaveBeenCalled();
     expect(dbBatch).not.toHaveBeenCalled();
@@ -170,6 +175,19 @@ describe("AccountService.spaces.registerBatch", () => {
     ["quota (413)", { code: ErrorCodes.STORAGE_LIMIT_REACHED, message: "Storage limit reached", service: "kv" }],
     ["space not hosted (404)", { code: "KV_WRITE_FAILED", message: "404 - Space not found", service: "kv", meta: { status: 404 } }],
     ["caller abort", { code: ErrorCodes.ABORTED, message: "Request was aborted.", service: "kv" }],
+    ["auth required (client-side, nothing constructed)", { code: ErrorCodes.AUTH_REQUIRED, message: "Authentication required. Please sign in first.", service: "kv" }],
+    ["invalid input (duplicate key, never dispatches, no meta)", { code: ErrorCodes.INVALID_INPUT, message: "KV batchPut received duplicate key after prefix resolution: spaces/x", service: "kv" }],
+    ["KV_WRITE_FAILED 400", { code: "KV_WRITE_FAILED", message: "400 - Bad Request", service: "kv", meta: { status: 400 } }],
+    ["KV_WRITE_FAILED 408", { code: "KV_WRITE_FAILED", message: "408 - Request Timeout", service: "kv", meta: { status: 408 } }],
+    ["KV_WRITE_FAILED 409", { code: "KV_WRITE_FAILED", message: "409 - Conflict", service: "kv", meta: { status: 409 } }],
+    ["KV_WRITE_FAILED 422", { code: "KV_WRITE_FAILED", message: "422 - Unprocessable Entity", service: "kv", meta: { status: 422 } }],
+    ["KV_WRITE_FAILED 429", { code: "KV_WRITE_FAILED", message: "429 - Too Many Requests", service: "kv", meta: { status: 429 } }],
+    ["KV_WRITE_FAILED 501", { code: "KV_WRITE_FAILED", message: "501 - Not Implemented", service: "kv", meta: { status: 501 } }],
+    ["KV_WRITE_FAILED 505", { code: "KV_WRITE_FAILED", message: "505 - HTTP Version Not Supported", service: "kv", meta: { status: 505 } }],
+    ["NETWORK_ERROR with no meta at all", { code: ErrorCodes.NETWORK_ERROR, message: "fetch failed", service: "kv" }],
+    ["NETWORK_ERROR with requestMayHaveDispatched: false (pre-dispatch throw)", { code: ErrorCodes.NETWORK_ERROR, message: "fetch failed", service: "kv", meta: { requestMayHaveDispatched: false } }],
+    ["TIMEOUT with requestMayHaveDispatched: false (pre-fetch invokeAny timeout)", { code: ErrorCodes.TIMEOUT, message: "Request timed out.", service: "kv", meta: { requestMayHaveDispatched: false } }],
+    ["an unknown/future error code", { code: "SOME_FUTURE_CODE", message: "something new", service: "kv" }],
   ])("never falls back to per-space put for %s", async (_label, error) => {
     const { service, put, batchPut } = makeHarness({
       batchPutImpl: async () => ({ ok: false, error }),
@@ -209,6 +227,16 @@ describe("AccountService.spaces.registerBatch", () => {
 
       expect(result.ok).toBe(true);
       expect(put).toHaveBeenCalledTimes(5);
+
+      // Primary contract (TC-361): the recovery is surfaced structurally on
+      // the success payload, not only via console.warn.
+      if (result.ok) {
+        expect(result.data.spaces).toHaveLength(5);
+        expect(result.data.recoveredFromBatchError?.code).toBe("KV_WRITE_FAILED");
+        expect(result.data.recoveredFromBatchError?.message).toContain(
+          "500 - internal error after commit",
+        );
+      }
 
       // The fallback must reuse the EXACT SAME record objects computed for
       // the batch attempt, not regenerate them via a second
@@ -277,5 +305,41 @@ describe("AccountService.spaces.registerBatch", () => {
     // Crucially: the index failure must not cause a retry/rewrite of the KV data.
     expect(put).not.toHaveBeenCalled();
     expect(dbBatch).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    [
+      "NETWORK_ERROR with requestMayHaveDispatched: true",
+      { code: ErrorCodes.NETWORK_ERROR, message: "connection reset mid-flight", service: "kv", meta: { requestMayHaveDispatched: true } },
+    ],
+    [
+      "TIMEOUT with requestMayHaveDispatched: true",
+      { code: ErrorCodes.TIMEOUT, message: "Request timed out.", service: "kv", meta: { requestMayHaveDispatched: true } },
+    ],
+    [
+      "the unconfirmed-2xx shape",
+      {
+        code: ErrorCodes.NETWORK_ERROR,
+        message: "KV batchPut response did not confirm all 5 requested key(s) were written",
+        service: "kv",
+        meta: { requestMayHaveDispatched: true, responseReceived: true, status: 200, outcome: "batch-unconfirmed" },
+      },
+    ],
+    ["KV_WRITE_FAILED 500 (commit-then-500)", { code: "KV_WRITE_FAILED", message: "500 - internal error after commit", service: "kv", meta: { status: 500 } }],
+    ["KV_WRITE_FAILED 502", { code: "KV_WRITE_FAILED", message: "502 bad gateway", service: "kv", meta: { status: 502 } }],
+    ["KV_WRITE_FAILED 503", { code: "KV_WRITE_FAILED", message: "503 service unavailable", service: "kv", meta: { status: 503 } }],
+    ["KV_WRITE_FAILED 504", { code: "KV_WRITE_FAILED", message: "504 gateway timeout", service: "kv", meta: { status: 504 } }],
+  ])("reconciles via per-space puts for %s (one row per include decision)", async (_label, error) => {
+    const { service, put } = makeHarness({
+      batchPutImpl: async () => ({ ok: false, error }),
+    });
+
+    const result = await service.spaces.registerBatch(FIVE_SPACES);
+
+    expect(result.ok).toBe(true);
+    expect(put).toHaveBeenCalledTimes(5);
+    if (result.ok) {
+      expect(result.data.recoveredFromBatchError?.code).toBe(error.code);
+    }
   });
 });

--- a/packages/node-sdk/src/account/AccountService.registerBatch.test.ts
+++ b/packages/node-sdk/src/account/AccountService.registerBatch.test.ts
@@ -184,6 +184,12 @@ describe("AccountService.spaces.registerBatch", () => {
     ["KV_WRITE_FAILED 429", { code: "KV_WRITE_FAILED", message: "429 - Too Many Requests", service: "kv", meta: { status: 429 } }],
     ["KV_WRITE_FAILED 501", { code: "KV_WRITE_FAILED", message: "501 - Not Implemented", service: "kv", meta: { status: 501 } }],
     ["KV_WRITE_FAILED 505", { code: "KV_WRITE_FAILED", message: "505 - HTTP Version Not Supported", service: "kv", meta: { status: 505 } }],
+    // Sol B1: Cloudflare 52x family, excluded members — the request never
+    // reached the origin (connection refused / connect timeout / routing
+    // failure), so nothing was written.
+    ["KV_WRITE_FAILED 521 (Cloudflare: web server is down)", { code: "KV_WRITE_FAILED", message: "521 - Web Server Is Down", service: "kv", meta: { status: 521 } }],
+    ["KV_WRITE_FAILED 522 (Cloudflare: connection timed out)", { code: "KV_WRITE_FAILED", message: "522 - Connection Timed Out", service: "kv", meta: { status: 522 } }],
+    ["KV_WRITE_FAILED 523 (Cloudflare: origin is unreachable)", { code: "KV_WRITE_FAILED", message: "523 - Origin Is Unreachable", service: "kv", meta: { status: 523 } }],
     ["NETWORK_ERROR with no meta at all", { code: ErrorCodes.NETWORK_ERROR, message: "fetch failed", service: "kv" }],
     ["NETWORK_ERROR with requestMayHaveDispatched: false (pre-dispatch throw)", { code: ErrorCodes.NETWORK_ERROR, message: "fetch failed", service: "kv", meta: { requestMayHaveDispatched: false } }],
     ["TIMEOUT with requestMayHaveDispatched: false (pre-fetch invokeAny timeout)", { code: ErrorCodes.TIMEOUT, message: "Request timed out.", service: "kv", meta: { requestMayHaveDispatched: false } }],
@@ -329,6 +335,11 @@ describe("AccountService.spaces.registerBatch", () => {
     ["KV_WRITE_FAILED 502", { code: "KV_WRITE_FAILED", message: "502 bad gateway", service: "kv", meta: { status: 502 } }],
     ["KV_WRITE_FAILED 503", { code: "KV_WRITE_FAILED", message: "503 service unavailable", service: "kv", meta: { status: 503 } }],
     ["KV_WRITE_FAILED 504", { code: "KV_WRITE_FAILED", message: "504 gateway timeout", service: "kv", meta: { status: 504 } }],
+    // Sol B1: Cloudflare 52x family, included members — the origin was
+    // reached (some response, or the origin received the request and
+    // processed it before the timeout), so the write may have landed.
+    ["KV_WRITE_FAILED 520 (Cloudflare: unknown origin error)", { code: "KV_WRITE_FAILED", message: "520 - Web Server Returned An Unknown Error", service: "kv", meta: { status: 520 } }],
+    ["KV_WRITE_FAILED 524 (Cloudflare: a timeout occurred)", { code: "KV_WRITE_FAILED", message: "524 - A Timeout Occurred", service: "kv", meta: { status: 524 } }],
   ])("reconciles via per-space puts for %s (one row per include decision)", async (_label, error) => {
     const { service, put } = makeHarness({
       batchPutImpl: async () => ({ ok: false, error }),

--- a/packages/node-sdk/src/account/AccountService.ts
+++ b/packages/node-sdk/src/account/AccountService.ts
@@ -14,4 +14,5 @@ export type {
   AccountSpace,
   AccountSpaceListOptions,
   AccountStatus,
+  RegisterBatchSuccess,
 } from "@tinycloud/sdk-core";

--- a/packages/node-sdk/src/core.ts
+++ b/packages/node-sdk/src/core.ts
@@ -121,6 +121,7 @@ export {
   type OwnerDelegationReceipt,
   type RegisterOwnerSharePolicyParams,
   type OwnerSharePolicyRegistrationReceipt,
+  type BootstrapWarning,
 } from "./TinyCloudNode";
 
 export { AccountService } from "./account/AccountService";
@@ -139,6 +140,7 @@ export type {
   AccountSpace,
   AccountSpaceListOptions,
   AccountStatus,
+  RegisterBatchSuccess,
 } from "./account/AccountService";
 
 // Capability-chain primitives (spec: .claude/specs/capability-chain.md).

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -148,6 +148,7 @@ export {
   type SecretReadInput,
   type SecretPermissionHint,
   type SecretReadResult,
+  type BootstrapWarning,
 } from "./TinyCloudNode";
 export type { OwnerDelegationPermission } from "@tinycloud/sdk-core";
 
@@ -167,6 +168,7 @@ export type {
   AccountSpace,
   AccountSpaceListOptions,
   AccountStatus,
+  RegisterBatchSuccess,
 } from "./account/AccountService";
 
 // Capability-chain primitives (spec: .claude/specs/capability-chain.md).

--- a/packages/sdk-core/src/account/AccountService.ts
+++ b/packages/sdk-core/src/account/AccountService.ts
@@ -2,8 +2,10 @@ import {
   err,
   ok,
   serviceError,
+  ErrorCodes,
   type IDatabaseHandle,
   type IKVService,
+  type KVBatchPutItem,
   type QueryResponse,
   type Result,
   type ServiceError,
@@ -335,6 +337,84 @@ export class AccountService {
 
       const registered = spaceFromRecord(spaceKey(stored.space_id), stored);
       await this.upsertSpaceIndexQuietly(registered);
+      return ok(registered);
+    },
+
+    /**
+     * Register multiple spaces in one KV batch write + one multi-row index
+     * write, instead of one `register()` round trip per space (TC-373).
+     *
+     * The stored records are computed exactly once and reused for both the
+     * batch attempt and any reconciliation below, so a fallback never mints a
+     * fresh timestamp for a space that already has a written record — a
+     * second `spaceRecordFromInput` call would produce a new content hash and
+     * leave the first attempt's blocks orphaned.
+     */
+    registerBatch: async (
+      spaces: readonly (SpaceInfo | AccountSpace)[],
+    ): Promise<Result<AccountSpace[]>> => {
+      if (spaces.length === 0) return ok([]);
+
+      await this.config.ensureAccountSpaceHosted?.();
+
+      const kvResult = this.accountKV();
+      if (!kvResult.ok) return kvResult;
+
+      const stored = spaces.map((space) => spaceRecordFromInput(space));
+      const registered = stored.map((record) =>
+        spaceFromRecord(spaceKey(record.space_id), record),
+      );
+      const items: KVBatchPutItem[] = stored.map((record) => ({
+        key: spaceKey(record.space_id),
+        value: record,
+      }));
+
+      const batchResult = await kvResult.data.batchPut(items);
+
+      if (batchResult.ok) {
+        // Index write is derived/best-effort: its failure must never cause a
+        // KV rewrite, so it stays on the existing "quietly" path.
+        await this.upsertSpacesIndexQuietly(registered);
+        return ok(registered);
+      }
+
+      if (!isAmbiguousBatchFailure(batchResult.error)) {
+        return accountErr(batchResult.error);
+      }
+
+      // Ambiguous transport failure: the node's content-addressed block store
+      // can persist writes before (or independently of) the response that
+      // reports success, so "the batch errored" does not mean "nothing was
+      // written". Reconcile with per-space puts using the SAME precomputed
+      // bytes: anything that already landed is an idempotent overwrite, not a
+      // new differently-timestamped blob.
+      const reconcileFailures: string[] = [];
+      for (const record of stored) {
+        const written = await kvResult.data.put(spaceKey(record.space_id), record);
+        if (!written.ok) {
+          reconcileFailures.push(`${record.space_id}: ${written.error.message}`);
+        }
+      }
+
+      if (reconcileFailures.length > 0) {
+        return err(
+          serviceError(
+            "KV_BATCH_RECONCILE_FAILED",
+            `KV batch write for ${items.length} space(s) failed ambiguously (${batchResult.error.message}) and per-space reconciliation also failed for: ${reconcileFailures.join("; ")}`,
+            SERVICE_NAME,
+            { cause: batchResult.error.cause, meta: { originalError: batchResult.error } },
+          ),
+        );
+      }
+
+      // Reconciliation succeeded, but the batch's own error must not vanish
+      // silently — that exact swallow is what turns an ambiguous transport
+      // failure into an undiagnosable half-provisioned account later.
+      console.warn(
+        `[AccountService] KV batch write for ${items.length} space(s) returned an ambiguous error and was reconciled via per-space fallback. Original error: ${batchResult.error.message}`,
+      );
+
+      await this.upsertSpacesIndexQuietly(registered);
       return ok(registered);
     },
 
@@ -783,6 +863,53 @@ export class AccountService {
     return ok(undefined);
   }
 
+  private async upsertSpacesIndexQuietly(spaces: AccountSpace[]): Promise<void> {
+    await ignoreIndexFailure(() => this.upsertSpacesIndex(spaces));
+  }
+
+  /**
+   * Upsert multiple space index rows in ONE multi-row `INSERT OR REPLACE`
+   * statement (TC-373), rather than one statement per space. This matters
+   * because `IDatabaseHandle.batch()` executes its statement list as a plain
+   * loop, not a single database transaction — an N-statement batch is not
+   * atomic. A single multi-row INSERT is one SQLite statement, so it applies
+   * atomically: all rows or none.
+   */
+  private async upsertSpacesIndex(spaces: AccountSpace[]): Promise<Result<void>> {
+    if (spaces.length === 0) return ok(undefined);
+
+    const dbResult = this.accountDb();
+    if (!dbResult.ok) return ok(undefined);
+    const schema = await this.ensureAccountIndex(dbResult.data);
+    if (!schema.ok) return schema;
+
+    const placeholders = spaces.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?)").join(", ");
+    const params = spaces.flatMap((space) => {
+      const updatedAt = space.updatedAt ?? new Date().toISOString();
+      return [
+        space.spaceId,
+        space.name,
+        space.ownerDid,
+        space.type,
+        JSON.stringify(space.permissions),
+        space.status,
+        space.registeredAt ?? updatedAt,
+        updatedAt,
+        space.expiresAt?.toISOString() ?? null,
+      ];
+    });
+
+    const written = await dbResult.data.batch([
+      {
+        sql:
+          `INSERT OR REPLACE INTO spaces (space_id, name, owner_did, type, permissions_json, status, registered_at, updated_at, expires_at) VALUES ${placeholders}`,
+        params,
+      },
+    ]);
+    if (!written.ok) return accountErr(written.error);
+    return ok(undefined);
+  }
+
   private async deleteSpaceIndexQuietly(spaceId: string): Promise<void> {
     await ignoreIndexFailure(() => this.deleteSpaceIndex(spaceId));
   }
@@ -1224,6 +1351,28 @@ function accountErr(error: ServiceError): Result<never> {
 
 function isMissingIndexError(error: ServiceError): boolean {
   return /no such table:/i.test(error.message);
+}
+
+/**
+ * Classify a KV batch write failure for the seed-spaces reconciliation
+ * fallback (TC-373).
+ *
+ * Only AMBIGUOUS transport failures are safe to retry: the node's
+ * content-addressed block store can persist a write before (or independently
+ * of) the response that would report success, so an errored batch does not
+ * imply nothing was written. Failures the node reports unambiguously must
+ * never be retried — retrying would either repeat a definite rejection for
+ * no benefit (auth, quota, a space that doesn't exist) or ignore an explicit
+ * caller cancellation.
+ */
+function isAmbiguousBatchFailure(error: ServiceError): boolean {
+  if (error.code === ErrorCodes.AUTH_UNAUTHORIZED) return false; // 401/403
+  if (error.code === ErrorCodes.STORAGE_QUOTA_EXCEEDED) return false; // 402
+  if (error.code === ErrorCodes.STORAGE_LIMIT_REACHED) return false; // 413
+  if (error.code === ErrorCodes.ABORTED) return false; // caller abort
+  if (error.meta?.status === 404) return false; // space not hosted
+
+  return true;
 }
 
 async function ignoreIndexFailure(task: () => Promise<unknown>): Promise<void> {

--- a/packages/sdk-core/src/account/AccountService.ts
+++ b/packages/sdk-core/src/account/AccountService.ts
@@ -1379,17 +1379,24 @@ function isMissingIndexError(error: ServiceError): boolean {
  *      origin was reached and may have already committed the write.
  *    - 521 (web server is down) — EXCLUDED. Cloudflare could not open a
  *      connection to the origin at all; the request never arrived.
- *    - 522 (connection timed out) — EXCLUDED. The TCP handshake to the
- *      origin itself timed out; nothing was ever delivered to the origin.
+ *    - 522 (connection timed out) — INCLUDED. Cloudflare documents two
+ *      distinct 522 modes: in one, the TCP handshake to the origin itself
+ *      times out and nothing is ever delivered; in the other, the TCP
+ *      connection IS established and the request is sent, but the origin
+ *      never ACKs the response. That second mode means the request can
+ *      have reached the origin and been processed before the timeout
+ *      fired, so a committed write cannot be ruled out
+ *      (https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522/).
  *    - 523 (origin unreachable) — EXCLUDED. Routing/DNS failure reaching the
- *      origin; same as 521/522, the request never arrived.
+ *      origin; unlike 522's post-connection mode, the request never
+ *      arrived.
  *    - 524 (a timeout occurred) — INCLUDED. Cloudflare connected to the
  *      origin and forwarded the request, but the origin did not answer
  *      within the timeout; the origin may have processed (and committed)
  *      the write before the response was dropped. This was excluded by the
  *      old deny-list only by omission, not by intent — that was a
  *      regression this allow-list must not repeat. */
-const AMBIGUOUS_WRITE_STATUSES = new Set([500, 502, 503, 504, 520, 524]);
+const AMBIGUOUS_WRITE_STATUSES = new Set([500, 502, 503, 504, 520, 522, 524]);
 
 /**
  * Classify a KV batch write failure for the seed-spaces reconciliation

--- a/packages/sdk-core/src/account/AccountService.ts
+++ b/packages/sdk-core/src/account/AccountService.ts
@@ -53,6 +53,14 @@ export interface AccountSpace {
   expiresAt?: Date;
 }
 
+export interface RegisterBatchSuccess {
+  spaces: AccountSpace[];
+  /** Present iff the batch write failed ambiguously and per-space
+   *  reconciliation recovered it. The original batch error verbatim, so
+   *  callers can record the degradation structurally (TC-361). */
+  recoveredFromBatchError?: ServiceError;
+}
+
 export interface AccountDelegation {
   cid: string;
   direction: "granted" | "received";
@@ -352,8 +360,8 @@ export class AccountService {
      */
     registerBatch: async (
       spaces: readonly (SpaceInfo | AccountSpace)[],
-    ): Promise<Result<AccountSpace[]>> => {
-      if (spaces.length === 0) return ok([]);
+    ): Promise<Result<RegisterBatchSuccess>> => {
+      if (spaces.length === 0) return ok({ spaces: [] });
 
       await this.config.ensureAccountSpaceHosted?.();
 
@@ -375,7 +383,7 @@ export class AccountService {
         // Index write is derived/best-effort: its failure must never cause a
         // KV rewrite, so it stays on the existing "quietly" path.
         await this.upsertSpacesIndexQuietly(registered);
-        return ok(registered);
+        return ok({ spaces: registered });
       }
 
       if (!isAmbiguousBatchFailure(batchResult.error)) {
@@ -415,7 +423,7 @@ export class AccountService {
       );
 
       await this.upsertSpacesIndexQuietly(registered);
-      return ok(registered);
+      return ok({ spaces: registered, recoveredFromBatchError: batchResult.error });
     },
 
     syncAccessible: async (): Promise<Result<AccountSpace[]>> => {
@@ -1353,6 +1361,16 @@ function isMissingIndexError(error: ServiceError): boolean {
   return /no such table:/i.test(error.message);
 }
 
+/** Server/gateway statuses where the write may have committed before the
+ *  failure. 500 is included on node-side evidence: the KV invoke route can
+ *  complete `invoke_with_options` — i.e. COMMIT the batch — and only then
+ *  return 500 while validating the committed outcomes
+ *  (tinycloud-node-server/src/routes/mod.rs:1631-1641, "KV batch put
+ *  committed unexpected invocation outcomes"). 501/505 (protocol
+ *  rejections), 408, 429 and every other 4xx are definitive: nothing was
+ *  written. */
+const AMBIGUOUS_WRITE_STATUSES = new Set([500, 502, 503, 504]);
+
 /**
  * Classify a KV batch write failure for the seed-spaces reconciliation
  * fallback (TC-373).
@@ -1364,15 +1382,32 @@ function isMissingIndexError(error: ServiceError): boolean {
  * never be retried — retrying would either repeat a definite rejection for
  * no benefit (auth, quota, a space that doesn't exist) or ignore an explicit
  * caller cancellation.
+ *
+ * This is an ALLOW-LIST: default `false`. Only the states enumerated below
+ * are treated as ambiguous; everything else — including every unknown or
+ * future error code — is deterministic and must surface immediately rather
+ * than trigger five pointless per-space reconcile puts.
  */
 function isAmbiguousBatchFailure(error: ServiceError): boolean {
-  if (error.code === ErrorCodes.AUTH_UNAUTHORIZED) return false; // 401/403
-  if (error.code === ErrorCodes.STORAGE_QUOTA_EXCEEDED) return false; // 402
-  if (error.code === ErrorCodes.STORAGE_LIMIT_REACHED) return false; // 413
-  if (error.code === ErrorCodes.ABORTED) return false; // caller abort
-  if (error.meta?.status === 404) return false; // space not hosted
+  // Transport-layer failures: ambiguous ONLY if a fully-constructed request
+  // was actually handed to fetch. A pre-dispatch throw (serialization, WASM
+  // signing — including one wrapError labels TIMEOUT) is deterministic.
+  if (
+    error.code === ErrorCodes.NETWORK_ERROR ||
+    error.code === ErrorCodes.TIMEOUT
+  ) {
+    return error.meta?.requestMayHaveDispatched === true;
+  }
 
-  return true;
+  // The server responded, but the outcome is unstated.
+  if (error.code === ErrorCodes.KV_WRITE_FAILED) {
+    const status = error.meta?.status;
+    return typeof status === "number" && AMBIGUOUS_WRITE_STATUSES.has(status);
+  }
+
+  // Everything else — including every unknown/future code — is treated as
+  // deterministic. Unknown ≠ ambiguous: fail fast and surface.
+  return false;
 }
 
 async function ignoreIndexFailure(task: () => Promise<unknown>): Promise<void> {

--- a/packages/sdk-core/src/account/AccountService.ts
+++ b/packages/sdk-core/src/account/AccountService.ts
@@ -1368,8 +1368,28 @@ function isMissingIndexError(error: ServiceError): boolean {
  *  (tinycloud-node-server/src/routes/mod.rs:1631-1641, "KV batch put
  *  committed unexpected invocation outcomes"). 501/505 (protocol
  *  rejections), 408, 429 and every other 4xx are definitive: nothing was
- *  written. */
-const AMBIGUOUS_WRITE_STATUSES = new Set([500, 502, 503, 504]);
+ *  written.
+ *
+ *  Cloudflare's edge-specific 52x family (production is Cloudflare-proxied)
+ *  is evaluated by the same test — did the request reach the origin? — and
+ *  cross-checked against `packages/sdk-services/src/responseErrors.ts:26-30`,
+ *  which already special-cases 524 as an upstream timeout:
+ *    - 520 (unknown origin error) — INCLUDED. Cloudflare received *some*
+ *      response from the origin, just not a well-formed HTTP one, so the
+ *      origin was reached and may have already committed the write.
+ *    - 521 (web server is down) — EXCLUDED. Cloudflare could not open a
+ *      connection to the origin at all; the request never arrived.
+ *    - 522 (connection timed out) — EXCLUDED. The TCP handshake to the
+ *      origin itself timed out; nothing was ever delivered to the origin.
+ *    - 523 (origin unreachable) — EXCLUDED. Routing/DNS failure reaching the
+ *      origin; same as 521/522, the request never arrived.
+ *    - 524 (a timeout occurred) — INCLUDED. Cloudflare connected to the
+ *      origin and forwarded the request, but the origin did not answer
+ *      within the timeout; the origin may have processed (and committed)
+ *      the write before the response was dropped. This was excluded by the
+ *      old deny-list only by omission, not by intent — that was a
+ *      regression this allow-list must not repeat. */
+const AMBIGUOUS_WRITE_STATUSES = new Set([500, 502, 503, 504, 520, 524]);
 
 /**
  * Classify a KV batch write failure for the seed-spaces reconciliation

--- a/packages/sdk-core/src/account/multiRowInsertAtomicity.test.ts
+++ b/packages/sdk-core/src/account/multiRowInsertAtomicity.test.ts
@@ -1,0 +1,128 @@
+/**
+ * TC-373 point 3: the corrected design replaces a 5-statement `db.batch`
+ * call (which tinycloud-node 1.12.0 runs as a plain, non-transactional
+ * statement loop — see AccountService.upsertSpacesIndex) with ONE multi-row
+ * `INSERT OR REPLACE ... VALUES (...),(...),...` statement, relying on
+ * SQLite's per-statement atomicity: a single statement either fully applies
+ * or fully rejects.
+ *
+ * This exercises that exact property against a real SQLite engine
+ * (bun:sqlite, in-memory), using the account index's own `spaces` table
+ * schema, independent of any HTTP/service mocking. It cannot be verified by
+ * mocking `IDatabaseHandle.batch()` — a mock can only assert what SQL text
+ * was sent, not whether the underlying engine actually applies it
+ * atomically.
+ */
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { ACCOUNT_INDEX_SCHEMA } from "@tinycloud/bootstrap";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  for (const statement of ACCOUNT_INDEX_SCHEMA) {
+    db.run(statement);
+  }
+  return db;
+}
+
+const INSERT_SPACES_SQL =
+  "INSERT OR REPLACE INTO spaces (space_id, name, owner_did, type, permissions_json, status, registered_at, updated_at, expires_at) VALUES ";
+
+function goodRow(id: string): unknown[] {
+  return [
+    `tinycloud:pkh:eip155:1:0xabc:${id}`,
+    id,
+    "did:pkh:eip155:1:0xabc",
+    "owned",
+    JSON.stringify(["*"]),
+    "active",
+    "2026-01-01T00:00:00.000Z",
+    "2026-01-01T00:00:00.000Z",
+    null,
+  ];
+}
+
+describe("multi-row INSERT OR REPLACE atomicity (TC-373 point 3)", () => {
+  test("a single bad row in a multi-row statement rejects the WHOLE statement — none of the good rows in it apply either", () => {
+    const db = freshDb();
+
+    // `name` is declared NOT NULL in ACCOUNT_INDEX_SCHEMA; null here must
+    // abort the entire multi-row statement.
+    const badRow: unknown[] = [
+      "tinycloud:pkh:eip155:1:0xabc:secrets",
+      null,
+      "did:pkh:eip155:1:0xabc",
+      "owned",
+      JSON.stringify(["*"]),
+      "active",
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-01T00:00:00.000Z",
+      null,
+    ];
+
+    const rows = [goodRow("default"), badRow, goodRow("public")];
+    const sql = INSERT_SPACES_SQL + rows.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?)").join(", ");
+    const params = rows.flat();
+
+    expect(() => db.run(sql, params as any)).toThrow();
+
+    const remaining = db.query("SELECT space_id FROM spaces").all();
+    // Atomicity: the two well-formed rows in the SAME statement must NOT
+    // have been applied either.
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("a fully well-formed multi-row statement applies all rows", () => {
+    const db = freshDb();
+
+    const rows = ["default", "applications", "account", "secrets", "public"].map(goodRow);
+    const sql = INSERT_SPACES_SQL + rows.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?)").join(", ");
+    const params = rows.flat();
+
+    db.run(sql, params as any);
+
+    const remaining = db.query("SELECT space_id FROM spaces ORDER BY space_id").all() as Array<{
+      space_id: string;
+    }>;
+    expect(remaining.map((row) => row.space_id)).toEqual(
+      ["account", "applications", "default", "public", "secrets"].map(
+        (id) => `tinycloud:pkh:eip155:1:0xabc:${id}`,
+      ),
+    );
+  });
+
+  test("contrast: a loop of 5 separate statements (today's db.batch shape) is NOT atomic — statements before a failing one persist", () => {
+    const db = freshDb();
+
+    const insertOne = (id: string, name: string | null) =>
+      db.run(INSERT_SPACES_SQL + "(?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+        `tinycloud:pkh:eip155:1:0xabc:${id}`,
+        name,
+        "did:pkh:eip155:1:0xabc",
+        "owned",
+        JSON.stringify(["*"]),
+        "active",
+        "2026-01-01T00:00:00.000Z",
+        "2026-01-01T00:00:00.000Z",
+        null,
+      ] as any);
+
+    insertOne("default", "default");
+    insertOne("applications", "applications");
+    // The node's statement loop returns (stops) at the first failure — see
+    // NO-GO reason #3 ("failure returns before artifact persistence") — so a
+    // trailing well-formed statement is never reached in this scenario.
+    expect(() => insertOne("secrets", null)).toThrow(); // fails on the 3rd statement
+
+    const remaining = db.query("SELECT space_id FROM spaces ORDER BY space_id").all() as Array<{
+      space_id: string;
+    }>;
+    // NOT atomic: the two statements that ran before the failing one are
+    // already committed. This is exactly the gap the corrected design's
+    // single multi-row statement closes.
+    expect(remaining.map((row) => row.space_id)).toEqual([
+      "tinycloud:pkh:eip155:1:0xabc:applications",
+      "tinycloud:pkh:eip155:1:0xabc:default",
+    ]);
+  });
+});

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -265,6 +265,7 @@ export type {
   AccountSpace,
   AccountSpaceListOptions,
   AccountStatus,
+  RegisterBatchSuccess,
 } from "./account/AccountService";
 
 // Re-export service types from sdk-services for convenience

--- a/packages/sdk-services/src/kv/KVService.test.ts
+++ b/packages/sdk-services/src/kv/KVService.test.ts
@@ -415,6 +415,14 @@ describe("KVService.batchPut", () => {
     if (!result.ok) {
       expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
       expect(result.error.message).toContain("5 requested key(s)");
+      // TC-373 §2a: the node DID answer 2xx, so the ambiguity is carried in
+      // meta rather than a new error code (Sol B4).
+      expect(result.error.meta).toEqual({
+        requestMayHaveDispatched: true,
+        responseReceived: true,
+        status: 200,
+        outcome: "batch-unconfirmed",
+      });
     }
   });
 
@@ -432,6 +440,12 @@ describe("KVService.batchPut", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+      expect(result.error.meta).toEqual({
+        requestMayHaveDispatched: true,
+        responseReceived: true,
+        status: 200,
+        outcome: "batch-unconfirmed",
+      });
     }
   });
 
@@ -452,6 +466,121 @@ describe("KVService.batchPut", () => {
 
     const result = await service.batchPut(fiveItems());
     expect(result.ok).toBe(false);
+    // Sol B6d: this test asserted only result.ok === false before; give it
+    // the same explicit code + meta assertions as its siblings.
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+      expect(result.error.meta).toEqual({
+        requestMayHaveDispatched: true,
+        responseReceived: true,
+        status: 200,
+        outcome: "batch-unconfirmed",
+      });
+    }
+  });
+
+  test("rejects a 2xx response whose body cannot be normalized at all (missing written/count)", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () => response(true, 200, {}), [], [])
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+      expect(result.error.meta).toEqual({
+        requestMayHaveDispatched: true,
+        responseReceived: true,
+        status: 200,
+        outcome: "batch-unconfirmed",
+      });
+    }
+  });
+
+  test("a fetch-level throw (post-dispatch) is NETWORK_ERROR with requestMayHaveDispatched: true", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () => {
+        throw new Error("connection reset");
+      }, [], [])
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+      expect(result.error.meta?.requestMayHaveDispatched).toBe(true);
+    }
+  });
+
+  test("a fetch-level TimeoutError throw is TIMEOUT with requestMayHaveDispatched: true", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () => {
+        const timeoutError = new Error("the operation timed out");
+        timeoutError.name = "TimeoutError";
+        throw timeoutError;
+      }, [], [])
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.TIMEOUT);
+      expect(result.error.meta?.requestMayHaveDispatched).toBe(true);
+    }
+  });
+
+  test("a pre-fetch invokeAny throw (plain Error) is NETWORK_ERROR with requestMayHaveDispatched: false and never reaches fetch", async () => {
+    let fetchCalls = 0;
+    const service = new KVService({});
+    const baseContext = createContext(async () => {
+      fetchCalls++;
+      return response(true, 200, { written: [...FIVE_KEYS], count: 5 });
+    }, [], []);
+    service.initialize({
+      ...baseContext,
+      invokeAny: () => {
+        throw new Error("signing failed");
+      },
+    });
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+      expect(result.error.meta?.requestMayHaveDispatched).toBe(false);
+    }
+    expect(fetchCalls).toBe(0);
+  });
+
+  // Sol B1/B6c: a pre-fetch throw whose name/message says "timeout" must NOT
+  // be reconciled by AccountService — it is deterministic (nothing was
+  // dispatched), even though wrapError labels it TIMEOUT.
+  test("a pre-fetch invokeAny TimeoutError throw is TIMEOUT with requestMayHaveDispatched: false and never reaches fetch", async () => {
+    let fetchCalls = 0;
+    const service = new KVService({});
+    const baseContext = createContext(async () => {
+      fetchCalls++;
+      return response(true, 200, { written: [...FIVE_KEYS], count: 5 });
+    }, [], []);
+    service.initialize({
+      ...baseContext,
+      invokeAny: () => {
+        const timeoutError = new Error("the operation timed out");
+        timeoutError.name = "TimeoutError";
+        throw timeoutError;
+      },
+    });
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.TIMEOUT);
+      expect(result.error.meta?.requestMayHaveDispatched).toBe(false);
+    }
+    expect(fetchCalls).toBe(0);
   });
 
   test("JSON values written via batchPut round-trip through get() as parsed objects (canonical read)", async () => {

--- a/packages/sdk-services/src/kv/KVService.test.ts
+++ b/packages/sdk-services/src/kv/KVService.test.ts
@@ -583,6 +583,85 @@ describe("KVService.batchPut", () => {
     expect(fetchCalls).toBe(0);
   });
 
+  // Sol B2: `this.context.fetch` is a getter (context.ts:154-156) that can
+  // itself throw (assertActive()) before any request is constructed or
+  // handed to a transport. The flag must only be set AFTER that getter has
+  // been evaluated, so this throw is deterministic — never reconciled.
+  test("a context.fetch getter throw is NETWORK_ERROR with requestMayHaveDispatched: false and never dispatches", async () => {
+    const service = new KVService({});
+    const baseContext = createContext(async () => {
+      throw new Error("fetch should never be invoked");
+    }, [], []);
+    const contextWithThrowingFetchGetter: IServiceContext = {
+      ...baseContext,
+      get fetch(): IServiceContext["fetch"] {
+        throw new Error("context is no longer active");
+      },
+    };
+    service.initialize(contextWithThrowingFetchGetter);
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+      expect(result.error.meta?.requestMayHaveDispatched).toBe(false);
+    }
+  });
+
+  // Sol B3: a 2xx response whose body is not valid JSON must be classified
+  // as the unconfirmed-2xx case with the FULL metadata block, not lose it by
+  // falling through to the generic catch.
+  test("a 2xx response whose body is not valid JSON is unconfirmed-2xx with full metadata", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () => {
+        const res = response(true, 200, {});
+        res.json = async () => {
+          throw new SyntaxError("Unexpected end of JSON input");
+        };
+        return res;
+      }, [], [])
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+      expect(result.error.meta).toEqual({
+        requestMayHaveDispatched: true,
+        responseReceived: true,
+        status: 200,
+        outcome: "batch-unconfirmed",
+      });
+    }
+  });
+
+  // Sol B4: a deterministic 4xx whose body read rejects must stay
+  // deterministic — it must NOT be relabeled NETWORK_ERROR with
+  // requestMayHaveDispatched: true (which would make AccountService
+  // reconcile a write that the node definitively rejected).
+  test("a 400 response whose body read rejects stays a deterministic KV_WRITE_FAILED", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () => {
+        const res = response(false, 400, "Bad Request");
+        res.text = async () => {
+          throw new Error("body stream already consumed");
+        };
+        return res;
+      }, [], [])
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.KV_WRITE_FAILED);
+      expect(result.error.meta).toEqual({ status: 400, statusText: "Error" });
+      // Must not be misclassified into the ambiguous transport-failure shape.
+      expect(result.error.meta?.requestMayHaveDispatched).toBeUndefined();
+    }
+  });
+
   test("JSON values written via batchPut round-trip through get() as parsed objects (canonical read)", async () => {
     let batchPartType: string | undefined;
     const service = new KVService({ prefix: "app" });

--- a/packages/sdk-services/src/kv/KVService.test.ts
+++ b/packages/sdk-services/src/kv/KVService.test.ts
@@ -374,6 +374,129 @@ describe("KVService.batchPut", () => {
     }
     expect(fetchCalls).toBe(0);
   });
+
+  // TC-373 point 6: validate against the EXACT requested path set and count,
+  // not just internal self-consistency (count === written.length would
+  // accept a malformed response reporting the right count for wrong keys).
+  const FIVE_KEYS = ["default", "applications", "account", "secrets", "public"].map(
+    (name) => `spaces/tinycloud:pkh:eip155:1:0xabc:${name}`
+  );
+  function fiveItems() {
+    return FIVE_KEYS.map((key, i) => ({ key, value: { spaceId: key, index: i } }));
+  }
+
+  test("accepts a response confirming all 5 requested keys were written", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () =>
+        response(true, 200, { written: [...FIVE_KEYS], count: 5 }), [], []
+      )
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects a response reporting the right count but the wrong keys", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () =>
+        // Internally consistent (count === written.length === 5) but one
+        // requested key was swapped for an unrelated one.
+        response(true, 200, {
+          written: [...FIVE_KEYS.slice(0, 4), "spaces/not-what-was-requested"],
+          count: 5,
+        }), [], []
+      )
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+      expect(result.error.message).toContain("5 requested key(s)");
+    }
+  });
+
+  test("rejects a response with fewer written keys than requested, even if internally consistent", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () =>
+        // count === written.length (4 === 4), but only 4 of the 5 requested
+        // keys are reported written — a partial write must not look like success.
+        response(true, 200, { written: FIVE_KEYS.slice(0, 4), count: 4 }), [], []
+      )
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.NETWORK_ERROR);
+    }
+  });
+
+  test("rejects a response with duplicate written keys padding the count to look complete", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () =>
+        // count (5) === written.length (5), and every written key IS one of
+        // the requested keys — but one key is duplicated and another is
+        // missing entirely. The exact-SET check catches this; a naive
+        // count-only check would not.
+        response(true, 200, {
+          written: [...FIVE_KEYS.slice(0, 4), FIVE_KEYS[0]],
+          count: 5,
+        }), [], []
+      )
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+  });
+
+  test("JSON values written via batchPut round-trip through get() as parsed objects (canonical read)", async () => {
+    let batchPartType: string | undefined;
+    const service = new KVService({ prefix: "app" });
+    let calls = 0;
+    service.initialize(
+      createContext(async (_url, init) => {
+        calls++;
+        if (calls === 1) {
+          // The batchPut call: capture the content-type actually assigned to
+          // a plain JS object value.
+          const form = init!.body as FormData;
+          const part = form.get("app%2Fsettings.json") as Blob;
+          batchPartType = part.type;
+          return response(true, 200, { written: ["app/settings.json"], count: 1 });
+        }
+        // The subsequent get() call: the node echoes back the content-type it
+        // stored for that blob — application/json for a JSON value, per
+        // serializeBatchPutValue. Ordinary put() does not set this
+        // explicitly, so this is the divergence TC-373 flagged as worth
+        // testing explicitly rather than assuming byte-for-byte equivalence.
+        const result = response(true, 200, { theme: "dark", version: 2 });
+        result.headers = {
+          get: (name: string) =>
+            name.toLowerCase() === "content-type" ? "application/json" : null,
+        };
+        return result;
+      }, [], [])
+    );
+
+    const written = await service.batchPut([
+      { key: "settings.json", value: { theme: "dark", version: 2 } },
+    ]);
+    expect(written.ok).toBe(true);
+    expect(batchPartType).toStartWith("application/json");
+
+    const read = await service.get<{ theme: string; version: number }>("settings.json");
+    expect(read.ok).toBe(true);
+    if (read.ok) {
+      // Canonical read: a parsed object, not the raw JSON text.
+      expect(read.data.data).toEqual({ theme: "dark", version: 2 });
+      expect(typeof read.data.data).toBe("object");
+    }
+  });
 });
 
 describe("KVService.createSignedReadUrl", () => {

--- a/packages/sdk-services/src/kv/KVService.test.ts
+++ b/packages/sdk-services/src/kv/KVService.test.ts
@@ -662,6 +662,38 @@ describe("KVService.batchPut", () => {
     }
   });
 
+  // Non-blocking coverage gap noted in the TC-373 round-2 review: only the
+  // deterministic-400 body-read-rejects branch was directly tested above.
+  // An AMBIGUOUS 5xx (503 is a member of AccountService's
+  // AMBIGUOUS_WRITE_STATUSES) whose body read also rejects must stay
+  // KV_WRITE_FAILED with its real status, exactly like the 400 case — the
+  // production code path is identical for both, but only the status
+  // determines whether AccountService.registerBatch later reconciles it via
+  // per-space puts.
+  test("a 503 response whose body read rejects stays KV_WRITE_FAILED with its real status (ambiguous, DOES trigger reconciliation)", async () => {
+    const service = new KVService({});
+    service.initialize(
+      createContext(async () => {
+        const res = response(false, 503, "Service Unavailable");
+        res.text = async () => {
+          throw new Error("body stream already consumed");
+        };
+        return res;
+      }, [], [])
+    );
+
+    const result = await service.batchPut(fiveItems());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCodes.KV_WRITE_FAILED);
+      expect(result.error.meta).toEqual({ status: 503, statusText: "Error" });
+      expect(result.error.meta?.requestMayHaveDispatched).toBeUndefined();
+      // 503 is in AMBIGUOUS_WRITE_STATUSES (AccountService.ts), unlike 400 in
+      // the sibling test above — this is the status that governs whether
+      // AccountService.registerBatch reconciles via per-space puts.
+    }
+  });
+
   test("JSON values written via batchPut round-trip through get() as parsed objects (canonical read)", async () => {
     let batchPartType: string | undefined;
     const service = new KVService({ prefix: "app" });

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -997,11 +997,38 @@ export class KVService extends BaseService implements IKVService {
           signal: this.combineSignals(options?.signal),
         };
 
+        // Resolve the fetch function to a local BEFORE flipping the flag.
+        // `this.context.fetch` is a getter (context.ts:154-156) that can
+        // itself throw (assertActive()) — if the flag were set first, that
+        // throw would be mislabeled as "may have dispatched" even though no
+        // request was ever handed to a transport (Sol B2).
+        const fetchFn = this.context.fetch;
         requestMayHaveDispatched = true;
-        const response = await this.context.fetch(url, init);
+        const response = await fetchFn(url, init);
 
         if (!response.ok) {
-          const errorText = await response.text();
+          let errorText: string;
+          try {
+            errorText = await response.text();
+          } catch {
+            // A response was received — the status is known and
+            // authoritative — but its body could not be read. Falling
+            // through to the generic catch below would report
+            // NETWORK_ERROR + requestMayHaveDispatched: true, which the
+            // allow-list treats as ambiguous regardless of status. That
+            // would turn a deterministic 4xx (nothing written) into a false
+            // ambiguity (Sol B4). Classify by status alone instead; whether
+            // this is later reconciled is still governed solely by
+            // AMBIGUOUS_WRITE_STATUSES, exactly like the body-readable path.
+            return err(
+              serviceError(
+                ErrorCodes.KV_WRITE_FAILED,
+                `Failed to batch put ${items.length} key(s): ${response.status} - <response body could not be read>`,
+                "kv",
+                { meta: { status: response.status, statusText: response.statusText } }
+              )
+            );
+          }
 
           if (response.status === 401 || response.status === 403) {
             const { resource, action } = parseAuthError(errorText);
@@ -1031,7 +1058,35 @@ export class KVService extends BaseService implements IKVService {
           );
         }
 
-        const batchResponse = this.normalizeBatchPutResponse(await response.json());
+        let rawBody: unknown;
+        try {
+          rawBody = await response.json();
+        } catch {
+          // A 2xx response whose body isn't valid JSON is precisely the
+          // unconfirmed-2xx case — the node answered success but the write
+          // set can't be confirmed. Falling through to the generic catch
+          // below would carry only `requestMayHaveDispatched`, omitting
+          // `responseReceived`/`status`/`outcome`, so this must be classified
+          // here with the identical metadata block used by the two sibling
+          // unconfirmed branches (Sol B3).
+          return err(
+            serviceError(
+              ErrorCodes.NETWORK_ERROR,
+              "KV batchPut response was not valid JSON",
+              "kv",
+              {
+                meta: {
+                  requestMayHaveDispatched: true,
+                  responseReceived: true,
+                  status: response.status,
+                  outcome: "batch-unconfirmed",
+                },
+              }
+            )
+          );
+        }
+
+        const batchResponse = this.normalizeBatchPutResponse(rawBody);
         if (!batchResponse) {
           // The code stays NETWORK_ERROR deliberately: adding a member to
           // ErrorCodes (types.ts:73-115) widens the exported ErrorCode union

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -1010,7 +1010,7 @@ export class KVService extends BaseService implements IKVService {
           let errorText: string;
           try {
             errorText = await response.text();
-          } catch {
+          } catch (textError) {
             // A response was received — the status is known and
             // authoritative — but its body could not be read. Falling
             // through to the generic catch below would report
@@ -1020,12 +1020,19 @@ export class KVService extends BaseService implements IKVService {
             // ambiguity (Sol B4). Classify by status alone instead; whether
             // this is later reconciled is still governed solely by
             // AMBIGUOUS_WRITE_STATUSES, exactly like the body-readable path.
+            //
+            // Sol B2 (round 2): preserve the underlying rejection instead of
+            // discarding it — a bare `catch {}` here would make a
+            // body-read failure silently invisible, which is exactly the
+            // debugging trap the no-swallowed-errors rule exists to
+            // prevent.
+            const cause = textError instanceof Error ? textError : new Error(String(textError));
             return err(
               serviceError(
                 ErrorCodes.KV_WRITE_FAILED,
-                `Failed to batch put ${items.length} key(s): ${response.status} - <response body could not be read>`,
+                `Failed to batch put ${items.length} key(s): ${response.status} - <response body could not be read: ${cause.message}>`,
                 "kv",
-                { meta: { status: response.status, statusText: response.statusText } }
+                { cause, meta: { status: response.status, statusText: response.statusText } }
               )
             );
           }
@@ -1061,7 +1068,7 @@ export class KVService extends BaseService implements IKVService {
         let rawBody: unknown;
         try {
           rawBody = await response.json();
-        } catch {
+        } catch (jsonError) {
           // A 2xx response whose body isn't valid JSON is precisely the
           // unconfirmed-2xx case — the node answered success but the write
           // set can't be confirmed. Falling through to the generic catch
@@ -1069,12 +1076,20 @@ export class KVService extends BaseService implements IKVService {
           // `responseReceived`/`status`/`outcome`, so this must be classified
           // here with the identical metadata block used by the two sibling
           // unconfirmed branches (Sol B3).
+          //
+          // Sol B2 (round 2): preserve the underlying rejection instead of
+          // discarding it — a bare `catch {}` here would make a
+          // JSON-parse failure silently invisible, which is exactly the
+          // debugging trap the no-swallowed-errors rule exists to
+          // prevent.
+          const cause = jsonError instanceof Error ? jsonError : new Error(String(jsonError));
           return err(
             serviceError(
               ErrorCodes.NETWORK_ERROR,
-              "KV batchPut response was not valid JSON",
+              `KV batchPut response was not valid JSON: ${cause.message}`,
               "kv",
               {
+                cause,
                 meta: {
                   requestMayHaveDispatched: true,
                   responseReceived: true,

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -962,6 +962,14 @@ export class KVService extends BaseService implements IKVService {
         seen.add(path);
       }
 
+      // Conservative: `true` means we handed a fully-constructed request to
+      // fetch(). It does NOT prove bytes reached the node — DNS/connect
+      // failures and synchronous fetch rejections are included. Proving
+      // actual dispatch requires lower-level transport instrumentation (out
+      // of scope). The over-approximation is intentional and bounded: it can
+      // only cause a reconciliation of at most N idempotent, byte-identical
+      // overwrites — never a corrupted or differently-timestamped record.
+      let requestMayHaveDispatched = false;
       try {
         const body = new FormData();
         for (let index = 0; index < items.length; index++) {
@@ -981,12 +989,16 @@ export class KVService extends BaseService implements IKVService {
           }))
         );
 
-        const response = await this.context.fetch(`${this.host}/invoke`, {
+        const url = `${this.host}/invoke`;
+        const init = {
           method: "POST",
           headers,
           body,
           signal: this.combineSignals(options?.signal),
-        });
+        };
+
+        requestMayHaveDispatched = true;
+        const response = await this.context.fetch(url, init);
 
         if (!response.ok) {
           const errorText = await response.text();
@@ -1021,11 +1033,25 @@ export class KVService extends BaseService implements IKVService {
 
         const batchResponse = this.normalizeBatchPutResponse(await response.json());
         if (!batchResponse) {
+          // The code stays NETWORK_ERROR deliberately: adding a member to
+          // ErrorCodes (types.ts:73-115) widens the exported ErrorCode union
+          // (:117) and would break consumers with exhaustive switches. The
+          // node answered 2xx (the write very likely landed) but the body
+          // could not confirm it, so the ambiguity is carried in metadata
+          // instead of a dedicated code.
           return err(
             serviceError(
               ErrorCodes.NETWORK_ERROR,
               "KV batchPut response did not include matching written keys and count",
-              "kv"
+              "kv",
+              {
+                meta: {
+                  requestMayHaveDispatched: true,
+                  responseReceived: true,
+                  status: response.status,
+                  outcome: "batch-unconfirmed",
+                },
+              }
             )
           );
         }
@@ -1043,18 +1069,32 @@ export class KVService extends BaseService implements IKVService {
           batchResponse.written.every((key) => requestedPaths.has(key));
 
         if (!matchesRequest) {
+          // Same rationale as above: NETWORK_ERROR is kept and the
+          // ambiguity is carried in meta rather than a new ErrorCodes member.
           return err(
             serviceError(
               ErrorCodes.NETWORK_ERROR,
               `KV batchPut response did not confirm all ${paths.length} requested key(s) were written`,
-              "kv"
+              "kv",
+              {
+                meta: {
+                  requestMayHaveDispatched: true,
+                  responseReceived: true,
+                  status: response.status,
+                  outcome: "batch-unconfirmed",
+                },
+              }
             )
           );
         }
 
         return ok(batchResponse);
       } catch (error) {
-        return err(wrapError("kv", error));
+        const wrapped = wrapError("kv", error);
+        return err({
+          ...wrapped,
+          meta: { ...wrapped.meta, requestMayHaveDispatched },
+        });
       }
     });
   }

--- a/packages/sdk-services/src/kv/KVService.ts
+++ b/packages/sdk-services/src/kv/KVService.ts
@@ -1020,11 +1020,33 @@ export class KVService extends BaseService implements IKVService {
         }
 
         const batchResponse = this.normalizeBatchPutResponse(await response.json());
-        if (!batchResponse || batchResponse.count !== batchResponse.written.length) {
+        if (!batchResponse) {
           return err(
             serviceError(
               ErrorCodes.NETWORK_ERROR,
               "KV batchPut response did not include matching written keys and count",
+              "kv"
+            )
+          );
+        }
+
+        // Validate against the exact requested path set, not just internal
+        // self-consistency (count === written.length would accept a
+        // malformed response that reports the right count for the wrong
+        // keys, e.g. a partial write padded to look complete).
+        const requestedPaths = new Set(paths);
+        const writtenPaths = new Set(batchResponse.written);
+        const matchesRequest =
+          batchResponse.count === paths.length &&
+          batchResponse.written.length === paths.length &&
+          writtenPaths.size === paths.length &&
+          batchResponse.written.every((key) => requestedPaths.has(key));
+
+        if (!matchesRequest) {
+          return err(
+            serviceError(
+              ErrorCodes.NETWORK_ERROR,
+              `KV batchPut response did not confirm all ${paths.length} requested key(s) were written`,
               "kv"
             )
           );

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -12,7 +12,7 @@ export {
   type EstablishOpenKeySessionResult,
   type EstablishOpenKeySessionStatus,
 } from "./openkey-session";
-export type { SecretReadInput, SecretReadResult } from "@tinycloud/node-sdk";
+export type { SecretReadInput, SecretReadResult, BootstrapWarning } from "@tinycloud/node-sdk";
 export type {
   CreateOwnerDelegationParams,
   OwnerDelegationPermission,
@@ -133,6 +133,7 @@ export type {
   AccountSpace,
   AccountSpaceListOptions,
   AccountStatus,
+  RegisterBatchSuccess,
   SignInOptions,
   TinyCloudDebugEvent,
   TinyCloudDebugLevel,

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -13,6 +13,7 @@
 import {
   TinyCloudNode,
   TinyCloudNodeConfig,
+  type BootstrapWarning,
   type DelegateToOptions,
   type DelegateToResult,
   type ISessionStorage,
@@ -480,7 +481,7 @@ export class TinyCloudWeb {
   /** Whether the last signIn() skipped client-side account bootstrap. */
   get bootstrapSkipped(): boolean { return this.node.bootstrapSkipped; }
   /** Outcome of the last signIn()'s account-bootstrap attempt. */
-  get bootstrapStatus(): { skipped: boolean; reason?: string } { return this.node.bootstrapStatus; }
+  get bootstrapStatus(): { skipped: boolean; reason?: string; warnings?: BootstrapWarning[] } { return this.node.bootstrapStatus; }
 
   /** Space-scoped SQL service for a non-primary space (e.g. the owner's `applications` space). */
   sqlForSpace(spaceId: string): ISQLService { return this.node.sqlForSpace(spaceId); }


### PR DESCRIPTION
Collapses the 5 sequential per-space KV writes and 5 per-space SQL index writes in account bootstrap's seed-spaces step into one KV batch write and one multi-row SQL index write, per the Sol-corrected design: `invokeAny` is threaded into `createSpaceScopedKVService` (the missing piece that made the original naive plan a no-op), the stored records are precomputed once and reused byte-for-byte in any reconciliation fallback, the index write is a single atomic multi-row statement instead of a non-transactional 5-statement batch, an index-write failure can never trigger a KV rewrite, the ambiguous-failure fallback never fires for auth/quota/space-not-found/abort and always preserves the original error, and `batchPut` now validates the exact requested path set (not just a count) before reporting success.

Part of TC-318 sign-in trim; corrected per Sol plan review.

## Live-node verification (node.tinycloud.xyz, throwaway keys)

| | requests during signIn | `/invoke` POSTs | multipart KV batch writes | multi-stmt SQL batches |
|---|---|---|---|---|
| before (stashed fix) | 40 | 18 | 0 | 10 |
| after (this PR) | 32 | 10 | 1 (covers all 5 spaces) | 6 |

**Delta: -8 requests**, matching the spec's "~8 requests" estimate exactly. All 5 spaces (`default`, `applications`, `account`, `secrets`, `public`) were registered, owned by the signed-in DID, and readable back through the canonical (non-index) KV read path — not just the SQL index.

<details>
<summary>Before trace (pre-fix, stashed)</summary>

```
  [21] POST    3523ms  200  json-batch(2 stmts)  /invoke
  [22] POST    1821ms  200  json-query          /invoke
  [23] POST    2345ms  200  json-batch(11 stmts)  /invoke
  [24] POST     463ms  200  none                /delegate
  [25] POST    2296ms  200  json                /invoke        <- put "default"
  [26] POST    2419ms  200  json-batch(1 stmt)  /invoke        <- index write "default"
  [27] POST    2611ms  200  json                /invoke        <- put "applications"
  [28] POST    2521ms  200  json-batch(1 stmt)  /invoke        <- index write "applications"
  [29] POST    2394ms  200  json                /invoke        <- put "account"
  [30] POST    2496ms  200  json-batch(1 stmt)  /invoke        <- index write "account"
  [31] POST    2726ms  200  json                /invoke        <- put "secrets"
  [32] POST    2415ms  200  json-batch(1 stmt)  /invoke        <- index write "secrets"
  [33] POST    2303ms  200  json                /invoke        <- put "public"
  [34] POST    2481ms  200  json-batch(1 stmt)  /invoke        <- index write "public"
  [35] POST    2269ms  200  json                /invoke
  [36] POST    2423ms  200  json-batch(2 stmts)  /invoke
  [37] POST    2791ms  200  json                /encryption/networks
  [38] POST    4981ms  200  json-batch(2 stmts)  /invoke
  [39] POST    1902ms  200  json-query          /invoke
  [40] POST    2305ms  200  json-batch(2 stmts)  /invoke

total signIn: 68383ms, 40 requests
/invoke POST calls: 18
  multipart KV batch writes: 0 (expect 1, covering all 5 spaces)
  multi-statement SQL batch calls: 10
FAIL  exactly one multipart KV batch write  (got 0)
```

The 5×(put + index-batch) pairs at [25-34] are exactly the pre-fix seed-spaces loop.
</details>

<details>
<summary>After trace (this fix)</summary>

```
  [21] POST    3402ms  200  json-batch(2 stmts)  /invoke
  [22] POST    1878ms  200  json-query          /invoke
  [23] POST    2288ms  200  json-batch(11 stmts)  /invoke
  [24] POST     386ms  200  none                /delegate
  [25] POST    3302ms  200  multipart(5 parts)  /invoke        <- ONE batch write, all 5 spaces
  [26] POST    2424ms  200  json-batch(1 stmt)  /invoke        <- ONE multi-row index write
  [27] POST    2583ms  200  json                /invoke
  [28] POST    2430ms  200  json-batch(2 stmts)  /invoke
  [29] POST    2555ms  200  json                /encryption/networks
  [30] POST    3430ms  200  json-batch(2 stmts)  /invoke
  [31] POST    1825ms  200  json-query          /invoke
  [32] POST    2165ms  200  json-batch(2 stmts)  /invoke

total signIn: 46727ms, 32 requests
/invoke POST calls: 10
  multipart KV batch writes: 1 (expect 1, covering all 5 spaces)
  multi-statement SQL batch calls: 6
ok    exactly one multipart KV batch write  (got 1)
ok    batch write covers exactly 5 parts  (multipart(5 parts))
ok    all 5 spaces present  (got 5: account,applications,default,public,secrets)
ok    space "default"/"applications"/"account"/"secrets"/"public" registered, ownerDid matches, status active
RESULT: PASS
```

Reproduce with `bun run --cwd apps/node-demo src/tc-373-live-verify.ts` (turbo build the node-sdk chain first).
</details>

## Tests

New: `packages/sdk-services/src/kv/KVService.test.ts` (exact requested-path-set + count validation, JSON canonical-read round-trip through `application/json`), `packages/node-sdk/src/account/AccountService.registerBatch.test.ts` (one batch call for all 5 spaces, one multi-row index statement, no fallback on 401/403/402/413/404/abort, ambiguous-failure reconciliation with identical bytes + preserved original error via `console.warn`, index failure never triggers a KV rewrite), `packages/node-sdk/src/TinyCloudNode.spaceScopedKV.test.ts` (`node.spaces.get(accountSpaceId).kv.batchPut()` reaches `invokeAny`), `packages/node-sdk/src/TinyCloudNode.seedSpacesBatch.test.ts` (bootstrap's seed-spaces step calls `registerBatch` once, never the old per-space loop), `packages/sdk-core/src/account/multiRowInsertAtomicity.test.ts` (real `bun:sqlite` proof that a single multi-row `INSERT OR REPLACE` is atomic — one bad row rejects the whole statement — in contrast to a 5-statement loop, which is not).

Every safety-critical invariant above (narrow fallback classification, byte-identical reconciliation, seed-spaces batching) was mutation-checked: the corresponding test was confirmed to fail when the invariant was deliberately broken, then the source was restored.

`bun run build` (turbo) and `bun test src/` are clean in `sdk-core`, `sdk-services`, and `node-sdk`: 194 + 249 + 810 = 1253 passing, 0 failing. `sdk-core`/`sdk-services`/`node-sdk` don't define a package-level `lint` script (only `web-sdk` does, unaffected by this change), so type-checking happens via `build`'s `tsup`/DTS step, which is clean.

CI note: the `authority` job has a pre-existing flake (TC-372, tracked separately) — not chased here.

Not merging — Sol reviews the code after this is up.