### PR TITLE
chore(TC-500): record published beta versions

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -35,8 +35,10 @@
     "tc-500-account-session-restore",
     "tc-500-accountless-share-receive",
     "tc-500-browser-compact-ucan",
+    "tc-500-embedded-policy-runtime",
     "tc-500-production-receiver-followup",
     "tc-500-received-share-metadata",
+    "tc-500-share-release-correction",
     "tidy-cats-share"
   ]
 }

--- a/apps/manage-key-reference-clients/CHANGELOG.md
+++ b/apps/manage-key-reference-clients/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @tinycloud/manage-key-reference-clients
 
+## 0.0.1-beta.6
+
+### Patch Changes
+
+- Updated dependencies [657c1ff]
+  - @tinycloud/sdk-core@3.0.0-beta.7
+  - @tinycloud/web-sdk@3.0.0-beta.7
+  - @tinycloud/node-sdk@3.0.0-beta.7
+
 ## 0.0.1-beta.5
 
 ### Patch Changes

--- a/apps/manage-key-reference-clients/package.json
+++ b/apps/manage-key-reference-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/manage-key-reference-clients",
-  "version": "0.0.1-beta.5",
+  "version": "0.0.1-beta.6",
   "private": true,
   "type": "module",
   "main": "src/run.ts",

--- a/apps/node-demo/CHANGELOG.md
+++ b/apps/node-demo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @tinycloudlabs/node-demo
 
+## 0.0.31-beta.5
+
+### Patch Changes
+
+- Updated dependencies [657c1ff]
+  - @tinycloud/sdk-core@3.0.0-beta.7
+  - @tinycloud/node-sdk@3.0.0-beta.7
+  - @tinycloud/vfs@0.1.14-beta.5
+
 ## 0.0.31-beta.4
 
 ### Patch Changes

--- a/apps/node-demo/package.json
+++ b/apps/node-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/node-demo",
-  "version": "0.0.31-beta.4",
+  "version": "0.0.31-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/openkey-example/CHANGELOG.md
+++ b/apps/openkey-example/CHANGELOG.md
@@ -1,5 +1,12 @@
 # tinycloud-openkey-example-app
 
+## 0.0.29-beta.7
+
+### Patch Changes
+
+- Updated dependencies [657c1ff]
+  - @tinycloud/web-sdk@3.0.0-beta.7
+
 ## 0.0.29-beta.6
 
 ### Patch Changes

--- a/apps/openkey-example/package.json
+++ b/apps/openkey-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinycloud-openkey-example-app",
-  "version": "0.0.29-beta.6",
+  "version": "0.0.29-beta.7",
   "private": true,
   "repository": {
     "url": "ssh://git@github.com:TinyCloudLabs/web-sdk.git"

--- a/apps/openkey-vite/CHANGELOG.md
+++ b/apps/openkey-vite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openkey-vite
 
+## 0.0.27-beta.7
+
+### Patch Changes
+
+- Updated dependencies [657c1ff]
+  - @tinycloud/web-sdk@3.0.0-beta.7
+
 ## 0.0.27-beta.6
 
 ### Patch Changes

--- a/apps/openkey-vite/package.json
+++ b/apps/openkey-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openkey-vite",
   "private": true,
-  "version": "0.0.27-beta.6",
+  "version": "0.0.27-beta.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "apps/manage-key-reference-clients": {
       "name": "@tinycloud/manage-key-reference-clients",
-      "version": "0.0.1-beta.5",
+      "version": "0.0.1-beta.6",
       "dependencies": {
         "@tinycloud/node-sdk": "workspace:*",
         "@tinycloud/sdk-core": "workspace:*",
@@ -37,7 +37,7 @@
     },
     "apps/node-demo": {
       "name": "@tinycloud/node-demo",
-      "version": "0.0.31-beta.4",
+      "version": "0.0.31-beta.5",
       "dependencies": {
         "@tinycloud/node-sdk": "workspace:*",
         "@tinycloud/node-sdk-wasm": "workspace:*",
@@ -52,7 +52,7 @@
     },
     "apps/openkey-example": {
       "name": "tinycloud-openkey-example-app",
-      "version": "0.0.29-beta.6",
+      "version": "0.0.29-beta.7",
       "dependencies": {
         "@openkey/sdk": "^0.8.7",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -102,7 +102,7 @@
     },
     "apps/openkey-vite": {
       "name": "openkey-vite",
-      "version": "0.0.27-beta.6",
+      "version": "0.0.27-beta.7",
       "dependencies": {
         "@openkey/sdk": "0.8.7",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -196,7 +196,7 @@
     },
     "packages/cli": {
       "name": "@tinycloud/cli",
-      "version": "0.9.1-beta.7",
+      "version": "0.9.1-beta.8",
       "bin": {
         "tc": "./bin/tc",
       },
@@ -220,7 +220,7 @@
     },
     "packages/mcp": {
       "name": "@tinycloud/mcp",
-      "version": "0.3.3-beta.4",
+      "version": "0.3.3-beta.5",
       "bin": {
         "tinycloud-mcp": "./bin/tinycloud-mcp",
         "tinycloud-mcp-http": "./bin/tinycloud-mcp-http",
@@ -242,7 +242,7 @@
     },
     "packages/node-sdk": {
       "name": "@tinycloud/node-sdk",
-      "version": "3.0.0-beta.6",
+      "version": "3.0.0-beta.7",
       "dependencies": {
         "@tinycloud/node-sdk-wasm": "1.7.6",
         "@tinycloud/sdk-core": "3.0.0-beta.1",
@@ -257,7 +257,7 @@
     },
     "packages/operations": {
       "name": "@tinycloud/operations",
-      "version": "0.3.3-beta.4",
+      "version": "0.3.3-beta.5",
       "dependencies": {
         "@tinycloud/node-sdk": "2.11.0-beta.7",
         "@tinycloud/sdk-core": "2.11.0-beta.7",
@@ -273,7 +273,7 @@
     },
     "packages/sdk-core": {
       "name": "@tinycloud/sdk-core",
-      "version": "3.0.0-beta.6",
+      "version": "3.0.0-beta.7",
       "dependencies": {
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-to-uri": "^12.0.0",
@@ -343,7 +343,7 @@
     },
     "packages/server": {
       "name": "@tinycloud/server",
-      "version": "2.4.12-beta.4",
+      "version": "2.4.12-beta.5",
       "dependencies": {
         "@tinycloud/node-sdk": "2.7.0-beta.3",
         "@tinycloud/sdk-core": "2.7.0-beta.3",
@@ -357,7 +357,7 @@
     },
     "packages/share-envelope": {
       "name": "@tinycloud/share-envelope",
-      "version": "0.2.1-beta.1",
+      "version": "0.2.1-beta.2",
       "dependencies": {
         "@noble/curves": "^1.9.2",
         "@noble/hashes": "^1.8.0",
@@ -373,7 +373,7 @@
     },
     "packages/share-sdk": {
       "name": "@tinycloud/share-sdk",
-      "version": "0.3.0-beta.1",
+      "version": "0.3.0-beta.2",
       "dependencies": {
         "@noble/curves": "^1.9.2",
         "@noble/hashes": "^1.8.0",
@@ -389,7 +389,7 @@
     },
     "packages/vfs": {
       "name": "@tinycloud/vfs",
-      "version": "0.1.14-beta.4",
+      "version": "0.1.14-beta.5",
       "dependencies": {
         "@platformatic/vfs": "^0.4.0",
         "@tinycloud/node-sdk": "2.7.0-beta.3",
@@ -402,7 +402,7 @@
     },
     "packages/web-sdk": {
       "name": "@tinycloud/web-sdk",
-      "version": "3.0.0-beta.6",
+      "version": "3.0.0-beta.7",
       "dependencies": {
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-to-uri": "^12.0.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @tinycloud/cli
 
+## 0.9.1-beta.8
+
+### Patch Changes
+
+- Updated dependencies [026bf15]
+  - @tinycloud/share-sdk@0.3.0-beta.2
+  - @tinycloud/share-envelope@0.2.1-beta.2
+  - @tinycloud/node-sdk@3.0.0-beta.7
+  - @tinycloud/operations@0.3.3-beta.5
+
 ## 0.9.1-beta.7
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/cli",
-  "version": "0.9.1-beta.7",
+  "version": "0.9.1-beta.8",
   "description": "TinyCloud CLI - manage data, delegations, and nodes from the terminal",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -27,11 +27,11 @@
     "smoke:delegated-secrets": "bun scripts/live-delegated-secrets-smoke.ts"
   },
   "dependencies": {
-    "@tinycloud/share-sdk": "0.3.0-beta.1",
-    "@tinycloud/share-envelope": "0.2.1-beta.1",
-    "@tinycloud/node-sdk": "3.0.0-beta.6",
+    "@tinycloud/share-sdk": "0.3.0-beta.2",
+    "@tinycloud/share-envelope": "0.2.1-beta.2",
+    "@tinycloud/node-sdk": "3.0.0-beta.7",
     "@tinycloud/node-sdk-wasm": "1.7.6",
-    "@tinycloud/operations": "0.3.3-beta.4",
+    "@tinycloud/operations": "0.3.3-beta.5",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",
     "open": "^11.0.0",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinycloud/mcp
 
+## 0.3.3-beta.5
+
+### Patch Changes
+
+- @tinycloud/node-sdk@3.0.0-beta.7
+- @tinycloud/operations@0.3.3-beta.5
+
 ## 0.3.3-beta.4
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/mcp",
-  "version": "0.3.3-beta.4",
+  "version": "0.3.3-beta.5",
   "description": "TinyCloud delegated operations MCP server",
   "keywords": [
     "tinycloud",
@@ -71,9 +71,9 @@
   "dependencies": {
     "@modelcontextprotocol/node": "2.0.0-beta.4",
     "@modelcontextprotocol/server": "2.0.0-beta.4",
-    "@tinycloud/node-sdk": "3.0.0-beta.6",
+    "@tinycloud/node-sdk": "3.0.0-beta.7",
     "@tinycloud/node-sdk-wasm": "1.7.6",
-    "@tinycloud/operations": "0.3.3-beta.4",
+    "@tinycloud/operations": "0.3.3-beta.5",
     "jose": "6.1.3"
   },
   "devDependencies": {

--- a/packages/node-sdk/CHANGELOG.md
+++ b/packages/node-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinycloudlabs/node-sdk
 
+## 3.0.0-beta.7
+
+### Patch Changes
+
+- Updated dependencies [657c1ff]
+  - @tinycloud/sdk-core@3.0.0-beta.7
+
 ## 3.0.0-beta.6
 
 ### Patch Changes

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/node-sdk",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "TinyCloud SDK for Node.js with configurable authorization strategies",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@tinycloud/sdk-services": "2.11.0",
-    "@tinycloud/sdk-core": "3.0.0-beta.6",
+    "@tinycloud/sdk-core": "3.0.0-beta.7",
     "@tinycloud/node-sdk-wasm": "1.7.6",
     "siwe": "^3.0.0"
   },

--- a/packages/operations/CHANGELOG.md
+++ b/packages/operations/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tinycloud/operations
 
+## 0.3.3-beta.5
+
+### Patch Changes
+
+- Updated dependencies [657c1ff]
+  - @tinycloud/sdk-core@3.0.0-beta.7
+  - @tinycloud/node-sdk@3.0.0-beta.7
+
 ## 0.3.3-beta.4
 
 ### Patch Changes

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/operations",
-  "version": "0.3.3-beta.4",
+  "version": "0.3.3-beta.5",
   "description": "TinyCloud shared operations contracts and runtime",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -59,8 +59,8 @@
     "check:generated": "bun scripts/generate.ts --check"
   },
   "dependencies": {
-    "@tinycloud/node-sdk": "3.0.0-beta.6",
-    "@tinycloud/sdk-core": "3.0.0-beta.6",
+    "@tinycloud/node-sdk": "3.0.0-beta.7",
+    "@tinycloud/sdk-core": "3.0.0-beta.7",
     "node-sql-parser": "5.4.0",
     "zod": "^3.22.0",
     "zod-to-json-schema": "^3.22.0"

--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @tinycloudlabs/sdk-core
 
+## 3.0.0-beta.7
+
+### Minor Changes
+
+- 657c1ff: Route accountless credential policy admission to the embedded TinyCloud Node
+  runtime and activate the ordinary result through generic `/delegate`, with no
+  Share data-plane request.
+
+### Patch Changes
+
+- Updated dependencies [026bf15]
+  - @tinycloud/share-sdk@0.3.0-beta.2
+  - @tinycloud/share-envelope@0.2.1-beta.2
+
 ## 3.0.0-beta.6
 
 ### Patch Changes

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/sdk-core",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "Core TinyCloud SDK - shared interfaces and TinyCloud class",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -53,8 +53,8 @@
     "@multiformats/multiaddr-to-uri": "^12.0.0",
     "@multiformats/uri-to-multiaddr": "^10.0.0",
     "@noble/curves": "^1.9.7",
-    "@tinycloud/share-envelope": "0.2.1-beta.1",
-    "@tinycloud/share-sdk": "0.3.0-beta.1",
+    "@tinycloud/share-envelope": "0.2.1-beta.2",
+    "@tinycloud/share-sdk": "0.3.0-beta.2",
     "@tinycloud/bootstrap": "2.7.0",
     "@tinycloud/sdk-services": "2.11.0",
     "multiformats": "^13.4.1",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tinycloud/server
 
+## 2.4.12-beta.5
+
+### Patch Changes
+
+- Updated dependencies [657c1ff]
+  - @tinycloud/sdk-core@3.0.0-beta.7
+  - @tinycloud/node-sdk@3.0.0-beta.7
+
 ## 2.4.12-beta.4
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/server",
-  "version": "2.4.12-beta.4",
+  "version": "2.4.12-beta.5",
   "description": "Reusable TinyCloud server and agent integration helpers",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -28,8 +28,8 @@
     "test": "bun test src/"
   },
   "dependencies": {
-    "@tinycloud/node-sdk": "3.0.0-beta.6",
-    "@tinycloud/sdk-core": "3.0.0-beta.6",
+    "@tinycloud/node-sdk": "3.0.0-beta.7",
+    "@tinycloud/sdk-core": "3.0.0-beta.7",
     "viem": "^2.21.53"
   },
   "devDependencies": {

--- a/packages/share-envelope/CHANGELOG.md
+++ b/packages/share-envelope/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinycloud/share-envelope
 
+## 0.2.1-beta.2
+
+### Patch Changes
+
+- 026bf15: Ship browser-safe compact-UCAN verification and canonical embedded-policy delivery/receive with holder-bound delegation through generic `/delegate` and `/invoke`, without Node `/share/*`.
+
 ## 0.2.1-beta.1
 
 ### Patch Changes

--- a/packages/share-envelope/package.json
+++ b/packages/share-envelope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/share-envelope",
-  "version": "0.2.1-beta.1",
+  "version": "0.2.1-beta.2",
   "description": "Canonical TinyCloud Share envelope codecs and ordered verifier.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/share-sdk/CHANGELOG.md
+++ b/packages/share-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @tinycloud/share-sdk
 
+## 0.3.0-beta.2
+
+### Patch Changes
+
+- 026bf15: Ship browser-safe compact-UCAN verification and canonical embedded-policy delivery/receive with holder-bound delegation through generic `/delegate` and `/invoke`, without Node `/share/*`.
+- Updated dependencies [026bf15]
+  - @tinycloud/share-envelope@0.2.1-beta.2
+
 ## 0.3.0-beta.1
 
 ### Patch Changes

--- a/packages/share-sdk/package.json
+++ b/packages/share-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/share-sdk",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "Canonical headless TinyCloud Share operations for browser and Node.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@noble/curves": "^1.9.2",
     "@noble/hashes": "^1.8.0",
-    "@tinycloud/share-envelope": "0.2.1-beta.1",
+    "@tinycloud/share-envelope": "0.2.1-beta.2",
     "multiformats": "^13.3.6"
   },
   "devDependencies": {

--- a/packages/vfs/CHANGELOG.md
+++ b/packages/vfs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinycloud/vfs
 
+## 0.1.14-beta.5
+
+### Patch Changes
+
+- @tinycloud/node-sdk@3.0.0-beta.7
+
 ## 0.1.14-beta.4
 
 ### Patch Changes

--- a/packages/vfs/package.json
+++ b/packages/vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/vfs",
-  "version": "0.1.14-beta.4",
+  "version": "0.1.14-beta.5",
   "description": "TinyCloud Virtual File System for Node.js",
   "author": "TinyCloud, Inc.",
   "license": "EGPL",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@platformatic/vfs": "^0.4.0",
-    "@tinycloud/node-sdk": "3.0.0-beta.6"
+    "@tinycloud/node-sdk": "3.0.0-beta.7"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/web-sdk/CHANGELOG.md
+++ b/packages/web-sdk/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @tinycloudlabs/web-sdk
 
+## 3.0.0-beta.7
+
+### Minor Changes
+
+- 657c1ff: Route accountless credential policy admission to the embedded TinyCloud Node
+  runtime and activate the ordinary result through generic `/delegate`, with no
+  Share data-plane request.
+
+### Patch Changes
+
+- Updated dependencies [657c1ff]
+- Updated dependencies [026bf15]
+  - @tinycloud/sdk-core@3.0.0-beta.7
+  - @tinycloud/share-sdk@0.3.0-beta.2
+  - @tinycloud/share-envelope@0.2.1-beta.2
+  - @tinycloud/node-sdk@3.0.0-beta.7
+
 ## 3.0.0-beta.6
 
 ### Patch Changes

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinycloud/web-sdk",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "A set of tools and utilities to help you build your app with TinyCloud.",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
@@ -43,10 +43,10 @@
   "dependencies": {
     "@multiformats/multiaddr": "^13.0.1",
     "@multiformats/multiaddr-to-uri": "^12.0.0",
-    "@tinycloud/node-sdk": "3.0.0-beta.6",
-    "@tinycloud/sdk-core": "3.0.0-beta.6",
-    "@tinycloud/share-envelope": "0.2.1-beta.1",
-    "@tinycloud/share-sdk": "0.3.0-beta.1",
+    "@tinycloud/node-sdk": "3.0.0-beta.7",
+    "@tinycloud/sdk-core": "3.0.0-beta.7",
+    "@tinycloud/share-envelope": "0.2.1-beta.2",
+    "@tinycloud/share-sdk": "0.3.0-beta.2",
     "@tinycloud/web-sdk-wasm": "1.7.6",
     "axios": "^1.7.9",
     "viem": "^2.45.0",


### PR DESCRIPTION
## Summary
- reconstruct the exact generated beta version commit from release head `026bf158`
- record packages published by changesets run `32442913200`
- leave the later `fresh-secrets-catalog` changeset pending for the next beta

## Evidence
- npm `beta` tags match the recorded versions
- reconstructed diff exactly matches the rejected Actions commit stat: 30 files, 172 insertions, 47 deletions
- `git diff --check` passes

Refs TC-500.