### PR TITLE
fix(TC-500): verify compact UCAN roots in browsers

### DIFF
--- a/.changeset/tc-500-browser-compact-ucan.md
+++ b/.changeset/tc-500-browser-compact-ucan.md
@@ -1,0 +1,5 @@
+---
+"@tinycloud/share-envelope": patch
+---
+
+Use the browser-safe base64url codec when verifying compact UCAN roots, even when the host bundle exposes a partial `Buffer` polyfill.

--- a/packages/share-envelope/src/compact-ucan.ts
+++ b/packages/share-envelope/src/compact-ucan.ts
@@ -2,6 +2,7 @@ import { ed25519 } from "@noble/curves/ed25519";
 import { blake3 } from "@noble/hashes/blake3";
 import { CID } from "multiformats/cid";
 import { create as createDigest } from "multiformats/hashes/digest";
+import { fromBase64Url, toBase64Url } from "./bytes.js";
 import { canonicalize } from "./jcs.js";
 import { ed25519PublicKeyFromDidKey } from "./didkey.js";
 
@@ -44,7 +45,7 @@ export async function signCompactUcanAuthorization(
   const publicKey = ed25519PublicKeyFromDidKey(principal);
   const header = {
     alg: "EdDSA",
-    jwk: { alg: "EdDSA", crv: "Ed25519", kty: "OKP", x: encodeBase64Url(publicKey) },
+    jwk: { alg: "EdDSA", crv: "Ed25519", kty: "OKP", x: toBase64Url(publicKey) },
     typ: "JWT",
     ucv: "0.10.0",
   };
@@ -60,13 +61,13 @@ export async function signCompactUcanAuthorization(
     nnc: input.nonce,
     prf: input.proofs,
   };
-  const protectedSegment = encodeBase64Url(new TextEncoder().encode(canonicalize(header)));
-  const payloadSegment = encodeBase64Url(new TextEncoder().encode(canonicalize(payload)));
+  const protectedSegment = toBase64Url(new TextEncoder().encode(canonicalize(header)));
+  const payloadSegment = toBase64Url(new TextEncoder().encode(canonicalize(payload)));
   const signingInput = new TextEncoder().encode(`${protectedSegment}.${payloadSegment}`);
   const signature = await input.sign(signingInput);
   if (signature.length !== 64) throw new TypeError("compact Authorization signature must be Ed25519");
   return verifyCompactUcanAuthorization(
-    `${protectedSegment}.${payloadSegment}.${encodeBase64Url(signature)}`,
+    `${protectedSegment}.${payloadSegment}.${toBase64Url(signature)}`,
   );
 }
 
@@ -78,9 +79,9 @@ export function verifyCompactUcanAuthorization(
   const segments = authorization.split(".");
   if (segments.length !== 3 || segments.some((segment) => segment.length === 0)) throw new TypeError("compact Authorization must contain three segments");
   const [headerSegment, payloadSegment, signatureSegment] = segments as [string, string, string];
-  const headerBytes = decodeBase64Url(headerSegment);
-  const payloadBytes = decodeBase64Url(payloadSegment);
-  const signature = decodeBase64Url(signatureSegment);
+  const headerBytes = fromBase64Url(headerSegment);
+  const payloadBytes = fromBase64Url(payloadSegment);
+  const signature = fromBase64Url(signatureSegment);
   const decoder = new TextDecoder("utf-8", { fatal: true });
   const header = JSON.parse(decoder.decode(headerBytes)) as Record<string, unknown>;
   const payload = JSON.parse(decoder.decode(payloadBytes)) as Record<string, unknown>;
@@ -93,7 +94,7 @@ export function verifyCompactUcanAuthorization(
   if (typeof payload.iss !== "string" || typeof payload.aud !== "string" || typeof payload.nnc !== "string" || !Number.isInteger(payload.nbf) || !Number.isInteger(payload.exp) || (payload.nbf as number) >= (payload.exp as number) || !Array.isArray(payload.prf) || payload.prf.some((proof) => typeof proof !== "string") || !Array.isArray(payload.fct) || payload.fct.length !== 1) throw new TypeError("compact Authorization payload is invalid");
   const principal = payload.iss.split("#", 1)[0]!;
   const publicKey = ed25519PublicKeyFromDidKey(principal);
-  if (!equal(publicKey, decodeBase64Url(jwk.x))) throw new TypeError("compact Authorization JWK does not bind issuer");
+  if (!equal(publicKey, fromBase64Url(jwk.x))) throw new TypeError("compact Authorization JWK does not bind issuer");
   if (!ed25519.verify(signature, new TextEncoder().encode(`${headerSegment}.${payloadSegment}`), publicKey, { zip215: false })) throw new TypeError("compact Authorization signature is invalid");
   const cid = CID.createV1(0x55, createDigest(0x1e, blake3(new TextEncoder().encode(authorization)))).toString();
   if (expectedCid !== undefined && cid !== expectedCid) throw new TypeError("compact Authorization CID mismatch");
@@ -107,24 +108,6 @@ function object(value: unknown, label: string): Record<string, unknown> {
 
 function assertExactKeys(value: Record<string, unknown>, keys: readonly string[], label: string): void {
   if (Object.keys(value).length !== keys.length || Object.keys(value).some((key) => !keys.includes(key))) throw new TypeError(`${label} has unknown or missing fields`);
-}
-
-function decodeBase64Url(value: string): Uint8Array {
-  if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) throw new TypeError("compact Authorization segment is not base64url");
-  const bytes = typeof Buffer !== "undefined"
-    ? new Uint8Array(Buffer.from(value, "base64url"))
-    : Uint8Array.from(atob(value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=")), (character) => character.charCodeAt(0));
-  const encoded = typeof Buffer !== "undefined"
-    ? Buffer.from(bytes).toString("base64url")
-    : btoa(String.fromCharCode(...bytes)).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
-  if (encoded !== value) throw new TypeError("compact Authorization segment is not canonical");
-  return bytes;
-}
-
-function encodeBase64Url(value: Uint8Array): string {
-  return typeof Buffer !== "undefined"
-    ? Buffer.from(value).toString("base64url")
-    : btoa(String.fromCharCode(...value)).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
 }
 
 function equal(left: Uint8Array, right: Uint8Array): boolean {

--- a/packages/share-envelope/test/compact-ucan.test.ts
+++ b/packages/share-envelope/test/compact-ucan.test.ts
@@ -1,0 +1,40 @@
+import { ed25519 } from "@noble/curves/ed25519";
+import { describe, expect, it } from "vitest";
+
+import {
+  didKeyFromEd25519PublicKey,
+  signCompactUcanAuthorization,
+  verifyCompactUcanAuthorization,
+} from "../src/index.js";
+
+describe("compact UCAN browser codec", () => {
+  it("ignores an ambient Buffer polyfill that cannot encode base64url", async () => {
+    const privateKey = new Uint8Array(32).fill(83);
+    const issuerDid = didKeyFromEd25519PublicKey(ed25519.getPublicKey(privateKey));
+    const originalBuffer = Object.getOwnPropertyDescriptor(globalThis, "Buffer");
+    Object.defineProperty(globalThis, "Buffer", {
+      configurable: true,
+      value: { from: () => { throw new Error("browser Buffer polyfill does not support base64url"); } },
+    });
+
+    try {
+      const authorization = await signCompactUcanAuthorization({
+        issuerDid,
+        audienceDid: "did:key:z6MkReceiver",
+        attenuation: { "tinycloud:test/kv/report.txt": { "tinycloud.kv/get": [{}] } },
+        facts: [{ type: "tinycloud.policy.root/v1" }],
+        proofs: [],
+        notBefore: 1_786_100_000,
+        expiresAt: 1_786_100_060,
+        nonce: "browser-codec",
+        sign: async (bytes) => ed25519.sign(bytes, privateKey),
+      });
+
+      expect(verifyCompactUcanAuthorization(authorization.authorization, authorization.cid).payload.iss)
+        .toBe(`${issuerDid}#${issuerDid.slice("did:key:".length)}`);
+    } finally {
+      if (originalBuffer === undefined) delete (globalThis as { Buffer?: unknown }).Buffer;
+      else Object.defineProperty(globalThis, "Buffer", originalBuffer);
+    }
+  });
+});

--- a/packages/share-sdk/src/recipient.ts
+++ b/packages/share-sdk/src/recipient.ts
@@ -506,7 +506,7 @@ export class ShareRecipientClient {
     if (envelope.version !== 3 || this.session === undefined || this.v3Authorization === undefined || this.v3NodeAudience === undefined || signer === undefined) throw new Error("v3 policy session signer is required");
     const encrypted = parseV3InlineEncryptedEnvelope(bytes, envelope);
     const receiverPrivateKey = crypto.getRandomValues(new Uint8Array(32));
-    const receiverPublicKey = toBase64Url(x25519.getPublicKey(receiverPrivateKey));
+    const receiverPublicKey = toBase64(x25519.getPublicKey(receiverPrivateKey));
     const receiverPublicKeyHash = canonicalHashHex(receiverPublicKey);
     const body = { type: "tinycloud.encryption.decrypt/v1", targetNode: this.v3NodeAudience, networkId: encrypted.networkId, alg: encrypted.alg, keyVersion: encrypted.keyVersion, encryptedSymmetricKey: encrypted.encryptedSymmetricKey, encryptedSymmetricKeyHash: encrypted.encryptedSymmetricKeyHash, receiverPublicKey, receiverPublicKeyHash };
     const bodyHash = hex(sha256(new TextEncoder().encode(canonicalize(body))));

--- a/packages/share-sdk/src/recipient.ts
+++ b/packages/share-sdk/src/recipient.ts
@@ -546,7 +546,7 @@ export class ShareRecipientClient {
       const symmetricKey = await aesGcmDecrypt(shared, wrapped.slice(33));
       shared.fill(0);
       if (symmetricKey.length !== 32) throw new Error("v3 content key is malformed");
-      const plaintext = await aesGcmDecrypt(symmetricKey, fromBase64Url(encrypted.ciphertext));
+      const plaintext = await aesGcmDecrypt(symmetricKey, fromBase64(encrypted.ciphertext, "v3 encrypted content"));
       this.v3ContentKey?.fill(0);
       this.v3ContentKey = symmetricKey;
       this.v3ContentEnvelope = encrypted;

--- a/packages/share-sdk/src/recipient.ts
+++ b/packages/share-sdk/src/recipient.ts
@@ -541,9 +541,9 @@ export class ShareRecipientClient {
       const signature = fromBase64(value.nodeSignature, "v3 decrypt response signature");
       if (signature.length !== 64 || !ed25519.verify(signature, new TextEncoder().encode(canonicalize(unsigned)), ed25519PublicKeyFromDidKey(body.targetNode), { zip215: false })) throw new Error("v3 decrypt response signature is invalid");
       const wrapped = fromBase64(value.wrappedKey, "v3 wrapped content key");
-      if (wrapped.length < 60) throw new Error("v3 wrapped content key is malformed");
+      if (wrapped.length < 61 || wrapped[32] !== 1) throw new Error("v3 wrapped content key is malformed");
       const shared = x25519.getSharedSecret(receiverPrivateKey, wrapped.slice(0, 32));
-      const symmetricKey = await aesGcmDecrypt(shared, wrapped.slice(32));
+      const symmetricKey = await aesGcmDecrypt(shared, wrapped.slice(33));
       shared.fill(0);
       if (symmetricKey.length !== 32) throw new Error("v3 content key is malformed");
       const plaintext = await aesGcmDecrypt(symmetricKey, fromBase64Url(encrypted.ciphertext));

--- a/packages/share-sdk/test/recipient-v3.test.ts
+++ b/packages/share-sdk/test/recipient-v3.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ed25519, x25519 } from "@noble/curves/ed25519";
 import { sha256 } from "@noble/hashes/sha256";
-import { canonicalize, didKeyFromEd25519PublicKey, signCompactUcanAuthorization, toBase64Url, verifyCompactUcanAuthorization } from "@tinycloud/share-envelope";
+import { canonicalize, didKeyFromEd25519PublicKey, signCompactUcanAuthorization, verifyCompactUcanAuthorization } from "@tinycloud/share-envelope";
 import { ShareRecipientClient } from "../src/recipient.js";
 
 const hex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
@@ -28,7 +28,7 @@ describe("v3 recipient content", () => {
     const session = await signCompactUcanAuthorization({ issuerDid: nodeDid, audienceDid: recipientDid, attenuation: { [networkId]: { "tinycloud.encryption/decrypt": [{}] } }, facts: [{ profile: "policy-session-ucan/v1", policyCid: "policy", recipientDid }], proofs: ["policy-root", "enforcement-root"], notBefore: now - 1, expiresAt: now + 59, nonce: "session", sign: async (bytes) => ed25519.sign(bytes, nodeKey) });
     const symmetricKey = new Uint8Array(32).fill(41);
     const ciphertext = await aesEncrypt(symmetricKey, new TextEncoder().encode("hello"));
-    const stored = new TextEncoder().encode(canonicalize({ v: 1, networkId, alg: "x25519-aes256gcm/v1", keyVersion: 1, encryptedSymmetricKey, encryptedSymmetricKeyHash, ciphertext: toBase64Url(ciphertext), metadata: { contentType: "text/plain" } }));
+    const stored = new TextEncoder().encode(canonicalize({ v: 1, networkId, alg: "x25519-aes256gcm/v1", keyVersion: 1, encryptedSymmetricKey, encryptedSymmetricKeyHash, ciphertext: base64(ciphertext), metadata: { contentType: "text/plain" } }));
     const fetchFn: typeof fetch = async (_input, init) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
       const encodedReceiverPublicKey = String(body.receiverPublicKey);

--- a/packages/share-sdk/test/recipient-v3.test.ts
+++ b/packages/share-sdk/test/recipient-v3.test.ts
@@ -31,7 +31,9 @@ describe("v3 recipient content", () => {
     const stored = new TextEncoder().encode(canonicalize({ v: 1, networkId, alg: "x25519-aes256gcm/v1", keyVersion: 1, encryptedSymmetricKey, encryptedSymmetricKeyHash, ciphertext: toBase64Url(ciphertext), metadata: { contentType: "text/plain" } }));
     const fetchFn: typeof fetch = async (_input, init) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
-      const receiverPublicKey = Uint8Array.from(Buffer.from(String(body.receiverPublicKey), "base64url"));
+      const encodedReceiverPublicKey = String(body.receiverPublicKey);
+      const receiverPublicKey = Uint8Array.from(Buffer.from(encodedReceiverPublicKey, "base64"));
+      expect(base64(receiverPublicKey)).toBe(encodedReceiverPublicKey);
       const ephemeralPrivate = new Uint8Array(32).fill(23);
       const ephemeralPublic = x25519.getPublicKey(ephemeralPrivate);
       const shared = x25519.getSharedSecret(ephemeralPrivate, receiverPublicKey);

--- a/packages/share-sdk/test/recipient-v3.test.ts
+++ b/packages/share-sdk/test/recipient-v3.test.ts
@@ -40,7 +40,7 @@ describe("v3 recipient content", () => {
       const wrapped = await aesEncrypt(shared, symmetricKey);
       const invocation = verifyCompactUcanAuthorization(new Headers(init?.headers).get("Authorization")!);
       const bodyHash = canonicalHash(body);
-      const unsigned = { type: "tinycloud.encryption.decrypt-result/v1", targetNode: nodeDid, networkId, invocationCid: invocation.cid, encryptedSymmetricKeyHash, receiverPublicKeyHash: body.receiverPublicKeyHash, wrappedKey: base64(Uint8Array.from([...ephemeralPublic, ...wrapped])), alg: "x25519-aes256gcm/v1", keyVersion: 1, requestHash: hex(sha256(new TextEncoder().encode(`${invocation.cid}${bodyHash}`))), nodeId: nodeDid };
+      const unsigned = { type: "tinycloud.encryption.decrypt-result/v1", targetNode: nodeDid, networkId, invocationCid: invocation.cid, encryptedSymmetricKeyHash, receiverPublicKeyHash: body.receiverPublicKeyHash, wrappedKey: base64(Uint8Array.from([...ephemeralPublic, 1, ...wrapped])), alg: "x25519-aes256gcm/v1", keyVersion: 1, requestHash: hex(sha256(new TextEncoder().encode(`${invocation.cid}${bodyHash}`))), nodeId: nodeDid };
       return Response.json({ ...unsigned, nodeSignature: base64(ed25519.sign(new TextEncoder().encode(canonicalize(unsigned)), nodeKey)) });
     };
     const envelope = { version: 3, target: { nodeAudience: nodeDid }, encryptionNetwork: networkId, contentSource: { keyVersion: 1, encryptedSymmetricKeyDigestHex: encryptedSymmetricKeyHash }, metadata: { mediaType: "text/plain" } } as any;


### PR DESCRIPTION
## Summary
- replace ambient `Buffer` selection in compact-UCAN base64url encoding with the existing browser-safe multiformats codec
- preserve strict canonical re-encoding checks
- add a regression that exposes an incompatible browser `Buffer` polyfill and proves compact root signing/verification still succeeds

## Verification
- compact UCAN + Policy/v2 focused tests: 2/2 passed
- `@tinycloud/share-envelope` typecheck passed
- `@tinycloud/share-envelope` build passed
- joined TC-500 browser diagnostic isolated the previous failure to compact root parsing

Linear: TC-500
