### PR TITLE
fix(TC-500): correct beta release plan

### DIFF
--- a/.changeset/tc-500-share-release-correction.md
+++ b/.changeset/tc-500-share-release-correction.md
@@ -1,0 +1,6 @@
+---
+"@tinycloud/share-sdk": patch
+"@tinycloud/share-envelope": patch
+---
+
+Ship browser-safe compact-UCAN verification and canonical embedded-policy delivery/receive with holder-bound delegation through generic `/delegate` and `/invoke`, without Node `/share/*`.

--- a/scripts/check-beta-release-plan.test.mjs
+++ b/scripts/check-beta-release-plan.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
@@ -10,11 +10,29 @@ import test from "node:test";
 
 const script = new URL("./check-beta-release-plan.mjs", import.meta.url);
 const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
-const tc500Correction = join(
-  repositoryRoot,
-  ".changeset",
-  "tc-500-share-release-correction.md",
-);
+const changesetDirectory = join(repositoryRoot, ".changeset");
+const tc500CorrectionId = "tc-500-share-release-correction";
+const tc500Correction = join(changesetDirectory, `${tc500CorrectionId}.md`);
+
+// This assertion only means anything while the TC-500 correction is still a
+// pending beta changeset. Pre mode does not delete a consumed changeset; it
+// records the id in pre.json and leaves the file on disk until
+// `changeset pre exit`, so keying on existence alone would leave the test
+// asserting a plan the beta release has already shipped. Mirror
+// check-beta-release-plan.mjs and treat an admitted changeset as consumed;
+// outside pre mode there is no beta plan to pin at all.
+function tc500CorrectionPending() {
+  if (!existsSync(tc500Correction)) return false;
+  try {
+    const pre = JSON.parse(
+      readFileSync(join(changesetDirectory, "pre.json"), "utf8"),
+    );
+    return !pre.changesets?.includes(tc500CorrectionId);
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
 const major = `---\n"@tinycloud/web-sdk": major\n---\n\nBreaking change.\n`;
 
 async function fixture(preChangesets, extraChangesets = {}) {
@@ -63,7 +81,7 @@ test("still rejects a newly introduced major changeset", async () => {
 test(
   "TC-500 release plan includes all five corrected beta versions",
   {
-    skip: !existsSync(tc500Correction),
+    skip: !tc500CorrectionPending(),
   },
   async () => {
     const outputName = `.changeset/.tc-500-release-plan-${process.pid}.json`;

--- a/scripts/check-beta-release-plan.test.mjs
+++ b/scripts/check-beta-release-plan.test.mjs
@@ -1,25 +1,40 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const script = new URL("./check-beta-release-plan.mjs", import.meta.url);
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const tc500Correction = join(
+  repositoryRoot,
+  ".changeset",
+  "tc-500-share-release-correction.md",
+);
 const major = `---\n"@tinycloud/web-sdk": major\n---\n\nBreaking change.\n`;
 
 async function fixture(preChangesets, extraChangesets = {}) {
   const directory = await mkdtemp(join(tmpdir(), "tinycloud-beta-plan-"));
-  await writeFile(join(directory, "pre.json"), JSON.stringify({ mode: "pre", tag: "beta", changesets: preChangesets }));
+  await writeFile(
+    join(directory, "pre.json"),
+    JSON.stringify({ mode: "pre", tag: "beta", changesets: preChangesets }),
+  );
   await writeFile(join(directory, "reviewed-major.md"), major);
-  for (const [name, source] of Object.entries(extraChangesets)) await writeFile(join(directory, name), source);
+  for (const [name, source] of Object.entries(extraChangesets))
+    await writeFile(join(directory, name), source);
   return directory;
 }
 
 test("ignores major changesets already admitted to pre.json", async () => {
   const directory = await fixture(["reviewed-major"]);
   try {
-    const result = spawnSync(process.execPath, [script.pathname, directory], { encoding: "utf8" });
+    const result = spawnSync(process.execPath, [script.pathname, directory], {
+      encoding: "utf8",
+    });
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /contains no major bumps/);
   } finally {
@@ -28,12 +43,74 @@ test("ignores major changesets already admitted to pre.json", async () => {
 });
 
 test("still rejects a newly introduced major changeset", async () => {
-  const directory = await fixture(["reviewed-major"], { "new-major.md": major });
+  const directory = await fixture(["reviewed-major"], {
+    "new-major.md": major,
+  });
   try {
-    const result = spawnSync(process.execPath, [script.pathname, directory], { encoding: "utf8" });
+    const result = spawnSync(process.execPath, [script.pathname, directory], {
+      encoding: "utf8",
+    });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /Automatic beta release refuses unconfirmed major bumps/);
+    assert.match(
+      result.stderr,
+      /Automatic beta release refuses unconfirmed major bumps/,
+    );
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test(
+  "TC-500 release plan includes all five corrected beta versions",
+  {
+    skip: !existsSync(tc500Correction),
+  },
+  async () => {
+    const outputName = `.changeset/.tc-500-release-plan-${process.pid}.json`;
+    const outputPath = join(repositoryRoot, outputName);
+    const changesetBin = createRequire(import.meta.url).resolve(
+      "@changesets/cli/bin.js",
+    );
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [changesetBin, "status", `--output=${outputName}`],
+        {
+          cwd: repositoryRoot,
+          encoding: "utf8",
+        },
+      );
+      assert.equal(result.status, 0, result.stderr);
+
+      const plan = JSON.parse(await readFile(outputPath, "utf8"));
+      const versions = new Map(
+        plan.releases.map(({ name, newVersion }) => [name, newVersion]),
+      );
+      assert.deepEqual(
+        Object.fromEntries(
+          [...versions].filter(([name]) =>
+            [
+              "@tinycloud/node-sdk",
+              "@tinycloud/sdk-core",
+              "@tinycloud/web-sdk",
+              "@tinycloud/share-sdk",
+              "@tinycloud/share-envelope",
+            ].includes(name),
+          ),
+        ),
+        {
+          "@tinycloud/sdk-core": "3.0.0-beta.7",
+          "@tinycloud/web-sdk": "3.0.0-beta.7",
+          "@tinycloud/share-sdk": "0.3.0-beta.2",
+          "@tinycloud/share-envelope": "0.2.1-beta.2",
+          "@tinycloud/node-sdk": "3.0.0-beta.7",
+        },
+      );
+    } finally {
+      await unlink(outputPath).catch((error) => {
+        if (error?.code !== "ENOENT") throw error;
+      });
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- add the missing share-sdk and share-envelope patch changeset for the TC-500 beta release
- add a release-plan regression test proving all five intended beta versions while the correction changeset is pending
- keep the general beta major-version guard unchanged

This corrects the incomplete plan exposed by failed release run 32436277763: https://github.com/TinyCloudLabs/js-sdk/actions/runs/32436277763

Calculated versions:
- @tinycloud/node-sdk 3.0.0-beta.7
- @tinycloud/sdk-core 3.0.0-beta.7
- @tinycloud/web-sdk 3.0.0-beta.7
- @tinycloud/share-sdk 0.3.0-beta.2
- @tinycloud/share-envelope 0.2.1-beta.2

## Checks
- node --test scripts/check-beta-release-plan.test.mjs
- bun changeset status --output
- bun run build:release
- Prettier check for changed files
- git diff --check

## Blocker
Publishing remains externally blocked until the repository NPM_TOKEN is repaired. This PR does not publish, modify credentials, or work around that blocker.