### PR TITLE
fix(TC-490): add explicit major beta release path

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: 'Type "release" to confirm stable release'
+        description: 'Type "release" for stable or "major-beta" for an explicitly reviewed major beta'
         required: true
 
 concurrency:
@@ -18,7 +18,9 @@ jobs:
   # On push to master: publish incrementing beta pre-releases
   beta:
     name: Beta Release
-    if: github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')
+    if: >-
+      (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm == 'major-beta')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -51,6 +53,8 @@ jobs:
       - name: Reject unconfirmed major beta releases
         if: steps.check.outputs.pending != '0'
         run: node scripts/check-beta-release-plan.mjs
+        env:
+          ALLOW_MAJOR_BETA: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.confirm == 'major-beta' }}
 
       - name: List pending changesets
         if: steps.check.outputs.pending != '0'

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -20,7 +20,7 @@ jobs:
     name: Beta Release
     if: >-
       (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm == 'major-beta')
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' && github.event.inputs.confirm == 'major-beta')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -54,7 +54,7 @@ jobs:
         if: steps.check.outputs.pending != '0'
         run: node scripts/check-beta-release-plan.mjs
         env:
-          ALLOW_MAJOR_BETA: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.confirm == 'major-beta' }}
+          ALLOW_MAJOR_BETA: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' && github.event.inputs.confirm == 'major-beta' }}
 
       - name: List pending changesets
         if: steps.check.outputs.pending != '0'


### PR DESCRIPTION
## Summary

- preserve the automatic guard against unconfirmed major beta releases
- add an explicit `major-beta` workflow-dispatch confirmation path
- set `ALLOW_MAJOR_BETA` only for that manually confirmed dispatch

This unblocks the reviewed TC-292 major beta and TC-490 manage-key changesets without weakening push-triggered release safety.

## Verification

- `actionlint -ignore SC2015 .github/workflows/changesets.yml`
- unconfirmed major fixture rejected by `scripts/check-beta-release-plan.mjs`
- same fixture accepted only with `ALLOW_MAJOR_BETA=true`
- `git diff --check`

Linear: TC-490
