### PR TITLE
fix(TC-500): restore account sessions for automatic share receive

### DIFF
--- a/.changeset/tc-500-account-session-restore.md
+++ b/.changeset/tc-500-account-session-restore.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/web-sdk": patch
+---
+
+Restore the most recently persisted TinyCloud account for `share.receive(..., { identity: "auto" })` before falling back to an accountless receiver key.

--- a/packages/sdk-rs/packages/web/tsconfig.json
+++ b/packages/sdk-rs/packages/web/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "declaration": true
+    "declaration": true,
+    "moduleResolution": "node"
   }
 }

--- a/packages/web-sdk/src/adapters/BrowserSessionStorage.ts
+++ b/packages/web-sdk/src/adapters/BrowserSessionStorage.ts
@@ -5,6 +5,7 @@ import {
 } from "@tinycloud/sdk-core";
 
 const STORAGE_PREFIX = "tinycloud:session:";
+const ACTIVE_ADDRESS_SUFFIX = "active-address";
 
 export type BrowserSessionLoadStatus =
   | "loaded"
@@ -43,6 +44,16 @@ export class BrowserSessionStorage implements ISessionStorage {
     return this.keyPrefix + address.toLowerCase();
   }
 
+  private activeAddressKey(): string {
+    return this.keyPrefix + ACTIVE_ADDRESS_SUFFIX;
+  }
+
+  private clearActiveAddress(address: string): void {
+    if (this.storage?.getItem(this.activeAddressKey()) === address.toLowerCase()) {
+      this.storage.removeItem(this.activeAddressKey());
+    }
+  }
+
   private assertPersistable(data: PersistedSessionData): void {
     const result = validatePersistedSessionData(data);
     if (!result.ok) {
@@ -67,8 +78,21 @@ export class BrowserSessionStorage implements ISessionStorage {
   save(address: string, data: PersistedSessionData): Promise<void> {
     if (!this.storage) return Promise.resolve();
     this.assertPersistable(data);
-    this.storage.setItem(this.key(address), JSON.stringify(data));
+    const normalizedAddress = address.toLowerCase();
+    this.storage.setItem(this.key(normalizedAddress), JSON.stringify(data));
+    this.storage.setItem(this.activeAddressKey(), normalizedAddress);
     return Promise.resolve();
+  }
+
+  /** Most recently saved, still-valid session address for provider-free reloads. */
+  activeAddress(): string | undefined {
+    if (!this.storage) return undefined;
+    const address = this.storage.getItem(this.activeAddressKey());
+    if (address === null || !this.exists(address)) {
+      this.storage.removeItem(this.activeAddressKey());
+      return undefined;
+    }
+    return address;
   }
 
   load(address: string): Promise<PersistedSessionData | null> {
@@ -89,11 +113,13 @@ export class BrowserSessionStorage implements ISessionStorage {
       const result = validatePersistedSessionData(parsed);
       if (!result.ok) {
         this.storage.removeItem(key);
+        this.clearActiveAddress(address);
         return { status: "corrupt", data: null };
       }
 
       if (!result.data.tinycloudSession?.spaceId) {
         this.storage.removeItem(key);
+        this.clearActiveAddress(address);
         return { status: "corrupt", data: null };
       }
 
@@ -104,24 +130,28 @@ export class BrowserSessionStorage implements ISessionStorage {
         }
       } catch {
         this.storage.removeItem(key);
+        this.clearActiveAddress(address);
         return { status: "corrupt", data: null };
       }
 
       const expiresAt = new Date(result.data.expiresAt);
       if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= Date.now()) {
         this.storage.removeItem(key);
+        this.clearActiveAddress(address);
         return { status: "expired", data: null };
       }
 
       return { status: "loaded", data: result.data };
     } catch {
       this.storage.removeItem(key);
+      this.clearActiveAddress(address);
       return { status: "corrupt", data: null };
     }
   }
 
   clear(address: string): Promise<void> {
     this.storage?.removeItem(this.key(address));
+    this.clearActiveAddress(address);
     return Promise.resolve();
   }
 

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -612,7 +612,12 @@ export class TinyCloudWeb {
   private async resolveRestoreAddress(address?: string): Promise<string | undefined> {
     if (address) return address;
     if (this._node?.address) return this._node.address;
-    return this.walletSigner?.getConnectedAddress();
+    const connected = await this.walletSigner?.getConnectedAddress();
+    if (connected !== undefined) return connected;
+    const storage = this.sessionStorage as
+      | (ISessionStorage & { activeAddress?: () => string | undefined })
+      | undefined;
+    return storage?.activeAddress?.();
   }
 
   private async loadPersistedSession(

--- a/packages/web-sdk/src/share/service.ts
+++ b/packages/web-sdk/src/share/service.ts
@@ -284,6 +284,10 @@ export class ReceivedShareImpl implements ReceivedShare {
       { key: metadataKey, value: metadata, contentType: "application/json" },
     ], { signal: options.signal });
     if (!written.ok) throw new Error("share import failed");
+    const readback = await kv.get<{ readonly byteDigest?: string }>(metadataKey, { signal: options.signal });
+    if ("error" in readback || readback.data.data.byteDigest !== this.content.byteDigest) {
+      throw new Error("share import readback failed");
+    }
     this.options.onProgress?.({ state: "import", status: "completed" });
     return Object.freeze({ status: "imported", path: logicalPath, byteDigest: this.content.byteDigest });
   }

--- a/packages/web-sdk/src/share/service.ts
+++ b/packages/web-sdk/src/share/service.ts
@@ -81,7 +81,7 @@ export async function selectShareReceiverAccountSession(
 ): Promise<ReturnType<ShareReceiverClient["session"]>> {
   if (requestedIdentity === "receiver") return undefined;
   const active = client.session();
-  if (active !== undefined || requestedIdentity === "auto") return active;
+  if (active !== undefined) return active;
   const restored = await client.restoreSession();
   return restored.status === "restored" ? restored.session : undefined;
 }

--- a/packages/web-sdk/tests/share.receiver.test.ts
+++ b/packages/web-sdk/tests/share.receiver.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@tinycloud/sdk-core";
 import { didKeyFromEd25519PublicKey, ed25519PublicKeyFromDidKey } from "@tinycloud/share-envelope";
 import { interpretCredentialFlow } from "../src/credentials/interpreter";
+import { BrowserSessionStorage } from "../src/adapters/BrowserSessionStorage";
 import type { CredentialAcquisitionTransport, CredentialRequestState } from "../src/credentials/types";
 import { SessionReceiverCredentialCustody } from "../src/share/receiver-credentials";
 import { createOrRestoreShareReceiverSession, SHARE_RECEIVER_SESSION_STORAGE_KEY } from "../src/share/receiver-session";
@@ -82,21 +83,54 @@ test("share links are bound to the configured out-of-band Share origin", () => {
   expect(() => validateShareReceiverExpectedOrigin("https://share.example/s/claim#secret", "https://share.example/path")).toThrow("configured Share deployment");
 });
 
-test("auto identity never restores through a wallet provider before guest receive", async () => {
+test("auto identity restores an existing account session before falling back to guest receive", async () => {
   let restoreCalls = 0;
   const restoredSession = { address: "0x1" } as any;
   const signedOutClient = {
     session: () => undefined,
     restoreSession: async () => { restoreCalls += 1; return { status: "restored", session: restoredSession }; },
   } as any;
-  expect(await selectShareReceiverAccountSession(signedOutClient, "auto")).toBeUndefined();
-  expect(restoreCalls).toBe(0);
-  expect(await selectShareReceiverAccountSession(signedOutClient, "account")).toBe(restoredSession);
+  expect(await selectShareReceiverAccountSession(signedOutClient, "auto")).toBe(restoredSession);
   expect(restoreCalls).toBe(1);
+  expect(await selectShareReceiverAccountSession(signedOutClient, "account")).toBe(restoredSession);
+  expect(restoreCalls).toBe(2);
 
   const activeClient = { ...signedOutClient, session: () => restoredSession };
   expect(await selectShareReceiverAccountSession(activeClient, "auto")).toBe(restoredSession);
-  expect(restoreCalls).toBe(1);
+  expect(restoreCalls).toBe(2);
+
+  const missingClient = {
+    session: () => undefined,
+    restoreSession: async () => ({ status: "missing" }),
+  } as any;
+  expect(await selectShareReceiverAccountSession(missingClient, "auto")).toBeUndefined();
+});
+
+test("browser persistence exposes the latest valid account without a wallet provider", async () => {
+  const backend = memoryStorage();
+  const storage = new BrowserSessionStorage({ storage: backend as Storage });
+  const address = "0x1234567890abcdef1234567890abcdef12345678";
+  const now = new Date();
+  await storage.save(address, {
+    address,
+    chainId: 1,
+    sessionKey: JSON.stringify({ kty: "OKP", crv: "Ed25519", d: "secret" }),
+    siwe: "example.com wants you to sign in",
+    signature: "0xsig",
+    tinycloudSession: {
+      delegationHeader: { Authorization: "Bearer delegation" },
+      delegationCid: "bafydelegation",
+      spaceId: "space://tinycloud/1/owner/default",
+      verificationMethod: "did:key:z6MkSession#z6MkSession",
+    },
+    expiresAt: new Date(now.getTime() + 60_000).toISOString(),
+    createdAt: now.toISOString(),
+    version: "1.0",
+  });
+  expect(storage.activeAddress()).toBe(address);
+
+  await storage.clear(address);
+  expect(storage.activeAddress()).toBeUndefined();
 });
 
 test("Share trust requires a did:key target and keeps invitation verification identity separate", () => {

--- a/packages/web-sdk/tests/share.receiver.test.ts
+++ b/packages/web-sdk/tests/share.receiver.test.ts
@@ -234,10 +234,14 @@ function receivedShareForImport(onProgress?: (event: unknown) => void): Received
 test("share import is idempotent and writes content plus non-sensitive metadata once", async () => {
   let storedMetadata: Record<string, unknown> | undefined;
   let batchWrites = 0;
+  let metadataReads = 0;
   const kv = {
-    get: async () => storedMetadata === undefined
-      ? { ok: false, error: { code: "KV_NOT_FOUND", message: "missing", service: "kv" } }
-      : { ok: true, data: { data: storedMetadata, headers: {} } },
+    get: async () => {
+      metadataReads += 1;
+      return storedMetadata === undefined
+        ? { ok: false, error: { code: "KV_NOT_FOUND", message: "missing", service: "kv" } }
+        : { ok: true, data: { data: storedMetadata, headers: {} } };
+    },
     batchPut: async (items: { key: string; value: unknown }[]) => {
       batchWrites += 1;
       storedMetadata = items.find((item) => item.key.includes("/metadata/"))?.value as Record<string, unknown>;
@@ -255,6 +259,7 @@ test("share import is idempotent and writes content plus non-sensitive metadata 
   expect(imported.status).toBe("imported");
   expect(existing.status).toBe("existing");
   expect(batchWrites).toBe(1);
+  expect(metadataReads).toBe(3);
   expect(storedMetadata).toEqual({
     filename: "received.txt",
     mediaType: "text/plain",
@@ -283,4 +288,25 @@ test("share import fails closed on metadata read errors and cancellation", async
   controller.abort(new DOMException("cancelled", "AbortError"));
   await expect(received.importInto(accountClient, { namespace: "files-for-you", signal: controller.signal })).rejects.toThrow("cancelled");
   expect(batchWrites).toBe(0);
+});
+
+test("share import requires authenticated metadata readback after writing", async () => {
+  let reads = 0;
+  const accountClient = {
+    session: () => ({}) as any,
+    ensureOwnedSpaceHosted: async () => "did:key:z6MkAccount:files-for-you",
+    kvForSpace: () => ({
+      get: async () => {
+        reads += 1;
+        return reads === 1
+          ? { ok: false, error: { code: "KV_NOT_FOUND", message: "missing", service: "kv" } }
+          : { ok: false, error: { code: "AUTH_UNAUTHORIZED", message: "denied", service: "kv" } };
+      },
+      batchPut: async () => ({ ok: true, data: { count: 2, keys: [] } }),
+    }) as any,
+  };
+
+  await expect(receivedShareForImport().importInto(accountClient, { namespace: "files-for-you" }))
+    .rejects.toThrow("readback failed");
+  expect(reads).toBe(2);
 });


### PR DESCRIPTION
## Summary

- make the web WASM wrapper resolve cleanly generated `wasm-pack` JavaScript bindings
- restore the latest valid persisted TinyCloud account before `share.receive(..., { identity: "auto" })` falls back to an accountless receiver key
- keep provider-free reloads free of wallet/OpenKey prompts by indexing the last valid browser session address

## Verification

- account auto-restore and receiver tests: 11/11
- `@tinycloud/web-sdk` CJS + ESM build passes
- generated web and Node WASM builds pass from clean bindings
- Node and web SDK package builds pass

Follow-up to TC-500 / #399. Includes a web-sdk patch changeset for the next beta; no stable major release.
