### PR TITLE
feat(TC-500): expose received share metadata

### DIFF
--- a/.changeset/tc-500-received-share-metadata.md
+++ b/.changeset/tc-500-received-share-metadata.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/web-sdk": patch
+---
+
+Expose verified share metadata on the first-class `share.receive()` result so host applications can render without re-parsing the share.

--- a/packages/web-sdk/src/share/service.ts
+++ b/packages/web-sdk/src/share/service.ts
@@ -7,7 +7,7 @@ import {
   type CredentialRequirement,
   type UnifiedPolicyV2,
 } from "@tinycloud/sdk-core";
-import { inspectShare, ShareRecipientClient } from "@tinycloud/share-sdk";
+import { inspectShare, ShareRecipientClient, type ShareMetadata } from "@tinycloud/share-sdk";
 import { ed25519PublicKeyFromDidKey, type ShareEnvelopeV3 } from "@tinycloud/share-envelope";
 import { CredentialsService, type CredentialClient } from "../credentials";
 import { SessionReceiverCredentialCustody } from "./receiver-credentials";
@@ -131,7 +131,7 @@ export class ReceivedShareImpl implements ReceivedShare {
 
   constructor(
     readonly identity: ShareReceiverIdentity,
-    readonly shareId: string,
+    readonly metadata: ShareMetadata,
     private readonly envelope: ShareEnvelopeV3,
     private readonly credentials: CredentialsService,
     private readonly sign: (bytes: Uint8Array) => Promise<Uint8Array>,
@@ -140,6 +140,8 @@ export class ReceivedShareImpl implements ReceivedShare {
     private readonly credentialDiscoveryUrl: string,
     private readonly trustedNode: { readonly invitationKid: string; readonly invitationPublicKey: Uint8Array },
   ) {}
+
+  get shareId(): string { return this.metadata.shareId; }
 
   get(): Promise<ShareReceivedContent> {
     if (this.content !== undefined) return Promise.resolve(this.content);
@@ -338,6 +340,6 @@ export class ShareReceiverService {
       sign = (bytes) => receiver.sign(bytes);
     }
     options.onProgress?.({ state: "identity-selection", status: "completed", identity });
-    return new ReceivedShareImpl(identity, inspection.metadata.shareId, envelope, credentials, sign, options, this.fetchFn, this.config.credentialDiscoveryUrl ?? DEFAULT_CREDENTIAL_DISCOVERY, trustedNode);
+    return new ReceivedShareImpl(identity, inspection.metadata, envelope, credentials, sign, options, this.fetchFn, this.config.credentialDiscoveryUrl ?? DEFAULT_CREDENTIAL_DISCOVERY, trustedNode);
   }
 }

--- a/packages/web-sdk/src/share/types.ts
+++ b/packages/web-sdk/src/share/types.ts
@@ -1,4 +1,5 @@
 import type { ClientSession, IKVService } from "@tinycloud/sdk-core";
+import type { ShareMetadata } from "@tinycloud/share-sdk";
 import type { CredentialsService } from "../credentials";
 
 export type ShareReceiverIdentity =
@@ -52,6 +53,7 @@ export interface ShareImportAccountClient {
 
 export interface ReceivedShare {
   readonly identity: ShareReceiverIdentity;
+  readonly metadata: ShareMetadata;
   readonly shareId: string;
   get(): Promise<ShareReceivedContent>;
   importInto(accountClient: ShareImportAccountClient, options: ShareImportOptions): Promise<ShareImportResult>;

--- a/packages/web-sdk/tests/share.receiver.test.ts
+++ b/packages/web-sdk/tests/share.receiver.test.ts
@@ -205,7 +205,17 @@ test("receiver holder binding uses the receiver signer without an OpenKey approv
 function receivedShareForImport(onProgress?: (event: unknown) => void): ReceivedShareImpl {
   const received = new ReceivedShareImpl(
     { kind: "receiver", holderDid: "did:key:z6MkReceiver", custody: "session", origin: "https://share.example" },
-    "share-1",
+    {
+      protocol: "tinycloud-share",
+      version: 1,
+      shareId: "share-1",
+      origin: "https://share.example",
+      target: { kind: "email", origin: "https://node.example", nodeAudience: "did:key:z6MkEnforcer", spaceId: "space-1" },
+      resource: { kind: "exact", path: "shares/share-1/received.txt" },
+      actions: ["read"],
+      expiresAt: "2030-01-02T00:00:00.000Z",
+      display: { filename: "received.txt" },
+    },
     {} as never,
     {} as never,
     async () => new Uint8Array(64),
@@ -228,6 +238,7 @@ function receivedShareForImport(onProgress?: (event: unknown) => void): Received
     receivedAt: "2030-01-01T00:00:00.000Z",
   });
   (received as unknown as { content: ShareReceivedContent }).content = content;
+  expect(received.shareId).toBe(received.metadata.shareId);
   return received;
 }
 


### PR DESCRIPTION
## Summary
- expose verified `ShareMetadata` on `ReceivedShare`
- derive the public `shareId` from that metadata
- let thin consumers render verified share details without reparsing the legacy envelope

## Verification
- focused web-sdk receiver tests: 12/12 passed
- full monorepo build passed

Linear: TC-500
