### PR TITLE
chore(release): exit pre mode — cut a stable SDK release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@tinycloud/node-demo": "0.0.29",


### PR DESCRIPTION
## What this does

Flips `.changeset/pre.json` from `pre` to `exit`. CI runs `changeset version` + `changeset publish`, so this one-line change is what promotes 25 accumulated changesets from the `beta` channel to stable.

## Resulting versions

Simulated locally (`pre exit` + `version`, then reverted):

| package | current beta | stable |
|---|---|---|
| `@tinycloud/bootstrap` | 2.7.0-beta.1 | **2.7.0** |
| `@tinycloud/sdk-core` | 2.11.0-beta.12 | **2.11.0** |
| `@tinycloud/sdk-services` | 2.11.0-beta.11 | **2.11.0** |
| `@tinycloud/node-sdk` | 2.11.0-beta.12 | **2.11.0** |
| `@tinycloud/web-sdk` | 2.11.0-beta.12 | **2.11.0** |
| `@tinycloud/cli` | — | **0.9.0** |

## Why this is safe now

The stable release was gated on OpenKey, not on the SDK. The widened bootstrap request (account-space coverage, TC-393) is denied by the *old* OpenKey evaluator — so shipping stable first would have broken auto-sign for existing users.

**That gate is cleared:** OpenKey's fail-closed unique-candidate evaluator is merged and deployed (`de5220df`, deploy workflow success, `api.openkey.so/health` 200). It accepts the widened request, and still accepts the old default-only request as an anchored subset — so older SDK consumers keep working.

## Verification

- node-sdk **0 failures** (354 tests), sdk-core **864/0**, bootstrap **21/0**
- The 2 remaining node-sdk errors are the cross-repo harness-not-found guards, which fail closed when unconfigured locally and occur identically on `master`
- Turbo build green

## Note for whoever runs this

If node-sdk tests look broken locally, rebuild first — node-sdk resolves sdk-core through `dist`, and a stale `dist` produces misleading `Export named ... not found` errors. That is not a real failure.

Follow-up (not blocking): OpenKey pins `@tinycloud/bootstrap@2.7.0-beta.1`. The beta stays valid, but it's worth moving that pin to `2.7.0` once published.