### PR TITLE
fix(TC-500): restore account sessions for auto receive

### DIFF
--- a/.changeset/tc-500-restored-account-fast-path.md
+++ b/.changeset/tc-500-restored-account-fast-path.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/web-sdk": patch
+---
+
+Restore one unambiguous persisted TinyCloud account session for `share.receive({ identity: "auto" })` without consulting a wallet provider, preserving the account fast path and zero-OpenKey guest claiming.

--- a/packages/web-sdk/src/adapters/BrowserSessionStorage.ts
+++ b/packages/web-sdk/src/adapters/BrowserSessionStorage.ts
@@ -17,6 +17,10 @@ export type BrowserSessionLoadResult =
   | { status: "loaded"; data: PersistedSessionData }
   | { status: Exclude<BrowserSessionLoadStatus, "loaded">; data: null };
 
+export type BrowserSessionSelectionResult =
+  | { status: "loaded"; address: string; data: PersistedSessionData }
+  | { status: Exclude<BrowserSessionLoadStatus, "loaded">; data: null };
+
 export interface BrowserSessionStorageOptions {
   /** Storage backend. Defaults to globalThis.localStorage when available. */
   storage?: Storage;
@@ -118,6 +122,39 @@ export class BrowserSessionStorage implements ISessionStorage {
       this.storage.removeItem(key);
       return { status: "corrupt", data: null };
     }
+  }
+
+  /**
+   * Load the only valid account session in this app's storage namespace.
+   *
+   * This deliberately does not consult a wallet provider. If more than one
+   * account session is present, there is no unambiguous signed-in identity and
+   * callers must keep using the accountless path until the app activates one.
+   */
+  async loadUnambiguousWithStatus(): Promise<BrowserSessionSelectionResult> {
+    if (!this.storage) return { status: "storage-unavailable", data: null };
+    const addresses: string[] = [];
+    try {
+      for (let index = 0; index < this.storage.length; index += 1) {
+        const key = this.storage.key(index);
+        if (key === null || !key.startsWith(this.keyPrefix)) continue;
+        const address = key.slice(this.keyPrefix.length);
+        if (/^0x[a-f0-9]{40}$/.test(address)) addresses.push(address);
+      }
+    } catch {
+      return { status: "storage-unavailable", data: null };
+    }
+
+    const loaded: { address: string; data: PersistedSessionData }[] = [];
+    for (const address of addresses) {
+      const result = await this.loadWithStatus(address);
+      if (result.status === "loaded" && result.data.address.toLowerCase() === address) {
+        loaded.push({ address: result.data.address, data: result.data });
+      }
+    }
+    return loaded.length === 1
+      ? { status: "loaded", ...loaded[0]! }
+      : { status: "missing", data: null };
   }
 
   clear(address: string): Promise<void> {

--- a/packages/web-sdk/src/adapters/index.ts
+++ b/packages/web-sdk/src/adapters/index.ts
@@ -7,6 +7,7 @@ export { BrowserSessionStorage } from "./BrowserSessionStorage";
 export type {
   BrowserSessionLoadResult,
   BrowserSessionLoadStatus,
+  BrowserSessionSelectionResult,
   BrowserSessionStorageOptions,
 } from "./BrowserSessionStorage";
 export { BrowserENSResolver } from "./BrowserENSResolver";

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -40,6 +40,7 @@ export {
 export type {
   BrowserSessionLoadResult,
   BrowserSessionLoadStatus,
+  BrowserSessionSelectionResult,
   BrowserSessionStorageOptions,
   BrowserProvider,
   BrowserWalletProvider,

--- a/packages/web-sdk/src/modules/tcw.ts
+++ b/packages/web-sdk/src/modules/tcw.ts
@@ -670,6 +670,27 @@ export class TinyCloudWeb {
     }
   }
 
+  /**
+   * Restore an unambiguous persisted TinyCloud account session without asking
+   * a wallet provider for an address. Accountless share receiving uses this so
+   * `identity: "auto"` can reuse a real session without opening OpenKey.
+   */
+  async restorePersistedSession(): Promise<SessionRestoreResult> {
+    const storage = this.sessionStorage as (ISessionStorage & {
+      loadUnambiguousWithStatus?: BrowserSessionStorage["loadUnambiguousWithStatus"];
+    }) | undefined;
+    if (!storage || typeof storage.loadUnambiguousWithStatus !== "function") {
+      this._sessionRestoreStatus = this.sessionStorage ? "missing" : "disabled";
+      return { status: this._sessionRestoreStatus };
+    }
+    const selected = await storage.loadUnambiguousWithStatus();
+    if (selected.status !== "loaded") {
+      this._sessionRestoreStatus = selected.status;
+      return { status: selected.status };
+    }
+    return this.restoreSession(selected.address);
+  }
+
   async clearPersistedSession(address?: string): Promise<void> {
     if (!this.sessionStorage) return;
     const restoreAddress = await this.resolveRestoreAddress(address);

--- a/packages/web-sdk/src/share/service.ts
+++ b/packages/web-sdk/src/share/service.ts
@@ -81,7 +81,11 @@ export async function selectShareReceiverAccountSession(
 ): Promise<ReturnType<ShareReceiverClient["session"]>> {
   if (requestedIdentity === "receiver") return undefined;
   const active = client.session();
-  if (active !== undefined || requestedIdentity === "auto") return active;
+  if (active !== undefined) return active;
+  if (requestedIdentity === "auto") {
+    const restored = await client.restorePersistedSession();
+    return restored.status === "restored" ? restored.session : undefined;
+  }
   const restored = await client.restoreSession();
   return restored.status === "restored" ? restored.session : undefined;
 }

--- a/packages/web-sdk/src/share/types.ts
+++ b/packages/web-sdk/src/share/types.ts
@@ -61,6 +61,7 @@ export interface ShareReceiverClient extends ShareImportAccountClient {
   readonly credentialHolderDid: string;
   readonly credentialHolderKid: string;
   readonly credentials: CredentialsService;
+  restorePersistedSession(): Promise<{ readonly status: string; readonly session?: ClientSession }>;
   restoreSession(): Promise<{ readonly status: string; readonly session?: ClientSession }>;
   signSessionBytes(bytes: Uint8Array): Promise<Uint8Array>;
 }

--- a/packages/web-sdk/tests/browser-session-storage.bun.ts
+++ b/packages/web-sdk/tests/browser-session-storage.bun.ts
@@ -136,6 +136,32 @@ describe("BrowserSessionStorage", () => {
     await expect(appA.load(ADDRESS)).resolves.toEqual(sessionA);
     await expect(appB.load(ADDRESS)).resolves.toEqual(sessionB);
   });
+
+  it("selects one valid app session without consulting a wallet", async () => {
+    const backend = new MemoryStorage();
+    const storage = new BrowserSessionStorage({ storage: backend, keyPrefix: "share:" });
+    const session = persistedSession();
+    await storage.save(ADDRESS, session);
+    backend.setItem("other:0x1111111111111111111111111111111111111111", "not this app");
+
+    await expect(storage.loadUnambiguousWithStatus()).resolves.toEqual({
+      status: "loaded",
+      address: ADDRESS,
+      data: session,
+    });
+  });
+
+  it("does not choose between multiple valid app sessions", async () => {
+    const storage = new BrowserSessionStorage({ storage: new MemoryStorage(), keyPrefix: "share:" });
+    const otherAddress = "0x1111111111111111111111111111111111111111";
+    await storage.save(ADDRESS, persistedSession());
+    await storage.save(otherAddress, persistedSession({ address: otherAddress }));
+
+    await expect(storage.loadUnambiguousWithStatus()).resolves.toEqual({
+      status: "missing",
+      data: null,
+    });
+  });
 });
 
 describe("browser session restore data", () => {

--- a/packages/web-sdk/tests/share.receiver.test.ts
+++ b/packages/web-sdk/tests/share.receiver.test.ts
@@ -82,21 +82,25 @@ test("share links are bound to the configured out-of-band Share origin", () => {
   expect(() => validateShareReceiverExpectedOrigin("https://share.example/s/claim#secret", "https://share.example/path")).toThrow("configured Share deployment");
 });
 
-test("auto identity never restores through a wallet provider before guest receive", async () => {
-  let restoreCalls = 0;
+test("auto identity restores persisted TinyCloud authority without probing a wallet provider", async () => {
+  let walletRestoreCalls = 0;
+  let persistedRestoreCalls = 0;
   const restoredSession = { address: "0x1" } as any;
   const signedOutClient = {
     session: () => undefined,
-    restoreSession: async () => { restoreCalls += 1; return { status: "restored", session: restoredSession }; },
+    restorePersistedSession: async () => { persistedRestoreCalls += 1; return { status: "restored", session: restoredSession }; },
+    restoreSession: async () => { walletRestoreCalls += 1; return { status: "restored", session: restoredSession }; },
   } as any;
-  expect(await selectShareReceiverAccountSession(signedOutClient, "auto")).toBeUndefined();
-  expect(restoreCalls).toBe(0);
+  expect(await selectShareReceiverAccountSession(signedOutClient, "auto")).toBe(restoredSession);
+  expect(persistedRestoreCalls).toBe(1);
+  expect(walletRestoreCalls).toBe(0);
   expect(await selectShareReceiverAccountSession(signedOutClient, "account")).toBe(restoredSession);
-  expect(restoreCalls).toBe(1);
+  expect(walletRestoreCalls).toBe(1);
 
   const activeClient = { ...signedOutClient, session: () => restoredSession };
   expect(await selectShareReceiverAccountSession(activeClient, "auto")).toBe(restoredSession);
-  expect(restoreCalls).toBe(1);
+  expect(persistedRestoreCalls).toBe(1);
+  expect(walletRestoreCalls).toBe(1);
 });
 
 test("Share trust requires a did:key target and keeps invitation verification identity separate", () => {


### PR DESCRIPTION
## Summary

- restore exactly one validated app-scoped persisted TinyCloud account session for `share.receive({ identity: "auto" })`
- never query a wallet provider or OpenKey while selecting the automatic receive identity
- fail closed to the receiver-session branch when persisted account identity is missing, ambiguous, expired, corrupt, or unavailable
- preserve explicit `identity: "account"` restore behavior

This closes the signed-in fast-path gap found during the independent TC-500 Share integration review. It follows the merged TC-500 receive facade in #399 and remains a beta/patch rollout.

## Verification

- `bunx turbo build --filter=@tinycloud/web-sdk... --output-logs=errors-only` — 10/10 build tasks
- `bun test packages/web-sdk/tests/share.receiver.test.ts` — 10/10
- focused BrowserSessionStorage selection assertions — 2/2
- `bun run --cwd packages/web-sdk lint`
- beta release guard — 2/2, no new major bump
- independent Sol review: approved with no security/session blocker

The directly invoked pre-existing `browser-session-storage.bun.ts` still has an unrelated stale expectation for fields already returned by `restoreDataFromPersisted`; the two TC-500 selection assertions pass and this change does not alter that restore shape.

Linear: TC-500
