### PR TITLE
fix(core): make loopback discovery opt-in (TC-13)

### DIFF
--- a/.changeset/calm-sites-stay-local.md
+++ b/.changeset/calm-sites-stay-local.md
@@ -1,0 +1,10 @@
+---
+"@tinycloud/sdk-core": patch
+"@tinycloud/node-sdk": patch
+"@tinycloud/web-sdk": patch
+"@tinycloud/cli": patch
+---
+
+Stop implicitly probing `127.0.0.1` during TinyCloud host discovery. Loopback
+discovery now requires an explicit `localNodeUrl`, while configured and
+registry-discovered `*.local.tinycloud.link` nodes continue to work.

--- a/packages/cli/src/config/profiles.ts
+++ b/packages/cli/src/config/profiles.ts
@@ -172,9 +172,10 @@ export class ProfileManager {
    * Host resolution:    options.host    > TC_HOST env    > discovered local node > profile.host > DEFAULT_HOST
    *
    * Local-node discovery (TC-106) only runs when no explicit host was given
-   * (`--host` / `TC_HOST`); it probes for a locally-running TinyCloud node and,
-   * after DID verification against the profile's pinned identity, prefers it
-   * over the stored/default host. Disable per profile with
+   * (`--host` / `TC_HOST`); it probes configured or registered local nodes and,
+   * after DID verification against the profile's pinned identity, prefers one
+   * over the stored/default host. Loopback requires an explicit `localNodeUrl`.
+   * Disable discovery per profile with
    * `autoDiscoverLocalNode: false` in profile.json.
    */
   static async resolveContext(options: {

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -72,12 +72,12 @@ export interface ProfileConfig {
    */
   openkeyHost?: string;
   /**
-   * Probe for a locally-running TinyCloud node before using the profile's
+   * Probe configured/registered local nodes before using the profile's
    * stored host. Default: true. Set false to restore the pre-TC-106
    * resolution order (--host > TC_HOST > profile.host > default).
    */
   autoDiscoverLocalNode?: boolean;
-  /** Local loopback node URL to probe. Default: http://127.0.0.1:8000. */
+  /** Local loopback node URL to probe. Omit to avoid probing loopback. */
   localNodeUrl?: string;
   /** Known `*.local.tinycloud.link` subdomain name, probed directly. */
   localLinkName?: string;

--- a/packages/cli/src/lib/host.ts
+++ b/packages/cli/src/lib/host.ts
@@ -41,7 +41,7 @@ export function profileLocalNodeIdentityStore(
 }
 
 /**
- * Probe for a locally-running TinyCloud node using the profile's discovery
+ * Probe for a configured or registered local TinyCloud node using the profile's discovery
  * knobs and profile-persisted DID pins. Returns the verified local node URL,
  * or null when discovery is disabled, nothing local is running, or the local
  * node fails identity verification — callers fall back to their normal host.

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -619,9 +619,9 @@ export interface TinyCloudNodeConfig {
   tinycloudRegistryUrl?: string | null;
   /** Fallback TinyCloud hosts. Default: hosted TinyCloud node. */
   tinycloudFallbackHosts?: string[] | null;
-  /** Probe for a locally-running TinyCloud node before registry/fallback resolution. Default: true. */
+  /** Probe configured/registered local nodes before registry/fallback resolution. Default: true. */
   autoDiscoverLocalNode?: boolean;
-  /** Local loopback node URL to probe. Default: http://127.0.0.1:8000. */
+  /** Local loopback node URL to probe. Omit to avoid probing loopback. */
   localNodeUrl?: string;
   /** Known `*.local.tinycloud.link` subdomain name, probed directly. */
   localLinkName?: string;

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -107,9 +107,9 @@ export interface NodeUserAuthorizationConfig {
   tinycloudRegistryUrl?: string | null;
   /** Fallback TinyCloud hosts. Default: hosted TinyCloud node. */
   tinycloudFallbackHosts?: string[] | null;
-  /** Probe for a locally-running TinyCloud node before registry/fallback resolution. Default: true. */
+  /** Probe configured/registered local nodes before registry/fallback resolution. Default: true. */
   autoDiscoverLocalNode?: boolean;
-  /** Local loopback node URL to probe. Default: http://127.0.0.1:8000. */
+  /** Local loopback node URL to probe. Omit to avoid probing loopback. */
   localNodeUrl?: string;
   /** Known `*.local.tinycloud.link` subdomain name, probed directly. */
   localLinkName?: string;

--- a/packages/sdk-core/src/location.test.ts
+++ b/packages/sdk-core/src/location.test.ts
@@ -243,10 +243,11 @@ describe("resolveCloudLocation", () => {
 });
 
 describe("discoverLocalTinyCloudNode candidate ordering", () => {
-  it("adopts the default loopback candidate first and pins its DID", async () => {
+  it("adopts an explicitly configured loopback candidate and pins its DID", async () => {
     const requests: string[] = [];
     const store = createInMemoryLocalNodeIdentityStore();
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } }, requests),
       identityStore: store,
     });
@@ -267,6 +268,7 @@ describe("discoverLocalTinyCloudNode candidate ordering", () => {
     const linkUrl = "https://myname.local.tinycloud.link";
     const requests: string[] = [];
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       localLinkName: "myname",
       fetch: fakeFetch({ [linkUrl]: { nodeDid: NODE_DID } }, requests),
       identityStore: createInMemoryLocalNodeIdentityStore(),
@@ -300,6 +302,7 @@ describe("discoverLocalTinyCloudNode candidate ordering", () => {
   it("only consults the registry after the static candidates fail", async () => {
     const requests: string[] = [];
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       subject: TEST_SUBJECT,
       registryUrl: "https://registry.example",
       verifyRecords: false,
@@ -329,6 +332,7 @@ describe("discoverLocalTinyCloudNode probe failures", () => {
   for (const [label, error] of failureModes) {
     it(`silently returns null on ${label}`, async () => {
       const discovered = await discoverLocalTinyCloudNode({
+        localNodeUrl: DEFAULT_LOCAL_NODE_URL,
         fetch: fakeFetch({}, [], () => error),
         identityStore: createInMemoryLocalNodeIdentityStore(),
       });
@@ -338,6 +342,7 @@ describe("discoverLocalTinyCloudNode probe failures", () => {
 
   it("skips a candidate whose /healthz is unhealthy", async () => {
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { healthy: false } }),
       identityStore: createInMemoryLocalNodeIdentityStore(),
     });
@@ -347,6 +352,7 @@ describe("discoverLocalTinyCloudNode probe failures", () => {
   it("skips a healthy candidate whose /info reports no nodeId", async () => {
     const store = createInMemoryLocalNodeIdentityStore();
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: {} }),
       identityStore: store,
     });
@@ -358,6 +364,7 @@ describe("discoverLocalTinyCloudNode probe failures", () => {
 describe("discoverLocalTinyCloudNode identity pinning", () => {
   it("adopts a node whose DID matches expectedNodeDid", async () => {
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       expectedNodeDid: NODE_DID,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } }),
       identityStore: createInMemoryLocalNodeIdentityStore(),
@@ -368,6 +375,7 @@ describe("discoverLocalTinyCloudNode identity pinning", () => {
   it("rejects a node whose DID does not match expectedNodeDid", async () => {
     const store = createInMemoryLocalNodeIdentityStore();
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       expectedNodeDid: NODE_DID,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: OTHER_NODE_DID } }),
       identityStore: store,
@@ -381,6 +389,7 @@ describe("discoverLocalTinyCloudNode identity pinning", () => {
     const store = createInMemoryLocalNodeIdentityStore();
 
     const first = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } }),
       identityStore: store,
     });
@@ -388,6 +397,7 @@ describe("discoverLocalTinyCloudNode identity pinning", () => {
     expect(await store.get(DEFAULT_LOCAL_NODE_URL)).toBe(NODE_DID);
 
     const second = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: OTHER_NODE_DID } }),
       identityStore: store,
     });
@@ -401,6 +411,7 @@ describe("discoverLocalTinyCloudNode identity pinning", () => {
     await store.set(DEFAULT_LOCAL_NODE_URL, NODE_DID);
 
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } }),
       identityStore: store,
     });
@@ -412,6 +423,7 @@ describe("discoverLocalTinyCloudNode identity pinning", () => {
     await store.set(DEFAULT_LOCAL_NODE_URL, OTHER_NODE_DID);
 
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       expectedNodeDid: NODE_DID,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } }),
       identityStore: store,
@@ -425,6 +437,7 @@ describe("discoverLocalTinyCloudNode identity pinning", () => {
 
     // First call: expectedNodeDid confirms the node's real DID.
     const first = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       expectedNodeDid: NODE_DID,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } }),
       identityStore: store,
@@ -436,6 +449,7 @@ describe("discoverLocalTinyCloudNode identity pinning", () => {
     // Second call: caller drops expectedNodeDid entirely. It must succeed
     // against the refreshed pin rather than falling back to the stale one.
     const second = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } }),
       identityStore: store,
     });
@@ -447,6 +461,7 @@ describe("discoverLocalTinyCloudNode localLinkName validation", () => {
   it("rejects a localLinkName that isn't a single DNS label", async () => {
     const requests: string[] = [];
     const discovered = await discoverLocalTinyCloudNode({
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       localLinkName: "evil.com/",
       fetch: fakeFetch({}, requests),
       identityStore: createInMemoryLocalNodeIdentityStore(),
@@ -511,7 +526,6 @@ describe("discoverLocalTinyCloudNode local-link registry extraction", () => {
     });
     // Hosted node.tinycloud.xyz and the insecure link entry were never probed.
     expect(requests).toEqual([
-      `${DEFAULT_LOCAL_NODE_URL}/healthz`,
       `https://registry.example/v1/locations/${encodeURIComponent(TEST_SUBJECT)}`,
       `${linkUrl}/healthz`,
       `${linkUrl}/info`,
@@ -541,14 +555,15 @@ describe("discoverLocalTinyCloudNode local-link registry extraction", () => {
       identityStore: createInMemoryLocalNodeIdentityStore(),
     });
     expect(discovered).toBeNull();
-    expect(requests).toEqual([`${DEFAULT_LOCAL_NODE_URL}/healthz`]);
+    expect(requests).toEqual([]);
   });
 });
 
 describe("resolveTinyCloudHosts local discovery integration", () => {
-  it("prefers a verified local node over registry and fallback", async () => {
+  it("prefers an explicitly configured, verified loopback node over registry and fallback", async () => {
     const requests: string[] = [];
     const resolved = await resolveTinyCloudHosts(TEST_SUBJECT, {
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch({ [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } }, requests),
       localNodeIdentityStore: createInMemoryLocalNodeIdentityStore(),
     });
@@ -563,7 +578,7 @@ describe("resolveTinyCloudHosts local discovery integration", () => {
     ).toBe(false);
   });
 
-  it("falls back to registry resolution when every local probe fails", async () => {
+  it("does not probe loopback by default before registry resolution", async () => {
     const requests: string[] = [];
     const resolved = await resolveTinyCloudHosts(TEST_SUBJECT, {
       fetch: fakeFetch({}, requests, (url) =>
@@ -576,7 +591,10 @@ describe("resolveTinyCloudHosts local discovery integration", () => {
 
     expect(resolved.location.source).toBe("fallback");
     expect(resolved.hosts).toEqual([DEFAULT_TINYCLOUD_FALLBACK_HOST]);
-    expect(requests[0]).toBe(`${DEFAULT_LOCAL_NODE_URL}/healthz`);
+    expect(requests).not.toContain(`${DEFAULT_LOCAL_NODE_URL}/healthz`);
+    expect(requests[0]).toBe(
+      `${DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL}/v1/locations/${encodeURIComponent(TEST_SUBJECT)}`,
+    );
   });
 
   it("fetches the subject's registry LocationRecord only once, even though local discovery and centralized resolution both need it", async () => {
@@ -600,6 +618,7 @@ describe("resolveTinyCloudHosts local discovery integration", () => {
 
   it("falls back when the local node fails identity verification", async () => {
     const resolved = await resolveTinyCloudHosts(TEST_SUBJECT, {
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       expectedNodeDid: NODE_DID,
       fetch: fakeFetch(
         { [DEFAULT_LOCAL_NODE_URL]: { nodeDid: OTHER_NODE_DID } },
@@ -620,6 +639,7 @@ describe("resolveTinyCloudHosts local discovery integration", () => {
     const requests: string[] = [];
     const resolved = await resolveTinyCloudHosts(TEST_SUBJECT, {
       autoDiscoverLocalNode: false,
+      localNodeUrl: DEFAULT_LOCAL_NODE_URL,
       fetch: fakeFetch(
         { [DEFAULT_LOCAL_NODE_URL]: { nodeDid: NODE_DID } },
         requests,

--- a/packages/sdk-core/src/location.ts
+++ b/packages/sdk-core/src/location.ts
@@ -44,7 +44,7 @@ export const DEFAULT_TINYCLOUD_LOCATION_REGISTRY_URL =
   "https://registry.tinycloud.xyz";
 export const DEFAULT_TINYCLOUD_FALLBACK_HOST = "https://node.tinycloud.xyz";
 
-/** Default local loopback node URL probed before registry/fallback resolution. */
+/** Conventional local loopback node URL. Probed only when explicitly configured. */
 export const DEFAULT_LOCAL_NODE_URL = "http://127.0.0.1:8000";
 /** Probe timeout for the local loopback candidate. No retries. */
 export const LOCAL_LOOPBACK_PROBE_TIMEOUT_MS = 250;
@@ -194,7 +194,7 @@ export interface DiscoverLocalTinyCloudNodeOptions {
   subject?: string;
   /** Enable local-node auto-discovery. Default true. */
   autoDiscoverLocalNode?: boolean;
-  /** Local loopback node URL to probe. Default http://127.0.0.1:8000. */
+  /** Local loopback node URL to probe. Omit to avoid probing loopback. */
   localNodeUrl?: string;
   /** Known `*.local.tinycloud.link` subdomain name, probed directly. */
   localLinkName?: string;
@@ -230,12 +230,12 @@ export interface ResolveTinyCloudHostsOptions {
   /** Verify centralized/blockchain record signatures. Default true. */
   verifyRecords?: boolean;
   /**
-   * Probe for a locally-running TinyCloud node before falling back to
-   * registry/hosted resolution. Default true. Setting false restores the
-   * exact pre-TC-106 resolution order (registry → fallback).
+   * Probe configured and registered local TinyCloud node endpoints before
+   * falling back to registry/hosted resolution. Default true. The loopback
+   * URL is probed only when `localNodeUrl` is explicitly configured.
    */
   autoDiscoverLocalNode?: boolean;
-  /** Local loopback node URL to probe. Default http://127.0.0.1:8000. */
+  /** Local loopback node URL to probe. Omit to avoid probing loopback. */
   localNodeUrl?: string;
   /** Known `*.local.tinycloud.link` subdomain name, probed directly. */
   localLinkName?: string;
@@ -544,17 +544,18 @@ export async function discoverLocalTinyCloudNode(
   const identityStore =
     options.identityStore ?? defaultLocalNodeIdentityStore;
 
-  // Cheap, static candidates first — no network round trip beyond the probe
-  // itself. The registry lookup below is only reached if these don't pan
-  // out, so the common case (a node running at the default loopback) never
-  // pays for an extra registry request.
-  const staticCandidates: LocalNodeCandidate[] = [
-    {
+  // Explicit static candidates first — no network round trip beyond their
+  // probes. Loopback is intentionally opt-in: silently fetching 127.0.0.1
+  // from a web SDK can trigger a browser local-network permission prompt.
+  // Registry-discovered *.local.tinycloud.link candidates remain enabled.
+  const staticCandidates: LocalNodeCandidate[] = [];
+  if (options.localNodeUrl) {
+    staticCandidates.push({
       source: "local-loopback",
-      url: options.localNodeUrl ?? DEFAULT_LOCAL_NODE_URL,
+      url: options.localNodeUrl,
       timeoutMs: LOCAL_LOOPBACK_PROBE_TIMEOUT_MS,
-    },
-  ];
+    });
+  }
   if (options.localLinkName) {
     if (isValidDnsLabel(options.localLinkName)) {
       staticCandidates.push({

--- a/packages/web-sdk/scripts/build-coordinationos-vendor.ts
+++ b/packages/web-sdk/scripts/build-coordinationos-vendor.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const CONTRACT_VERSION = "2.11.0-beta.1";
+const CONTRACT_VERSION = "2.11.0-beta.2";
 const CONTRACT_EXPORTS = [
   "TinyCloudWeb",
   "createOpenKeyCallbackSigningStrategy",

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -121,9 +121,9 @@ export interface Config extends ClientConfig {
   tinycloudRegistryUrl?: string | null;
   /** Fallback TinyCloud hosts. Default: hosted TinyCloud node. */
   tinycloudFallbackHosts?: string[] | null;
-  /** Probe for a locally-running TinyCloud node before registry/fallback resolution. Default: true. */
+  /** Probe configured/registered local nodes before registry/fallback resolution. Default: true. */
   autoDiscoverLocalNode?: boolean;
-  /** Local loopback node URL to probe. Default: http://127.0.0.1:8000. */
+  /** Local loopback node URL to probe. Omit to avoid probing loopback. */
   localNodeUrl?: string;
   /** Known `*.local.tinycloud.link` subdomain name, probed directly. */
   localLinkName?: string;

--- a/packages/web-sdk/tests/coordinationos-vendor.test.ts
+++ b/packages/web-sdk/tests/coordinationos-vendor.test.ts
@@ -6,15 +6,15 @@ import { createCoordinationOsVendorManifest } from "../scripts/build-coordinatio
 test("creates deterministic CoordinationOS vendor metadata for fixed bytes", () => {
   const manifest = createCoordinationOsVendorManifest(
     new TextEncoder().encode("coordinationos-vendor-fixture"),
-    { name: "@tinycloud/web-sdk", version: "2.11.0-beta.1" },
+    { name: "@tinycloud/web-sdk", version: "2.11.0-beta.2" },
   );
 
   expect(`${JSON.stringify(manifest, null, 2)}\n`).toBe(`{
   "schemaVersion": 1,
   "package": "@tinycloud/web-sdk",
-  "version": "2.11.0-beta.1",
+  "version": "2.11.0-beta.2",
   "format": "esm",
-  "entry": "tinycloud-web-sdk-2.11.0-beta.1.mjs",
+  "entry": "tinycloud-web-sdk-2.11.0-beta.2.mjs",
   "sha384": "sha384-zTsa9taxYVJimor3dNdKXbUbVXyzk5gN5aFhdcYYE0abTiwwWLqp7M8ZN34IUiAk",
   "exports": [
     "TinyCloudWeb",
@@ -41,7 +41,7 @@ test("the generated manifest and ESM namespace expose exactly the contract", asy
     await readFile(
       resolve(
         vendorRoot,
-        "tinycloud-web-sdk-2.11.0-beta.1.vendor.json",
+        "tinycloud-web-sdk-2.11.0-beta.2.vendor.json",
       ),
       "utf8",
     ),
@@ -125,7 +125,7 @@ test("the generated manifest and ESM namespace expose exactly the contract", asy
   ];
 
   expect(manifest.format).toBe("esm");
-  expect(manifest.version).toBe("2.11.0-beta.1");
+  expect(manifest.version).toBe("2.11.0-beta.2");
   expect(manifest.exports).toEqual(expected);
   expect(Object.keys(namespace).sort()).toEqual([...expected].sort());
 });

--- a/packages/web-sdk/webpack.coordinationos-vendor.config.cjs
+++ b/packages/web-sdk/webpack.coordinationos-vendor.config.cjs
@@ -6,7 +6,7 @@ module.exports = {
   entry: "./src/coordinationos-vendor.ts",
   output: {
     ...esmConfig.output,
-    filename: "tinycloud-web-sdk-2.11.0-beta.1.mjs",
+    filename: "tinycloud-web-sdk-2.11.0-beta.2.mjs",
     path: path.resolve(__dirname, "dist/vendor"),
   },
 };


### PR DESCRIPTION
## Summary
- stop implicitly probing `http://127.0.0.1:8000` during TinyCloud host resolution
- keep explicit `localNodeUrl`, configured `localLinkName`, and registry-discovered `*.local.tinycloud.link` discovery working
- build the CoordinationOS vendor contract at the current `@tinycloud/web-sdk` package version (`2.11.0-beta.2`)
- update directly related SDK/CLI configuration documentation

## Tests
- `bun test packages/sdk-core/src/location.test.ts packages/sdk-core/src/capabilities.test.ts packages/web-sdk/tests/openkey-session.test.ts` (132 pass)
- `bunx turbo build --filter=@tinycloud/web-sdk...` (8 packages pass)
- `bun run --cwd packages/web-sdk build:coordinationos-vendor`
- `bun test packages/web-sdk/tests/coordinationos-vendor.test.ts` (3 pass)
- `bun run --cwd packages/sdk-core build`
- `bun run --cwd packages/web-sdk lint`

Includes latest master capability restore fix from #374.