### PR TITLE
fix(core): combine split ReCap actions

### DIFF
--- a/.changeset/smart-clouds-unite.md
+++ b/.changeset/smart-clouds-unite.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/sdk-core": patch
+---
+
+Recognize grouped manifest actions when a verified ReCap returns one capability entry per action.

--- a/packages/sdk-core/src/capabilities.test.ts
+++ b/packages/sdk-core/src/capabilities.test.ts
@@ -186,6 +186,38 @@ describe("isCapabilitySubset — action subset", () => {
     expect(isCapabilitySubset(requested, granted).subset).toBe(true);
   });
 
+  it("combines actions split across equivalent ReCap entries", () => {
+    const requested: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "app/",
+        actions: ["tinycloud.kv/get", "tinycloud.kv/put"],
+      },
+    ];
+    const splitGrant: PermissionEntry[] = [
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "app/",
+        actions: ["tinycloud.kv/get"],
+        caveats: [],
+      },
+      {
+        service: "tinycloud.kv",
+        space: "s1",
+        path: "app/",
+        actions: ["tinycloud.kv/put"],
+        caveats: [],
+      },
+    ];
+
+    expect(isCapabilitySubset(requested, splitGrant)).toEqual({
+      subset: true,
+      missing: [],
+    });
+  });
+
   it("rejects when an action is missing", () => {
     const requested: PermissionEntry[] = [
       {

--- a/packages/sdk-core/src/capabilities.ts
+++ b/packages/sdk-core/src/capabilities.ts
@@ -136,8 +136,11 @@ export interface SubsetCheckResult {
  * - Action containment: every requested URN must be matched exactly or by a
  *   service-scoped wildcard such as `tinycloud.kv/*`.
  *
- * Any `requested` entry that does not find a matching `granted` entry is
- * added to `missing` and the overall result is non-subset.
+ * Grant entries with the same service, space, path coverage, and caveats are
+ * considered together. This matters because ReCap parsers may return one
+ * entry per action even when the original manifest grouped those actions.
+ * Any `requested` entry whose actions are not collectively covered is added
+ * to `missing` and the overall result is non-subset.
  *
  * Both sides are expected to be in the canonical long-form shape (service
  * starts with `tinycloud.`, actions are full URNs). Use {@link parseRecapCapabilities}
@@ -150,12 +153,24 @@ export function isCapabilitySubset(
   const missing: PermissionEntry[] = [];
 
   for (const req of requested) {
-    const match = granted.find((g) => canonicalizeEntryMatches(req, g));
-    if (match === undefined) {
+    const matchingScope = granted.filter((entry) =>
+      canonicalizeEntryScopeMatches(req, entry)
+    );
+    const requestedActions = expandActionShortNames(
+      req.service,
+      req.actions
+    );
+    const grantedActions = matchingScope.flatMap((entry) =>
+      expandActionShortNames(entry.service, entry.actions)
+    );
+    const covered = requestedActions.every((requestedAction) =>
+      grantedActions.some((grantedAction) =>
+        actionContains(grantedAction, requestedAction)
+      )
+    );
+    if (!covered) {
       missing.push(cloneEntry(req));
-      continue;
     }
-    // `match` is confirmed to cover `req`; nothing to record.
   }
 
   return { subset: missing.length === 0, missing };
@@ -165,7 +180,7 @@ export function isCapabilitySubset(
  * Returns true when `granted` fully covers `requested` — same service, same
  * space, path containment per spec, and action set containment.
  */
-function canonicalizeEntryMatches(
+function canonicalizeEntryScopeMatches(
   requested: PermissionEntry,
   granted: PermissionEntry
 ): boolean {
@@ -183,18 +198,6 @@ function canonicalizeEntryMatches(
   }
   if (!pathContains(granted.path, requested.path)) {
     return false;
-  }
-  // Normalize actions to full URN form on both sides before set comparison,
-  // so a caller passing short names ("get") against a granted entry with
-  // full URNs still behaves correctly.
-  const reqActions = new Set(
-    expandActionShortNames(requested.service, requested.actions)
-  );
-  const grantedActions = expandActionShortNames(granted.service, granted.actions);
-  for (const a of reqActions) {
-    if (!grantedActions.some((grantedAction) => actionContains(grantedAction, a))) {
-      return false;
-    }
   }
   // There is no safe general partial ordering for arbitrary ReCap caveat
   // objects. A caveated authority therefore only covers the same caveat set;


### PR DESCRIPTION
## Summary
- treat equivalent verified ReCap entries as a collective action grant
- preserve exact service, space, path-containment, and caveat matching
- fix restored multi-action sessions being incorrectly classified as stale

## Production reproduction
CoordinationOS requested `get` + `put` on two exact KV records. The verified ReCap correctly restored four one-action entries, but the subset checker required both actions in one entry and cleared the valid persisted session.

## Verification
- `bun test packages/sdk-core/src/capabilities.test.ts` (34 passed)
- `bun run --cwd packages/sdk-services build`
- `bun run --cwd packages/sdk-core build`
- `bun test packages/sdk-core/src/capabilities.test.ts packages/sdk-core/src/publicExports.test.ts` (35 passed)
- full package run reached 810 passes; one pre-build public-export resolution error disappeared after building dependencies

Linear: TC-13