### PR TITLE
fix(release): block unconfirmed major betas (TC-493)

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -48,6 +48,10 @@ jobs:
           COUNT=$(find .changeset -name '*.md' ! -name 'README.md' | wc -l)
           echo "pending=$COUNT" >> "$GITHUB_OUTPUT"
 
+      - name: Reject unconfirmed major beta releases
+        if: steps.check.outputs.pending != '0'
+        run: node scripts/check-beta-release-plan.mjs
+
       - name: List pending changesets
         if: steps.check.outputs.pending != '0'
         run: |

--- a/scripts/check-beta-release-plan.mjs
+++ b/scripts/check-beta-release-plan.mjs
@@ -1,0 +1,25 @@
+import { readdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const changesetDirectory = resolve(process.argv[2] ?? ".changeset");
+const allowMajor = process.env.ALLOW_MAJOR_BETA === "true";
+const majorPackages = new Set();
+
+for (const name of await readdir(changesetDirectory)) {
+  if (!name.endsWith(".md") || name === "README.md") continue;
+  const source = await readFile(resolve(changesetDirectory, name), "utf8");
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source)?.[1];
+  if (frontmatter === undefined) continue;
+  for (const line of frontmatter.split(/\r?\n/)) {
+    const entry = /^\s*["']?([^"':]+)["']?\s*:\s*major\s*$/.exec(line);
+    if (entry?.[1] !== undefined) majorPackages.add(entry[1]);
+  }
+}
+
+if (majorPackages.size > 0 && !allowMajor) {
+  throw new Error(`Automatic beta release refuses unconfirmed major bumps: ${[...majorPackages].sort().join(", ")}. Use an explicitly reviewed major-release workflow.`);
+}
+
+console.log(majorPackages.size === 0
+  ? "Beta release plan contains no major bumps."
+  : `Explicit major beta release confirmed for: ${[...majorPackages].sort().join(", ")}`);


### PR DESCRIPTION
## Summary

- Inspect every pending Changeset before the automatic master beta release.
- Refuse any major bump unless a separately reviewed release path explicitly sets `ALLOW_MAJOR_BETA=true`.
- Keep ordinary patch/minor beta publication unchanged.

This prevents the TC-493/TC-292 coupling that accidentally published `@tinycloud/web-sdk@3.0.0-beta.0`.

## Verification

- Current master plan fails with `@tinycloud/web-sdk` identified as an unconfirmed major.
- The explicit `ALLOW_MAJOR_BETA=true` escape hatch passes and names the confirmed package.
- Workflow YAML passes parsing; actionlint reports only the workflow's two pre-existing informational shell warnings.

Relates to TC-493.
