### PR TITLE
TC-407: performance optimization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -226,9 +226,10 @@
       "version": "2.11.0-beta.4",
       "dependencies": {
         "@tinycloud/node-sdk-wasm": "1.7.5",
-        "@tinycloud/sdk-core": "2.9.0",
-        "@tinycloud/sdk-services": "2.8.0",
+        "@tinycloud/sdk-core": "2.11.0-beta.4",
+        "@tinycloud/sdk-services": "2.10.0",
         "siwe": "^3.0.0",
+        "undici": "^6.21.0",
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -262,7 +263,7 @@
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "1.8.0",
         "@tinycloud/bootstrap": "2.6.0",
-        "@tinycloud/sdk-services": "2.8.0",
+        "@tinycloud/sdk-services": "2.10.0",
         "ms": "^2.1.3",
         "multiformats": "^13.4.1",
         "siwe": "^3.0.0",
@@ -5084,7 +5085,7 @@
 
     "underscore": ["underscore@1.13.6", "", {}, "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="],
 
-    "undici": ["undici@7.21.0", "", {}, "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg=="],
+    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -5895,6 +5896,8 @@
     "cbw-sdk/clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
 
     "cbw-sdk/preact": ["preact@10.28.3", "", {}, "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA=="],
+
+    "cheerio/undici": ["undici@7.21.0", "", {}, "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -36,7 +36,8 @@
     "@tinycloud/sdk-services": "2.10.0",
     "@tinycloud/sdk-core": "2.11.0-beta.4",
     "@tinycloud/node-sdk-wasm": "1.7.5",
-    "siwe": "^3.0.0"
+    "siwe": "^3.0.0",
+    "undici": "6.28.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/node-sdk/src/DelegatedAccess.ts
+++ b/packages/node-sdk/src/DelegatedAccess.ts
@@ -60,6 +60,13 @@ export class DelegatedAccess {
     invoke: InvokeFunction,
     invokeAny?: InvokeAnyFunction,
     telemetry?: TelemetryConfig,
+    /**
+     * Fetch implementation to use for every request this access makes
+     * (TC-407). Callers should pass the owning `TinyCloudNode`'s resolved
+     * instance fetch so delegated access observes the same configured
+     * transport. Defaults to global fetch for standalone use.
+     */
+    fetchFn: typeof fetch = globalThis.fetch.bind(globalThis),
   ) {
     this.session = session;
     this._delegation = delegation;
@@ -73,7 +80,7 @@ export class DelegatedAccess {
     this._serviceContext = new ServiceContext({
       invoke,
       invokeAny,
-      fetch: globalThis.fetch.bind(globalThis),
+      fetch: fetchFn,
       hosts: [host],
       telemetry,
     });

--- a/packages/node-sdk/src/TinyCloudNode.ts
+++ b/packages/node-sdk/src/TinyCloudNode.ts
@@ -682,6 +682,17 @@ export interface TinyCloudNodeConfig {
   autoBootstrapAccount?: boolean;
   /** Default-off service telemetry. */
   telemetry?: TelemetryConfig;
+  /**
+   * Explicit fetch override (TC-407). Resolved once for this instance's
+   * lifetime and used for every request the instance makes — discovery,
+   * sign-in, service graphs, and raw host calls alike. Bypasses the
+   * Node-registered bounded default transport entirely and is isolated
+   * from other clients (including for activation single-flight
+   * coalescing). Defaults to the Node-registered bounded transport, or
+   * plain global fetch when no Node defaults are registered (e.g. under
+   * `/core` in browser builds).
+   */
+  fetch?: typeof fetch;
 }
 
 /**
@@ -873,6 +884,12 @@ function authorizationHeader(headers: Record<string, string> | [string, string][
 export interface NodeDefaults {
   createWasmBindings: () => IWasmBindings;
   createSigner: (privateKey: string, chainId?: number) => ISigner;
+  /**
+   * Returns the process-wide bounded default fetch (TC-407). Registered only
+   * by the Node entry point so the `/core` (browser) entry point never
+   * touches the Undici-backed transport module.
+   */
+  createDefaultFetch?: () => typeof fetch;
 }
 
 export class TinyCloudNode {
@@ -891,6 +908,15 @@ export class TinyCloudNode {
   private tc: TinyCloud | null = null;
   private _address?: string;
   private _chainId: number = 1;
+  /**
+   * The single fetch selected for this instance's lifetime (TC-407):
+   * `config.fetch` if provided, else the Node-registered bounded default,
+   * else plain global fetch (e.g. under `/core` in browser builds). Every
+   * normal instance request — discovery, sign-in, service graphs, and the
+   * raw `/info`/share/encryption calls — is threaded through this same
+   * value so a configured fetch is observed everywhere.
+   */
+  private readonly _fetch: typeof fetch;
   private wasmBindings: IWasmBindings;
   private sessionManager: ISessionManager;
   private _serviceGraph!: ServiceGraphLifetime;
@@ -1092,6 +1118,19 @@ export class TinyCloudNode {
       host: config.host ?? DEFAULT_HOST,
     };
 
+    // Resolve exactly one fetch for this instance's lifetime (TC-407): an
+    // explicit override wins outright and is fully isolated from the
+    // module-shared default; otherwise use the Node-registered bounded
+    // transport, or plain global fetch when no Node defaults are registered
+    // (e.g. under `/core` in browser builds). The plain-global-fetch case
+    // forwards rather than eagerly `.bind()`s so a caller that reassigns
+    // `globalThis.fetch` after construction (e.g. a test double) is still
+    // observed.
+    this._fetch =
+      config.fetch ??
+      TinyCloudNode.nodeDefaults?.createDefaultFetch?.() ??
+      ((input, init) => globalThis.fetch(input, init));
+
     // Initialize WASM bindings (uses registered Node defaults if not provided)
     if (config.wasmBindings) {
       this.wasmBindings = config.wasmBindings;
@@ -1163,7 +1202,7 @@ export class TinyCloudNode {
         // Create a new service context for the KV service
         const kvContext = receiveOnlyGraph.track(new ServiceContext({
           invoke: config.invoke,
-          fetch: config.fetch ?? globalThis.fetch.bind(globalThis),
+          fetch: config.fetch ?? this._fetch,
           hosts: config.hosts,
           telemetry: this.config.telemetry,
         }));
@@ -1212,6 +1251,7 @@ export class TinyCloudNode {
       localLinkName: config.localLinkName,
       expectedNodeDid: config.expectedNodeDid,
       localNodeIdentityStore: config.localNodeIdentityStore,
+      fetch: this._fetch,
       autoCreateSpace: useBootstrapSignInRequest ? false : config.autoCreateSpace,
       enablePublicSpace: config.enablePublicSpace ?? true,
       spaceCreationHandler: useBootstrapSignInRequest
@@ -1246,10 +1286,9 @@ export class TinyCloudNode {
     return new ServiceGraphLifetime(
       this.invokeWithRuntimePermissions,
       this.invokeAnyWithRuntimePermissions,
-      // Resolve fetch at request time. This keeps the graph-owned lifetime
-      // signal while preserving the SDK's existing injectable global fetch
-      // behavior (including adapters that install it after construction).
-      (url, init) => globalThis.fetch(url, init),
+      // Route every graph request through this instance's single resolved
+      // fetch (TC-407) rather than the raw global — see `this._fetch`.
+      (url, init) => this._fetch(url, init),
     );
   }
 
@@ -1674,7 +1713,7 @@ export class TinyCloudNode {
       if (!session) {
         throw new Error(`Missing bootstrap session for ${step.space}`);
       }
-      const activated = await activateSessionWithHost(host, session.delegationHeader);
+      const activated = await activateSessionWithHost(host, session.delegationHeader, this._fetch);
       if (!activated.success || activated.skipped?.includes(step.spaceId)) {
         throw new Error(
           `Failed to activate bootstrap session for ${step.spaceId}: ${
@@ -2104,7 +2143,7 @@ export class TinyCloudNode {
       throw new Error("Owned space hosting requires a TinyCloud host");
     }
 
-    const activation = await activateSessionWithHost(host, session.delegationHeader);
+    const activation = await activateSessionWithHost(host, session.delegationHeader, this._fetch);
     if (activation.success && !activation.skipped?.includes(spaceId)) {
       this.confirmedHostedSpaceIds.add(spaceId);
       return;
@@ -2123,7 +2162,7 @@ export class TinyCloudNode {
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    const retry = await activateSessionWithHost(host, session.delegationHeader);
+    const retry = await activateSessionWithHost(host, session.delegationHeader, this._fetch);
     if (!retry.success || retry.skipped?.includes(spaceId)) {
       throw new Error(
         `Failed to activate session after creating owned space ${spaceId}: ${
@@ -2180,6 +2219,7 @@ export class TinyCloudNode {
     const activation = await activateSessionWithHost(
       host,
       this.auth.tinyCloudSession.delegationHeader,
+      this._fetch,
     );
     if (!activation.success || activation.skipped?.includes(spaceId)) {
       throw new Error(
@@ -2760,7 +2800,7 @@ export class TinyCloudNode {
         const service = new KVService({ prefix: config.pathPrefix?.replace(/\/$/, '') });
         const context = graph.track(new ServiceContext({
           invoke: config.invoke,
-          fetch: config.fetch ?? globalThis.fetch.bind(globalThis),
+          fetch: config.fetch ?? this._fetch,
           hosts: config.hosts,
           telemetry: this.config.telemetry,
         }));
@@ -2910,6 +2950,7 @@ export class TinyCloudNode {
       localLinkName: this.config.localLinkName,
       expectedNodeDid: this.config.expectedNodeDid,
       localNodeIdentityStore: this.config.localNodeIdentityStore,
+      fetch: this._fetch,
     });
     return resolved.hosts[0];
   }
@@ -2984,6 +3025,7 @@ export class TinyCloudNode {
       localLinkName: this.config.localLinkName,
       expectedNodeDid: this.config.expectedNodeDid,
       localNodeIdentityStore: this.config.localNodeIdentityStore,
+      fetch: this._fetch,
       autoCreateSpace: useBootstrapSignInRequest ? false : this.config.autoCreateSpace,
       enablePublicSpace: this.config.enablePublicSpace ?? true,
       spaceCreationHandler: useBootstrapSignInRequest
@@ -3051,6 +3093,7 @@ export class TinyCloudNode {
       localLinkName: this.config.localLinkName,
       expectedNodeDid: this.config.expectedNodeDid,
       localNodeIdentityStore: this.config.localNodeIdentityStore,
+      fetch: this._fetch,
       autoCreateSpace: useBootstrapSignInRequest ? false : this.config.autoCreateSpace,
       enablePublicSpace: this.config.enablePublicSpace ?? true,
       spaceCreationHandler: useBootstrapSignInRequest
@@ -3266,7 +3309,7 @@ export class TinyCloudNode {
     const cached = this.auth?.nodeIdForHost(this.config.host!);
     if (cached) return cached;
 
-    const response = await fetch(`${this.config.host}/info`);
+    const response = await this._fetch(`${this.config.host}/info`);
     if (!response.ok) {
       throw new Error(`Failed to fetch node info: HTTP ${response.status}`);
     }
@@ -3541,7 +3584,7 @@ export class TinyCloudNode {
           return self._publicKV ?? self.tc!.publicKV;
         },
         readPublicSpace: <T>(host: string, targetSpaceId: string, key: string) =>
-          TinyCloud.readPublicSpace<T>(host, targetSpaceId, key),
+          TinyCloud.readPublicSpace<T>(host, targetSpaceId, key, self._fetch),
         makePublicSpaceId: TinyCloud.makePublicSpaceId,
         did,
         address: address ?? "",
@@ -3854,7 +3897,7 @@ export class TinyCloudNode {
     const signature = await this.signer.signMessage(prepared.siwe);
     assertOwnerGraphActive();
     const delegationSession = this.wasmBindings.completeSessionSetup({ ...prepared, signature });
-    const activation = await activateSessionWithHost(host, delegationSession.delegationHeader);
+    const activation = await activateSessionWithHost(host, delegationSession.delegationHeader, this._fetch);
     assertOwnerGraphActive();
     if (!activation.success) {
       throw new Error(`Owner delegation import failed: ${activation.status} ${activation.error ?? ""}`.trim());
@@ -3891,7 +3934,7 @@ export class TinyCloudNode {
   ): Promise<OwnerSharePolicyRegistrationReceipt> {
     this._serviceGraph.assertActive();
     if (params.policy.bytes.byteLength > 2 * 1024 * 1024) throw new Error("Owner share policy is too large");
-    const response = await fetch(`${this.config.host!}/share/v2/policies`, {
+    const response = await this._fetch(`${this.config.host!}/share/v2/policies`, {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json" },
       body: JSON.stringify({
@@ -3904,7 +3947,14 @@ export class TinyCloudNode {
     if (!response.ok) {
       let code = "";
       try {
-        const body = await response.clone().json() as { readonly error?: { readonly code?: unknown } };
+        // Read the body once via `.text()` rather than `.clone().json()`:
+        // the pooled Node transport only tracks a checked-out connection as
+        // released once *this* response's own body-consuming methods
+        // settle (see nodeTransport.ts's `wrapResponseForRelease`); `clone()`
+        // hands back an independent `Response` whose consumption that
+        // tracking never observes, leaking the slot on every non-2xx reply.
+        const text = await response.text();
+        const body = JSON.parse(text) as { readonly error?: { readonly code?: unknown } };
         if (typeof body.error?.code === "string") code = ` ${body.error.code}`;
       } catch {
         // Keep the stable HTTP failure when the server did not return JSON.
@@ -3954,7 +4004,7 @@ export class TinyCloudNode {
     const requestBodyDigest = base64UrlEncode(new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonicalizeEncryptionJson(body)))));
     const request = { ...body, requestBodyDigest };
     const authorization = authorizationHeader(this.invokeAnyWithRuntimePermissions(serviceSession, [{ spaceId: session.spaceId, service: "kv", path: input.resourcePath, action: "tinycloud.kv/get" }]));
-    const response = await fetch(`${this.config.host!}/share/v2/deliveries/authorize`, {
+    const response = await this._fetch(`${this.config.host!}/share/v2/deliveries/authorize`, {
       method: "POST",
       headers: { accept: "application/json", "content-type": "application/json", authorization },
       body: canonicalizeEncryptionJson(request),
@@ -4145,7 +4195,7 @@ export class TinyCloudNode {
     return this.fetchEncryptionNetworkAt(
       this.config.host!,
       networkId,
-      globalThis.fetch.bind(globalThis),
+      this._fetch,
     );
   }
 
@@ -4177,7 +4227,7 @@ export class TinyCloudNode {
       action: NETWORK_CREATE_ACTION,
       facts,
     });
-    const response = await fetch(`${this.config.host}/encryption/networks`, {
+    const response = await this._fetch(`${this.config.host}/encryption/networks`, {
       method: "POST",
       headers: {
         Authorization: signed.authorization,
@@ -4568,6 +4618,7 @@ export class TinyCloudNode {
     const activateResult = await activateSessionWithHost(
       targetHost,
       delegation.delegationHeader,
+      this._fetch,
     );
     if (!activateResult.success) {
       throw new Error(
@@ -4681,6 +4732,7 @@ export class TinyCloudNode {
       const activateResult = await activateSessionWithHost(
         this.config.host!,
         delegatedSession.delegationHeader,
+        this._fetch,
       );
       if (!activateResult.success) {
         throw new Error(
@@ -4893,7 +4945,8 @@ export class TinyCloudNode {
 
     const activateResult = await activateSessionWithHost(
       this.config.host!,
-      delegationSession.delegationHeader
+      delegationSession.delegationHeader,
+      this._fetch,
     );
 
     if (!activateResult.success) {
@@ -5394,6 +5447,7 @@ export class TinyCloudNode {
     const activateResult = await activateSessionWithHost(
       this.config.host!,
       delegationHeader,
+      this._fetch,
     );
     if (!activateResult.success) {
       throw new Error(
@@ -5440,6 +5494,7 @@ export class TinyCloudNode {
     const activateResult = await activateSessionWithHost(
       targetHost,
       delegationHeader,
+      this._fetch,
     );
     if (!activateResult.success) {
       throw new Error(
@@ -6300,7 +6355,8 @@ export class TinyCloudNode {
     // Activate the delegation with the server
     const activateResult = await activateSessionWithHost(
       this.config.host!,
-      delegationSession.delegationHeader
+      delegationSession.delegationHeader,
+      this._fetch,
     );
 
     if (!activateResult.success) {
@@ -6349,7 +6405,8 @@ export class TinyCloudNode {
 
       const publicActivateResult = await activateSessionWithHost(
         this.config.host!,
-        publicSession.delegationHeader
+        publicSession.delegationHeader,
+        this._fetch,
       );
 
       if (publicActivateResult.success) {
@@ -6439,6 +6496,7 @@ export class TinyCloudNode {
         this.wasmBindings.invoke,
         this.wasmBindings.invokeAny,
         this.config.telemetry,
+        this._fetch,
       );
     }
 
@@ -6495,7 +6553,8 @@ export class TinyCloudNode {
     // Activate with server
     const activateResult = await activateSessionWithHost(
       targetHost,
-      invokerSession.delegationHeader
+      invokerSession.delegationHeader,
+      this._fetch,
     );
 
     if (!activateResult.success) {
@@ -6537,6 +6596,7 @@ export class TinyCloudNode {
       this.wasmBindings.invoke,
       this.wasmBindings.invokeAny,
       this.config.telemetry,
+      this._fetch,
     );
   }
 
@@ -6650,7 +6710,8 @@ export class TinyCloudNode {
     // Activate the sub-delegation with the server
     const activateResult = await activateSessionWithHost(
       targetHost,
-      subDelegationSession.delegationHeader
+      subDelegationSession.delegationHeader,
+      this._fetch,
     );
 
     if (!activateResult.success) {

--- a/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
+++ b/packages/node-sdk/src/authorization/NodeUserAuthorization.ts
@@ -153,6 +153,15 @@ export interface NodeUserAuthorizationConfig {
   capabilityRequest?: ComposedManifestRequest;
   /** Include implicit account registry permissions when composing `manifest`. Default true. */
   includeAccountRegistryPermissions?: boolean;
+  /**
+   * Fetch implementation to use for every network request this instance
+   * makes (TC-407): host resolution, `/info`, peer-ID lookup, host
+   * delegation, and session activation. Callers should pass the same
+   * resolved fetch used elsewhere (e.g. `TinyCloudNode`'s configured/pooled
+   * default) so a configured transport is observed everywhere. Defaults to
+   * global fetch.
+   */
+  fetch?: typeof fetch;
 }
 
 export interface CreateBootstrapSessionOptions {
@@ -241,9 +250,16 @@ export class NodeUserAuthorization implements IUserAuthorization {
    */
   private _nodeInfoIdentity?: { host: string; nodeId: string };
   private _lastActivationSkippedSpaceIds: string[] = [];
+  /** The single fetch resolved for this instance's lifetime (TC-407). */
+  private readonly fetch: typeof fetch;
 
   constructor(config: NodeUserAuthorizationConfig) {
     this.wasm = config.wasmBindings;
+    // Forward rather than eagerly `.bind()` the current `globalThis.fetch`
+    // when no override is supplied: this instance is long-lived, so a
+    // caller that reassigns `globalThis.fetch` after construction (e.g. a
+    // test double) must still be observed.
+    this.fetch = config.fetch ?? ((input, init) => globalThis.fetch(input, init));
 
     this.signer = config.signer;
     this.signStrategy = config.signStrategy ?? defaultSignStrategy;
@@ -463,6 +479,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       localLinkName: this.localLinkName,
       expectedNodeDid: this.expectedNodeDid,
       localNodeIdentityStore: this.localNodeIdentityStore,
+      fetch: this.fetch,
     });
     this.tinycloudHosts = resolved.hosts;
   }
@@ -711,7 +728,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const spaceId = targetSpaceId ?? this._tinyCloudSession.spaceId;
 
     // Get peer ID from TinyCloud server
-    const peerId = await fetchPeerId(host, spaceId);
+    const peerId = await fetchPeerId(host, spaceId, this.fetch);
 
     // Generate host SIWE message
     const siwe = this.wasm.generateHostSIWEMessage({
@@ -728,7 +745,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
 
     // Convert to delegation headers and submit
     const headers = this.wasm.siweToDelegationHeaders({ siwe, signature });
-    const result = await submitHostDelegation(host, headers);
+    const result = await submitHostDelegation(host, headers, this.fetch);
 
     return result.success;
   }
@@ -773,6 +790,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const result = await activateSessionWithHost(
       host,
       this._tinyCloudSession.delegationHeader,
+      this.fetch,
     );
     this.recordActivationSkippedSpaces(result, primarySpaceId);
 
@@ -835,6 +853,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       const retryResult = await activateSessionWithHost(
         host,
         this._tinyCloudSession.delegationHeader,
+        this.fetch,
       );
 
       if (!retryResult.success) {
@@ -880,6 +899,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
       const retryResult = await activateSessionWithHost(
         host,
         this._tinyCloudSession.delegationHeader,
+        this.fetch,
       );
 
       if (!retryResult.success) {
@@ -1116,6 +1136,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const nodeInfo = await checkNodeInfo(
       infoHost,
       this.wasm.protocolVersion(),
+      this.fetch,
     );
     this._nodeFeatures = nodeInfo.features;
     // `/info` already told us the node DID. Keep it so encryption-network
@@ -1372,6 +1393,7 @@ export class NodeUserAuthorization implements IUserAuthorization {
     const nodeInfo = await checkNodeInfo(
       infoHost,
       this.wasm.protocolVersion(),
+      this.fetch,
     );
     this._nodeFeatures = nodeInfo.features;
     // `/info` already told us the node DID. Keep it so encryption-network

--- a/packages/node-sdk/src/nodeDefaults.ts
+++ b/packages/node-sdk/src/nodeDefaults.ts
@@ -1,13 +1,14 @@
 /**
  * Node.js-specific defaults registration.
  *
- * Importing this module registers NodeWasmBindings and PrivateKeySigner
- * as default factories on TinyCloudNode, so Node.js users get the same
- * zero-config experience (e.g., `new TinyCloudNode({ privateKey: '...' })`).
+ * Importing this module registers NodeWasmBindings, PrivateKeySigner, and a
+ * bounded Undici-backed default fetch as default factories on TinyCloudNode,
+ * so Node.js users get the same zero-config experience (e.g.,
+ * `new TinyCloudNode({ privateKey: '...' })`).
  *
  * The main entry point (index.ts) imports this for side effects.
  * The /core entry point does NOT import this, keeping it free of
- * @tinycloud/node-sdk-wasm dependencies for browser bundling.
+ * @tinycloud/node-sdk-wasm and `undici` dependencies for browser bundling.
  *
  * @packageDocumentation
  */
@@ -15,8 +16,10 @@
 import { NodeWasmBindings } from "./NodeWasmBindings";
 import { PrivateKeySigner } from "./signers/PrivateKeySigner";
 import { TinyCloudNode } from "./TinyCloudNode";
+import { getDefaultNodeFetch } from "./transport/nodeTransport";
 
 TinyCloudNode.registerNodeDefaults({
   createWasmBindings: () => new NodeWasmBindings(),
   createSigner: (privateKey: string, chainId?: number) => new PrivateKeySigner(privateKey, chainId),
+  createDefaultFetch: () => getDefaultNodeFetch(),
 });

--- a/packages/node-sdk/src/transport/nodeTransport.test.ts
+++ b/packages/node-sdk/src/transport/nodeTransport.test.ts
@@ -1,0 +1,590 @@
+/**
+ * Tests for the Node bounded transport (TC-407).
+ *
+ * These exercise the pool registry directly via `getSharedNodeTransportManager()`
+ * rather than through `getDefaultNodeFetch()`, because the test runner itself is
+ * Bun (`bun test`), and `getDefaultNodeFetch()`'s Bun-runtime check would always
+ * route through plain global fetch under that runner — never exercising the
+ * pooled path. Hitting the manager directly is what a Node-only consumer's
+ * `getDefaultNodeFetch()` call resolves to at runtime.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import {
+  BoundedNodeTransportManager,
+  MAX_CONNECTIONS_PER_ORIGIN,
+  MAX_QUEUED_PER_ORIGIN,
+  MAX_RETAINED_ORIGINS,
+  TransportManagerClosedError,
+  TransportOriginLimitError,
+  TransportQueueLimitError,
+  __resetNodeTransportForTests,
+  getSharedNodeTransportManager,
+} from "./nodeTransport";
+
+/** A local HTTP server that assigns a monotonically increasing ID to each raw TCP connection. */
+class ConnectionTrackingServer {
+  readonly server: http.Server;
+  readonly url: string;
+  readonly connectionIdsByRequest: number[] = [];
+  activeSockets = 0;
+  peakActiveSockets = 0;
+  requestCount = 0;
+
+  private nextConnectionId = 0;
+  private readonly socketIds = new WeakMap<import("node:net").Socket, number>();
+
+  private constructor(server: http.Server, url: string) {
+    this.server = server;
+    this.url = url;
+  }
+
+  static async start(
+    handler: (req: http.IncomingMessage, res: http.ServerResponse, connectionId: number) => void,
+  ): Promise<ConnectionTrackingServer> {
+    const server = http.createServer();
+    const instance = new ConnectionTrackingServer(server, "");
+    server.on("connection", (socket) => {
+      const id = instance.nextConnectionId++;
+      instance.socketIds.set(socket, id);
+      instance.activeSockets++;
+      instance.peakActiveSockets = Math.max(instance.peakActiveSockets, instance.activeSockets);
+      socket.on("close", () => {
+        instance.activeSockets--;
+      });
+    });
+    server.on("request", (req, res) => {
+      instance.requestCount++;
+      const socketId = instance.socketIds.get(req.socket) ?? -1;
+      instance.connectionIdsByRequest.push(socketId);
+      // Fully drain the request body before responding, per test-plan requirement.
+      req.resume();
+      handler(req, res, socketId);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    (instance as { url: string }).url = `http://127.0.0.1:${port}`;
+    return instance;
+  }
+
+  distinctConnectionIds(): Set<number> {
+    return new Set(this.connectionIdsByRequest);
+  }
+
+  async close(): Promise<void> {
+    // A destroyed/discarded client-side socket doesn't always propagate to
+    // Bun's `node:http` server-side socket bookkeeping promptly (verified:
+    // the same destroy-then-reconnect sequence settles immediately under
+    // real Node — see nodeTransport.ts's module header). `closeAllConnections`
+    // forces the issue; the timeout is a last-resort bound so that Bun-only
+    // teardown latency in this test harness can never hang the suite.
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const settle = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        err ? reject(err) : resolve();
+      };
+      this.server.close((err) => settle(err ?? undefined));
+      this.server.closeAllConnections?.();
+      setTimeout(() => settle(), 2000).unref();
+    });
+  }
+}
+
+function jsonOk(res: http.ServerResponse, body: unknown = { ok: true }): void {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+let manager: BoundedNodeTransportManager | undefined;
+const servers: ConnectionTrackingServer[] = [];
+
+afterEach(async () => {
+  if (manager) {
+    await manager.shutdown();
+    manager = undefined;
+  }
+  await __resetNodeTransportForTests();
+  await Promise.all(servers.splice(0).map((s) => s.close()));
+});
+
+describe("BoundedNodeTransportManager: sequential reuse", () => {
+  test("20 sequential body-consuming requests to one origin use exactly one connection", async () => {
+    const server = await ConnectionTrackingServer.start((_req, res) => jsonOk(res));
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    for (let i = 0; i < 20; i++) {
+      const res = await manager.fetch(`${server.url}/kv/get`);
+      expect(res.ok).toBe(true);
+      await res.json();
+    }
+
+    expect(server.requestCount).toBe(20);
+    expect(server.distinctConnectionIds().size).toBe(1);
+  }, 10000);
+
+  test("a server-initiated close after request 10 yields exactly two connections and all requests complete", async () => {
+    let requestIndex = 0;
+    const server = await ConnectionTrackingServer.start((_req, res) => {
+      requestIndex++;
+      if (requestIndex === 10) {
+        res.setHeader("Connection", "close");
+      }
+      jsonOk(res, { requestIndex });
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    for (let i = 0; i < 20; i++) {
+      const res = await manager.fetch(`${server.url}/kv/get`);
+      expect(res.ok).toBe(true);
+      await res.json();
+    }
+
+    expect(server.requestCount).toBe(20);
+    expect(server.distinctConnectionIds().size).toBe(2);
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: concurrency bound", () => {
+  test("concurrent requests to one origin never exceed MAX_CONNECTIONS_PER_ORIGIN active sockets", async () => {
+    const server = await ConnectionTrackingServer.start((_req, res) => {
+      // Hold the response open briefly so several requests overlap in flight.
+      setTimeout(() => jsonOk(res), 75);
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    const concurrency = MAX_CONNECTIONS_PER_ORIGIN * 3;
+    await Promise.all(
+      Array.from({ length: concurrency }, () =>
+        manager!.fetch(`${server.url}/kv/get`).then((res) => res.json()),
+      ),
+    );
+
+    expect(server.requestCount).toBe(concurrency);
+    expect(server.peakActiveSockets).toBeLessThanOrEqual(MAX_CONNECTIONS_PER_ORIGIN);
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: origin retention bound", () => {
+  test("more than MAX_RETAINED_ORIGINS origins never grow the registry past the bound", async () => {
+    manager = new BoundedNodeTransportManager();
+    const originCount = MAX_RETAINED_ORIGINS + 1;
+
+    for (let i = 0; i < originCount; i++) {
+      const server = await ConnectionTrackingServer.start((_req, res) => jsonOk(res));
+      servers.push(server);
+      const res = await manager.fetch(`${server.url}/info`);
+      await res.json();
+      expect(manager.originCount).toBeLessThanOrEqual(MAX_RETAINED_ORIGINS);
+    }
+
+    expect(manager.originCount).toBeLessThanOrEqual(MAX_RETAINED_ORIGINS);
+  }, 20000);
+
+  test("more than MAX_RETAINED_ORIGINS concurrent first-time requests to distinct origins never admit more than the bound", async () => {
+    manager = new BoundedNodeTransportManager();
+    const originCount = MAX_RETAINED_ORIGINS + 1;
+
+    const localServers: ConnectionTrackingServer[] = [];
+    for (let i = 0; i < originCount; i++) {
+      const server = await ConnectionTrackingServer.start((_req, res) => jsonOk(res));
+      servers.push(server);
+      localServers.push(server);
+    }
+
+    // Fire every origin's first request in the same synchronous burst
+    // (no `await` between them) so their admission checks race exactly as
+    // TransportOriginLimitError's fix targets: none of these origins is
+    // registered in `origins` yet when the others' checks run.
+    const results = await Promise.allSettled(
+      localServers.map((server) => manager!.fetch(`${server.url}/info`).then((res) => res.json())),
+    );
+
+    // At most MAX_RETAINED_ORIGINS of the (MAX_RETAINED_ORIGINS + 1)
+    // concurrent distinct-origin requests may succeed; the rest must be
+    // rejected with TransportOriginLimitError rather than the registry
+    // silently growing past the bound.
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled.length).toBeLessThanOrEqual(MAX_RETAINED_ORIGINS);
+    expect(rejected.length).toBeGreaterThanOrEqual(1);
+    for (const r of rejected) {
+      expect((r as PromiseRejectedResult).reason).toBeInstanceOf(TransportOriginLimitError);
+    }
+    expect(manager.originCount).toBeLessThanOrEqual(MAX_RETAINED_ORIGINS);
+  }, 20000);
+});
+
+describe("BoundedNodeTransportManager: ownership and lifecycle", () => {
+  test("getSharedNodeTransportManager() returns the same instance across calls", () => {
+    const a = getSharedNodeTransportManager();
+    const b = getSharedNodeTransportManager();
+    expect(a).toBe(b);
+  });
+
+  test("multiple consumers of the shared manager reuse one pool per origin, not one per caller", async () => {
+    const server = await ConnectionTrackingServer.start((_req, res) => jsonOk(res));
+    servers.push(server);
+
+    const shared = getSharedNodeTransportManager();
+    // Simulate two independent TinyCloudNode instances resolving the same
+    // process-wide default and issuing requests through it.
+    const fetchA = shared.fetch;
+    const fetchB = shared.fetch;
+
+    for (let i = 0; i < 5; i++) {
+      await (await fetchA(`${server.url}/a`)).json();
+      await (await fetchB(`${server.url}/b`)).json();
+    }
+
+    expect(server.distinctConnectionIds().size).toBe(1);
+  }, 10000);
+
+  test("__resetNodeTransportForTests() deterministically closes sockets and starts a fresh manager", async () => {
+    const server = await ConnectionTrackingServer.start((_req, res) => jsonOk(res));
+    servers.push(server);
+
+    const shared = getSharedNodeTransportManager();
+    await (await shared.fetch(`${server.url}/kv/get`)).json();
+    expect(shared.originCount).toBe(1);
+
+    await __resetNodeTransportForTests();
+
+    const fresh = getSharedNodeTransportManager();
+    expect(fresh).not.toBe(shared);
+    expect(fresh.originCount).toBe(0);
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: non-2xx error-body release", () => {
+  test("reading a non-2xx response body directly (not via .clone()) releases the connection for reuse", async () => {
+    // Mirrors TinyCloudNode.registerOwnerSharePolicy's error path: on a
+    // non-2xx reply it reads the body once via `.text()`/`JSON.parse` to
+    // extract an error code, rather than `.clone().json()` — `clone()`
+    // returns an independent `Response` this pool's release tracking never
+    // observes being consumed, which used to leak the checked-out client on
+    // every non-2xx reply.
+    const server = await ConnectionTrackingServer.start((_req, res) => {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { code: "bad_request" } }));
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    for (let i = 0; i < MAX_CONNECTIONS_PER_ORIGIN + 1; i++) {
+      const res = await manager.fetch(`${server.url}/share/v2/policies`, { method: "POST" });
+      expect(res.ok).toBe(false);
+      const body = JSON.parse(await res.text()) as { error: { code: string } };
+      expect(body.error.code).toBe("bad_request");
+    }
+
+    // More non-2xx requests than the pool has connections all completed
+    // above; a release leak would have exhausted every slot and hung this
+    // follow-up request behind a queue that never drains.
+    expect(server.distinctConnectionIds().size).toBe(1);
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: connection-failure surfacing", () => {
+  test("a connection reset after the request body is received surfaces after exactly one attempt", async () => {
+    let requestCount = 0;
+    const server = await ConnectionTrackingServer.start((req, res) => {
+      requestCount++;
+      // Destroy the socket after reading the body, without responding —
+      // no automatic transport-level retry should paper over this.
+      req.on("end", () => res.socket?.destroy());
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    await expect(
+      manager.fetch(`${server.url}/kv/put`, {
+        method: "POST",
+        body: JSON.stringify({ authenticated: true }),
+      }),
+    ).rejects.toBeTruthy();
+
+    expect(requestCount).toBe(1);
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: Hooks/SSE streaming release", () => {
+  test("draining response.body directly (not via .json()/.text()) releases the connection for reuse", async () => {
+    const server = await ConnectionTrackingServer.start((req, res) => {
+      if (req.url === "/hooks/subscribe") {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write("data: hello\n\n");
+        res.end();
+        return;
+      }
+      jsonOk(res);
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    const streamRes = await manager.fetch(`${server.url}/hooks/subscribe`);
+    const reader = streamRes.body!.getReader();
+    // Drain to completion exactly like HooksService's async-iterator path.
+    while (!(await reader.read()).done) {
+      // keep draining
+    }
+
+    // A sequential request must reuse the same connection — proof the first
+    // request's client was actually released back to the pool once the
+    // stream finished, even though `.json()`/`.text()` was never called.
+    const kvRes = await manager.fetch(`${server.url}/kv/get`);
+    await kvRes.json();
+
+    expect(server.distinctConnectionIds().size).toBe(1);
+  }, 10000);
+
+  test("cancelling a response.body stream discards the connection instead of reusing it", async () => {
+    const server = await ConnectionTrackingServer.start((req, res) => {
+      if (req.url === "/hooks/subscribe") {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write("data: first\n\n");
+        // Deliberately never ends — the client cancels instead of waiting.
+        return;
+      }
+      jsonOk(res);
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    const streamRes = await manager.fetch(`${server.url}/hooks/subscribe`);
+    const reader = streamRes.body!.getReader();
+    await reader.read();
+    await reader.cancel();
+
+    const kvRes = await manager.fetch(`${server.url}/kv/get`);
+    await kvRes.json();
+
+    // A cancelled stream leaves unknown bytes in flight on the socket, so
+    // per TC-407's discard policy the connection must be destroyed rather
+    // than reused — the follow-up request opens a fresh, second connection.
+    expect(server.distinctConnectionIds().size).toBe(2);
+  }, 10000);
+
+  test("repeatedly opening and cancelling streams does not starve ordinary KV traffic on the same origin", async () => {
+    const server = await ConnectionTrackingServer.start((req, res) => {
+      if (req.url === "/hooks/subscribe") {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write("data: tick\n\n");
+        // Never ends on its own — every stream is cancelled by the client.
+        return;
+      }
+      jsonOk(res);
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    // Open and cancel more streams than the pool has connections. A release
+    // leak would permanently occupy the whole pool after this loop.
+    for (let i = 0; i < MAX_CONNECTIONS_PER_ORIGIN * 2; i++) {
+      const streamRes = await manager.fetch(`${server.url}/hooks/subscribe`);
+      const reader = streamRes.body!.getReader();
+      await reader.read();
+      await reader.cancel();
+    }
+
+    const kvRes = await manager.fetch(`${server.url}/kv/get`);
+    expect((await kvRes.json()).ok).toBe(true);
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: active-origin pressure", () => {
+  test("a new origin is rejected with TransportOriginLimitError when every retained origin is active", async () => {
+    manager = new BoundedNodeTransportManager();
+    const releaseFns: Array<() => void> = [];
+    const pending: Array<Promise<unknown>> = [];
+
+    for (let i = 0; i < MAX_RETAINED_ORIGINS; i++) {
+      const server = await ConnectionTrackingServer.start((_req, res) => {
+        releaseFns.push(() => jsonOk(res));
+        // Deliberately do not respond yet, so this origin's pool stays
+        // checked-out (active) rather than idle.
+      });
+      servers.push(server);
+      pending.push(manager.fetch(`${server.url}/kv/get`).catch(() => undefined));
+      // Flush microtasks so the checkout registers before the next iteration.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(manager.originCount).toBe(MAX_RETAINED_ORIGINS);
+
+    const extraServer = await ConnectionTrackingServer.start((_req, res) => jsonOk(res));
+    servers.push(extraServer);
+
+    await expect(manager.fetch(`${extraServer.url}/kv/get`)).rejects.toThrow(
+      TransportOriginLimitError,
+    );
+    expect(manager.originCount).toBe(MAX_RETAINED_ORIGINS);
+
+    for (const release of releaseFns) release();
+    await Promise.all(pending);
+  }, 20000);
+});
+
+describe("BoundedNodeTransportManager: queue limit", () => {
+  test("a request beyond MAX_QUEUED_PER_ORIGIN rejects immediately with TransportQueueLimitError instead of queuing", async () => {
+    const server = await ConnectionTrackingServer.start(() => {
+      // Never respond — keeps every checked-out connection permanently busy
+      // and every queued request permanently queued.
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    const saturating = Array.from({ length: MAX_CONNECTIONS_PER_ORIGIN }, () =>
+      manager!.fetch(`${server.url}/kv/get`).catch(() => undefined),
+    );
+    // Let all MAX_CONNECTIONS_PER_ORIGIN connections actually check out.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const queued = Array.from({ length: MAX_QUEUED_PER_ORIGIN }, () =>
+      manager!.fetch(`${server.url}/kv/get`).catch(() => undefined),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The 65th request (4 checked out + 64 queued already) must be rejected
+    // outright rather than growing the queue past its bound.
+    await expect(manager.fetch(`${server.url}/kv/get`)).rejects.toBeInstanceOf(
+      TransportQueueLimitError,
+    );
+
+    await manager.shutdown();
+    // The saturating requests were already dispatched when their client was
+    // destroyed. Node's fetch reliably rejects a dispatch whose dispatcher
+    // was destroyed mid-flight (verified directly against undici under
+    // Node), but Bun's fetch does not always propagate that same rejection
+    // for an already-running request — bound the wait so a Bun-only
+    // dispatcher-teardown quirk in this test's runtime can never hang the
+    // suite; the queue-limit assertion above is what this test exists to
+    // verify.
+    await Promise.race([
+      Promise.all([...saturating, ...queued]),
+      new Promise((resolve) => setTimeout(resolve, 2000)),
+    ]);
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: closed state", () => {
+  test("fetch() rejects with TransportManagerClosedError after shutdown() instead of opening new connections", async () => {
+    const server = await ConnectionTrackingServer.start((_req, res) => jsonOk(res));
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    await (await manager.fetch(`${server.url}/kv/get`)).json();
+    await manager.shutdown();
+
+    await expect(manager.fetch(`${server.url}/kv/get`)).rejects.toBeInstanceOf(
+      TransportManagerClosedError,
+    );
+    // No new origin should have been opened for the post-shutdown attempt.
+    expect(manager.originCount).toBe(0);
+    manager = undefined;
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: abort after headers", () => {
+  test("aborting the request signal after headers arrive discards the connection instead of leaking the slot", async () => {
+    const server = await ConnectionTrackingServer.start((req, res) => {
+      if (req.url === "/hooks/subscribe") {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write("data: first\n\n");
+        // Deliberately never ends — the client aborts instead of the stream
+        // ever finishing naturally.
+        return;
+      }
+      jsonOk(res);
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    const controller = new AbortController();
+    const res = await manager.fetch(`${server.url}/hooks/subscribe`, {
+      signal: controller.signal,
+    });
+    // Headers have arrived (the promise above settled); abort now, without
+    // reading or cancelling the body through any other path.
+    controller.abort();
+    // Let the abort listener's discard-and-replace logic run.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    void res;
+
+    // A follow-up request must still succeed — proof the aborted response's
+    // checked-out client was discarded and its slot replaced rather than
+    // left permanently occupied.
+    const kvRes = await manager.fetch(`${server.url}/kv/get`);
+    expect((await kvRes.json()).ok).toBe(true);
+  }, 10000);
+
+  test("aborting via a signal carried on the Request input (not RequestInit) discards the connection instead of leaking the slot", async () => {
+    const server = await ConnectionTrackingServer.start((req, res) => {
+      if (req.url === "/hooks/subscribe") {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write("data: first\n\n");
+        // Deliberately never ends — the client aborts instead of the stream
+        // ever finishing naturally.
+        return;
+      }
+      jsonOk(res);
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    const controller = new AbortController();
+    // No `init.signal` here — the signal is only reachable via the `Request`
+    // object itself, exactly the shape `resolveEffectiveSignal` exists for.
+    const request = new Request(`${server.url}/hooks/subscribe`, { signal: controller.signal });
+    const res = await manager.fetch(request);
+    controller.abort();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    void res;
+
+    const kvRes = await manager.fetch(`${server.url}/kv/get`);
+    expect((await kvRes.json()).ok).toBe(true);
+  }, 10000);
+});
+
+describe("BoundedNodeTransportManager: shutdown rejects queued acquisitions", () => {
+  test("shutdown() rejects a request queued for a connection instead of hanging", async () => {
+    const server = await ConnectionTrackingServer.start(() => {
+      // Never respond — keeps every checked-out connection permanently busy.
+    });
+    servers.push(server);
+    manager = new BoundedNodeTransportManager();
+
+    const saturating = Array.from({ length: MAX_CONNECTIONS_PER_ORIGIN }, () =>
+      manager!.fetch(`${server.url}/kv/get`).catch(() => undefined),
+    );
+    // Let all MAX_CONNECTIONS_PER_ORIGIN connections actually check out.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // A 5th request has no free connection, so it queues behind a waiter
+    // instead of opening a 5th connection.
+    const queued = manager.fetch(`${server.url}/kv/get`);
+
+    await manager.shutdown();
+    const shutdownManager = manager;
+    manager = undefined;
+
+    await expect(queued).rejects.toThrow(/closed while a request was/);
+    // The saturating requests were already dispatched when their client was
+    // destroyed. Node's fetch reliably rejects a dispatch whose dispatcher
+    // was destroyed mid-flight (verified directly against undici under
+    // Node), but Bun's fetch does not always propagate that same rejection
+    // for an already-running request — bound the wait so a Bun-only
+    // dispatcher-teardown quirk in this test's runtime can never hang the
+    // suite; the queued-waiter assertion above is what this test exists to
+    // verify.
+    await Promise.race([Promise.all(saturating), new Promise((resolve) => setTimeout(resolve, 2000))]);
+    void shutdownManager;
+  }, 10000);
+});

--- a/packages/node-sdk/src/transport/nodeTransport.ts
+++ b/packages/node-sdk/src/transport/nodeTransport.ts
@@ -1,0 +1,799 @@
+/**
+ * Node-only bounded HTTP transport (TC-407).
+ *
+ * A single module-shared connection-pool registry backs every default
+ * (non-overridden) request TinyCloudNode makes, instead of one `undici`
+ * agent per request/graph/session/instance. It deliberately does NOT call
+ * `setGlobalDispatcher` — pooling is applied per request via
+ * `RequestInit.dispatcher`, so it cannot affect unrelated `fetch` calls
+ * elsewhere in the process.
+ *
+ * This module imports `undici` and must only be reachable from the Node
+ * entry point (`index.ts` -> `nodeDefaults.ts`), never from `TinyCloudNode.ts`
+ * directly or from the `/core` entry point browser consumers use — that
+ * boundary is what keeps Undici out of browser bundles.
+ *
+ * Per-origin pooling is implemented directly on top of `undici.Client`
+ * (one persistent connection each) rather than `undici.Pool`, and checkout
+ * of a client for a request is tracked with our own LIFO free list instead
+ * of relying on `Pool`'s internal per-client busy signal. `Pool` picks
+ * among its clients based on an internal "needs drain" flag that clears
+ * asynchronously relative to when a response body finishes streaming, so a
+ * tight sequential loop (dispatch, fully read the response, dispatch again)
+ * can observe a stale "still busy" signal and open a second connection it
+ * didn't need — verified empirically against the real package under Node
+ * 20. Owning checkout ourselves and releasing a client only once *our own*
+ * response wrapper sees its body fully drained keeps that decision on the
+ * exact promise chain the caller already awaits, which removes the race
+ * and guarantees sequential single-flight traffic reuses one connection.
+ *
+ * The `undici.Client` constructor is resolved lazily by runtime rather than
+ * imported statically from the package root (see {@link resolveClientConstructor}):
+ * under real Node the supported root export is used directly; under Bun
+ * (used to run this package's own test suite) the bare `"undici"` specifier
+ * resolves to Bun's own built-in compatibility shim whose `Client` is a
+ * non-functional stub, so a deep, non-exports-mapped subpath import is used
+ * instead — reached only by this package's own `bun test` run, never by
+ * Bun-runtime production traffic (see `getDefaultNodeFetch`). See
+ * `./undici-client.d.ts` for the matching type declaration.
+ *
+ * No transport-level retries: this module never re-dispatches a request. A
+ * dispatch failure (connection refused, a stale pooled connection the
+ * server had already closed, a peer reset, etc.) is surfaced to the caller
+ * as a rejected promise, and the checked-out client is discarded (see
+ * `OriginConnectionPool.discard`) rather than reused. The only case that
+ * opens a fresh connection instead of failing outright is a *known-closed*
+ * connection being replaced before a new request is dispatched on it (see
+ * `OriginConnectionPool.discard`'s waiter handoff) — that is capacity
+ * replacement for a connection nothing was ever sent on, not a retry of a
+ * request. A request that may have already reached the server (anything
+ * past a successful dispatch) is never replayed, since TinyCloudNode's
+ * authorization/delegation requests carry durable nonce/state-based replay
+ * protection that this transport must not risk double-submitting against.
+ * Callers that want retry semantics (e.g. idempotent GETs) must implement
+ * them above this layer with full knowledge of what is safe to resend.
+ *
+ * @packageDocumentation
+ */
+
+import type { Client as ClientNamespace, Dispatcher } from "undici";
+
+/** Max concurrent HTTP/1.1 connections held open per origin. */
+export const MAX_CONNECTIONS_PER_ORIGIN = 4;
+/** Max number of distinct origins retained at once. */
+export const MAX_RETAINED_ORIGINS = 16;
+/** Max acquisitions queued per origin once every connection is checked out. */
+export const MAX_QUEUED_PER_ORIGIN = 64;
+/** No real pipelining: one in-flight request per connection. */
+export const PIPELINING = 1;
+/** Time allowed to establish a new connection. */
+export const CONNECT_TIMEOUT_MS = 10_000;
+/** A connection (or an origin's pool entry) idle this long is reclaimed. */
+export const IDLE_TIMEOUT_MS = 30_000;
+/** Upper bound placed on server keep-alive hints; never exceeds the idle bound. */
+export const MAX_KEEP_ALIVE_HINT_MS = IDLE_TIMEOUT_MS;
+
+type ClientConstructor = new (origin: string, options: ClientNamespace.Options) => ClientNamespace;
+
+let clientConstructorPromise: Promise<ClientConstructor> | undefined;
+
+/**
+ * Resolve the `undici.Client` constructor once, choosing the import path by
+ * runtime. Under real Node, the supported package-root export
+ * (`import("undici")`) is the actual, fully-functional implementation. Under
+ * Bun, that same specifier resolves to Bun's built-in stub (`request()` is a
+ * no-op), so the deep subpath is used instead — solely so this package's own
+ * `bun test` run can exercise genuine pooling behavior; Bun-runtime
+ * production fetch never calls this function (see `getDefaultNodeFetch`).
+ */
+function resolveClientConstructor(): Promise<ClientConstructor> {
+  if (!clientConstructorPromise) {
+    clientConstructorPromise = isBunRuntime()
+      ? import("undici/lib/dispatcher/client.js").then(
+        (mod) => (mod.default ?? mod) as ClientConstructor,
+      )
+      : import("undici").then((mod) => mod.Client as unknown as ClientConstructor);
+  }
+  return clientConstructorPromise;
+}
+
+type NodeFetchInit = RequestInit & { dispatcher?: Dispatcher };
+
+function resolveRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+/**
+ * Resolve the `AbortSignal` that actually governs a `fetch()` call, matching
+ * the Fetch spec's own precedence: `init.signal` wins whenever the caller
+ * specifies the `signal` property at all (including explicit `null`, which
+ * means "no signal" even if `input` is a `Request` carrying one); otherwise,
+ * when `input` is a `Request`, its own `.signal` applies.
+ *
+ * Reading only `init?.signal` misses the common `fetch(new Request(url, {
+ * signal }))` shape entirely — an abort firing after headers arrive would
+ * never reach {@link wrapResponseForRelease}'s abort listener, leaving that
+ * response's checked-out client stuck open until (if ever) something reads
+ * its body.
+ */
+function resolveEffectiveSignal(input: RequestInfo | URL, init?: RequestInit): AbortSignal | undefined {
+  if (init && "signal" in init) {
+    return init.signal ?? undefined;
+  }
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return input.signal;
+  }
+  return undefined;
+}
+
+const BODY_CONSUMER_METHODS = new Set<PropertyKey>([
+  "arrayBuffer",
+  "blob",
+  "bytes",
+  "formData",
+  "json",
+  "text",
+]);
+
+/**
+ * Wrap a `ReadableStream` so exactly one of `onDrained`/`onDiscard` fires
+ * once the stream is fully drained, cancelled, or errors.
+ *
+ * Hooks/SSE consumes `response.body` directly (as an async iterable or via
+ * `getReader()`) instead of calling a body-consuming method, so without this
+ * the client checkout above would never be released for a streaming
+ * response — a handful of opened-and-cancelled streams could permanently
+ * occupy every connection in an origin's pool and starve ordinary traffic.
+ * Reimplemented as a pass-through stream (rather than e.g. `tee()`) so
+ * `cancel()` propagates to the real underlying reader.
+ *
+ * A natural end-of-stream (`done: true`) is the only outcome that leaves the
+ * HTTP/1.1 connection in a state safe to keep alive for reuse, so it alone
+ * triggers `onDrained`. Cancelling mid-stream (the normal way a Hooks/SSE
+ * consumer gives up on an unbounded stream) or a read error both leave
+ * unknown bytes in flight on the socket — those cannot be safely
+ * pipelined into a next request, so both trigger `onDiscard` instead.
+ */
+function wrapStreamForRelease(
+  stream: ReadableStream<Uint8Array>,
+  onDrained: () => void,
+  onDiscard: () => void,
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          onDrained();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        controller.error(error);
+        onDiscard();
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        onDiscard();
+      }
+    },
+  });
+}
+
+/**
+ * Wrap a `Response` so exactly one of `onDrained`/`onDiscard` fires once a
+ * body-consuming method settles, or once a stream obtained via the `.body`
+ * getter is fully drained/cancelled/errored — i.e. exactly when the
+ * connection's fate (safe to keep alive vs. must be discarded) is known, on
+ * the same promise chain (or stream) the caller is already consuming.
+ * Callers that never read the body never settle either callback, matching
+ * real keep-alive semantics: an undrained response genuinely can't be reused
+ * for the next request either.
+ *
+ * `signal`, when given, is the effective `AbortSignal` governing the request
+ * (see {@link resolveEffectiveSignal}). An abort firing after headers arrive
+ * (the response promise already settled, so the `fetch()` call site's own
+ * try/catch can no longer see it) would otherwise leave the checked-out
+ * client stuck open forever, since neither a body-consuming call nor a
+ * `.body` read is guaranteed to ever happen — observing the signal directly
+ * is what lets an abort-after-headers still discard the client and free its
+ * slot for queued work.
+ */
+function wrapResponseForRelease(
+  response: Response,
+  onDrained: () => void,
+  onDiscard: () => void,
+  signal?: AbortSignal,
+): Response {
+  let settled = false;
+  let detachAbortListener: (() => void) | undefined;
+  const settleOnce = (action: () => void): void => {
+    if (settled) return;
+    settled = true;
+    detachAbortListener?.();
+    action();
+  };
+  if (signal) {
+    const onAbort = () => settleOnce(onDiscard);
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+      detachAbortListener = () => signal.removeEventListener("abort", onAbort);
+    }
+  }
+  let wrappedBody: ReadableStream<Uint8Array> | null | undefined;
+  return new Proxy(response, {
+    get(target, property) {
+      if (property === "body") {
+        if (wrappedBody === undefined) {
+          const original = Reflect.get(target, property, target) as ReadableStream<Uint8Array> | null;
+          wrappedBody = original === null
+            ? null
+            : wrapStreamForRelease(
+              original,
+              () => settleOnce(onDrained),
+              () => settleOnce(onDiscard),
+            );
+        }
+        return wrappedBody;
+      }
+      if (BODY_CONSUMER_METHODS.has(property)) {
+        const consume = Reflect.get(target, property, target);
+        if (typeof consume === "function") {
+          return async (...args: unknown[]) => {
+            try {
+              const result = await consume.apply(target, args);
+              settleOnce(onDrained);
+              return result;
+            } catch (error) {
+              settleOnce(onDiscard);
+              throw error;
+            }
+          };
+        }
+      }
+      // Getters like `.ok`/`.status` are brand-checked against a genuine
+      // `Response` instance, so they must run with `target` as `this`, not
+      // `receiver` (the proxy) — passing `receiver` here throws.
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+/**
+ * A queued connection request, rejected (never left hanging) if the pool is
+ * closed before a connection becomes available.
+ */
+interface Waiter {
+  resolve: (client: ClientNamespace) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * One persistent `undici.Client` per checked-out connection, up to
+ * {@link MAX_CONNECTIONS_PER_ORIGIN}. Checkout is a LIFO free list we
+ * manage ourselves (see module header for why) rather than `Pool`'s
+ * internal client selection.
+ */
+class OriginConnectionPool {
+  private readonly clientOptions: ClientNamespace.Options;
+  private readonly all = new Set<ClientNamespace>();
+  private readonly idle: ClientNamespace[] = [];
+  private readonly waiters: Waiter[] = [];
+  /** In-flight `client.destroy()` calls from {@link discard}, awaited by {@link close}. */
+  private readonly discarding = new Set<Promise<void>>();
+  /**
+   * Set synchronously as the first step of {@link close}. `close()` clears
+   * `all`/`idle` before its first `await`, but a caller's `fetch()` can be
+   * paused mid-microtask-chain (e.g. at its own `await` inside
+   * `getOriginPool`) when that happens — without this flag, that call would
+   * resume into an `acquire()` that sees empty `all`/`idle` sets and treats
+   * them as fresh capacity, silently opening an orphaned connection this
+   * (now-closed) pool never tracks, destroys, or awaits.
+   */
+  private closed = false;
+
+  constructor(
+    private readonly origin: string,
+    private readonly maxConnections: number,
+    private readonly maxQueued: number,
+    private readonly clientCtor: ClientConstructor,
+    /** Invoked whenever this pool transitions between idle and in-use. */
+    private readonly onIdleChange: (isIdle: boolean) => void,
+  ) {
+    this.clientOptions = {
+      pipelining: PIPELINING,
+      connectTimeout: CONNECT_TIMEOUT_MS,
+      keepAliveTimeout: IDLE_TIMEOUT_MS,
+      keepAliveMaxTimeout: MAX_KEEP_ALIVE_HINT_MS,
+    };
+  }
+
+  /** Active (checked-out or idle) connection count. Test/introspection only. */
+  get connectionCount(): number {
+    return this.all.size;
+  }
+
+  /** Checked-out (in-use) connection count. Test/introspection only. */
+  get checkedOutCount(): number {
+    return this.all.size - this.idle.length;
+  }
+
+  /** Queued acquisitions awaiting a free connection. Test/introspection only. */
+  get queuedCount(): number {
+    return this.waiters.length;
+  }
+
+  /**
+   * No checked-out connections and no queued acquisitions — i.e. genuinely
+   * safe to close without dropping in-flight or queued work. A pool with a
+   * long-lived open request (e.g. Hooks/SSE) is never idle, however long
+   * that request has been running.
+   */
+  get isIdle(): boolean {
+    return this.checkedOutCount === 0 && this.waiters.length === 0;
+  }
+
+  private acquire(): ClientNamespace | Promise<ClientNamespace> {
+    if (this.closed) {
+      throw new Error(`Node transport pool for ${this.origin} closed while a request was starting`);
+    }
+
+    const wasIdle = this.isIdle;
+    let result: ClientNamespace | Promise<ClientNamespace>;
+
+    const idleClient = this.idle.pop();
+    if (idleClient) {
+      result = idleClient;
+    } else if (this.all.size < this.maxConnections) {
+      const client = new this.clientCtor(this.origin, this.clientOptions);
+      this.all.add(client);
+      result = client;
+    } else if (this.waiters.length >= this.maxQueued) {
+      throw new TransportQueueLimitError(this.origin, this.maxQueued);
+    } else {
+      result = new Promise<ClientNamespace>((resolve, reject) => this.waiters.push({ resolve, reject }));
+    }
+
+    if (wasIdle) this.onIdleChange(false);
+    return result;
+  }
+
+  private release(client: ClientNamespace): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      // Hand the connection directly to the next queued caller instead of
+      // round-tripping through the idle stack. Still checked out, so no
+      // idle-state transition here.
+      waiter.resolve(client);
+      return;
+    }
+    this.idle.push(client);
+    if (this.isIdle) this.onIdleChange(true);
+  }
+
+  /**
+   * Discard and destroy a checked-out connection whose state is unknown or
+   * unsafe to reuse (cancellation, body error, abort, peer reset, or a
+   * dispatch rejection) instead of returning it to the idle pool.
+   *
+   * The freed capacity is handed to the next queued waiter, if any, as a
+   * brand-new connection — never the discarded one, since its socket state
+   * is exactly what made it unsafe to reuse in the first place.
+   */
+  private discard(client: ClientNamespace): void {
+    this.all.delete(client);
+    const destroying = client.destroy().catch(() => {
+      // Best-effort: we only need the socket gone, not confirmation.
+    });
+    this.discarding.add(destroying);
+    void destroying.finally(() => this.discarding.delete(destroying));
+
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      const replacement = new this.clientCtor(this.origin, this.clientOptions);
+      this.all.add(replacement);
+      waiter.resolve(replacement);
+      return;
+    }
+    if (this.isIdle) this.onIdleChange(true);
+  }
+
+  async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const client = await this.acquire();
+    let response: Response;
+    try {
+      const nodeInit: NodeFetchInit = { ...init, dispatcher: client };
+      response = await globalThis.fetch(input, nodeInit as RequestInit);
+    } catch (error) {
+      this.discard(client);
+      throw error;
+    }
+
+    // No body to drain (HEAD, 204, 304, or an explicitly null body): the
+    // connection is already free, so release it now rather than waiting
+    // for a body-consuming call that will never come.
+    if (response.body === null || response.status === 204 || response.status === 304) {
+      this.release(client);
+      return response;
+    }
+
+    return wrapResponseForRelease(
+      response,
+      () => this.release(client),
+      () => this.discard(client),
+      resolveEffectiveSignal(input, init),
+    );
+  }
+
+  /**
+   * Close every held connection and reject any queued acquisitions — a
+   * queued caller must be told the pool is gone rather than hang forever
+   * awaiting a connection that will never arrive.
+   *
+   * Uses `destroy()`, not `close()`: `close()` gracefully waits for any
+   * in-flight request on that client to finish first, which would hang
+   * shutdown indefinitely against a server that never responds to a
+   * checked-out client's outstanding request.
+   */
+  async close(): Promise<void> {
+    // Set before anything else (including before the first `await`): this
+    // is what makes a same-origin `acquire()` racing this call observe a
+    // closed pool instead of an emptied-but-still-open one. See the
+    // `closed` field doc for why that race is otherwise reachable.
+    this.closed = true;
+    const closing = [...this.all].map((client) =>
+      client.destroy().catch(() => {
+        // Best-effort: the client is already unreachable from new requests.
+      }),
+    );
+    this.all.clear();
+    this.idle.length = 0;
+    const pendingWaiters = this.waiters.splice(0);
+    for (const waiter of pendingWaiters) {
+      waiter.reject(new Error(`Node transport pool for ${this.origin} closed while a request was queued`));
+    }
+    await Promise.all([...closing, ...this.discarding]);
+  }
+}
+
+interface OriginEntry {
+  pool: OriginConnectionPool;
+  /**
+   * Timestamp the pool last became fully idle, or `undefined` while it has
+   * checked-out connections or queued acquisitions. Only an `idleSince`
+   * origin is eligible for idle-timeout or capacity eviction — this is what
+   * keeps a long-lived Hooks/SSE request (open far longer than
+   * {@link IDLE_TIMEOUT_MS}) from having its origin reclaimed out from
+   * under it.
+   */
+  idleSince: number | undefined;
+  /** Pending precise eviction timer scheduled from {@link idleSince}, if any. */
+  idleTimer: ReturnType<typeof setTimeout> | undefined;
+}
+
+/** Thrown when a request is made after {@link BoundedNodeTransportManager.shutdown} has started. */
+export class TransportManagerClosedError extends Error {
+  constructor() {
+    super("Node transport manager is shut down and cannot open new connections");
+    this.name = "TransportManagerClosedError";
+  }
+}
+
+/** Thrown when an origin's acquisition queue is already at {@link MAX_QUEUED_PER_ORIGIN}. */
+export class TransportQueueLimitError extends Error {
+  constructor(origin: string, limit: number) {
+    super(
+      `Node transport queue for ${origin} is full: ${limit} requests are already waiting for a connection`,
+    );
+    this.name = "TransportQueueLimitError";
+  }
+}
+
+/** Thrown when a new origin cannot be admitted because every retained origin is active. */
+export class TransportOriginLimitError extends Error {
+  constructor(origin: string, limit: number) {
+    super(
+      `Node transport cannot open origin ${origin}: ${limit} origins are already retained and active (no idle origin available to evict)`,
+    );
+    this.name = "TransportOriginLimitError";
+  }
+}
+
+/**
+ * Bounded per-origin connection-pool registry. One instance is meant to be
+ * shared for the lifetime of the process (see {@link getSharedNodeTransportManager}).
+ *
+ * Origins are evicted (closed) when fully idle for {@link IDLE_TIMEOUT_MS},
+ * or, failing that, the oldest-idle origin is evicted first once
+ * {@link MAX_RETAINED_ORIGINS} is reached — so retained state can never grow
+ * unbounded regardless of how many distinct hosts a process talks to.
+ * Active origins (checked-out connections or queued acquisitions) are never
+ * evicted; if every retained origin is active when a new one is needed, the
+ * request fails with {@link TransportOriginLimitError} rather than silently
+ * exceeding the bound.
+ */
+export class BoundedNodeTransportManager {
+  private readonly origins = new Map<string, OriginEntry>();
+  /** Close() promises for origins currently being torn down, keyed by origin. */
+  private readonly closing = new Map<string, Promise<void>>();
+  /**
+   * In-flight first-time creation promises, keyed by origin. Registered
+   * synchronously before the only `await` in {@link createOriginPool} so
+   * concurrent `getOriginPool()` calls racing for the same brand-new origin
+   * (e.g. several requests fired at once at startup) all observe and await
+   * the same promise instead of each independently concluding no pool
+   * exists yet and constructing its own — which would silently multiply the
+   * per-origin connection cap by however many requests raced the creation.
+   */
+  private readonly creating = new Map<string, Promise<OriginConnectionPool>>();
+  /**
+   * Set synchronously as the first step of {@link shutdown}, before any
+   * `await`, for the same reason `OriginConnectionPool.closed` is: without
+   * it, a `fetch()` call already paused mid-microtask-chain when shutdown
+   * starts could resume into `getOriginPool` and open a brand-new origin
+   * this manager will never track or close.
+   */
+  private closed = false;
+  private clientCtor?: ClientConstructor;
+
+  private async ensureClientConstructor(): Promise<ClientConstructor> {
+    if (!this.clientCtor) {
+      this.clientCtor = await resolveClientConstructor();
+    }
+    return this.clientCtor;
+  }
+
+  /**
+   * Schedule (or reschedule) a precise eviction for `origin` exactly
+   * {@link IDLE_TIMEOUT_MS} after it became idle, instead of relying on a
+   * periodic sweep — a fixed-interval sweep can retain an origin idle for
+   * up to nearly double the configured bound depending on when it happens
+   * to go idle relative to the last tick.
+   */
+  private scheduleIdleEviction(origin: string, entry: OriginEntry): void {
+    this.cancelIdleEviction(entry);
+    const timer = setTimeout(() => {
+      const current = this.origins.get(origin);
+      if (current === entry && entry.idleSince !== undefined) {
+        this.closeEntry(origin, entry);
+      }
+    }, IDLE_TIMEOUT_MS);
+    timer.unref?.();
+    entry.idleTimer = timer;
+  }
+
+  private cancelIdleEviction(entry: OriginEntry): void {
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer);
+      entry.idleTimer = undefined;
+    }
+  }
+
+  /** Evict the oldest fully-idle origin, if any. Returns whether one was evicted. */
+  private evictOldestIdleOrigin(): boolean {
+    let oldestOrigin: string | undefined;
+    let oldestAt = Infinity;
+    for (const [origin, entry] of this.origins) {
+      if (entry.idleSince !== undefined && entry.idleSince < oldestAt) {
+        oldestAt = entry.idleSince;
+        oldestOrigin = origin;
+      }
+    }
+    if (oldestOrigin === undefined) return false;
+    const entry = this.origins.get(oldestOrigin);
+    if (!entry) return false;
+    this.closeEntry(oldestOrigin, entry);
+    return true;
+  }
+
+  /**
+   * Remove `origin`'s entry and start (but do not await) closing its pool.
+   * The close is tracked in {@link closing} so a request for the same
+   * origin arriving before the close finishes waits for it instead of
+   * opening a second, overlapping set of connections to that origin.
+   */
+  private closeEntry(origin: string, entry: OriginEntry): void {
+    this.cancelIdleEviction(entry);
+    this.origins.delete(origin);
+    const closePromise = entry.pool.close();
+    this.closing.set(origin, closePromise);
+    void closePromise.finally(() => {
+      if (this.closing.get(origin) === closePromise) {
+        this.closing.delete(origin);
+      }
+    });
+  }
+
+  private async getOriginPool(origin: string): Promise<OriginConnectionPool> {
+    if (this.closed) {
+      throw new TransportManagerClosedError();
+    }
+
+    const pendingClose = this.closing.get(origin);
+    if (pendingClose) {
+      // Let a just-evicted origin's teardown finish before reusing its key,
+      // so the old and new connection sets for that origin never overlap.
+      await pendingClose;
+    }
+    // Re-check: shutdown() may have started while the above await was pending.
+    if (this.closed) {
+      throw new TransportManagerClosedError();
+    }
+
+    const existing = this.origins.get(origin);
+    if (existing) {
+      return existing.pool;
+    }
+
+    // A creation already in flight for this origin (from a concurrent
+    // caller that reached here first): await and share its result rather
+    // than starting a second, independent pool for the same origin.
+    const pendingCreate = this.creating.get(origin);
+    if (pendingCreate) {
+      return pendingCreate;
+    }
+
+    // Registered synchronously (before the `await` inside) so any other
+    // `getOriginPool()` call for this origin that runs before this one
+    // resolves sees it via `this.creating.get(origin)` above.
+    const createPromise = this.createOriginPool(origin);
+    this.creating.set(origin, createPromise);
+    try {
+      return await createPromise;
+    } finally {
+      if (this.creating.get(origin) === createPromise) {
+        this.creating.delete(origin);
+      }
+    }
+  }
+
+  private async createOriginPool(origin: string): Promise<OriginConnectionPool> {
+    // Counts both fully-registered origins (`this.origins`) and creations
+    // already admitted but still in flight (`this.creating`) — the latter
+    // have not inserted into `this.origins` yet (that only happens after the
+    // `await` below), so checking `this.origins.size` alone would let every
+    // concurrent first-time request to a distinct origin observe spare
+    // capacity and all pass this check before any of them registers,
+    // admitting more than `MAX_RETAINED_ORIGINS` origins at once. Because
+    // `getOriginPool` registers its entry in `this.creating` synchronously
+    // right after calling this method (before yielding to any other call),
+    // this check always sees every concurrent admission that was accepted
+    // earlier in the same synchronous burst.
+    if (this.origins.size + this.creating.size >= MAX_RETAINED_ORIGINS) {
+      const evicted = this.evictOldestIdleOrigin();
+      if (!evicted) {
+        throw new TransportOriginLimitError(origin, MAX_RETAINED_ORIGINS);
+      }
+    }
+
+    const clientCtor = await this.ensureClientConstructor();
+    // Re-check again: shutdown() may have started during constructor resolution.
+    if (this.closed) {
+      throw new TransportManagerClosedError();
+    }
+
+    const entry: OriginEntry = {
+      pool: undefined as unknown as OriginConnectionPool,
+      idleSince: Date.now(),
+      idleTimer: undefined,
+    };
+    entry.pool = new OriginConnectionPool(
+      origin,
+      MAX_CONNECTIONS_PER_ORIGIN,
+      MAX_QUEUED_PER_ORIGIN,
+      clientCtor,
+      (isIdle) => {
+        if (isIdle) {
+          entry.idleSince = Date.now();
+          this.scheduleIdleEviction(origin, entry);
+        } else {
+          entry.idleSince = undefined;
+          this.cancelIdleEviction(entry);
+        }
+      },
+    );
+    this.origins.set(origin, entry);
+    this.scheduleIdleEviction(origin, entry);
+    return entry.pool;
+  }
+
+  /** Number of distinct origins currently retained. Test/introspection only. */
+  get originCount(): number {
+    return this.origins.size;
+  }
+
+  /**
+   * Bound method: safe to hand out as a `typeof fetch` value (e.g. assigned
+   * to `TinyCloudNode`'s resolved default fetch) without losing `this`.
+   */
+  readonly fetch: typeof globalThis.fetch = async (input, init) => {
+    if (this.closed) {
+      throw new TransportManagerClosedError();
+    }
+    const origin = new URL(resolveRequestUrl(input)).origin;
+    const pool = await this.getOriginPool(origin);
+    return pool.fetch(input, init);
+  };
+
+  /**
+   * Deterministically close every pooled connection and stop all idle
+   * eviction timers, rejecting any queued acquisitions rather than leaving
+   * them to hang. Not wired to any process-exit signal — this package does
+   * not install a `process.on("exit"/"SIGINT"/"SIGTERM")` hook, since the
+   * process-wide shared manager (see {@link getSharedNodeTransportManager})
+   * is meant to live for the process's natural lifetime and its sockets are
+   * `unref()`'d (see {@link scheduleIdleEviction}), so they never keep the
+   * process alive on their own. `shutdown()` exists as an explicit lifecycle
+   * seam for callers (currently only this package's own test suite, via
+   * {@link __resetNodeTransportForTests}) that need pooled connections
+   * closed deterministically before continuing.
+   */
+  async shutdown(): Promise<void> {
+    // Set before anything else (including before the first `await`): see
+    // the `closed` field doc for why a same-tick `fetch()` race otherwise
+    // reaches `getOriginPool` and opens an origin this manager never closes.
+    this.closed = true;
+    for (const entry of this.origins.values()) {
+      this.cancelIdleEviction(entry);
+    }
+    const stillClosing = [...this.closing.values()];
+    const closingNow = [...this.origins.values()].map((entry) => entry.pool.close());
+    this.origins.clear();
+    this.closing.clear();
+    await Promise.all([...stillClosing, ...closingNow]);
+  }
+}
+
+let sharedManager: BoundedNodeTransportManager | undefined;
+
+/** The process-wide bounded transport manager. Created lazily, once. */
+export function getSharedNodeTransportManager(): BoundedNodeTransportManager {
+  if (!sharedManager) {
+    sharedManager = new BoundedNodeTransportManager();
+  }
+  return sharedManager;
+}
+
+function isBunRuntime(): boolean {
+  return typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+}
+
+/**
+ * Default fetch for Node-initialized TinyCloudNode instances.
+ *
+ * Bun ships its own bounded `fetch` connection pool; handing Bun a Node
+ * `undici` dispatcher would be redundant at best and is not guaranteed to
+ * behave the same way, so Bun keeps using its native global fetch.
+ */
+export function getDefaultNodeFetch(): typeof fetch {
+  if (isBunRuntime()) {
+    // Forward rather than eagerly `.bind()` the current `globalThis.fetch`:
+    // this keeps working if a caller (e.g. a test double) reassigns
+    // `globalThis.fetch` after this function has already been called and
+    // its result stored on a long-lived instance.
+    return (input, init) => globalThis.fetch(input, init);
+  }
+  return getSharedNodeTransportManager().fetch;
+}
+
+/**
+ * Test-only deterministic shutdown seam. Closes and discards the current
+ * shared manager (if any) so the next {@link getSharedNodeTransportManager}
+ * call starts clean. Not part of the package's public API.
+ * @internal
+ */
+export async function __resetNodeTransportForTests(): Promise<void> {
+  const manager = sharedManager;
+  sharedManager = undefined;
+  if (manager) await manager.shutdown();
+}

--- a/packages/node-sdk/src/transport/undici-client.d.ts
+++ b/packages/node-sdk/src/transport/undici-client.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Type declaration for undici's deep `Client` module path.
+ *
+ * undici ships types only at the package root (`undici/types/client.d.ts`,
+ * aggregated via `undici/index.d.ts`), not alongside the deep runtime file
+ * `lib/dispatcher/client.js` that `./nodeTransport.ts` imports (see that
+ * file's header comment for why). This re-exports the real `Client` type
+ * from the package root so the deep import stays fully typed.
+ */
+declare module "undici/lib/dispatcher/client.js" {
+  import type { Client } from "undici";
+
+  const ClientImpl: typeof Client;
+  export default ClientImpl;
+}

--- a/packages/sdk-core/src/location.test.ts
+++ b/packages/sdk-core/src/location.test.ts
@@ -200,6 +200,47 @@ describe("resolveTinyCloudHosts", () => {
     expect(resolved.location.source).toBe("centralized");
     expect(resolved.hosts).toEqual(["https://registry.node.test"]);
   });
+
+  it("drains the shared response itself instead of relying on clone(), so pooled-transport release tracking works (TC-407)", async () => {
+    const subject =
+      "did:pkh:eip155:1:0x0000000000000000000000000000000000000000";
+    let underlyingFetchCalls = 0;
+    let drainedCount = 0;
+    // Mimics the Node bounded transport (packages/node-sdk/src/transport/nodeTransport.ts):
+    // a connection is only released once a body-consuming method on THIS
+    // SAME Response settles. `Response.clone()` returns new objects backed
+    // directly by the underlying implementation and bypasses that tracking
+    // entirely, so the memoizer must never call it.
+    const pooledFetch: typeof fetch = async () => {
+      underlyingFetchCalls++;
+      const real = new Response("{}", { status: 404 });
+      return new Proxy(real, {
+        get(target, prop) {
+          if (prop === "arrayBuffer" || prop === "json" || prop === "text") {
+            const consume = Reflect.get(target, prop, target);
+            return async (...args: unknown[]) => {
+              const result = await (consume as Function).apply(target, args);
+              drainedCount++;
+              return result;
+            };
+          }
+          if (prop === "clone") {
+            throw new Error("clone() must not be called on the pooled response");
+          }
+          const value = Reflect.get(target, prop, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    };
+
+    await resolveTinyCloudHosts(subject, {
+      autoDiscoverLocalNode: false,
+      fetch: pooledFetch,
+    });
+
+    expect(underlyingFetchCalls).toBe(1);
+    expect(drainedCount).toBe(1);
+  });
 });
 
 describe("resolveCloudLocation", () => {

--- a/packages/sdk-core/src/location.ts
+++ b/packages/sdk-core/src/location.ts
@@ -499,21 +499,51 @@ export async function resolveTinyCloudHosts(
  * Wrap a fetch implementation so identical (same-URL) requests within its
  * lifetime share one in-flight/completed response instead of firing twice.
  * Scoped to the caller — a fresh wrapper is created per {@link
- * resolveTinyCloudHosts} call, so nothing is cached across calls. Each
- * request's `Response` body is cloned on the way out so every caller gets an
- * independently readable body regardless of read order.
+ * resolveTinyCloudHosts} call, so nothing is cached across calls.
+ *
+ * The single underlying response's body is drained exactly once (via
+ * `arrayBuffer()`) and cached as a plain snapshot; every caller then gets an
+ * independent `Response` constructed from that snapshot. This deliberately
+ * avoids `Response.clone()`: a pooled transport (e.g. the Node bounded
+ * transport, TC-407) only tracks a connection's checked-out client as
+ * released once *its own* wrapped response's body-consuming methods settle,
+ * and `clone()` returns new `Response` objects backed directly by the
+ * underlying implementation, bypassing that tracking entirely — draining the
+ * one managed response ourselves keeps release accounting correct while
+ * still letting every caller read the body independently.
  */
 function memoizeFetch(fetchFn: typeof fetch): typeof fetch {
-  const cache = new Map<string, Promise<Response>>();
+  const cache = new Map<string, Promise<{
+    status: number;
+    statusText: string;
+    headers: Headers;
+    body: ArrayBuffer;
+  }>>();
   return (async (input, init) => {
     const key = String(input);
     let cached = cache.get(key);
     if (!cached) {
-      cached = fetchFn(input, init);
+      cached = (async () => {
+        const response = await fetchFn(input, init);
+        const body = await response.arrayBuffer();
+        return {
+          status: response.status,
+          statusText: response.statusText,
+          headers: new Headers(response.headers),
+          body,
+        };
+      })();
       cache.set(key, cached);
     }
-    const response = await cached;
-    return response.clone();
+    const snapshot = await cached;
+    // The Fetch spec forbids a non-null body on a "null body status"
+    // (204/205/304) response, regardless of byte length.
+    const isNullBodyStatus = snapshot.status === 204 || snapshot.status === 205 || snapshot.status === 304;
+    return new Response(isNullBodyStatus ? null : snapshot.body.slice(0), {
+      status: snapshot.status,
+      statusText: snapshot.statusText,
+      headers: snapshot.headers,
+    });
   }) as typeof fetch;
 }
 

--- a/packages/sdk-core/src/space.ts
+++ b/packages/sdk-core/src/space.ts
@@ -30,14 +30,18 @@ export interface SpaceHostResult {
  *
  * @param host - TinyCloud server URL (e.g., "https://node.tinycloud.xyz")
  * @param spaceId - The space ID to host
+ * @param fetchFn - Fetch implementation to use (TC-407: defaults to global fetch,
+ *   but callers should pass their instance's configured/pooled fetch so this
+ *   request observes the same transport as everything else they do)
  * @returns The peer ID string
  * @throws Error if the request fails
  */
 export async function fetchPeerId(
   host: string,
-  spaceId: string
+  spaceId: string,
+  fetchFn: typeof fetch = globalThis.fetch
 ): Promise<string> {
-  const res = await fetch(
+  const res = await fetchFn(
     `${host}/peer/generate/${encodeURIComponent(spaceId)}`
   );
 
@@ -57,13 +61,16 @@ export async function fetchPeerId(
  *
  * @param host - TinyCloud server URL
  * @param headers - Delegation headers (from siweToDelegationHeaders)
+ * @param fetchFn - Fetch implementation to use (TC-407: defaults to global fetch;
+ *   pass the caller's configured/pooled fetch to keep this on the same transport)
  * @returns Result indicating success/failure
  */
 export async function submitHostDelegation(
   host: string,
-  headers: Record<string, string>
+  headers: Record<string, string>,
+  fetchFn: typeof fetch = globalThis.fetch
 ): Promise<SpaceHostResult> {
-  const res = await fetch(`${host}/delegate`, {
+  const res = await fetchFn(`${host}/delegate`, {
     method: "POST",
     headers,
   });
@@ -120,22 +127,48 @@ export async function submitHostDelegation(
 const inFlightActivations = new Map<string, Promise<SpaceHostResult>>();
 
 /**
- * Build a collision-free single-flight key from the host and the *complete*
- * delegation header.
+ * Stable per-fetch-implementation identity (TC-407).
+ *
+ * Two `TinyCloudNode` instances can be configured with different `fetch`
+ * overrides (different pools, different trust boundaries) yet legitimately
+ * issue byte-identical activation requests to the same host. Coalescing
+ * those into one in-flight request would let one caller's transport
+ * override silently satisfy another's request, breaking transport
+ * isolation. A `WeakMap` keyed on the function reference assigns each
+ * distinct fetch identity a small integer id without retaining unrelated
+ * fetch functions (they're garbage-collectable once the owning instance is).
+ */
+const fetchIdentities = new WeakMap<typeof fetch, number>();
+let nextFetchIdentityId = 0;
+
+function fetchIdentity(fetchFn: typeof fetch): number {
+  let id = fetchIdentities.get(fetchFn);
+  if (id === undefined) {
+    id = nextFetchIdentityId++;
+    fetchIdentities.set(fetchFn, id);
+  }
+  return id;
+}
+
+/**
+ * Build a collision-free single-flight key from the host, the *complete*
+ * delegation header, and the fetch implementation's identity.
  *
  * The header is serialized in full (never truncated or hashed) as a sorted array
  * of entries, so two headers coalesce only if every name/value pair matches.
  * JSON encoding keeps the key unambiguous regardless of what characters appear
- * in a token.
+ * in a token. Including the fetch identity ensures coalescing never crosses
+ * a transport/trust boundary (see {@link fetchIdentity}).
  */
 function activationFlightKey(
   host: string,
-  delegationHeader: Record<string, string>
+  delegationHeader: Record<string, string>,
+  fetchFn: typeof fetch
 ): string {
   const entries = Object.entries(delegationHeader).sort(([a], [b]) =>
     a < b ? -1 : a > b ? 1 : 0
   );
-  return JSON.stringify([host, entries]);
+  return JSON.stringify([host, entries, fetchIdentity(fetchFn)]);
 }
 
 /**
@@ -150,16 +183,20 @@ function activationFlightKey(
  *
  * @param host - TinyCloud server URL
  * @param delegationHeader - Session delegation header (from session.delegationHeader)
+ * @param fetchFn - Fetch implementation to use (TC-407: defaults to global fetch;
+ *   pass the caller's configured/pooled fetch to keep this on the same transport).
+ *   Also partitions the single-flight coalescing key — see {@link fetchIdentity}.
  * @returns Result indicating success/failure (404 means space doesn't exist)
  */
 export async function activateSessionWithHost(
   host: string,
-  delegationHeader: { Authorization: string }
+  delegationHeader: { Authorization: string },
+  fetchFn: typeof fetch = globalThis.fetch
 ): Promise<SpaceHostResult> {
-  const key = activationFlightKey(host, delegationHeader as Record<string, string>);
+  const key = activationFlightKey(host, delegationHeader as Record<string, string>, fetchFn);
 
   const existing = inFlightActivations.get(key);
-  if (!existing) return startActivationFlight(key, host, delegationHeader);
+  if (!existing) return startActivationFlight(key, host, delegationHeader, fetchFn);
 
   try {
     return await existing;
@@ -172,7 +209,7 @@ export async function activateSessionWithHost(
     // as-is: they are the server's verdict on these exact bytes, and re-POSTing
     // them would reintroduce the fan-out. Callers keep their own retry policies
     // on top of this.
-    return joinOrStartActivationFlight(key, host, delegationHeader);
+    return joinOrStartActivationFlight(key, host, delegationHeader, fetchFn);
   }
 }
 
@@ -186,19 +223,21 @@ export async function activateSessionWithHost(
 function joinOrStartActivationFlight(
   key: string,
   host: string,
-  delegationHeader: { Authorization: string }
+  delegationHeader: { Authorization: string },
+  fetchFn: typeof fetch
 ): Promise<SpaceHostResult> {
   return (
-    inFlightActivations.get(key) ?? startActivationFlight(key, host, delegationHeader)
+    inFlightActivations.get(key) ?? startActivationFlight(key, host, delegationHeader, fetchFn)
   );
 }
 
 function startActivationFlight(
   key: string,
   host: string,
-  delegationHeader: { Authorization: string }
+  delegationHeader: { Authorization: string },
+  fetchFn: typeof fetch
 ): Promise<SpaceHostResult> {
-  const flight = postSessionActivation(host, delegationHeader);
+  const flight = postSessionActivation(host, delegationHeader, fetchFn);
   inFlightActivations.set(key, flight);
 
   // Evict on settle, for both fulfilment and rejection, so a rejected flight
@@ -216,9 +255,10 @@ function startActivationFlight(
 
 async function postSessionActivation(
   host: string,
-  delegationHeader: { Authorization: string }
+  delegationHeader: { Authorization: string },
+  fetchFn: typeof fetch
 ): Promise<SpaceHostResult> {
-  const res = await fetch(`${host}/delegate`, {
+  const res = await fetchFn(`${host}/delegate`, {
     method: "POST",
     headers: delegationHeader,
   });


### PR DESCRIPTION
TC-407: https://linear.app/tinycloud-labs/issue/TC-407/perftransport-reuse-client-and-ingress-connections-enforce-request

## Summary
1) nodeTransport.ts createOriginPool: capacity check now uses `origins.size + creating.size` instead of `origins.size` alone, since `creating` entries are registered synchronously (before the constructor-resolution await) and account for concurrent in-flight admissions that haven't inserted into `origins` yet — closes the race where >16 distinct-origin first requests fired concurrently could all pass the old check before any of them registered. 2) TinyCloudNode.ts registerOwnerSharePolicy: replaced `response.clone().json()` with `response.text()` + `JSON.parse()` on the non-2xx path so the pool's release-tracking proxy (which only observes consumption of the original wrapped Response, not independent clones) sees the body drained and releases the checked-out client instead of leaking it on every error reply. 3) nodeTransport.ts: added `resolveEffectiveSignal(input, init)` implementing Fetch-spec signal precedence (explicit `init.signal`, including `null`, wins; otherwise falls back to `input.signal` when `input` is a `Request`) and wired it into `OriginConnectionPool.fetch`'s call to `wrapResponseForRelease`, so `fetch(new Request(url, { signal }))` now discards on abort-after-headers exactly like `fetch(url, { signal })` already did. 4) Documentation: rewrote the `shutdown()` docstring to accurately state there is no process-exit hook (verified none exists) and explain the shared manager's unref'd-timer lifecycle instead; added a module-header paragraph documenting the zero-transport-retry policy and why a discard-and-replace of a known-closed connection is capacity replacement, not a retry, given durable nonce/state-based replay protection lives above this layer. Added three regression tests: concurrent >16 distinct-origin admission bound, abort via a Request-carried signal, and non-2xx body release via the fixed .text()/JSON.parse pattern (proxy for the TinyCloudNode.ts fix, since Bun's test runtime routes getDefaultNodeFetch() around the pool, matching the existing test file's documented rationale for testing the manager directly).

## Acceptance Criteria
1. Node consumers use one shared transport manager without setGlobalDispatcher; explicit config.fetch always wins, browser/core behavior is unchanged, and Bun fallback behavior is documented but excluded from Node acceptance evidence. The production Node adapter uses supported Undici APIs where viable; any pinned compatibility import must remain isolated from shared/core bundles and have build and Node-runtime coverage.
2. Every TinyCloudNode path uses the resolved fetch: discovery, /info, activation/hosting, service graphs, authorization, delegated access, sharing, and encryption. Activation single-flight is partitioned by fetch identity.
3. Each normalized origin has at most 4 connections, pipelining 1, 64 queued requests, 10-second connect timeout, and bounded server keep-alive hints. At most 16 origins are retained, idle resources close after 30 seconds, and only idle origins are evicted. Origin or queue exhaustion raises an explicit transport error without falling back to global fetch.
4. Drained responses release a client. Cancellation, body errors, aborts, peer resets, and dispatch rejection discard and destroy it. Discarding removes capacity accounting correctly, supplies queued work with replacement capacity, and is awaited during shutdown; no waiter may hang or slot leak.
5. Transport retries are zero. A connection known closed before dispatch may be replaced, but a request that may have reached the server is never replayed.
6. Twenty sequential body-drained requests to one local origin use one TCP connection. A forced peer close yields exactly one replacement and all requests complete. Concurrent traffic never exceeds four sockets per origin; retained origins and queues never exceed their limits.
7. Document the finite defaults, shutdown behavior, Bun distinction, and no-transport-retry policy. Limit the PR to the transport/default-fetch, TinyCloudNode authorization/delegation paths, sdk-core activation partition, necessary dependency metadata, and focused tests.

## Test Plan
Run deterministic acceptance tests under the declared Node >=20 runtime; Bun-only execution cannot establish pooling acceptance. Use a local HTTP server that counts raw TCP connections and server attempts, drains bodies explicitly, and closes cleanly after every case.
1. Transport reuse: 20 sequential requests equal one connection; forced server close equals two; parallel requests remain at or below four; a seventeenth retained origin fails or evicts only an idle origin according to the documented policy; a sixty-fifth queued request fails explicitly.
2. Lifecycle: verify full drain, streaming completion, clone where supported, cancel, abort, body-read error, reset, idle eviction, and manager close. After every discard, the next request opens a fresh connection. At maximum capacity, discard hands replacement capacity to a queued waiter and shutdown awaits destruction without hanging.
3. Replay: reset an authenticated POST after the server records receipt; assert one server attempt and a surfaced error. Also assert pool-limit errors never retry through native/global fetch.
4. Injection: use a recording explicit fetch and verify every TinyCloudNode network path observes it. Assert concurrent activation coalesces for the same fetch identity but not across two identities.
5. Packaging: build/typecheck node-sdk and sdk-core and verify the browser-safe /core output contains no Undici import. Run focused transport, space, authorization, and delegation tests, then existing node-sdk and sdk-core suites and git diff --check.
6. Request evidence: for profile target operations, assert one node HTTP request per completed KV get/list/put and SQL execute/query when fixture behavior is stable. Capture fresh/restored sign-in route multisets without imposing an exact count. Do not add batch APIs or batching work.

## Benchmark Plan
Use the supplied TC-407 profile unchanged: server revision 8457cced, tests/node-sdk/benchmarks/node-sdk.bench.ts, five rounds of 50 samples, and its configured build/run commands. The baseline is clean master and the candidate is the reviewed worktree revision. Both must use the same release-mode wasm-pack/server artifacts, dependency lockfile, Node/Bun toolchain versions, machine, environment, and fixture; a debug-versus-release or differing-server pairing is invalid. Alternate baseline and candidate rounds where the harness permits and run on an otherwise idle machine.
Targets are sdk.kv.get, sdk.kv.list, sdk.kv.put, sdk.sql.execute, and sdk.sql.query. Non-targets are every other scenario emitted by the unchanged profile, including setup/sign-in timing when reported; request-route counts are diagnostic evidence rather than new performance targets. The transport must remain observable through the harness's timed global fetch wrapper, so verify that each target sample contains its expected HTTP span and is not bypassed or double-counted.
Merge evidence consists of raw per-round artifacts, exact baseline/candidate commits, server revision, release-build confirmation, toolchain/environment metadata, request-count summaries, and an aggregate comparison. Reject a result only when at least four of five rounds consistently exceed both applicable limits: target or non-target mean regression greater than 5% and 0.15 ms; p95 greater than 7.5% and 0.25 ms; or p99 greater than 15% and 0.5 ms. Results inside both percentage/effect-size bands are noise. The deterministic 20-request socket trace supplies warm-reuse proof. Production DNS/connect/TLS/TTFB traces, deployed topology inspection, ingress/Rocket pooling, rollout thresholds, and batching opportunities are explicit follow-ups and do not block this PR.