### PR TITLE
fix(web-sdk): allow CoordinationOS invite record

### DIFF
--- a/.changeset/quiet-guests-store.md
+++ b/.changeset/quiet-guests-store.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/web-sdk": patch
+---
+
+Allow the CoordinationOS OpenKey session helper to grant its exact private invite-code record alongside the required canary record.

--- a/packages/web-sdk/scripts/build-coordinationos-vendor.ts
+++ b/packages/web-sdk/scripts/build-coordinationos-vendor.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const CONTRACT_VERSION = "2.10.0-beta.0";
+const CONTRACT_VERSION = "2.11.0-beta.1";
 const CONTRACT_EXPORTS = [
   "TinyCloudWeb",
   "createOpenKeyCallbackSigningStrategy",

--- a/packages/web-sdk/src/openkey-session.ts
+++ b/packages/web-sdk/src/openkey-session.ts
@@ -205,10 +205,10 @@ async function coordinationOsUserNamespace(keyId: string): Promise<string> {
     .slice(0, 22);
 }
 
-async function validateCanaryManifest(
+async function validateCoordinationOsManifest(
   manifest: Manifest,
   keyId: string,
-): Promise<string> {
+): Promise<string[]> {
   if (
     manifest === null ||
     typeof manifest !== "object" ||
@@ -229,8 +229,26 @@ async function validateCanaryManifest(
   ];
   const permissionKeys = ["service", "space", "path", "actions"];
   const permissions = (manifest as Manifest).permissions;
-  const permission = permissions?.[0];
   const namespace = await coordinationOsUserNamespace(keyId);
+  const canaryPath =
+    `coordinationos/integration/v1/${namespace}/canary`;
+  const inviteCodePath =
+    `coordinationos/integration/v1/${namespace}/invite-code`;
+  const validPermission = (
+    permission: Manifest["permissions"][number] | undefined,
+    path: string,
+  ): boolean =>
+    permission !== null &&
+    typeof permission === "object" &&
+    !Array.isArray(permission) &&
+    ownKeysEqual(permission, permissionKeys) &&
+    permission.service === "tinycloud.kv" &&
+    permission.space === "applications" &&
+    permission.path === path &&
+    Array.isArray(permission.actions) &&
+    permission.actions.length === 2 &&
+    permission.actions[0] === "get" &&
+    permission.actions[1] === "put";
   const valid =
     ownKeysEqual(manifest, manifestKeys) &&
     manifest.manifest_version === 1 &&
@@ -241,40 +259,33 @@ async function validateCanaryManifest(
     manifest.defaults === false &&
     manifest.expiry === "1h" &&
     Array.isArray(permissions) &&
-    permissions.length === 1 &&
-    permission !== null &&
-    typeof permission === "object" &&
-    !Array.isArray(permission) &&
-    ownKeysEqual(permission, permissionKeys) &&
-    permission.service === "tinycloud.kv" &&
-    permission.space === "applications" &&
-    permission.path ===
-      `coordinationos/integration/v1/${namespace}/canary` &&
-    Array.isArray(permission.actions) &&
-    permission.actions.length === 2 &&
-    permission.actions[0] === "get" &&
-    permission.actions[1] === "put";
+    (permissions.length === 1 || permissions.length === 2) &&
+    validPermission(permissions[0], canaryPath) &&
+    (
+      permissions.length === 1 ||
+      validPermission(permissions[1], inviteCodePath)
+    );
 
   if (!valid) {
-    throw new Error("Manifest must grant only the CoordinationOS KV canary");
+    throw new Error(
+      "Manifest must grant only the approved CoordinationOS KV records",
+    );
   }
-  return permission.path;
+  return permissions.map((permission) => permission.path);
 }
 
 function coordinationOsCapabilityRequest(
   manifest: Manifest,
-  canaryPath: string,
+  paths: string[],
 ): ComposedManifestRequest {
   return {
     manifests: [manifest],
-    resources: [
-      {
-        service: "tinycloud.kv",
-        space: "applications",
-        path: canaryPath,
-        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
-      },
-    ],
+    resources: paths.map((path) => ({
+      service: "tinycloud.kv",
+      space: "applications",
+      path,
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+    })),
     delegationTargets: [],
     registryRecords: [],
     expiryMs: SESSION_EXPIRATION_MS,
@@ -368,7 +379,7 @@ export async function establishOpenKeySession(
   if (options.sessionStorageKeyPrefix !== SESSION_STORAGE_KEY_PREFIX) {
     throw new Error("OpenKey session storage prefix is invalid");
   }
-  const canaryPath = await validateCanaryManifest(
+  const coordinationOsPaths = await validateCoordinationOsManifest(
     options.manifest,
     options.key.keyId,
   );
@@ -422,7 +433,7 @@ export async function establishOpenKeySession(
     manifest: options.manifest,
     capabilityRequest: coordinationOsCapabilityRequest(
       options.manifest,
-      canaryPath,
+      coordinationOsPaths,
     ),
     includeAccountRegistryPermissions: false,
     autoCreateSpace: false,

--- a/packages/web-sdk/tests/coordinationos-vendor.test.ts
+++ b/packages/web-sdk/tests/coordinationos-vendor.test.ts
@@ -6,15 +6,15 @@ import { createCoordinationOsVendorManifest } from "../scripts/build-coordinatio
 test("creates deterministic CoordinationOS vendor metadata for fixed bytes", () => {
   const manifest = createCoordinationOsVendorManifest(
     new TextEncoder().encode("coordinationos-vendor-fixture"),
-    { name: "@tinycloud/web-sdk", version: "2.10.0-beta.0" },
+    { name: "@tinycloud/web-sdk", version: "2.11.0-beta.1" },
   );
 
   expect(`${JSON.stringify(manifest, null, 2)}\n`).toBe(`{
   "schemaVersion": 1,
   "package": "@tinycloud/web-sdk",
-  "version": "2.10.0-beta.0",
+  "version": "2.11.0-beta.1",
   "format": "esm",
-  "entry": "tinycloud-web-sdk-2.10.0-beta.0.mjs",
+  "entry": "tinycloud-web-sdk-2.11.0-beta.1.mjs",
   "sha384": "sha384-zTsa9taxYVJimor3dNdKXbUbVXyzk5gN5aFhdcYYE0abTiwwWLqp7M8ZN34IUiAk",
   "exports": [
     "TinyCloudWeb",
@@ -41,7 +41,7 @@ test("the generated manifest and ESM namespace expose exactly the contract", asy
     await readFile(
       resolve(
         vendorRoot,
-        "tinycloud-web-sdk-2.10.0-beta.0.vendor.json",
+        "tinycloud-web-sdk-2.11.0-beta.1.vendor.json",
       ),
       "utf8",
     ),
@@ -125,7 +125,7 @@ test("the generated manifest and ESM namespace expose exactly the contract", asy
   ];
 
   expect(manifest.format).toBe("esm");
-  expect(manifest.version).toBe("2.10.0-beta.0");
+  expect(manifest.version).toBe("2.11.0-beta.1");
   expect(manifest.exports).toEqual(expected);
   expect(Object.keys(namespace).sort()).toEqual([...expected].sort());
 });

--- a/packages/web-sdk/tests/openkey-session.test.ts
+++ b/packages/web-sdk/tests/openkey-session.test.ts
@@ -111,6 +111,8 @@ const ENDPOINT = "https://openkey.example.test/api/delegate/sign";
 const SESSION_PREFIX = "coordinationos:tinycloud:session:v1:" as const;
 const CANARY_PATH =
   "coordinationos/integration/v1/XxEf1YZ9gjryBBuLxMubX_/canary";
+const INVITE_CODE_PATH =
+  "coordinationos/integration/v1/XxEf1YZ9gjryBBuLxMubX_/invite-code";
 const MANIFEST = {
   manifest_version: 1,
   app_id: "xyz.tinycloud.coordinationos",
@@ -124,6 +126,18 @@ const MANIFEST = {
       service: "tinycloud.kv",
       space: "applications",
       path: CANARY_PATH,
+      actions: ["get", "put"],
+    },
+  ],
+} as const;
+const INVITE_MANIFEST = {
+  ...MANIFEST,
+  permissions: [
+    ...MANIFEST.permissions,
+    {
+      service: "tinycloud.kv",
+      space: "applications",
+      path: INVITE_CODE_PATH,
       actions: ["get", "put"],
     },
   ],
@@ -375,6 +389,53 @@ test("fresh sign-in sends one unchanged SIWE sign-in body with one Bearer token"
     ...VALID_REQUEST,
     keyId: KEY_ID,
   });
+});
+
+test("fresh sign-in grants only the exact canary and invite-code records", async () => {
+  const input = options(TOKEN);
+  input.manifest = INVITE_MANIFEST as any;
+
+  const result = await establishOpenKeySession(input);
+
+  expect(result.status).toBe("established");
+  expect(constructedConfigs[0].capabilityRequest.resources).toEqual([
+    {
+      service: "tinycloud.kv",
+      space: "applications",
+      path: CANARY_PATH,
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+    },
+    {
+      service: "tinycloud.kv",
+      space: "applications",
+      path: INVITE_CODE_PATH,
+      actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+    },
+  ]);
+});
+
+test.each([
+  ["invite without canary", [INVITE_MANIFEST.permissions[1]]],
+  [
+    "unknown extra record",
+    [
+      ...INVITE_MANIFEST.permissions,
+      {
+        service: "tinycloud.kv",
+        space: "applications",
+        path: "coordinationos/integration/v1/extra",
+        actions: ["get", "put"],
+      },
+    ],
+  ],
+])("rejects %s before construction", async (_name, permissions) => {
+  const input = options(TOKEN);
+  input.manifest = {...MANIFEST, permissions} as any;
+
+  await expect(establishOpenKeySession(input)).rejects.toThrow(
+    "approved CoordinationOS KV records",
+  );
+  expect(constructorCount).toBe(0);
 });
 
 test("a simulated second callback rejects locally after one signer fetch", async () => {

--- a/packages/web-sdk/webpack.coordinationos-vendor.config.cjs
+++ b/packages/web-sdk/webpack.coordinationos-vendor.config.cjs
@@ -6,7 +6,7 @@ module.exports = {
   entry: "./src/coordinationos-vendor.ts",
   output: {
     ...esmConfig.output,
-    filename: "tinycloud-web-sdk-2.10.0-beta.0.mjs",
+    filename: "tinycloud-web-sdk-2.11.0-beta.1.mjs",
     path: path.resolve(__dirname, "dist/vendor"),
   },
 };


### PR DESCRIPTION
## Summary
- permit the exact CoordinationOS invite-code KV record alongside its required canary
- keep canary-only sessions backward compatible and reject any other manifest shape
- bump the CoordinationOS vendor contract to the current web-sdk version

## Verification
- `bunx turbo build --filter=@tinycloud/web-sdk...`
- `bun test packages/web-sdk/tests/openkey-session.test.ts` (60 passed)
- `bun run --cwd packages/web-sdk build:coordinationos-vendor`
- `bun test packages/web-sdk/tests/coordinationos-vendor.test.ts` (3 passed)
- `bun run --cwd packages/web-sdk lint`

Linear: TC-13